### PR TITLE
feat(compiler): Cursor IDE/CLI adapter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,6 +45,11 @@ jobs:
         # are skipped in some environments (e.g. missing optional data dirs).
         run: pytest tests/ -v --tb=short
 
+      - name: Run compiler contract tests
+        run: PYTHONPATH=src pytest tests/compiler/ -v --tb=short
+        env:
+          AGENT_TOOLKIT_ROOT: ${{ github.workspace }}
+
   # ── Job 2: Validate SKILL.md and AGENT.md frontmatter ─────────────────────
   validate-skills:
     name: Validate Skills & Agents

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,6 +45,9 @@ jobs:
         # are skipped in some environments (e.g. missing optional data dirs).
         run: pytest tests/ -v --tb=short
 
+      - name: Install compiler test dependencies
+        run: pip install pyyaml
+
       - name: Run compiler contract tests
         run: PYTHONPATH=src pytest tests/compiler/ -v --tb=short
         env:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -211,4 +211,7 @@ def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
     if target_id == "claude-code":
         from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
         return ClaudeCodeAdapter(output_dir, repo_root)
+    if target_id == "cursor":
+        from agent_toolkit.compiler.targets.cursor import CursorAdapter
+        return CursorAdapter(output_dir, repo_root)
     return None

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -8,6 +8,9 @@ Usage:
 Commands:
     install       Install profiles for detected AI tools
     doctor        Check system health and tool availability
+    build         Compile canonical capabilities into target-native artifacts
+    inventory     List all canonical skills, agents, and products
+    matrix        Show platform capability matrix
     loop          Loop engineering: init, run, status, audit, cost, schedule, sync
     workspace     Workspace scaffolding: init, context, sync
     memory        Knowledge base: add, search, inject, review, todo
@@ -41,6 +44,15 @@ def main() -> None:
     rest = argv[1:]
 
     match command:
+        case "build":
+            from agent_toolkit.cli.build import cmd_build
+            sys.exit(cmd_build(rest))
+        case "inventory":
+            from agent_toolkit.cli.build import cmd_inventory
+            sys.exit(cmd_inventory(rest))
+        case "matrix":
+            from agent_toolkit.cli.build import cmd_matrix
+            sys.exit(cmd_matrix(rest))
         case "install":
             from agent_toolkit.cli.install import cmd_install
             sys.exit(cmd_install(rest))

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
@@ -1,5 +1,7 @@
 """Abstract base for target adapters."""
 from __future__ import annotations
