### PR TITLE
fix(compiler): fail closed on malformed frontmatter/registry YAML (#66)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/hook_registry.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/hook_registry.py
@@ -50,26 +50,36 @@ class HookDefinition:
         )
 
 
-def load_hooks(hooks_dir: Path) -> dict[str, HookDefinition]:
-    """Load all hook definitions from capabilities/hooks/*.yaml."""
+def load_hooks(hooks_dir: Path) -> tuple[dict[str, HookDefinition], list[str]]:
+    """Load all hook definitions from capabilities/hooks/*.yaml.
+
+    Returns (hooks, errors). Malformed files are skipped and reported.
+    """
     hooks: dict[str, HookDefinition] = {}
+    errors: list[str] = []
     if not hooks_dir.is_dir():
-        return hooks
+        return hooks, errors
 
     try:
         import yaml
     except ImportError:
-        return hooks
+        return hooks, ["PyYAML is required to load hook definitions"]
 
     for yaml_file in sorted(hooks_dir.glob("*.yaml")):
         try:
             data = yaml.safe_load(yaml_file.read_text())
-            if data and "id" in data:
-                hooks[data["id"]] = HookDefinition.from_dict(data)
-        except Exception:
+        except Exception as exc:
+            errors.append(f"{yaml_file}: invalid YAML: {exc}")
             continue
+        if not data or "id" not in data:
+            errors.append(f"{yaml_file}: missing required 'id' field")
+            continue
+        try:
+            hooks[data["id"]] = HookDefinition.from_dict(data)
+        except Exception as exc:
+            errors.append(f"{yaml_file}: {exc}")
 
-    return hooks
+    return hooks, errors
 
 
 def generate_parity_document(hooks: dict[str, HookDefinition]) -> str:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -20,21 +20,32 @@ except ImportError:
     _YAML = False
 
 
-def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
-    """Parse YAML frontmatter from a Markdown file. Returns (frontmatter, body)."""
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str, str | None]:
+    """Parse YAML frontmatter from a Markdown file.
+
+    Returns (frontmatter, body, error). On YAML parse failure, frontmatter is
+    empty and error describes the failure (fail-closed — callers must not treat
+    the file as valid metadata).
+    """
     m = re.match(r"^---[ \t]*\n(.*?)\n---[ \t]*\n?(.*)", text, re.DOTALL)
     if not m:
-        return {}, text
+        return {}, text, None
     fm_text = m.group(1)
     body = m.group(2)
     if _YAML:
         try:
-            fm = yaml.safe_load(fm_text) or {}
-        except Exception:
-            fm = {}
+            loaded = yaml.safe_load(fm_text)
+        except Exception as exc:
+            return {}, body, f"invalid YAML frontmatter: {exc}"
+        if loaded is None:
+            fm: dict[str, Any] = {}
+        elif not isinstance(loaded, dict):
+            return {}, body, f"frontmatter must be a mapping, got {type(loaded).__name__}"
+        else:
+            fm = loaded
     else:
         fm = _simple_yaml(fm_text)
-    return fm, body
+    return fm, body, None
 
 
 def _simple_yaml(text: str) -> dict[str, Any]:
@@ -58,7 +69,10 @@ def load_skills(skills_root: Path) -> tuple[dict[str, Skill], list[str]]:
         skill_name = skill_md.parent.name
         skill_id = f"{domain}/{skill_name}"
 
-        fm, _body = _parse_frontmatter(skill_md.read_text(errors="replace"))
+        fm, _body, fm_err = _parse_frontmatter(skill_md.read_text(errors="replace"))
+        if fm_err:
+            errors.append(f"{skill_md}: {fm_err}")
+            continue
 
         declared_name = fm.get("name", "")
         if declared_name and declared_name != skill_name:
@@ -106,7 +120,10 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
 
     for agent_md in sorted(agents_root.rglob("AGENT.md")):
         agent_name = agent_md.parent.name
-        fm, body = _parse_frontmatter(agent_md.read_text(errors="replace"))
+        fm, body, fm_err = _parse_frontmatter(agent_md.read_text(errors="replace"))
+        if fm_err:
+            errors.append(f"{agent_md}: {fm_err}")
+            continue
 
         declared_name = fm.get("name", "")
         if declared_name and declared_name != agent_name:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/mcp_registry.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/mcp_registry.py
@@ -53,23 +53,33 @@ class McpProvider:
         return status in ("native", "bridged", "generated")
 
 
-def load_registry(registry_dir: Path) -> dict[str, McpProvider]:
-    """Load all providers from mcp/registry/*.yaml."""
+def load_registry(registry_dir: Path) -> tuple[dict[str, McpProvider], list[str]]:
+    """Load all providers from mcp/registry/*.yaml.
+
+    Returns (providers, errors). Malformed files are skipped and reported.
+    """
     providers: dict[str, McpProvider] = {}
+    errors: list[str] = []
     if not registry_dir.is_dir():
-        return providers
+        return providers, errors
 
     try:
         import yaml
     except ImportError:
-        return providers
+        return providers, ["PyYAML is required to load MCP registry"]
 
     for yaml_file in sorted(registry_dir.glob("*.yaml")):
         try:
             data = yaml.safe_load(yaml_file.read_text())
-            if data and "id" in data:
-                providers[data["id"]] = McpProvider.from_dict(data)
-        except Exception:
+        except Exception as exc:
+            errors.append(f"{yaml_file}: invalid YAML: {exc}")
             continue
