### PR TITLE
feat(compiler): GitHub Copilot CLI + Repository adapters

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -99,7 +99,7 @@ def cmd_build(args: list[str]) -> int:
         products_to_build = [graph.products[parsed.product]]
 
     # Select targets
-    available_targets = {"claude-code", "cursor", "opencode"}  # expand as adapters are added
+    available_targets = {"claude-code", "cursor", "opencode", "copilot-cli", "copilot-repository"}  # expand as adapters are added
     targets_to_build = [parsed.target] if parsed.target else list(available_targets)
 
     for t in targets_to_build:
@@ -214,6 +214,12 @@ def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
     if target_id == "cursor":
         from agent_toolkit.compiler.targets.cursor import CursorAdapter
         return CursorAdapter(output_dir, repo_root)
+    if target_id in ("copilot-cli", "copilot"):
+        from agent_toolkit.compiler.targets.copilot import CopilotCLIAdapter
+        return CopilotCLIAdapter(output_dir, repo_root)
+    if target_id == "copilot-repository":
+        from agent_toolkit.compiler.targets.copilot import CopilotRepositoryAdapter
+        return CopilotRepositoryAdapter(output_dir, repo_root)
     if target_id == "opencode":
         from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
         return OpenCodeAdapter(output_dir, repo_root)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/copilot.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/copilot.py