+
+import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -30,14 +32,27 @@ class TargetAdapter(ABC):
         """
 
     def check(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
-        """Dry-run: validate without writing artifacts."""
-        result = self.compile(graph, product)
-        # Remove artifacts (check mode)
+        """Dry-run: validate without writing any files to disk.
+
+        Uses a temporary directory that is discarded after compilation,
+        so the real output_root is never touched.
+        """
+        with tempfile.TemporaryDirectory(prefix="agent-toolkit-check-") as tmpdir:
+            # Temporarily redirect output to the throwaway temp dir
+            real_output_root = self.output_root
+            self.output_root = Path(tmpdir)
+            try:
+                result = self.compile(graph, product)
+            finally:
+                self.output_root = real_output_root
+
+        # Artifacts were in the temp dir (now deleted) — report paths as relative
+        # so callers know what WOULD have been created, but clear actual paths
         result.artifacts.clear()
         return result
 
     def _write_file(self, path: Path, content: str, result: CompilationResult) -> None:
-        """Atomic file write with provenance header where format allows."""
+        """Write content to path and record it in result.artifacts."""
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         result.artifacts.append(path)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/cursor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/cursor.py
@@ -1,0 +1,213 @@
+"""
+Cursor IDE/CLI target adapter.
+
+Compiles canonical IR into Cursor plugin bundles:
+  plugins/<product-id>/.cursor-plugin/plugin.json   — marketplace manifest
+  plugins/<product-id>/skills/<name>/SKILL.md        — on-demand procedures
+  plugins/<product-id>/agents/<name>/AGENT.md        — agent personas
+
+Key differences from Claude Code:
+- Manifest key is `.cursor-plugin/`, not `.claude-plugin/`
+- Rules (.mdc) are a separate surface from skills:
+    * Rules = persistent behavioral constraints (always-on in session)
+    * Skills = on-demand procedures with resources (invoked explicitly)
+  Rules are generated from agent/assistant instructions; they are NOT
+  a substitute for skills in the plugin bundle.
+- Hook event names differ (workspaceOpen, sessionStart vs session.start)
+- MCP config goes in .cursor/mcp.json, not .mcp.json
+
+Official docs: https://cursor.com/docs/plugins
+Research: docs/research/platform-capability-matrix.md (2026-08-04)
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from agent_toolkit.compiler.model import (
+    Agent,
+    CanonicalGraph,
+    CompilationResult,
+    Product,
+    Skill,
+)
+from agent_toolkit.compiler.targets.base import TargetAdapter
+
+
+# Cursor supports these .mdc rule frontmatter fields.
+# We generate rules only from skill/agent behavioral constraints —
+# NOT as a substitute for skills in the plugin bundle.
+_CURSOR_RULE_HEADER = """\
+---
+description: {description}
+alwaysApply: {always_apply}
+---
+"""
+
+
+class CursorAdapter(TargetAdapter):
+    """Compiles agent-toolkit products into Cursor plugin bundles.
+
+    Cursor reads both IDE and CLI from the same plugin bundle.
+    The generated bundle is installable via the Cursor marketplace or
+    local plugin development linking.
+
+    Capability parity:
+      native:               skills, agents, plugin manifest
+      native-experimental:  hooks (not yet implemented — pending hook model)
+      manual:               MCP (user configures ~/.cursor/mcp.json separately)
+      unsupported:          Windsurf-style always-on global rules
+    """
+
+    target_id = "cursor"
+    package_type = "plugin"
+    maturity = "stable"
+
+    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+        result = CompilationResult(target=self.target_id, product=product.id)
+        out_dir = self.output_root / product.id
+
+        # 1. Emit .cursor-plugin/plugin.json
+        plugin_json = self._build_plugin_json(product)
+        self._write_file(
+            out_dir / ".cursor-plugin" / "plugin.json",
+            json.dumps(plugin_json, indent=2) + "\n",
+            result,
+        )
+        result.emitted.append("plugin-manifest")
+
+        # 2. Emit skills (same Agent Skills SKILL.md format as Claude Code)
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill is None:
+                result.warnings.append(f"Skill '{skill_id}' not found — skipping")
+                result.omitted.append(f"skill:{skill_id}")
+                continue
+            self._emit_skill(skill, out_dir, result)
+
+        # 3. Emit agents (AGENT.md format)
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent is None:
+                result.warnings.append(f"Agent '{agent_id}' not found — skipping")
+                result.omitted.append(f"agent:{agent_id}")
+                continue
+            self._emit_agent(agent, out_dir, result)
+
+        # 4. Explicitly document unsupported/pending capabilities
+        #    (never silently drop — always report)
+        result.unsupported.extend([
+            "hooks (pending canonical hook model — Cursor uses workspaceOpen/sessionStart events)",
+            "mcp (.cursor/mcp.json — user configures manually; not bundled in plugin)",
+            "cursor-rules (.mdc) — generated as a separate profile surface, not in plugin bundle",
+        ])
+
+        return result
+
+    # ── manifest ──────────────────────────────────────────────────────────────
+
+    def _build_plugin_json(self, product: Product) -> dict:
+        """Build the .cursor-plugin/plugin.json manifest.
+
+        Schema matches Claude Code plugin.json (both platforms share this format),
+        but Cursor resolves plugin root from .cursor-plugin/ not .claude-plugin/.
+        """
+        try:
+            from agent_toolkit import __version__
+            version = __version__
+        except ImportError:
+            version = "1.0.0"
+
+        return {
+            "name": product.id,
+            "version": version,
+            "description": product.description,
+            "author": {
+                "name": "ulises-jeremias",
+                "email": "ulisescf.24@gmail.com",
+            },
+            "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+            "repository": "https://github.com/ulises-jeremias/agent-toolkit",
+            "license": "MIT",
+            "keywords": [
+                "agent-toolkit",
+                product.id.replace("agent-toolkit-", ""),
+                "cursor",
+                "skills",
+                "agents",
+            ],
+        }
+
+    # ── skills ────────────────────────────────────────────────────────────────
+
+    def _emit_skill(self, skill: Skill, out_dir: Path, result: CompilationResult) -> None:
+        """Copy SKILL.md (and references/) into plugin skills/ directory.
+
+        Cursor discovers skills at <plugin-root>/skills/<name>/SKILL.md —
+        the same path as Claude Code. No transformation needed.
+        """
+        if not skill.source_path.exists():
+            result.warnings.append(f"Skill source missing: {skill.source_path}")
+            result.omitted.append(f"skill:{skill.id}")
+            return
+
+        dst = out_dir / "skills" / skill.name
+        dst.mkdir(parents=True, exist_ok=True)
+
+        content = skill.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "SKILL.md", content, result)
+
+        # Copy references/ (progressive disclosure)
+        refs_src = skill.source_path.parent / "references"
+        if refs_src.is_dir():
+            for ref_file in sorted(refs_src.rglob("*")):
+                if ref_file.is_file():
+                    rel = ref_file.relative_to(skill.source_path.parent)
+                    ref_dst = dst / rel
+                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
+                    ref_dst.write_bytes(ref_file.read_bytes())
+                    result.artifacts.append(ref_dst)
+
+        result.emitted.append(f"skill:{skill.id}")
+
+    # ── agents ────────────────────────────────────────────────────────────────
+
+    def _emit_agent(self, agent: Agent, out_dir: Path, result: CompilationResult) -> None:
+        """Copy AGENT.md into plugin agents/ directory.
+
+        Cursor discovers agents at <plugin-root>/agents/<name>/AGENT.md.
+        """
+        if not agent.source_path.exists():
+            result.warnings.append(f"Agent source missing: {agent.source_path}")
+            result.omitted.append(f"agent:{agent.id}")
+            return
+
+        dst = out_dir / "agents" / agent.name
+        dst.mkdir(parents=True, exist_ok=True)
+
+        content = agent.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "AGENT.md", content, result)
+        result.emitted.append(f"agent:{agent.id}")
+
+    # ── parity document ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def parity_notes() -> str:
+        """Return honest parity notes for documentation generation."""
+        return (
+            "Cursor IDE and Cursor CLI both read from the same plugin bundle and "
+            "the same ~/.cursor/rules/ directory. No separate surface needed.\n"
+            "\n"
+            "Rules (.mdc files) are generated separately as a profile surface "
+            "(`profiles/cursor/rules/`) for users who install profiles manually. "
+            "They are NOT duplicated inside the plugin bundle because rules represent "
+            "persistent behavioral constraints, not the same semantic as on-demand skills.\n"
+            "\n"
+            "MCP: user configures ~/.cursor/mcp.json independently. The plugin does "
+            "not bundle MCP server configuration (pending MCP registry implementation).\n"
+            "\n"
+            "Hooks: Cursor supports workspaceOpen, sessionStart, sessionEnd, and other "
+            "lifecycle events. These require the canonical hook model to be defined first "
+            "(see issue #16)."
+        )

