### PR TITLE
feat(cli): diff command + provenance model

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/diff.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/diff.py
@@ -1,0 +1,149 @@
+"""
+diff — Show what would change between current canonical output and installed.
+
+Usage:
+    agent-toolkit diff [--target TARGET] [--product PRODUCT] [--json]
+
+Options:
+    --target TARGET    Target platform (claude-code, cursor, opencode, etc.)
+    --product PRODUCT  Product ID to diff
+    --json             Output as JSON
+    --help             Show this help
+
+Examples:
+    agent-toolkit diff --target cursor
+    agent-toolkit diff --target claude-code --product agent-toolkit-core
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from agent_toolkit._paths import toolkit_root
+
+
+def _file_digest(path: Path) -> str:
+    """SHA256 digest of a file's content."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _find_repo_root() -> Path:
+    root = toolkit_root()
+    if (root / "distributions").is_dir():
+        return root
+    if (root.parent / "distributions").is_dir():
+        return root.parent
+    return root
+
+
+def cmd_diff(args: list[str]) -> int:
+    """Show what would change if build were run."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="agent-toolkit diff", add_help=False)
+    parser.add_argument("--target", default=None)
+    parser.add_argument("--product", default=None)
+    parser.add_argument("--json", dest="json_out", action="store_true")
+    parser.add_argument("--help", "-h", action="store_true")
+    parsed, _ = parser.parse_known_args(args)
+
+    if parsed.help:
+        print(__doc__)
+        return 0
+
+    repo_root = _find_repo_root()
+
+    try:
+        import yaml  # noqa: F401
+        from agent_toolkit.compiler.loader import load_graph
+    except ImportError as e:
+        print(f"  ✗  Compiler unavailable: {e}", file=sys.stderr)
+        return 1
+
+    graph = load_graph(repo_root)
+    if graph.errors:
+        for err in graph.errors:
+            print(f"  ✗  {err}", file=sys.stderr)
+        return 1
+
+    plugins_dir = repo_root / "plugins"
+    targets = [parsed.target] if parsed.target else ["claude-code", "cursor", "opencode"]
+    products_to_diff = (
+        [graph.products[parsed.product]] if parsed.product and parsed.product in graph.products
+        else list(graph.products.values())
+    )
+
+    results = []
+
+    for target_id in targets:
+        adapter = _get_adapter(target_id, plugins_dir, repo_root)
+        if adapter is None:
+            continue
+
+        for product in products_to_diff:
+            import tempfile
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # Build into temp dir
+                adapter.output_root = Path(tmpdir)
+                result = adapter.compile(graph, product)
+                adapter.output_root = plugins_dir
+
+            # Compare with current plugin bundle
+            current_dir = plugins_dir / product.id
+            changes = {"added": [], "changed": [], "removed": []}
+
+            for artifact in result.artifacts:
+                try:
+                    rel = artifact.relative_to(Path(tmpdir))
+                    rel = rel.relative_to(product.id) if str(rel).startswith(product.id + '/') else rel
+                except ValueError:
+                    continue
+                current = current_dir / rel
+                if not current.exists():
+                    changes["added"].append(str(rel))
+                elif artifact.exists() and current.exists() and _file_digest(artifact) != _file_digest(current):
+                    changes["changed"].append(str(rel))
+
+            entry = {
+                "target": target_id,
+                "product": product.id,
+                "changes": changes,
+                "no_changes": not any(changes.values()),
+            }
+            results.append(entry)
+
+    if parsed.json_out:
+        print(json.dumps(results, indent=2))
+        return 0
+
+    any_changes = False
+    for entry in results:
+        header = f"~ {entry['product']} → {entry['target']}"
+        if entry["no_changes"]:
+            print(f"  ✓  {header}: no changes")
+            continue
+        any_changes = True
+        print(f"\n  {header}:")
+        for f in entry["changes"]["added"]:
+            print(f"    + {f}")
+        for f in entry["changes"]["changed"]:
+            print(f"    ~ {f}")
+        for f in entry["changes"]["removed"]:
+            print(f"    - {f}")
+    print()
+    return 1 if any_changes else 0
+
+
+def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
+    if target_id == "claude-code":
+        from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+        return ClaudeCodeAdapter(output_dir, repo_root)
+    if target_id == "cursor":
+        from agent_toolkit.compiler.targets.cursor import CursorAdapter
+        return CursorAdapter(output_dir, repo_root)
+    if target_id == "opencode":
+        from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
+        return OpenCodeAdapter(output_dir, repo_root)
+    return None

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -8,6 +8,7 @@ Usage:
 Commands:
     install       Install profiles for detected AI tools
     doctor        Check system health and tool availability
+    diff          Show changes vs currently installed plugin bundles
     build         Compile canonical capabilities into target-native artifacts
     inventory     List all canonical skills, agents, and products
     matrix        Show platform capability matrix
@@ -44,6 +45,9 @@ def main() -> None:
     rest = argv[1:]
 
     match command:
+        case "diff":
+            from agent_toolkit.cli.diff import cmd_diff
+            sys.exit(cmd_diff(rest))
         case "build":
             from agent_toolkit.cli.build import cmd_build
             sys.exit(cmd_build(rest))

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/provenance.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/provenance.py
@@ -1,0 +1,85 @@
+"""
+Provenance tracking for generated compiler artifacts.
+
+Every generated plugin bundle gets a .provenance.json sidecar that records:
+- Generator version
+- Source file paths and digests for each artifact
+- Build metadata (no timestamps in reproducible content)
+
+This enables drift detection: agent-toolkit plugin check compares
+artifact digests against provenance to catch manual edits.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ArtifactRecord:
+    """Provenance record for a single generated file."""
+    path: str               # relative path from plugin root
+    source_file: str        # canonical source (e.g. skills/core/assistant/SKILL.md)
+    source_digest: str      # SHA256[:12] of source content
+    generated_digest: str   # SHA256[:12] of generated content
+
+
+@dataclass
+class ProvenanceManifest:
+    """Provenance manifest for a complete plugin bundle."""
+    generator_version: str
+    product: str
+    target: str
+    artifacts: list[ArtifactRecord] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "generatorVersion": self.generator_version,
+            "product": self.product,
+            "target": self.target,
+            "artifacts": [
+                {
+                    "path": a.path,
+                    "sourceFile": a.source_file,
+                    "sourceDigest": a.source_digest,
+                    "generatedDigest": a.generated_digest,
+                }
+                for a in self.artifacts
+            ],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2) + "\n"
+
+
+def file_digest(path: Path) -> str:
+    """SHA256[:12] of file content."""
+    if not path.exists():
+        return "missing"
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def write_provenance(
+    out_dir: Path,
+    product_id: str,
+    target_id: str,
+    artifact_records: list[ArtifactRecord],
+) -> Path:
+    """Write .provenance.json to the plugin bundle root."""
+    try:
+        from agent_toolkit import __version__
+        version = __version__
+    except ImportError:
+        version = "unknown"
+
+    manifest = ProvenanceManifest(
+        generator_version=version,
+        product=product_id,
+        target=target_id,
+        artifacts=artifact_records,
+    )
+    provenance_path = out_dir / ".provenance.json"
+    provenance_path.write_text(manifest.to_json(), encoding="utf-8")
+    return provenance_path

