### PR TITLE
fix(release): stop double PyPI publish on tag releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,72 +1,48 @@
-name: Publish
+name: Publish (manual)
+
+# Manual-only publishing. Tag releases publish exclusively via release.yml.
+# Keeping this workflow prevents accidental double-publish when a GitHub
+# Release is created (release.yml already uploads to PyPI on v* tags).
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Deploy target'
+        description: "Deploy target"
         required: true
-        default: 'testpypi'
+        default: "testpypi"
         type: choice
         options: [testpypi, pypi]
 
 permissions:
   contents: read
-  id-token: write  # for trusted publishing
+  id-token: write  # trusted publishing
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: pip install hatchling build
-      - run: python -m build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Build wheel and sdist
+        run: |
+          uv build
+          ls -lh dist/
       - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
 
-  publish-pypi:
+  publish:
     needs: build
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || 'pypi' }}
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/download-artifact@v4
-        with: { name: dist, path: dist/ }
+        with:
+          name: dist
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ github.event.inputs.environment == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}
-
-  build-binaries:
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: pip install pyinstaller hatchling
-      - run: pip install -e .
-      - name: Build binary
-        run: |
-          pyinstaller \
-            --onefile \
-            --name agent-toolkit \
-            --add-data "skills:skills" \
-            --add-data "agents:agents" \
-            --add-data "loops:loops" \
-            --add-data "profiles:profiles" \
-            --add-data "mcp:mcp" \
-            src/agent_toolkit/cli/main.py
-      - uses: actions/upload-artifact@v4
-        with:
-          name: agent-toolkit-${{ matrix.os }}
-          path: dist/agent-toolkit*
+          repository-url: ${{ inputs.environment == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# Sole automated PyPI publish path for version tags (v*).
+# Manual TestPyPI/PyPI republish: workflow "Publish (manual)" only.
+
 on:
   push:
     tags:
@@ -33,13 +36,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Build wheel and sdist
         run: |
-          pip install build hatchling
-          python -m build
+          uv build
           ls -lh dist/
       - name: Publish to PyPI (Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -58,14 +59,16 @@ jobs:
           - { os: windows-latest, artifact: agent-toolkit-windows-x86_64 }
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install pyinstaller && pip install -e .
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install package and PyInstaller
+        run: |
+          uv sync --extra all
+          uv pip install pyinstaller
       - name: Build standalone binary
         shell: bash
         run: >-
-          pyinstaller --onefile --name agent-toolkit
+          uv run pyinstaller --onefile --name agent-toolkit
           --add-data "skills:skills"
           --add-data "agents:agents"
           --add-data "loops:loops"


### PR DESCRIPTION
## Summary

- `release.yml` is the sole automated PyPI publisher for `v*` tags.
- `publish.yml` no longer runs on `release: published` (that caused duplicate uploads); it is manual `workflow_dispatch` only (TestPyPI/PyPI).
- Switch build steps from `pip` to `uv` / `uv build`.

Closes #63

## Type

- [x] Bug fix

## Testing

- [x] Workflow YAML reviewed for trigger exclusivity (`on:` blocks)
- [ ] Dry-run a `workflow_dispatch` against TestPyPI after merge (manual)

## Checklist

- [x] No secrets committed
- [x] Commit messages in English / conventional commits