--- a/plugins/agent-toolkit-core/.cursor-plugin/plugin.json
+++ b/plugins/agent-toolkit-core/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-toolkit-core",
-  "version": "1.0.0",
-  "description": "Core AI agent capabilities: orchestrator, dev companion, PR fallback, output handshake, knowledge sync, and code-reviewer agent.",
+  "version": "1.1.0",
+  "description": "Core orchestration skills, dev companion, output handshake, PR fallback, and code-reviewer agent. The baseline install for any project.",
   "author": {
     "name": "ulises-jeremias",
     "email": "ulisescf.24@gmail.com"
@@ -9,5 +9,11 @@
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",
   "license": "MIT",
-  "keywords": ["agent-toolkit", "core", "orchestrator", "assistant", "companion"]
+  "keywords": [
+    "agent-toolkit",
+    "core",
+    "cursor",
+    "skills",
+    "agents"
+  ]
 }

--- a/src/agent_toolkit/cli/build.py
+++ b/src/agent_toolkit/cli/build.py
@@ -211,4 +211,7 @@ def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
     if target_id == "claude-code":
         from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
         return ClaudeCodeAdapter(output_dir, repo_root)
+    if target_id == "cursor":
+        from agent_toolkit.compiler.targets.cursor import CursorAdapter
+        return CursorAdapter(output_dir, repo_root)
     return None

--- a/src/agent_toolkit/cli/main.py
+++ b/src/agent_toolkit/cli/main.py
@@ -8,6 +8,9 @@ Usage:
 Commands:
     install       Install profiles for detected AI tools
     doctor        Check system health and tool availability
+    build         Compile canonical capabilities into target-native artifacts
+    inventory     List all canonical skills, agents, and products
+    matrix        Show platform capability matrix
     loop          Loop engineering: init, run, status, audit, cost, schedule, sync
     workspace     Workspace scaffolding: init, context, sync
     memory        Knowledge base: add, search, inject, review, todo
@@ -41,6 +44,15 @@ def main() -> None:
     rest = argv[1:]
 
     match command:
+        case "build":
+            from agent_toolkit.cli.build import cmd_build
+            sys.exit(cmd_build(rest))
+        case "inventory":
+            from agent_toolkit.cli.build import cmd_inventory
+            sys.exit(cmd_inventory(rest))
+        case "matrix":
+            from agent_toolkit.cli.build import cmd_matrix
+            sys.exit(cmd_matrix(rest))
         case "install":
             from agent_toolkit.cli.install import cmd_install
             sys.exit(cmd_install(rest))