--- a/src/agent_toolkit/cli/diff.py
+++ b/src/agent_toolkit/cli/diff.py
@@ -1,0 +1,149 @@
+"""
+diff — Show what would change between current canonical output and installed.
+
+Usage:
+    agent-toolkit diff [--target TARGET] [--product PRODUCT] [--json]
+
+Options:
+    --target TARGET    Target platform (claude-code, cursor, opencode, etc.)
+    --product PRODUCT  Product ID to diff
+    --json             Output as JSON
+    --help             Show this help
+
+Examples:
+    agent-toolkit diff --target cursor
+    agent-toolkit diff --target claude-code --product agent-toolkit-core
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from agent_toolkit._paths import toolkit_root
+
+
+def _file_digest(path: Path) -> str:
+    """SHA256 digest of a file's content."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _find_repo_root() -> Path:
+    root = toolkit_root()
+    if (root / "distributions").is_dir():
+        return root
+    if (root.parent / "distributions").is_dir():
+        return root.parent
+    return root
+
+
+def cmd_diff(args: list[str]) -> int:
+    """Show what would change if build were run."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="agent-toolkit diff", add_help=False)
+    parser.add_argument("--target", default=None)
+    parser.add_argument("--product", default=None)
+    parser.add_argument("--json", dest="json_out", action="store_true")
+    parser.add_argument("--help", "-h", action="store_true")
+    parsed, _ = parser.parse_known_args(args)
+
+    if parsed.help:
+        print(__doc__)
+        return 0
+
+    repo_root = _find_repo_root()
+
+    try:
+        import yaml  # noqa: F401
+        from agent_toolkit.compiler.loader import load_graph
+    except ImportError as e:
+        print(f"  ✗  Compiler unavailable: {e}", file=sys.stderr)
+        return 1
+
+    graph = load_graph(repo_root)
+    if graph.errors:
+        for err in graph.errors:
+            print(f"  ✗  {err}", file=sys.stderr)
+        return 1
+
+    plugins_dir = repo_root / "plugins"
+    targets = [parsed.target] if parsed.target else ["claude-code", "cursor", "opencode"]
+    products_to_diff = (
+        [graph.products[parsed.product]] if parsed.product and parsed.product in graph.products
+        else list(graph.products.values())
+    )
+
+    results = []
+
+    for target_id in targets:
+        adapter = _get_adapter(target_id, plugins_dir, repo_root)
+        if adapter is None:
+            continue
+
+        for product in products_to_diff:
+            import tempfile
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # Build into temp dir
+                adapter.output_root = Path(tmpdir)
+                result = adapter.compile(graph, product)
+                adapter.output_root = plugins_dir
+
+            # Compare with current plugin bundle
+            current_dir = plugins_dir / product.id
+            changes = {"added": [], "changed": [], "removed": []}
+
+            for artifact in result.artifacts:
+                try:
+                    rel = artifact.relative_to(Path(tmpdir))
+                    rel = rel.relative_to(product.id) if str(rel).startswith(product.id + '/') else rel
+                except ValueError:
+                    continue
+                current = current_dir / rel
+                if not current.exists():
+                    changes["added"].append(str(rel))
+                elif artifact.exists() and current.exists() and _file_digest(artifact) != _file_digest(current):
+                    changes["changed"].append(str(rel))
+
+            entry = {
+                "target": target_id,
+                "product": product.id,
+                "changes": changes,
+                "no_changes": not any(changes.values()),
+            }
+            results.append(entry)
+
+    if parsed.json_out:
+        print(json.dumps(results, indent=2))
+        return 0
+
+    any_changes = False
+    for entry in results:
+        header = f"~ {entry['product']} → {entry['target']}"
+        if entry["no_changes"]:
+            print(f"  ✓  {header}: no changes")
+            continue
+        any_changes = True
+        print(f"\n  {header}:")
+        for f in entry["changes"]["added"]:
+            print(f"    + {f}")
+        for f in entry["changes"]["changed"]:
+            print(f"    ~ {f}")
+        for f in entry["changes"]["removed"]:
+            print(f"    - {f}")
+    print()
+    return 1 if any_changes else 0
+
+
+def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
+    if target_id == "claude-code":
+        from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+        return ClaudeCodeAdapter(output_dir, repo_root)
+    if target_id == "cursor":
+        from agent_toolkit.compiler.targets.cursor import CursorAdapter
+        return CursorAdapter(output_dir, repo_root)
+    if target_id == "opencode":
+        from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
+        return OpenCodeAdapter(output_dir, repo_root)
+    return None

--- a/src/agent_toolkit/cli/main.py
+++ b/src/agent_toolkit/cli/main.py
@@ -8,6 +8,7 @@ Usage:
 Commands:
     install       Install profiles for detected AI tools
     doctor        Check system health and tool availability
+    diff          Show changes vs currently installed plugin bundles
     build         Compile canonical capabilities into target-native artifacts
     inventory     List all canonical skills, agents, and products
     matrix        Show platform capability matrix
@@ -44,6 +45,9 @@ def main() -> None:
     rest = argv[1:]
 
     match command:
+        case "diff":
+            from agent_toolkit.cli.diff import cmd_diff
+            sys.exit(cmd_diff(rest))
         case "build":
             from agent_toolkit.cli.build import cmd_build
             sys.exit(cmd_build(rest))

--- a/src/agent_toolkit/compiler/provenance.py
+++ b/src/agent_toolkit/compiler/provenance.py
@@ -1,0 +1,85 @@
+"""
+Provenance tracking for generated compiler artifacts.
+
+Every generated plugin bundle gets a .provenance.json sidecar that records:
+- Generator version
+- Source file paths and digests for each artifact
+- Build metadata (no timestamps in reproducible content)
+
+This enables drift detection: agent-toolkit plugin check compares
+artifact digests against provenance to catch manual edits.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ArtifactRecord:
+    """Provenance record for a single generated file."""
+    path: str               # relative path from plugin root
+    source_file: str        # canonical source (e.g. skills/core/assistant/SKILL.md)
+    source_digest: str      # SHA256[:12] of source content
+    generated_digest: str   # SHA256[:12] of generated content
+
+
+@dataclass
+class ProvenanceManifest:
+    """Provenance manifest for a complete plugin bundle."""
+    generator_version: str
+    product: str
+    target: str
+    artifacts: list[ArtifactRecord] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "generatorVersion": self.generator_version,
+            "product": self.product,
+            "target": self.target,
+            "artifacts": [
+                {
+                    "path": a.path,
+                    "sourceFile": a.source_file,
+                    "sourceDigest": a.source_digest,
+                    "generatedDigest": a.generated_digest,
+                }
+                for a in self.artifacts
+            ],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2) + "\n"
+
+
+def file_digest(path: Path) -> str:
+    """SHA256[:12] of file content."""
+    if not path.exists():
+        return "missing"
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def write_provenance(
+    out_dir: Path,
+    product_id: str,
+    target_id: str,
+    artifact_records: list[ArtifactRecord],
+) -> Path:
+    """Write .provenance.json to the plugin bundle root."""
+    try:
+        from agent_toolkit import __version__
+        version = __version__
+    except ImportError:
+        version = "unknown"
+
+    manifest = ProvenanceManifest(
+        generator_version=version,
+        product=product_id,
+        target=target_id,
+        artifacts=artifact_records,
+    )
+    provenance_path = out_dir / ".provenance.json"
+    provenance_path.write_text(manifest.to_json(), encoding="utf-8")
+    return provenance_path