+        if not data or "id" not in data:
+            errors.append(f"{yaml_file}: missing required 'id' field")
+            continue
+        try:
+            providers[data["id"]] = McpProvider.from_dict(data)
+        except Exception as exc:
+            errors.append(f"{yaml_file}: {exc}")
 
-    return providers
+    return providers, errors

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -15,12 +15,12 @@ def test_hooks_dir_exists():
 
 
 def test_registry_loads_hooks():
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     assert len(hooks) >= 2
 
 
 def test_hooks_have_required_fields():
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     for hook in hooks.values():
         assert hook.id
         assert hook.event
@@ -29,7 +29,7 @@ def test_hooks_have_required_fields():
 
 def test_destructive_hooks_disabled_by_default():
     """Write/destructive hooks must be opt-in (default_enabled=False)."""
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     for hook in hooks.values():
         if hook.security_classification == "destructive":
             assert not hook.default_enabled, (
@@ -38,7 +38,7 @@ def test_destructive_hooks_disabled_by_default():
 
 
 def test_all_hooks_have_bounded_timeout():
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     for hook in hooks.values():
         assert 100 <= hook.timeout_ms <= 60000, (
             f"Hook '{hook.id}' timeout {hook.timeout_ms}ms out of bounds [100, 60000]"
@@ -46,12 +46,12 @@ def test_all_hooks_have_bounded_timeout():
 
 
 def test_parity_document_generated():
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     doc = generate_parity_document(hooks)
     assert "| Hook |" in doc
     assert "claude-code" in doc
 
 
 def test_load_graceful_missing_dir(tmp_path):
-    hooks = load_hooks(tmp_path / "nonexistent")
+    hooks, _errs = load_hooks(tmp_path / "nonexistent")
     assert hooks == {}

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -15,19 +15,19 @@ def test_registry_dir_exists():
 
 
 def test_registry_loads_all_providers():
-    providers = load_registry(REGISTRY_DIR)
+    providers, _errs = load_registry(REGISTRY_DIR)
     assert len(providers) >= 6, f"Expected at least 6 providers, got {len(providers)}"
 
 
 def test_all_required_providers_present():
-    providers = load_registry(REGISTRY_DIR)
+    providers, _errs = load_registry(REGISTRY_DIR)
     required = {"github", "slack", "notion", "linear", "figma", "clickup"}
     missing = required - set(providers.keys())
     assert not missing, f"Missing providers: {missing}"
 
 
 def test_github_provider_fields():
-    providers = load_registry(REGISTRY_DIR)
+    providers, _errs = load_registry(REGISTRY_DIR)
     gh = providers["github"]
     assert gh.id == "github"
     assert gh.display_name == "GitHub"
@@ -49,7 +49,7 @@ def test_no_secrets_in_registry():
 
 
 def test_provider_platform_support():
-    providers = load_registry(REGISTRY_DIR)
+    providers, _errs = load_registry(REGISTRY_DIR)
     gh = providers["github"]
     assert gh.is_supported_for("claude-code")
     assert gh.is_supported_for("cursor")
@@ -63,5 +63,5 @@ def test_registry_no_private_hostnames():
 
 
 def test_load_registry_graceful_on_missing_dir(tmp_path):
-    providers = load_registry(tmp_path / "nonexistent")
+    providers, _errs = load_registry(tmp_path / "nonexistent")
     assert providers == {}

--- a/tests/test_strict_frontmatter.py
+++ b/tests/test_strict_frontmatter.py
@@ -1,0 +1,47 @@
+"""Malformed frontmatter/registry YAML must surface as errors, not silent defaults."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import _parse_frontmatter, load_skills
+from agent_toolkit.compiler.hook_registry import load_hooks
+from agent_toolkit.compiler.mcp_registry import load_registry
+
+
+def test_parse_frontmatter_reports_invalid_yaml() -> None:
+    text = "---\nname: [unclosed\n---\nbody\n"
+    fm, body, err = _parse_frontmatter(text)
+    assert err is not None
+    assert fm == {}
+    assert "body" in body
+
+
+def test_load_skills_skips_invalid_frontmatter(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "core" / "broken"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: [broken\n---\n# Broken\n",
+        encoding="utf-8",
+    )
+    skills, errors = load_skills(tmp_path)
+    assert "core/broken" not in skills
+    assert errors
+    assert any("invalid YAML" in e for e in errors)
+
+
+def test_load_hooks_reports_invalid_yaml(tmp_path: Path) -> None:
+    (tmp_path / "bad.yaml").write_text("id: [broken\n", encoding="utf-8")
+    hooks, errors = load_hooks(tmp_path)
+    assert hooks == {}
+    assert errors
+
+
+def test_load_registry_reports_invalid_yaml(tmp_path: Path) -> None:
+    (tmp_path / "bad.yaml").write_text("id: [broken\n", encoding="utf-8")
+    providers, errors = load_registry(tmp_path)
+    assert providers == {}
+    assert errors


### PR DESCRIPTION
## Summary
- Surface YAML parse errors from skill/agent frontmatter and hook/MCP registries instead of swallowing them into empty metadata.
- Skip malformed entries and record errors on the load path (`CanonicalGraph.errors` for skills/agents).
- Add regression tests in `tests/test_strict_frontmatter.py`.

Closes #66

## Test plan
- [x] `uv run pytest tests/test_strict_frontmatter.py tests/test_hook_registry.py tests/test_mcp_registry.py`
- [x] `uv run pytest tests/` (219 passed)
- [ ] CI green on stacked base `#111`

## Notes
Stacked on #111 (`refactor/61-uv-workspace-packages-sot`) because `src/` was removed in favor of `packages/agent-toolkit-cli`.