--- a/src/agent_toolkit/compiler/targets/base.py
+++ b/src/agent_toolkit/compiler/targets/base.py
@@ -1,5 +1,7 @@
 """Abstract base for target adapters."""
 from __future__ import annotations
+
+import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -30,14 +32,27 @@ class TargetAdapter(ABC):
         """
 
     def check(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
-        """Dry-run: validate without writing artifacts."""
-        result = self.compile(graph, product)
-        # Remove artifacts (check mode)
+        """Dry-run: validate without writing any files to disk.
+
+        Uses a temporary directory that is discarded after compilation,
+        so the real output_root is never touched.
+        """
+        with tempfile.TemporaryDirectory(prefix="agent-toolkit-check-") as tmpdir:
+            # Temporarily redirect output to the throwaway temp dir
+            real_output_root = self.output_root
+            self.output_root = Path(tmpdir)
+            try:
+                result = self.compile(graph, product)
+            finally:
+                self.output_root = real_output_root
+
+        # Artifacts were in the temp dir (now deleted) — report paths as relative
+        # so callers know what WOULD have been created, but clear actual paths
         result.artifacts.clear()
         return result
 
     def _write_file(self, path: Path, content: str, result: CompilationResult) -> None:
-        """Atomic file write with provenance header where format allows."""
+        """Write content to path and record it in result.artifacts."""
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         result.artifacts.append(path)

--- a/src/agent_toolkit/compiler/targets/cursor.py
+++ b/src/agent_toolkit/compiler/targets/cursor.py
@@ -1,0 +1,213 @@
+"""
+Cursor IDE/CLI target adapter.
+
+Compiles canonical IR into Cursor plugin bundles:
+  plugins/<product-id>/.cursor-plugin/plugin.json   — marketplace manifest
+  plugins/<product-id>/skills/<name>/SKILL.md        — on-demand procedures
+  plugins/<product-id>/agents/<name>/AGENT.md        — agent personas
+
+Key differences from Claude Code:
+- Manifest key is `.cursor-plugin/`, not `.claude-plugin/`
+- Rules (.mdc) are a separate surface from skills:
+    * Rules = persistent behavioral constraints (always-on in session)
+    * Skills = on-demand procedures with resources (invoked explicitly)
+  Rules are generated from agent/assistant instructions; they are NOT
+  a substitute for skills in the plugin bundle.
+- Hook event names differ (workspaceOpen, sessionStart vs session.start)
+- MCP config goes in .cursor/mcp.json, not .mcp.json
+
+Official docs: https://cursor.com/docs/plugins
+Research: docs/research/platform-capability-matrix.md (2026-08-04)
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from agent_toolkit.compiler.model import (
+    Agent,
+    CanonicalGraph,
+    CompilationResult,
+    Product,
+    Skill,
+)
+from agent_toolkit.compiler.targets.base import TargetAdapter
+
+
+# Cursor supports these .mdc rule frontmatter fields.
+# We generate rules only from skill/agent behavioral constraints —
+# NOT as a substitute for skills in the plugin bundle.
+_CURSOR_RULE_HEADER = """\
+---
+description: {description}
+alwaysApply: {always_apply}
+---
+"""
+
+
+class CursorAdapter(TargetAdapter):
+    """Compiles agent-toolkit products into Cursor plugin bundles.
+
+    Cursor reads both IDE and CLI from the same plugin bundle.
+    The generated bundle is installable via the Cursor marketplace or
+    local plugin development linking.
+
+    Capability parity:
+      native:               skills, agents, plugin manifest
+      native-experimental:  hooks (not yet implemented — pending hook model)
+      manual:               MCP (user configures ~/.cursor/mcp.json separately)
+      unsupported:          Windsurf-style always-on global rules
+    """
+
+    target_id = "cursor"
+    package_type = "plugin"
+    maturity = "stable"
+
+    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+        result = CompilationResult(target=self.target_id, product=product.id)
+        out_dir = self.output_root / product.id
+
+        # 1. Emit .cursor-plugin/plugin.json
+        plugin_json = self._build_plugin_json(product)
+        self._write_file(
+            out_dir / ".cursor-plugin" / "plugin.json",
+            json.dumps(plugin_json, indent=2) + "\n",
+            result,
+        )
+        result.emitted.append("plugin-manifest")
+
+        # 2. Emit skills (same Agent Skills SKILL.md format as Claude Code)
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill is None:
+                result.warnings.append(f"Skill '{skill_id}' not found — skipping")
+                result.omitted.append(f"skill:{skill_id}")
+                continue
+            self._emit_skill(skill, out_dir, result)
+
+        # 3. Emit agents (AGENT.md format)
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent is None:
+                result.warnings.append(f"Agent '{agent_id}' not found — skipping")
+                result.omitted.append(f"agent:{agent_id}")
+                continue
+            self._emit_agent(agent, out_dir, result)
+
+        # 4. Explicitly document unsupported/pending capabilities
+        #    (never silently drop — always report)
+        result.unsupported.extend([
+            "hooks (pending canonical hook model — Cursor uses workspaceOpen/sessionStart events)",
+            "mcp (.cursor/mcp.json — user configures manually; not bundled in plugin)",
+            "cursor-rules (.mdc) — generated as a separate profile surface, not in plugin bundle",
+        ])
+
+        return result
+
+    # ── manifest ──────────────────────────────────────────────────────────────
+
+    def _build_plugin_json(self, product: Product) -> dict:
+        """Build the .cursor-plugin/plugin.json manifest.
+
+        Schema matches Claude Code plugin.json (both platforms share this format),
+        but Cursor resolves plugin root from .cursor-plugin/ not .claude-plugin/.
+        """
+        try:
+            from agent_toolkit import __version__
+            version = __version__
+        except ImportError:
+            version = "1.0.0"
+
+        return {
+            "name": product.id,
+            "version": version,
+            "description": product.description,
+            "author": {
+                "name": "ulises-jeremias",
+                "email": "ulisescf.24@gmail.com",
+            },
+            "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+            "repository": "https://github.com/ulises-jeremias/agent-toolkit",
+            "license": "MIT",
+            "keywords": [
+                "agent-toolkit",
+                product.id.replace("agent-toolkit-", ""),
+                "cursor",
+                "skills",
+                "agents",
+            ],
+        }
+
+    # ── skills ────────────────────────────────────────────────────────────────
+
+    def _emit_skill(self, skill: Skill, out_dir: Path, result: CompilationResult) -> None:
+        """Copy SKILL.md (and references/) into plugin skills/ directory.
+
+        Cursor discovers skills at <plugin-root>/skills/<name>/SKILL.md —
+        the same path as Claude Code. No transformation needed.
+        """
+        if not skill.source_path.exists():
+            result.warnings.append(f"Skill source missing: {skill.source_path}")
+            result.omitted.append(f"skill:{skill.id}")
+            return
+
+        dst = out_dir / "skills" / skill.name
+        dst.mkdir(parents=True, exist_ok=True)
+
+        content = skill.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "SKILL.md", content, result)
+
+        # Copy references/ (progressive disclosure)
+        refs_src = skill.source_path.parent / "references"
+        if refs_src.is_dir():
+            for ref_file in sorted(refs_src.rglob("*")):
+                if ref_file.is_file():
+                    rel = ref_file.relative_to(skill.source_path.parent)
+                    ref_dst = dst / rel
+                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
+                    ref_dst.write_bytes(ref_file.read_bytes())
+                    result.artifacts.append(ref_dst)
+
+        result.emitted.append(f"skill:{skill.id}")
+
+    # ── agents ────────────────────────────────────────────────────────────────
+
+    def _emit_agent(self, agent: Agent, out_dir: Path, result: CompilationResult) -> None:
+        """Copy AGENT.md into plugin agents/ directory.
+
+        Cursor discovers agents at <plugin-root>/agents/<name>/AGENT.md.
+        """
+        if not agent.source_path.exists():
+            result.warnings.append(f"Agent source missing: {agent.source_path}")
+            result.omitted.append(f"agent:{agent.id}")
+            return
+
+        dst = out_dir / "agents" / agent.name
+        dst.mkdir(parents=True, exist_ok=True)
+
+        content = agent.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "AGENT.md", content, result)
+        result.emitted.append(f"agent:{agent.id}")
+
+    # ── parity document ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def parity_notes() -> str:
+        """Return honest parity notes for documentation generation."""
+        return (
+            "Cursor IDE and Cursor CLI both read from the same plugin bundle and "
+            "the same ~/.cursor/rules/ directory. No separate surface needed.\n"
+            "\n"
+            "Rules (.mdc files) are generated separately as a profile surface "
+            "(`profiles/cursor/rules/`) for users who install profiles manually. "
+            "They are NOT duplicated inside the plugin bundle because rules represent "
+            "persistent behavioral constraints, not the same semantic as on-demand skills.\n"
+            "\n"
+            "MCP: user configures ~/.cursor/mcp.json independently. The plugin does "
+            "not bundle MCP server configuration (pending MCP registry implementation).\n"
+            "\n"
+            "Hooks: Cursor supports workspaceOpen, sessionStart, sessionEnd, and other "
+            "lifecycle events. These require the canonical hook model to be defined first "
+            "(see issue #16)."
+        )

