### PR TITLE
fix(cli): return exit code 2 for install/doctor parse errors

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
@@ -356,15 +356,19 @@ def _print_result(r: CheckResult) -> None:
 # Argument parsing
 # ---------------------------------------------------------------------------
 
-def _parse_args(args: list[str]) -> tuple[bool, bool] | None:
-    """Return (json_output, fix) or None to signal early exit."""
+_PARSE_HELP = object()
+_PARSE_ERROR = object()
+
+
+def _parse_args(args: list[str]):
+    """Return (json_output, fix), _PARSE_HELP, or _PARSE_ERROR."""
     json_output = False
     fix = False
 
     for arg in args:
         if arg in ("-h", "--help"):
             print(__doc__)
-            return None
+            return _PARSE_HELP
         elif arg == "--json":
             json_output = True
         elif arg == "--fix":
@@ -372,7 +376,7 @@ def _parse_args(args: list[str]) -> tuple[bool, bool] | None:
         else:
             print(f"  ✗  Unknown option: {arg}  (run 'agent-toolkit doctor --help')",
                   file=sys.stderr)
-            return None
+            return _PARSE_ERROR
 
     return json_output, fix
 
@@ -384,11 +388,13 @@ def _parse_args(args: list[str]) -> tuple[bool, bool] | None:
 def cmd_doctor(args: list[str]) -> int:
     """Run health checks for the agent-toolkit installation.
 
-    Returns 0 if no errors, 1 if any errors found.
+    Returns 0 if no errors, 1 if any check errors, 2 on usage/parse errors.
     """
     result = _parse_args(args)
-    if result is None:
+    if result is _PARSE_HELP:
         return 0
+    if result is _PARSE_ERROR:
+        return 2
 
     json_output, fix = result
     toolkit_dir = toolkit_root()

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -308,8 +308,13 @@ def _install_pi(*, dry_run: bool, force: bool) -> bool:
 _VALID_TOOLS = ("claude-code", "cursor", "opencode", "copilot", "windsurf", "pi")
 
 
-def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
-    """Return (tools, dry_run, force) or None to signal early exit."""
+# Sentinel parse outcomes — must not be confused with a successful empty-tools tuple.
+_PARSE_HELP = object()
+_PARSE_ERROR = object()
+
+
+def _parse_args(args: list[str]):
+    """Return (tools, dry_run, force), _PARSE_HELP, or _PARSE_ERROR."""
     dry_run = False
     force = False
     requested: str = ""
@@ -319,7 +324,7 @@ def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
         arg = args[i]
         if arg in ("-h", "--help"):
             print(__doc__)
-            return None
+            return _PARSE_HELP
         elif arg == "--dry-run":
             dry_run = True
         elif arg == "--force":
@@ -327,12 +332,12 @@ def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
         elif arg == "--tools":
             if i + 1 >= len(args):
                 _err("--tools requires an argument")
-                return None
+                return _PARSE_ERROR
             requested = args[i + 1]
             i += 1
         else:
             _err(f"Unknown option: {arg}  (run 'agent-toolkit install --help' for usage)")
-            return None
+            return _PARSE_ERROR
         i += 1
 
     tools: list[str] = []
@@ -348,11 +353,13 @@ def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
 def cmd_install(args: list[str]) -> int:
     """Install agent-toolkit profiles for AI coding assistants.
 
-    Returns 0 on success, 1 on any failure.
+    Returns 0 on success, 1 on install failure, 2 on usage/parse errors.
     """
     result = _parse_args(args)
-    if result is None:
+    if result is _PARSE_HELP:
         return 0
+    if result is _PARSE_ERROR:
+        return 2
 
     tools, dry_run, force = result
 

--- a/src/agent_toolkit/cli/doctor.py
+++ b/src/agent_toolkit/cli/doctor.py
@@ -356,15 +356,19 @@ def _print_result(r: CheckResult) -> None:
 # Argument parsing
 # ---------------------------------------------------------------------------
 
-def _parse_args(args: list[str]) -> tuple[bool, bool] | None:
-    """Return (json_output, fix) or None to signal early exit."""
+_PARSE_HELP = object()
+_PARSE_ERROR = object()
+
+
+def _parse_args(args: list[str]):
+    """Return (json_output, fix), _PARSE_HELP, or _PARSE_ERROR."""
     json_output = False
     fix = False
 
     for arg in args:
         if arg in ("-h", "--help"):
             print(__doc__)
-            return None
+            return _PARSE_HELP
         elif arg == "--json":
             json_output = True
         elif arg == "--fix":