--- a/tests/test_diff_command.py
+++ b/tests/test_diff_command.py
@@ -1,0 +1,42 @@
+"""Tests for agent-toolkit diff command."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def run_diff(args=None):
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    import os; os.environ["AGENT_TOOLKIT_ROOT"] = str(REPO_ROOT)
+    from agent_toolkit.cli.diff import cmd_diff
+    return cmd_diff(args or [])
+
+
+def test_diff_no_changes_returns_0():
+    """When plugin bundles match canonical, diff returns 0."""
+    result = run_diff(["--target", "claude-code", "--product", "agent-toolkit-core"])
+    assert result == 0
+
+
+def test_diff_json_output():
+    out_lines = []
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        run_diff(["--target", "claude-code", "--json"])
+    output = buf.getvalue()
+    data = json.loads(output)
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+
+def test_diff_help():
+    result = run_diff(["--help"])
+    assert result == 0

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,77 @@
+"""Tests for the provenance module."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import tempfile
+
+import pytest
+
+from agent_toolkit.compiler.provenance import (
+    ArtifactRecord, ProvenanceManifest, file_digest, write_provenance
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def test_file_digest_stable(tmp_path):
+    f = tmp_path / "test.txt"
+    f.write_text("hello")
+    d1 = file_digest(f)
+    d2 = file_digest(f)
+    assert d1 == d2
+    assert len(d1) == 12
+
+
+def test_file_digest_missing_returns_sentinel():
+    assert file_digest(Path("/nonexistent/file.txt")) == "missing"
+
+
+def test_provenance_manifest_to_dict():
+    manifest = ProvenanceManifest(
+        generator_version="1.1.0",
+        product="agent-toolkit-core",
+        target="claude-code",
+        artifacts=[
+            ArtifactRecord(
+                path="skills/assistant/SKILL.md",
+                source_file="skills/core/assistant/SKILL.md",
+                source_digest="abc123def456",
+                generated_digest="abc123def456",
+            )
+        ],
+    )
+    d = manifest.to_dict()
+    assert d["product"] == "agent-toolkit-core"
+    assert d["target"] == "claude-code"
+    assert len(d["artifacts"]) == 1
+    assert d["artifacts"][0]["path"] == "skills/assistant/SKILL.md"
+
+
+def test_write_provenance_creates_json(tmp_path):
+    records = [
+        ArtifactRecord(
+            path="plugin.json",
+            source_file="distributions/products.yaml",
+            source_digest="abc123",
+            generated_digest="abc123",
+        )
+    ]
+    provenance_path = write_provenance(tmp_path, "agent-toolkit-core", "cursor", records)
+    assert provenance_path.exists()
+    data = json.loads(provenance_path.read_text())
+    assert "generatorVersion" in data
+    assert "artifacts" in data
+    assert len(data["artifacts"]) == 1
+
+
+def test_provenance_json_no_timestamps():
+    """Provenance content must be deterministic (no timestamps in content)."""
+    manifest = ProvenanceManifest(
+        generator_version="1.0.0",
+        product="test",
+        target="cursor",
+    )
+    content = manifest.to_json()
+    assert "timestamp" not in content.lower()
+    assert "date" not in content.lower()


### PR DESCRIPTION
Closes #22, closes #23

**diff command:** Shows changes between canonical build output and current installed plugin bundles. Uses temp dir — never modifies plugins/.

**Provenance model:** ArtifactRecord + ProvenanceManifest + write_provenance() for .provenance.json sidecars. Deterministic (no timestamps in content).

8 tests passing.