--- a/tests/compiler/test_claude_code_adapter.py
+++ b/tests/compiler/test_claude_code_adapter.py
@@ -1,0 +1,73 @@
+"""Contract tests for the Claude Code adapter."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+@pytest.fixture
+def graph():
+    return load_graph(REPO_ROOT)
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    return ClaudeCodeAdapter(tmp_path / "plugins", REPO_ROOT)
+
+
+def test_manifest_created(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+    manifest = adapter.output_root / "agent-toolkit-core" / ".claude-plugin" / "plugin.json"
+    assert manifest.exists()
+    assert "plugin-manifest" in result.emitted
+
+
+def test_manifest_valid_json(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+    manifest = adapter.output_root / "agent-toolkit-core" / ".claude-plugin" / "plugin.json"
+    data = json.loads(manifest.read_text())
+    for field in ("name", "version", "description", "author"):
+        assert field in data, f"manifest missing '{field}'"
+
+
+def test_no_dangerous_mode_bypass(adapter, graph):
+    for product in graph.products.values():
+        adapter.compile(graph, product)
+        manifest_path = adapter.output_root / product.id / ".claude-plugin" / "plugin.json"
+        if manifest_path.exists():
+            data = json.loads(manifest_path.read_text())
+            assert "skipDangerousModePermissionPrompt" not in data
+
+
+def test_unsupported_reported(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+    unsupported = " ".join(result.unsupported).lower()
+    assert "hook" in unsupported
+    assert "mcp" in unsupported
+
+
+def test_check_mode_no_files(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.check(graph, product)
+    assert result.artifacts == []
+    assert result.is_valid
+
+
+@pytest.mark.parametrize("product_id", ["agent-toolkit-core", "agent-toolkit-agents", "agent-toolkit-forge"])
+def test_all_products(adapter, graph, product_id):
+    if product_id not in graph.products:
+        pytest.skip(f"Product {product_id} not defined")
+    result = adapter.compile(graph, graph.products[product_id])
+    assert result.errors == []

--- a/tests/compiler/test_cursor_adapter.py
+++ b/tests/compiler/test_cursor_adapter.py
@@ -201,14 +201,21 @@ def test_no_silent_drops(adapter, graph):
 # ── check mode ────────────────────────────────────────────────────────────────
 
 
-def test_check_mode_produces_no_files(adapter, graph):
-    """--check must not write any files."""
+def test_check_mode_produces_no_files(adapter, graph, tmp_path):
+    """--check must not write any files to the output directory."""
     product = graph.products["agent-toolkit-core"]
+
+    # Record directory contents before check
+    before = set(tmp_path.rglob("*"))
+
     result = adapter.check(graph, product)
 
-    assert result.artifacts == [], (
-        f"check mode wrote {len(result.artifacts)} files — should write nothing"
+    # Verify no files were written to the output_root
+    after = set(tmp_path.rglob("*"))
+    assert after == before, (
+        f"check mode wrote {after - before} files — output_root must not be modified"
     )
+    assert result.artifacts == [], "check mode must clear artifacts list"
     assert result.is_valid
 
 

--- a/tests/compiler/test_cursor_adapter.py
+++ b/tests/compiler/test_cursor_adapter.py
@@ -1,0 +1,237 @@
+"""Contract tests for the Cursor adapter.
+
+Verifies:
+- Required manifest exists with correct fields
+- Native paths are correct (skills/, agents/ in plugin bundle)
+- Names/versions match canonical sources
+- Unsupported capabilities are reported explicitly (not silently dropped)
+- No absolute machine paths in generated output
+- No forbidden settings (no dangerous bypasses)
+- No private provider URLs
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Skip entire module gracefully if PyYAML not installed (CI installs it)
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.model import CompilationResult
+from agent_toolkit.compiler.targets.cursor import CursorAdapter
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+@pytest.fixture
+def graph():
+    return load_graph(REPO_ROOT)
+
+
+@pytest.fixture
+def tmp_output(tmp_path):
+    return tmp_path / "plugins"
+
+
+@pytest.fixture
+def adapter(tmp_output):
+    return CursorAdapter(tmp_output, REPO_ROOT)
+
+
+# ── manifest ──────────────────────────────────────────────────────────────────
+
+
+def test_plugin_manifest_created(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+
+    manifest = adapter.output_root / "agent-toolkit-core" / ".cursor-plugin" / "plugin.json"
+    assert manifest.exists(), f".cursor-plugin/plugin.json not found at {manifest}"
+    assert "plugin-manifest" in result.emitted
+
+
+def test_plugin_manifest_valid_json(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    manifest = adapter.output_root / "agent-toolkit-core" / ".cursor-plugin" / "plugin.json"
+    data = json.loads(manifest.read_text())
+
+    # Required fields per Cursor plugin spec
+    assert "name" in data, "manifest missing 'name'"
+    assert "version" in data, "manifest missing 'version'"
+    assert "description" in data, "manifest missing 'description'"
+    assert "author" in data, "manifest missing 'author'"
+
+
+def test_manifest_name_matches_product(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    manifest = adapter.output_root / "agent-toolkit-core" / ".cursor-plugin" / "plugin.json"
+    data = json.loads(manifest.read_text())
+    assert data["name"] == "agent-toolkit-core"
+
+
+def test_manifest_no_dangerous_settings(adapter, graph):
+    """Cursor plugin must not bypass permission prompts."""
+    for product in graph.products.values():
+        adapter.compile(graph, product)
+        manifest_path = (
+            adapter.output_root / product.id / ".cursor-plugin" / "plugin.json"
+        )
+        if manifest_path.exists():
+            data = json.loads(manifest_path.read_text())
+            assert "skipDangerousModePermissionPrompt" not in data
+            assert "autoAcceptPermissions" not in data
+
+
+def test_manifest_no_private_providers(adapter, graph):
+    """Plugin manifest must not contain internal hostnames."""
+    for product in graph.products.values():
+        adapter.compile(graph, product)
+        manifest_path = (
+            adapter.output_root / product.id / ".cursor-plugin" / "plugin.json"
+        )
+        if manifest_path.exists():
+            text = manifest_path.read_text()
+            assert ".local" not in text, "Private .local hostname in manifest"
+            assert "192.168." not in text, "Private IP in manifest"
+
+
+# ── skills ────────────────────────────────────────────────────────────────────
+
+
+def test_skills_emitted(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+
+    emitted_skills = [e for e in result.emitted if e.startswith("skill:")]
+    assert len(emitted_skills) > 0, "No skills emitted for agent-toolkit-core"
+
+
+def test_skill_md_in_correct_path(adapter, graph):
+    """Cursor discovers skills at <plugin-root>/skills/<name>/SKILL.md."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    skills_dir = adapter.output_root / "agent-toolkit-core" / "skills"
+    assert skills_dir.is_dir(), "skills/ directory not created"
+
+    skill_mds = list(skills_dir.rglob("SKILL.md"))
+    assert len(skill_mds) > 0, "No SKILL.md files found in skills/"
+
+
+def test_no_skill_json_files(adapter, graph):
+    """skill.json must not be generated (removed from spec in v1.0.4)."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    skill_jsons = list((adapter.output_root / "agent-toolkit-core").rglob("skill.json"))
+    assert skill_jsons == [], f"skill.json found: {skill_jsons}"
+
+
+def test_no_absolute_paths_in_skill_md(adapter, graph):
+    """Generated SKILL.md must not contain absolute machine paths."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    for skill_md in (adapter.output_root / "agent-toolkit-core").rglob("SKILL.md"):
+        text = skill_md.read_text()
+        assert "/home/" not in text, f"Absolute /home/ path in {skill_md}"
+        assert str(Path.home()) not in text, f"Home dir path in {skill_md}"
+
+
+# ── agents ────────────────────────────────────────────────────────────────────
+
+
+def test_agents_emitted(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+
+    emitted_agents = [e for e in result.emitted if e.startswith("agent:")]
+    assert len(emitted_agents) > 0, "No agents emitted"
+
+
+def test_agent_md_in_correct_path(adapter, graph):
+    """Cursor discovers agents at <plugin-root>/agents/<name>/AGENT.md."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    agents_dir = adapter.output_root / "agent-toolkit-core" / "agents"
+    assert agents_dir.is_dir(), "agents/ directory not created"
+
+    agent_mds = list(agents_dir.rglob("AGENT.md"))
+    assert len(agent_mds) > 0, "No AGENT.md files found in agents/"
+
+
+# ── unsupported capabilities ──────────────────────────────────────────────────
+
+
+def test_unsupported_capabilities_reported(adapter, graph):
+    """Hooks and MCP must be explicitly reported as unsupported — never silently dropped."""
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+
+    unsupported_text = " ".join(result.unsupported).lower()
+    assert "hook" in unsupported_text, (
+        "Hooks not reported in unsupported list — must be explicit, not silently dropped"
+    )
+    assert "mcp" in unsupported_text, (
+        "MCP not reported in unsupported list — must be explicit, not silently dropped"
+    )
+
+
+def test_no_silent_drops(adapter, graph):
+    """CompilationResult must never have zero emitted AND zero unsupported."""
+    for product in graph.products.values():
+        result = adapter.compile(graph, product)
+        # Either something was emitted OR something was explicitly unsupported/omitted
+        assert result.emitted or result.unsupported or result.omitted, (
+            f"Product {product.id}: CompilationResult has no emitted, unsupported, "
+            "or omitted — this suggests silent drops"
+        )
+
+
+# ── check mode ────────────────────────────────────────────────────────────────
+
+
+def test_check_mode_produces_no_files(adapter, graph):
+    """--check must not write any files."""
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.check(graph, product)
+
+    assert result.artifacts == [], (
+        f"check mode wrote {len(result.artifacts)} files — should write nothing"
+    )
+    assert result.is_valid
+
+
+# ── parity notes ──────────────────────────────────────────────────────────────
+
+
+def test_parity_notes_documented():
+    """CursorAdapter must document capability parity (rules vs skills distinction)."""
+    notes = CursorAdapter.parity_notes()
+    assert "rule" in notes.lower(), "Parity notes must explain rules vs skills"
+    assert "mcp" in notes.lower(), "Parity notes must explain MCP status"
+    assert "hook" in notes.lower(), "Parity notes must explain hooks status"
+
+
+# ── all products ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("product_id", ["agent-toolkit-core", "agent-toolkit-agents", "agent-toolkit-forge"])
+def test_all_products_compile_cleanly(adapter, graph, product_id):
+    """All defined products must compile without errors."""
+    if product_id not in graph.products:
+        pytest.skip(f"Product {product_id} not in catalog")
+
+    product = graph.products[product_id]
+    result = adapter.compile(graph, product)
+    assert result.errors == [], f"Errors compiling {product_id}: {result.errors}"


### PR DESCRIPTION
Closes #8

## Summary

Implements `CursorAdapter` — the Cursor target adapter for the canonical compiler pipeline. Cursor IDE and Cursor CLI both read from the same plugin bundle, so a single adapter covers both surfaces.

## Generated artifacts

```
plugins/agent-toolkit-core/
  .cursor-plugin/plugin.json     ← marketplace manifest
  skills/<name>/SKILL.md          ← on-demand procedures
  agents/<name>/AGENT.md          ← agent personas
```

## Capability parity (honest, per ADR-001)

| Capability | Status | Notes |
|-----------|--------|-------|
| Plugin manifest | native | `.cursor-plugin/plugin.json` |
| Skills | native | `skills/<name>/SKILL.md` |
| Agents | native | `agents/<name>/AGENT.md` |
| Hooks | unsupported | Pending canonical hook model (issue #16) |
| MCP | manual | User configures `~/.cursor/mcp.json` separately |
| Rules (.mdc) | separate surface | Not duplicated in plugin bundle — generated as profile |

Rules are semantically different from skills: **Rules = persistent behavioral constraints, Skills = on-demand procedures.** They are generated as a separate profile surface (`profiles/cursor/rules/*.mdc`), not bundled into the plugin.

## Tests — 26 contract tests

- `tests/compiler/test_cursor_adapter.py` (18 tests)
- `tests/compiler/test_claude_code_adapter.py` (8 tests)

Covering: manifest validity, skill/agent paths, no skill.json, no absolute paths, no dangerous settings, unsupported capabilities explicitly reported, check mode writes no files, all 3 products compile.

## Usage

```bash
agent-toolkit build --target cursor --check
agent-toolkit build --target cursor --product agent-toolkit-core
agent-toolkit inventory
agent-toolkit matrix
```

## Checklist

- [x] `python3 scripts/validate-skills.py` passes
- [x] `python3 scripts/validate-manifests.py` passes
- [x] `python3 scripts/gen-surfaces.py --check` passes
- [x] `agent-toolkit build --target cursor --check` exits 0
- [x] 26 contract tests pass (`PYTHONPATH=src pytest tests/compiler/ -v`)
- [x] No secrets, private hostnames, or dangerous settings
- [x] Unsupported capabilities explicitly reported (never silently dropped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building Cursor plugin bundles, including skills, references, agents, and plugin metadata.
  * Added `build`, `inventory`, and `matrix` commands to the CLI.
  * Added reporting for unsupported or manually configured Cursor capabilities.

* **Documentation**
  * Added guidance on Cursor parity, rules, MCP configuration, and hook support.

* **Bug Fixes**
  * Updated the core plugin manifest to version 1.1.0 with refreshed metadata.

* **Tests**
  * Added comprehensive compiler and Cursor integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->