@@ -372,7 +376,7 @@ def _parse_args(args: list[str]) -> tuple[bool, bool] | None:
         else:
             print(f"  ✗  Unknown option: {arg}  (run 'agent-toolkit doctor --help')",
                   file=sys.stderr)
-            return None
+            return _PARSE_ERROR
 
     return json_output, fix
 
@@ -384,11 +388,13 @@ def _parse_args(args: list[str]) -> tuple[bool, bool] | None:
 def cmd_doctor(args: list[str]) -> int:
     """Run health checks for the agent-toolkit installation.
 
-    Returns 0 if no errors, 1 if any errors found.
+    Returns 0 if no errors, 1 if any check errors, 2 on usage/parse errors.
     """
     result = _parse_args(args)
-    if result is None:
+    if result is _PARSE_HELP:
         return 0
+    if result is _PARSE_ERROR:
+        return 2
 
     json_output, fix = result
     toolkit_dir = toolkit_root()

--- a/src/agent_toolkit/cli/install.py
+++ b/src/agent_toolkit/cli/install.py
@@ -308,8 +308,13 @@ def _install_pi(*, dry_run: bool, force: bool) -> bool:
 _VALID_TOOLS = ("claude-code", "cursor", "opencode", "copilot", "windsurf", "pi")
 
 
-def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
-    """Return (tools, dry_run, force) or None to signal early exit."""
+# Sentinel parse outcomes — must not be confused with a successful empty-tools tuple.
+_PARSE_HELP = object()
+_PARSE_ERROR = object()
+
+
+def _parse_args(args: list[str]):
+    """Return (tools, dry_run, force), _PARSE_HELP, or _PARSE_ERROR."""
     dry_run = False
     force = False
     requested: str = ""
@@ -319,7 +324,7 @@ def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
         arg = args[i]
         if arg in ("-h", "--help"):
             print(__doc__)
-            return None
+            return _PARSE_HELP
         elif arg == "--dry-run":
             dry_run = True
         elif arg == "--force":
@@ -327,12 +332,12 @@ def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
         elif arg == "--tools":
             if i + 1 >= len(args):
                 _err("--tools requires an argument")
-                return None
+                return _PARSE_ERROR
             requested = args[i + 1]
             i += 1
         else:
             _err(f"Unknown option: {arg}  (run 'agent-toolkit install --help' for usage)")
-            return None
+            return _PARSE_ERROR
         i += 1
 
     tools: list[str] = []
@@ -348,11 +353,13 @@ def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
 def cmd_install(args: list[str]) -> int:
     """Install agent-toolkit profiles for AI coding assistants.
 
-    Returns 0 on success, 1 on any failure.
+    Returns 0 on success, 1 on install failure, 2 on usage/parse errors.
     """
     result = _parse_args(args)
-    if result is None:
+    if result is _PARSE_HELP:
         return 0
+    if result is _PARSE_ERROR:
+        return 2
 
     tools, dry_run, force = result
 

--- a/tests/test_cli_parse_exit_codes.py
+++ b/tests/test_cli_parse_exit_codes.py
@@ -1,0 +1,25 @@
+"""CLI parse failures must exit non-zero; --help stays 0."""
+from __future__ import annotations
+
+from agent_toolkit.cli import doctor as doctor_mod
+from agent_toolkit.cli import install as install_mod
+
+
+def test_install_help_exits_0() -> None:
+    assert install_mod.cmd_install(["--help"]) == 0
+
+
+def test_install_unknown_option_exits_2() -> None:
+    assert install_mod.cmd_install(["--not-a-real-flag"]) == 2
+
+
+def test_install_tools_missing_arg_exits_2() -> None:
+    assert install_mod.cmd_install(["--tools"]) == 2
+
+
+def test_doctor_help_exits_0() -> None:
+    assert doctor_mod.cmd_doctor(["--help"]) == 0
+
+
+def test_doctor_unknown_option_exits_2() -> None:
+    assert doctor_mod.cmd_doctor(["--nope"]) == 2


### PR DESCRIPTION
## Summary

- `agent-toolkit install` / `doctor` no longer treat parse failures like `--help`.
- Unknown options and missing `--tools` values exit `2`; `--help` stays `0`.

Closes #52

## Type

- [x] Bug fix

## Testing

- [x] `uv run --extra all pytest tests/test_cli_parse_exit_codes.py tests/test_cli.py -v`

## Checklist

- [x] No secrets committed
- [x] Commit messages in English / conventional commits