@@ -1,0 +1,262 @@
+"""
+GitHub Copilot CLI and Repository target adapter.
+
+GitHub Copilot has TWO distinct distribution surfaces — both generated from
+the same canonical IR but published separately:
+
+1. **Copilot CLI Plugin** — installable via `copilot plugin install`
+   Root-level `plugin.json` (NOT `.copilot-plugin/` — different schema
+   from Claude Code / Cursor).
+   Discovery paths: skills/, agents/, hooks.json
+
+2. **Repository Surface** — files committed to a project repository
+   `.github/copilot-instructions.md`    — global instructions
+   `.github/agents/<name>.agent.md`     — agent personas (different format!)
+   `.github/skills/<name>/SKILL.md`     — on-demand skills
+   `.github/hooks/<name>.json`          — lifecycle hooks (future)
+
+Official docs:
+  https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference
+Research:
+  docs/research/platform-capability-matrix.md (2026-08-04)
+
+Key differences from Claude Code / Cursor:
+- CLI plugin.json is at ROOT level, not in .copilot-plugin/
+- Agent format uses .agent.md extension (not AGENT.md)
+- Each surface (CLI plugin, repository) must be generated independently
+- Hooks require both Bash (.sh) AND PowerShell (.ps1) handlers
+- MCP: unknown-blocked (not confirmed from official docs as of research date)
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from agent_toolkit.compiler.model import (
+    Agent,
+    CanonicalGraph,
+    CompilationResult,
+    Product,
+    Skill,
+)
+from agent_toolkit.compiler.targets.base import TargetAdapter
+
+
+class CopilotCLIAdapter(TargetAdapter):
+    """Generates GitHub Copilot CLI plugin bundle.
+
+    The plugin is installed via:
+      copilot plugin install <name>@<marketplace>
+    or declared in .github/copilot/settings.json.
+
+    Capability parity:
+      native:         skills, agents (.agent.md format), plugin manifest
+      unknown-blocked: MCP (not confirmed from official docs)
+      unsupported:    hooks (handler format unclear; cross-platform requires
+                      both Bash + PowerShell — pending canonical hook model #16)
+    """
+
+    target_id = "copilot-cli"
+    package_type = "plugin"
+    maturity = "stable"
+
+    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+        result = CompilationResult(target=self.target_id, product=product.id)
+        out_dir = self.output_root / product.id
+
+        # 1. Root-level plugin.json (different from .claude-plugin/plugin.json)
+        self._write_file(
+            out_dir / "plugin.json",
+            json.dumps(self._build_plugin_json(product), indent=2) + "\n",
+            result,
+        )
+        result.emitted.append("plugin-manifest")
+
+        # 2. Skills
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill is None:
+                result.warnings.append(f"Skill '{skill_id}' not found — skipping")
+                result.omitted.append(f"skill:{skill_id}")
+                continue
+            self._emit_skill(skill, out_dir, result)
+
+        # 3. Agents (.agent.md format — distinct from AGENT.md)
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent is None:
+                result.warnings.append(f"Agent '{agent_id}' not found — skipping")
+                result.omitted.append(f"agent:{agent_id}")
+                continue
+            self._emit_agent_cli(agent, out_dir, result)
+
+        # 4. Explicitly report what is not yet implemented
+        result.unsupported.extend([
+            "hooks (cross-platform Bash+PowerShell handlers required — pending #16)",
+            "mcp (unknown-blocked: not confirmed in official Copilot CLI docs)",
+        ])
+
+        return result
+
+    def _build_plugin_json(self, product: Product) -> dict:
+        try:
+            from agent_toolkit import __version__
+            version = __version__
+        except ImportError:
+            version = "1.0.0"
+
+        return {
+            "name": product.id,
+            "version": version,
+            "description": product.description,
+            "author": {
+                "name": "ulises-jeremias",
+                "url": "https://github.com/ulises-jeremias/agent-toolkit",
+            },
+            "repository": "https://github.com/ulises-jeremias/agent-toolkit",
+            "license": "MIT",
+            "skills": "skills/",
+            "agents": "agents/",
+        }
+
+    def _emit_skill(self, skill: Skill, out_dir: Path, result: CompilationResult) -> None:
+        if not skill.source_path.exists():
+            result.warnings.append(f"Skill source missing: {skill.source_path}")
+            result.omitted.append(f"skill:{skill.id}")
+            return
+
+        dst = out_dir / "skills" / skill.name
+        dst.mkdir(parents=True, exist_ok=True)
+        content = skill.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "SKILL.md", content, result)
+
+        refs_src = skill.source_path.parent / "references"
+        if refs_src.is_dir():
+            for ref_file in sorted(refs_src.rglob("*")):
+                if ref_file.is_file():
+                    rel = ref_file.relative_to(skill.source_path.parent)
+                    ref_dst = dst / rel
+                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
+                    ref_dst.write_bytes(ref_file.read_bytes())
+                    result.artifacts.append(ref_dst)
+
+        result.emitted.append(f"skill:{skill.id}")
+
+    def _emit_agent_cli(self, agent: Agent, out_dir: Path, result: CompilationResult) -> None:
+        """Emit agent in Copilot CLI .agent.md format.
+
+        The Copilot CLI agent format uses <name>.agent.md (not AGENT.md).
+        Content is the same AGENT.md body with frontmatter.
+        """
+        if not agent.source_path.exists():
+            result.warnings.append(f"Agent source missing: {agent.source_path}")
+            result.omitted.append(f"agent:{agent.id}")
+            return
+
+        dst = out_dir / "agents"
+        dst.mkdir(parents=True, exist_ok=True)
+
+        content = agent.source_path.read_text(encoding="utf-8", errors="replace")
+        # Write as <name>.agent.md (Copilot CLI convention)
+        self._write_file(dst / f"{agent.name}.agent.md", content, result)
+        result.emitted.append(f"agent:{agent.id}")
+
+
+class CopilotRepositoryAdapter(TargetAdapter):
+    """Generates GitHub Copilot repository-scoped assets.
+
+    These are committed to a project repository and activate for
+    all Copilot surfaces (IDE, cloud-agent, CLI) within that repo.
+
+    Generated files:
+      .github/copilot-instructions.md     ← global instructions
+      .github/agents/<name>.agent.md      ← agent personas
+      .github/skills/<name>/SKILL.md      ← on-demand skills
+
+    Capability parity:
+      native:      copilot-instructions.md, agents (.agent.md), skills
+      unsupported: hooks, MCP (not confirmed for repository surface)
+    """
+
+    target_id = "copilot-repository"
+    package_type = "repository-customization"
+    maturity = "stable"
+
+    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+        result = CompilationResult(target=self.target_id, product=product.id)
+        out_dir = self.output_root / product.id
+
+        # 1. Global instructions from assistant agent body
+        self._emit_instructions(graph, product, out_dir, result)
+
+        # 2. Skills
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill is None:
+                result.omitted.append(f"skill:{skill_id}")
+                continue
+            self._emit_skill_repo(skill, out_dir, result)
+
+        # 3. Agents
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent is None:
+                result.omitted.append(f"agent:{agent_id}")
+                continue
+            self._emit_agent_repo(agent, out_dir, result)
+
+        result.unsupported.extend([
+            "hooks (unknown-blocked for repository surface)",
+            "mcp (unknown-blocked for repository surface)",
+        ])
+        return result
+
+    def _emit_instructions(
+        self, graph: CanonicalGraph, product: Product, out_dir: Path, result: CompilationResult
+    ) -> None:
+        """Generate .github/copilot-instructions.md from assistant agent."""
+        # Build instructions from assistant agent + product description
+        lines = [
+            f"# {product.name}",
+            "",
+            product.description,
+            "",
+            "## Available skills",
+            "",
+        ]
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill:
+                lines.append(f"- **{skill.name}**: {skill.description[:80]}")
+        lines.extend(["", "## Available agents", ""])
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent:
+                lines.append(f"- **{agent.name}**: {agent.description[:80]}")
+
+        content = "\n".join(lines) + "\n"
+        github_dir = out_dir / ".github"
+        github_dir.mkdir(parents=True, exist_ok=True)
+        self._write_file(github_dir / "copilot-instructions.md", content, result)
+        result.emitted.append("copilot-instructions.md")
+
+    def _emit_skill_repo(self, skill: Skill, out_dir: Path, result: CompilationResult) -> None:
+        if not skill.source_path.exists():
+            result.omitted.append(f"skill:{skill.id}")
+            return
+        dst = out_dir / ".github" / "skills" / skill.name
+        dst.mkdir(parents=True, exist_ok=True)
+        content = skill.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "SKILL.md", content, result)
+        result.emitted.append(f"skill:{skill.id}")
+
+    def _emit_agent_repo(self, agent: Agent, out_dir: Path, result: CompilationResult) -> None:
+        if not agent.source_path.exists():
+            result.omitted.append(f"agent:{agent.id}")
+            return
+        dst = out_dir / ".github" / "agents"
+        dst.mkdir(parents=True, exist_ok=True)
+        content = agent.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / f"{agent.name}.agent.md", content, result)
+        result.emitted.append(f"agent:{agent.id}")

--- a/src/agent_toolkit/cli/build.py
+++ b/src/agent_toolkit/cli/build.py
@@ -99,7 +99,7 @@ def cmd_build(args: list[str]) -> int:
         products_to_build = [graph.products[parsed.product]]
 
     # Select targets
-    available_targets = {"claude-code", "cursor", "opencode"}  # expand as adapters are added
+    available_targets = {"claude-code", "cursor", "opencode", "copilot-cli", "copilot-repository"}  # expand as adapters are added
     targets_to_build = [parsed.target] if parsed.target else list(available_targets)
 
     for t in targets_to_build:
@@ -214,6 +214,12 @@ def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
     if target_id == "cursor":
         from agent_toolkit.compiler.targets.cursor import CursorAdapter
         return CursorAdapter(output_dir, repo_root)
+    if target_id in ("copilot-cli", "copilot"):
+        from agent_toolkit.compiler.targets.copilot import CopilotCLIAdapter
+        return CopilotCLIAdapter(output_dir, repo_root)
+    if target_id == "copilot-repository":
+        from agent_toolkit.compiler.targets.copilot import CopilotRepositoryAdapter
+        return CopilotRepositoryAdapter(output_dir, repo_root)
     if target_id == "opencode":
         from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
         return OpenCodeAdapter(output_dir, repo_root)

--- a/src/agent_toolkit/compiler/targets/copilot.py
+++ b/src/agent_toolkit/compiler/targets/copilot.py
@@ -1,0 +1,262 @@
+"""
+GitHub Copilot CLI and Repository target adapter.
+
+GitHub Copilot has TWO distinct distribution surfaces — both generated from
+the same canonical IR but published separately:
+
+1. **Copilot CLI Plugin** — installable via `copilot plugin install`
+   Root-level `plugin.json` (NOT `.copilot-plugin/` — different schema
+   from Claude Code / Cursor).
+   Discovery paths: skills/, agents/, hooks.json
+
+2. **Repository Surface** — files committed to a project repository
+   `.github/copilot-instructions.md`    — global instructions
+   `.github/agents/<name>.agent.md`     — agent personas (different format!)
+   `.github/skills/<name>/SKILL.md`     — on-demand skills
+   `.github/hooks/<name>.json`          — lifecycle hooks (future)
+
+Official docs:
+  https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference
+Research:
+  docs/research/platform-capability-matrix.md (2026-08-04)
+
+Key differences from Claude Code / Cursor:
+- CLI plugin.json is at ROOT level, not in .copilot-plugin/
+- Agent format uses .agent.md extension (not AGENT.md)
+- Each surface (CLI plugin, repository) must be generated independently
+- Hooks require both Bash (.sh) AND PowerShell (.ps1) handlers
+- MCP: unknown-blocked (not confirmed from official docs as of research date)
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from agent_toolkit.compiler.model import (
+    Agent,
+    CanonicalGraph,
+    CompilationResult,
+    Product,
+    Skill,
+)
+from agent_toolkit.compiler.targets.base import TargetAdapter
+
+
+class CopilotCLIAdapter(TargetAdapter):
+    """Generates GitHub Copilot CLI plugin bundle.
+
+    The plugin is installed via:
+      copilot plugin install <name>@<marketplace>
+    or declared in .github/copilot/settings.json.
+
+    Capability parity:
+      native:         skills, agents (.agent.md format), plugin manifest
+      unknown-blocked: MCP (not confirmed from official docs)
+      unsupported:    hooks (handler format unclear; cross-platform requires
+                      both Bash + PowerShell — pending canonical hook model #16)
+    """
+
+    target_id = "copilot-cli"
+    package_type = "plugin"
+    maturity = "stable"
+
+    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+        result = CompilationResult(target=self.target_id, product=product.id)
+        out_dir = self.output_root / product.id
+
+        # 1. Root-level plugin.json (different from .claude-plugin/plugin.json)
+        self._write_file(
+            out_dir / "plugin.json",
+            json.dumps(self._build_plugin_json(product), indent=2) + "\n",
+            result,
+        )
+        result.emitted.append("plugin-manifest")
+
+        # 2. Skills
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill is None:
+                result.warnings.append(f"Skill '{skill_id}' not found — skipping")
+                result.omitted.append(f"skill:{skill_id}")
+                continue
+            self._emit_skill(skill, out_dir, result)
+
+        # 3. Agents (.agent.md format — distinct from AGENT.md)
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent is None:
+                result.warnings.append(f"Agent '{agent_id}' not found — skipping")
+                result.omitted.append(f"agent:{agent_id}")
+                continue
+            self._emit_agent_cli(agent, out_dir, result)
+
+        # 4. Explicitly report what is not yet implemented
+        result.unsupported.extend([
+            "hooks (cross-platform Bash+PowerShell handlers required — pending #16)",
+            "mcp (unknown-blocked: not confirmed in official Copilot CLI docs)",
+        ])
+
+        return result
+
+    def _build_plugin_json(self, product: Product) -> dict:
+        try:
+            from agent_toolkit import __version__
+            version = __version__
+        except ImportError:
+            version = "1.0.0"
+
+        return {
+            "name": product.id,
+            "version": version,
+            "description": product.description,
+            "author": {
+                "name": "ulises-jeremias",
+                "url": "https://github.com/ulises-jeremias/agent-toolkit",
+            },
+            "repository": "https://github.com/ulises-jeremias/agent-toolkit",
+            "license": "MIT",
+            "skills": "skills/",
+            "agents": "agents/",
+        }
+
+    def _emit_skill(self, skill: Skill, out_dir: Path, result: CompilationResult) -> None:
+        if not skill.source_path.exists():
+            result.warnings.append(f"Skill source missing: {skill.source_path}")
+            result.omitted.append(f"skill:{skill.id}")
+            return
+
+        dst = out_dir / "skills" / skill.name
+        dst.mkdir(parents=True, exist_ok=True)
+        content = skill.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "SKILL.md", content, result)
+
+        refs_src = skill.source_path.parent / "references"
+        if refs_src.is_dir():
+            for ref_file in sorted(refs_src.rglob("*")):
+                if ref_file.is_file():
+                    rel = ref_file.relative_to(skill.source_path.parent)
+                    ref_dst = dst / rel
+                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
+                    ref_dst.write_bytes(ref_file.read_bytes())
+                    result.artifacts.append(ref_dst)
+
+        result.emitted.append(f"skill:{skill.id}")
+
+    def _emit_agent_cli(self, agent: Agent, out_dir: Path, result: CompilationResult) -> None:
+        """Emit agent in Copilot CLI .agent.md format.
+
+        The Copilot CLI agent format uses <name>.agent.md (not AGENT.md).
+        Content is the same AGENT.md body with frontmatter.
+        """
+        if not agent.source_path.exists():
+            result.warnings.append(f"Agent source missing: {agent.source_path}")
+            result.omitted.append(f"agent:{agent.id}")
+            return
+
+        dst = out_dir / "agents"
+        dst.mkdir(parents=True, exist_ok=True)
+
+        content = agent.source_path.read_text(encoding="utf-8", errors="replace")
+        # Write as <name>.agent.md (Copilot CLI convention)
+        self._write_file(dst / f"{agent.name}.agent.md", content, result)
+        result.emitted.append(f"agent:{agent.id}")
+
+
+class CopilotRepositoryAdapter(TargetAdapter):
+    """Generates GitHub Copilot repository-scoped assets.
+
+    These are committed to a project repository and activate for
+    all Copilot surfaces (IDE, cloud-agent, CLI) within that repo.
+
+    Generated files:
+      .github/copilot-instructions.md     ← global instructions
+      .github/agents/<name>.agent.md      ← agent personas
+      .github/skills/<name>/SKILL.md      ← on-demand skills
+
+    Capability parity:
+      native:      copilot-instructions.md, agents (.agent.md), skills
+      unsupported: hooks, MCP (not confirmed for repository surface)
+    """
+
+    target_id = "copilot-repository"
+    package_type = "repository-customization"
+    maturity = "stable"
+
+    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+        result = CompilationResult(target=self.target_id, product=product.id)
+        out_dir = self.output_root / product.id
+
+        # 1. Global instructions from assistant agent body
+        self._emit_instructions(graph, product, out_dir, result)
+
+        # 2. Skills
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill is None:
+                result.omitted.append(f"skill:{skill_id}")
+                continue
+            self._emit_skill_repo(skill, out_dir, result)
+
+        # 3. Agents
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent is None:
+                result.omitted.append(f"agent:{agent_id}")
+                continue
+            self._emit_agent_repo(agent, out_dir, result)
+
+        result.unsupported.extend([
+            "hooks (unknown-blocked for repository surface)",
+            "mcp (unknown-blocked for repository surface)",
+        ])
+        return result
+
+    def _emit_instructions(
+        self, graph: CanonicalGraph, product: Product, out_dir: Path, result: CompilationResult
+    ) -> None:
+        """Generate .github/copilot-instructions.md from assistant agent."""
+        # Build instructions from assistant agent + product description
+        lines = [
+            f"# {product.name}",
+            "",
+            product.description,
+            "",
+            "## Available skills",
+            "",
+        ]
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill:
+                lines.append(f"- **{skill.name}**: {skill.description[:80]}")
+        lines.extend(["", "## Available agents", ""])
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent:
+                lines.append(f"- **{agent.name}**: {agent.description[:80]}")
+
+        content = "\n".join(lines) + "\n"
+        github_dir = out_dir / ".github"
+        github_dir.mkdir(parents=True, exist_ok=True)
+        self._write_file(github_dir / "copilot-instructions.md", content, result)
+        result.emitted.append("copilot-instructions.md")
+
+    def _emit_skill_repo(self, skill: Skill, out_dir: Path, result: CompilationResult) -> None:
+        if not skill.source_path.exists():
+            result.omitted.append(f"skill:{skill.id}")
+            return
+        dst = out_dir / ".github" / "skills" / skill.name
+        dst.mkdir(parents=True, exist_ok=True)
+        content = skill.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "SKILL.md", content, result)
+        result.emitted.append(f"skill:{skill.id}")
+
+    def _emit_agent_repo(self, agent: Agent, out_dir: Path, result: CompilationResult) -> None:
+        if not agent.source_path.exists():
+            result.omitted.append(f"agent:{agent.id}")
+            return
+        dst = out_dir / ".github" / "agents"
+        dst.mkdir(parents=True, exist_ok=True)
+        content = agent.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / f"{agent.name}.agent.md", content, result)
+        result.emitted.append(f"agent:{agent.id}")

