### PR TITLE
fix(installer): never overwrite ~/.claude/settings.json

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
@@ -155,8 +155,7 @@ def _check_profiles() -> list[CheckResult]:
     if shutil.which("claude") or (home / ".claude").is_dir():
         results.append(_profile_installed("profiles", "claude-code CLAUDE.md",
                                           home / ".claude" / "CLAUDE.md"))
-        results.append(_profile_installed("profiles", "claude-code settings.json",
-                                          home / ".claude" / "settings.json"))
+        # settings.json is user-owned and must not be managed by the installer.
         results.append(_profile_installed("profiles", "claude-code agents/",
                                           home / ".claude" / "agents"))
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -183,10 +183,18 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
 
     home = Path.home()
     success = True
+    # Install instruction/agent files only. Never write ~/.claude/settings.json —
+    # that file is user-owned (plugins, permissions, env). Target contract:
+    # distributions/targets/claude-code.yaml → plugin_settings_scope: plugin-local.
     success &= _copy_file(src / "CLAUDE.md", home / ".claude" / "CLAUDE.md",
                           dry_run=dry_run, force=force)
-    success &= _copy_file(src / "settings.json", home / ".claude" / "settings.json",
-                          dry_run=dry_run, force=force)
+    settings_src = src / "settings.json"
+    if settings_src.is_file():
+        _info(
+            "Skipping ~/.claude/settings.json (user-owned). "
+            "Use Claude Code marketplace plugins for toolkit capabilities; "
+            f"reference profile kept at {settings_src}"
+        )
     if (src / "agents").is_dir():
         success &= _copy_dir(src / "agents", home / ".claude" / "agents",
                              dry_run=dry_run, force=force)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -208,7 +208,9 @@ install_claude_code() {
   fi
 
   copy_file "${src}/CLAUDE.md"     "${HOME}/.claude/CLAUDE.md"
-  copy_file "${src}/settings.json" "${HOME}/.claude/settings.json"
+  # Never overwrite ~/.claude/settings.json — user-owned (plugins/permissions).
+  # Toolkit capabilities install via marketplace plugins, not global settings.
+  info "Skipping ~/.claude/settings.json (user-owned)"
 
   if [[ -d "${src}/agents" ]]; then
     copy_dir "${src}/agents" "${HOME}/.claude/agents"

--- a/src/agent_toolkit/cli/doctor.py
+++ b/src/agent_toolkit/cli/doctor.py
@@ -155,8 +155,7 @@ def _check_profiles() -> list[CheckResult]:
     if shutil.which("claude") or (home / ".claude").is_dir():
         results.append(_profile_installed("profiles", "claude-code CLAUDE.md",
                                           home / ".claude" / "CLAUDE.md"))
-        results.append(_profile_installed("profiles", "claude-code settings.json",
-                                          home / ".claude" / "settings.json"))
+        # settings.json is user-owned and must not be managed by the installer.
         results.append(_profile_installed("profiles", "claude-code agents/",
                                           home / ".claude" / "agents"))
 

--- a/src/agent_toolkit/cli/install.py
+++ b/src/agent_toolkit/cli/install.py
@@ -183,10 +183,18 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
 
     home = Path.home()
     success = True
+    # Install instruction/agent files only. Never write ~/.claude/settings.json —
+    # that file is user-owned (plugins, permissions, env). Target contract:
+    # distributions/targets/claude-code.yaml → plugin_settings_scope: plugin-local.
     success &= _copy_file(src / "CLAUDE.md", home / ".claude" / "CLAUDE.md",
                           dry_run=dry_run, force=force)
-    success &= _copy_file(src / "settings.json", home / ".claude" / "settings.json",
-                          dry_run=dry_run, force=force)
+    settings_src = src / "settings.json"
+    if settings_src.is_file():
+        _info(
+            "Skipping ~/.claude/settings.json (user-owned). "
+            "Use Claude Code marketplace plugins for toolkit capabilities; "
+            f"reference profile kept at {settings_src}"
+        )
     if (src / "agents").is_dir():
         success &= _copy_dir(src / "agents", home / ".claude" / "agents",
                              dry_run=dry_run, force=force)

--- a/tests/test_install_claude_settings.py
+++ b/tests/test_install_claude_settings.py
@@ -1,0 +1,64 @@
+"""Regression: Claude Code install must not overwrite ~/.claude/settings.json."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import install as install_mod
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture()
+def toolkit_with_claude_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    profile = root / "profiles" / "claude-code"
+    profile.mkdir(parents=True)
+    (profile / "CLAUDE.md").write_text("# Claude instructions\n", encoding="utf-8")
+    (profile / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"should-not-install@marketplace": True}}),
+        encoding="utf-8",
+    )
+    agents = profile / "agents"
+    agents.mkdir()
+    (agents / "code-reviewer.md").write_text("reviewer\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+    return root
+
+
+def test_claude_install_preserves_existing_user_settings(
+    fake_home: Path,
+    toolkit_with_claude_profile: Path,
+) -> None:
+    settings = fake_home / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    original = {"enabledPlugins": {"user-plugin@local": True}, "custom": "keep-me"}
+    settings.write_text(json.dumps(original, indent=2), encoding="utf-8")
+    before = settings.read_bytes()
+
+    ok = install_mod._install_claude_code(dry_run=False, force=True)
+
+    assert ok is True
+    assert settings.read_bytes() == before
+    assert json.loads(settings.read_text(encoding="utf-8")) == original
+    assert (fake_home / ".claude" / "CLAUDE.md").is_file()
+    assert (fake_home / ".claude" / "agents" / "code-reviewer.md").is_file()
+
+
+def test_claude_install_does_not_create_settings_when_absent(
+    fake_home: Path,
+    toolkit_with_claude_profile: Path,
+) -> None:
+    ok = install_mod._install_claude_code(dry_run=False, force=True)
+
+    assert ok is True
+    assert not (fake_home / ".claude" / "settings.json").exists()
+    assert (fake_home / ".claude" / "CLAUDE.md").is_file()


### PR DESCRIPTION
## Summary

- Stop copying `profiles/claude-code/settings.json` into `~/.claude/settings.json` (user-owned plugins/permissions).
- Install only `CLAUDE.md` and `agents/`; mirror the change in `scripts/install.sh` and the packages twin.
- Drop the doctor check that required a managed `settings.json`.
- Add clean-home regression tests proving existing settings stay byte-identical and absent settings are not created.

Closes #56

## Type

- [x] Bug fix

## Changes

- `src/agent_toolkit/cli/install.py` / packages twin — skip settings.json install
- `src/agent_toolkit/cli/doctor.py` / packages twin — stop treating settings.json as required profile
- `scripts/install.sh` — same skip for shell installer
- `tests/test_install_claude_settings.py` — regression coverage

## Testing

- [x] `uv run --extra dev pytest tests/test_install_claude_settings.py -v`
- [ ] Confirmed `validate` CI workflow passes (or ran checks locally)

## Checklist

- [x] No secrets, tokens, API keys, or credentials committed
- [x] Branding-neutral: no organization-specific references in public-facing files
- [x] Commit messages are in English and follow conventional commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude Code installation no longer overwrites or creates the user-owned settings file.
  * Existing Claude settings remain unchanged during installation.
  * Installation continues to provide the supported profile files and agents.

* **Tests**
  * Added coverage confirming settings are preserved and optional files are not created unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->