### PR TITLE
fix(loops): promote oss-pr-monitor to L3 for merge/close allowlist

### DIFF
--- a/catalogs/loop-catalog.yaml
+++ b/catalogs/loop-catalog.yaml
@@ -122,7 +122,7 @@ loops:
   # ── Multi-Repo Loops ─────────────────────────────────────────────────────────
 
   - name: oss-pr-monitor
-    tier: L2
+    tier: L3
     cadence: 1d
     scope: multi-repo
     resumable: true
@@ -132,6 +132,7 @@ loops:
       Dependabot PRs with passing CI, closes dirty Dependabot PRs that will
       regenerate, and writes a status report for human PRs. Supports resumability
       via STATE.md so runs can survive interruption across large repo sets.
+      Requires L3 because loop-gh-gate forbids merge/close at L2.
     use_case: >
       OSS maintainers managing 20-50 repositories who want automated Dependabot
       handling and a daily PR status digest without reviewing every repo manually.

--- a/docs/LOOPS.md
+++ b/docs/LOOPS.md
@@ -154,9 +154,9 @@ See the [OSS Maintenance Patterns](#oss-maintenance-patterns) section below for 
 
 ### oss-pr-monitor
 
-**Tier:** L2 | **Cadence:** daily | **Max tokens:** 300,000
+**Tier:** L3 | **Cadence:** daily | **Max tokens:** 300,000
 
-The most powerful loop in the toolkit. Monitors all open PRs across every configured OSS repo. Merges Dependabot PRs with passing CI, closes dirty Dependabot PRs (they regenerate automatically), and reports on human PRs with CI failures or conflicts. Never merges or closes human PRs.
+The most powerful loop in the toolkit. Monitors all open PRs across every configured OSS repo. Merges Dependabot PRs with passing CI, closes dirty Dependabot PRs (they regenerate automatically), and reports on human PRs with CI failures or conflicts. Never merges or closes human PRs. Requires **L3** because `loop-gh-gate` forbids merge/close at L2.
 
 Supports resumability via `STATE.md` checkpointing — if interrupted mid-run, it resumes from the last processed repo on the next execution.
 

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -276,7 +276,7 @@ The three OSS loops (`oss-daily-briefing`, `oss-triage`, `oss-pr-monitor`) are s
 - `oss-daily-briefing` (L1) — read-only. Safe to run from day one with no risk.
 - `oss-triage` (L1 + limited writes) — applies labels and posts comments. Requires a week of clean
   briefing runs to validate the AI's judgment before enabling.
-- `oss-pr-monitor` (L2) — merges Dependabot PRs. The highest-autonomy loop. Requires a week of
+- `oss-pr-monitor` (L3) — merges Dependabot PRs. The highest-autonomy loop. Requires a week of
   stable triage runs before enabling.
 
 This graduated structure lets you build confidence incrementally. You observe behavior at each tier

--- a/docs/wiki/Loop-Engineering.md
+++ b/docs/wiki/Loop-Engineering.md
@@ -266,7 +266,7 @@ deny: [comment, label, assign, merge, close, push, approve, force-push]
 
 | Attribute | Value |
 |-----------|-------|
-| **Tier** | L2 |
+| **Tier** | L3 |
 | **Cadence** | daily |
 | **Max tokens** | 300,000 |
 | **Resumable** | Yes |

--- a/loops/oss-pr-monitor/loop.yaml
+++ b/loops/oss-pr-monitor/loop.yaml
@@ -1,14 +1,15 @@
 # Loop starter: oss-pr-monitor
-# An L2 loop that monitors open PRs across a multi-repo OSS ecosystem.
+# An L3 loop that monitors open PRs across a multi-repo OSS ecosystem.
 # Cadence: daily. Cost: high (scales with repo count).
 # Designed for maintainers managing 20-50 repos.
+# Tier L3 is required: merge/close are forbidden at L2 by loop-gh-gate.
 #
 # Usage:
 #   ./bin/loop init oss-pr-monitor --pack packs/my-ecosystem.yaml
 
 name: oss-pr-monitor
-description: "Monitor open PRs across OSS ecosystem repos and take action (L2, daily)"
-tier: L2
+description: "Monitor open PRs across OSS ecosystem repos and take action (L3, daily)"
+tier: L3
 cadence: 1d
 resumable: true
 

--- a/tests/test_loop_tier_gate.py
+++ b/tests/test_loop_tier_gate.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+
+yaml = pytest.importorskip("yaml")
 
 from agent_toolkit.loop.gh_gate import evaluate_action, tier_forbids
 

--- a/tests/test_loop_tier_gate.py
+++ b/tests/test_loop_tier_gate.py
@@ -1,0 +1,49 @@
+"""Gate/tier consistency for loops that allowlist merge/close."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_toolkit.loop.gh_gate import evaluate_action, tier_forbids
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_l2_forbids_merge_and_close() -> None:
+    assert tier_forbids("L2", "merge")
+    assert tier_forbids("L2", "close")
+    ok, reason = evaluate_action(
+        "merge",
+        tier="L2",
+        allowlist=["merge", "close", "comment", "label"],
+        deny=[],
+    )
+    assert ok is False
+    assert "L2" in reason
+
+
+def test_l3_allows_allowlisted_merge() -> None:
+    assert tier_forbids("L3", "merge") is None
+    ok, reason = evaluate_action(
+        "merge",
+        tier="L3",
+        allowlist=["merge", "close", "comment", "label"],
+        deny=["approve"],
+    )
+    assert ok is True
+    assert reason == "allowlisted"
+
+
+def test_oss_pr_monitor_tier_allows_its_allowlist() -> None:
+    loop_path = REPO_ROOT / "loops" / "oss-pr-monitor" / "loop.yaml"
+    data = yaml.safe_load(loop_path.read_text(encoding="utf-8"))
+    tier = str(data["tier"]).upper()
+    allow = list(data.get("allowlist") or [])
+    deny = list(data.get("deny") or [])
+    assert tier.startswith("L3"), f"oss-pr-monitor must be L3, got {tier}"
+    for action in ("merge", "close"):
+        assert action in allow
+        ok, reason = evaluate_action(action, tier=tier, allowlist=allow, deny=deny)
+        assert ok is True, f"{action} blocked at {tier}: {reason}"


### PR DESCRIPTION
## Summary

- Promote `oss-pr-monitor` from L2 → L3 so its merge/close allowlist is enforceable by `loop-gh-gate`.
- Update catalog + loop docs/FAQ that still claimed L2.
- Add regression tests tying the loop YAML to gate evaluation.

Closes #82

## Type

- [x] Bug fix

## Testing

- [x] `uv run --extra all pytest tests/test_loop_tier_gate.py -v`

## Checklist

- [x] No secrets committed
- [x] Commit messages in English / conventional commits