--- a/tests/compiler/test_copilot_adapter.py
+++ b/tests/compiler/test_copilot_adapter.py
@@ -1,0 +1,220 @@
+"""Contract tests for GitHub Copilot CLI and Repository adapters.
+
+Two distinct surfaces are tested independently:
+1. CopilotCLIAdapter — root-level plugin.json, agents as .agent.md
+2. CopilotRepositoryAdapter — .github/ directory assets
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.targets.copilot import CopilotCLIAdapter, CopilotRepositoryAdapter
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+@pytest.fixture
+def graph():
+    return load_graph(REPO_ROOT)
+
+
+@pytest.fixture
+def cli_adapter(tmp_path):
+    return CopilotCLIAdapter(tmp_path / "copilot-cli", REPO_ROOT)
+
+
+@pytest.fixture
+def repo_adapter(tmp_path):
+    return CopilotRepositoryAdapter(tmp_path / "copilot-repo", REPO_ROOT)
+
+
+# ── CLI Plugin ────────────────────────────────────────────────────────────────
+
+
+def test_cli_plugin_json_at_root(cli_adapter, graph):
+    """plugin.json must be at root level (not .copilot-plugin/)."""
+    product = graph.products["agent-toolkit-core"]
+    cli_adapter.compile(graph, product)
+
+    manifest = cli_adapter.output_root / "agent-toolkit-core" / "plugin.json"
+    assert manifest.exists(), "Root-level plugin.json not found"
+
+    # Must NOT be in .copilot-plugin/ (that's Claude Code / Cursor convention)
+    wrong = cli_adapter.output_root / "agent-toolkit-core" / ".copilot-plugin" / "plugin.json"
+    assert not wrong.exists(), ".copilot-plugin/plugin.json must not exist for Copilot CLI"
+
+
+def test_cli_manifest_valid_json(cli_adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    cli_adapter.compile(graph, product)
+
+    manifest = cli_adapter.output_root / "agent-toolkit-core" / "plugin.json"
+    data = json.loads(manifest.read_text())
+    for field in ("name", "version", "description"):
+        assert field in data, f"CLI plugin.json missing '{field}'"
+
+
+def test_cli_agents_use_agent_md_extension(cli_adapter, graph):
+    """Copilot CLI agents use .agent.md extension (not AGENT.md)."""
+    product = graph.products["agent-toolkit-core"]
+    cli_adapter.compile(graph, product)
+
+    agents_dir = cli_adapter.output_root / "agent-toolkit-core" / "agents"
+    assert agents_dir.is_dir(), "agents/ directory not created"
+
+    agent_md_files = list(agents_dir.glob("*.agent.md"))
+    plain_md_files = list(agents_dir.glob("AGENT.md"))
+
+    assert len(agent_md_files) > 0, "No .agent.md files found"
+    assert plain_md_files == [], "AGENT.md files must not exist — use .agent.md convention"
+
+
+def test_cli_skills_at_skills_dir(cli_adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    cli_adapter.compile(graph, product)
+
+    skills_dir = cli_adapter.output_root / "agent-toolkit-core" / "skills"
+    assert skills_dir.is_dir()
+    assert list(skills_dir.rglob("SKILL.md")) != []
+
+
+def test_cli_no_dangerous_settings(cli_adapter, graph):
+    for product in graph.products.values():
+        cli_adapter.compile(graph, product)
+        manifest_path = cli_adapter.output_root / product.id / "plugin.json"
+        if manifest_path.exists():
+            data = json.loads(manifest_path.read_text())
+            assert "skipDangerousModePermissionPrompt" not in data
+            assert "autoAcceptPermissions" not in data
+
+
+def test_cli_unsupported_reported(cli_adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = cli_adapter.compile(graph, product)
+    unsupported = " ".join(result.unsupported).lower()
+    assert "hook" in unsupported
+    assert "mcp" in unsupported
+
+
+def test_cli_check_mode_no_files(cli_adapter, graph, tmp_path):
+    product = graph.products["agent-toolkit-core"]
+    before = set(tmp_path.rglob("*"))
+    result = cli_adapter.check(graph, product)
+    after = set(tmp_path.rglob("*"))
+    assert after == before
+    assert result.artifacts == []
+
+
+# ── Repository Surface ────────────────────────────────────────────────────────
+
+
+def test_repo_copilot_instructions_created(repo_adapter, graph):
+    """.github/copilot-instructions.md must be generated."""
+    product = graph.products["agent-toolkit-core"]
+    repo_adapter.compile(graph, product)
+
+    instructions = (
+        repo_adapter.output_root / "agent-toolkit-core" / ".github" / "copilot-instructions.md"
+    )
+    assert instructions.exists(), ".github/copilot-instructions.md not found"
+    assert "copilot-instructions.md" in [
+        e for e in repo_adapter.compile(graph, product).emitted
+    ]
+
+
+def test_repo_copilot_instructions_content(repo_adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    repo_adapter.compile(graph, product)
+
+    instructions = (
+        repo_adapter.output_root / "agent-toolkit-core" / ".github" / "copilot-instructions.md"
+    )
+    text = instructions.read_text()
+    assert len(text) > 50, "copilot-instructions.md is too short"
+    assert "skill" in text.lower() or "agent" in text.lower()
+
+
+def test_repo_agents_in_github_dir(repo_adapter, graph):
+    """.github/agents/<name>.agent.md — repository surface agent format."""
+    product = graph.products["agent-toolkit-core"]
+    repo_adapter.compile(graph, product)
+
+    agents_dir = repo_adapter.output_root / "agent-toolkit-core" / ".github" / "agents"
+    if agents_dir.exists():
+        agent_mds = list(agents_dir.glob("*.agent.md"))
+        assert len(agent_mds) > 0, "No .agent.md in .github/agents/"
+
+
+def test_repo_skills_in_github_dir(repo_adapter, graph):
+    """.github/skills/<name>/SKILL.md — repository surface skill format."""
+    product = graph.products["agent-toolkit-core"]
+    repo_adapter.compile(graph, product)
+
+    skills_dir = repo_adapter.output_root / "agent-toolkit-core" / ".github" / "skills"
+    if skills_dir.exists():
+        skill_mds = list(skills_dir.rglob("SKILL.md"))
+        assert len(skill_mds) > 0, "No SKILL.md in .github/skills/"
+
+
+def test_repo_no_absolute_paths(repo_adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    repo_adapter.compile(graph, product)
+
+    for f in (repo_adapter.output_root / "agent-toolkit-core").rglob("*.md"):
+        text = f.read_text()
+        assert "/home/" not in text, f"Absolute /home/ in {f}"
+
+
+def test_repo_check_mode_no_files(repo_adapter, graph, tmp_path):
+    product = graph.products["agent-toolkit-core"]
+    before = set(tmp_path.rglob("*"))
+    result = repo_adapter.check(graph, product)
+    after = set(tmp_path.rglob("*"))
+    assert after == before
+    assert result.artifacts == []
+
+
+# ── Surface independence ──────────────────────────────────────────────────────
+
+
+def test_two_surfaces_are_independent(cli_adapter, repo_adapter, graph):
+    """CLI plugin and repository surface must generate different structures."""
+    product = graph.products["agent-toolkit-core"]
+
+    cli_result = cli_adapter.compile(graph, product)
+    repo_result = repo_adapter.compile(graph, product)
+
+    # CLI has root plugin.json, repo has .github/ — they're different
+    assert cli_result.emitted != repo_result.emitted or (
+        cli_result.artifacts[0].name != repo_result.artifacts[0].name
+        if cli_result.artifacts and repo_result.artifacts else True
+    )
+
+
+# ── All products ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("product_id", [
+    "agent-toolkit-core", "agent-toolkit-agents", "agent-toolkit-forge"
+])
+def test_cli_all_products(cli_adapter, graph, product_id):
+    if product_id not in graph.products:
+        pytest.skip(f"Product {product_id} not defined")
+    result = cli_adapter.compile(graph, graph.products[product_id])
+    assert result.errors == []
+
+
+@pytest.mark.parametrize("product_id", [
+    "agent-toolkit-core", "agent-toolkit-agents", "agent-toolkit-forge"
+])
+def test_repo_all_products(repo_adapter, graph, product_id):
+    if product_id not in graph.products:
+        pytest.skip(f"Product {product_id} not defined")
+    result = repo_adapter.compile(graph, graph.products[product_id])
+    assert result.errors == []


### PR DESCRIPTION
Closes #9

## Two distinct surfaces

**CopilotCLIAdapter** (`--target copilot-cli`):
- Root-level `plugin.json` (not `.copilot-plugin/` — different from Claude/Cursor)
- Agents as `<name>.agent.md` (Copilot CLI convention)
- Skills in `skills/<name>/SKILL.md`

**CopilotRepositoryAdapter** (`--target copilot-repository`):
- `.github/copilot-instructions.md` — global instructions
- `.github/agents/<name>.agent.md`
- `.github/skills/<name>/SKILL.md`

Both surfaces generated from the same canonical IR but published separately.

## 18 new contract tests (65 total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Copilot CLI and repository build targets.
  * Generates Copilot plugin manifests, skills, agents, and repository instruction files.
  * Supports `copilot` as an alias for the Copilot CLI target.
  * Reports missing resources and unsupported hooks or MCP features clearly.

* **Bug Fixes**
  * Added safeguards for invalid paths and dangerous settings.
  * Check mode now avoids modifying files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->