### PR TITLE
fix(mcp): complete stub registry providers (#73)

### DIFF
--- a/mcp/registry/clickup.yaml
+++ b/mcp/registry/clickup.yaml
@@ -1,3 +1,48 @@
 # MCP Provider: clickup
-# Research: docs/research/platform-capability-matrix.md (2026-08-04)
+# Research: docs/wiki/MCP-Setup.md · mcp/templates/clickup/
 id: clickup
+display_name: ClickUp
+purpose: View and create tasks, manage lists and spaces, add comments, read and write Docs
+implementation:
+  provenance: community
+  package: mcp-clickup-server
+  repository: https://github.com/nazruden/clickup-mcp-server
+  license: MIT
+  version_policy: pin to minor
+transport:
+  supported: [stdio]
+  preferred: stdio
+auth:
+  supported: [bearer-env]
+  preferred: bearer-env
+  env: [CLICKUP_API_TOKEN]
+tools:
+  read:
+    - get_task
+    - get_list
+    - get_space
+    - get_doc
+  write:
+    - create_task
+    - update_task
+    - create_comment
+  destructive:
+    - delete_task
+approval:
+  default: read-only
+healthcheck:
+  strategy: tools-list
+  timeout_ms: 5000
+platforms:
+  claude-code: native
+  cursor: native
+  opencode: bridged
+  copilot-cli: unknown-blocked
+  gemini-cli: bridged
+  windsurf: manual
+  pi: bridged
+  codex: unknown-blocked
+security:
+  network_hosts: [api.clickup.com, app.clickup.com]
+  secret_storage: environment variable
+  notes: Prefer clickup-cli skill for day-to-day task ops; MCP for agent tool use

--- a/mcp/registry/figma.yaml
+++ b/mcp/registry/figma.yaml
@@ -1,3 +1,44 @@
 # MCP Provider: figma
-# Research: docs/research/platform-capability-matrix.md (2026-08-04)
+# Research: docs/wiki/MCP-Setup.md · mcp/templates/figma/
 id: figma
+display_name: Figma
+purpose: Fetch design context, file structure, component metadata, and screenshots for design-to-code
+implementation:
+  provenance: official
+  package: "https://mcp.figma.com/mcp"
+  repository: https://www.figma.com/developers/mcp
+  license: proprietary
+  version_policy: remote hosted
+transport:
+  supported: [streamable_http]
+  preferred: streamable_http
+auth:
+  supported: [bearer-env]
+  preferred: bearer-env
+  env: [FIGMA_OAUTH_TOKEN, FIGMA_REGION]
+tools:
+  read:
+    - get_design_context
+    - get_file_structure
+    - get_screenshot
+    - get_metadata
+  write: []
+  destructive: []
+approval:
+  default: read-only
+healthcheck:
+  strategy: tools-list
+  timeout_ms: 8000
+platforms:
+  claude-code: native
+  cursor: native
+  opencode: bridged
+  copilot-cli: unknown-blocked
+  gemini-cli: bridged
+  windsurf: manual
+  pi: bridged
+  codex: unknown-blocked
+security:
+  network_hosts: [mcp.figma.com, api.figma.com]
+  secret_storage: environment variable
+  notes: Prefer file-content read-only PAT; set FIGMA_REGION (us|eu) for regional routing

--- a/mcp/registry/linear.yaml
+++ b/mcp/registry/linear.yaml
@@ -1,3 +1,47 @@
 # MCP Provider: linear
-# Research: docs/research/platform-capability-matrix.md (2026-08-04)
+# Research: docs/wiki/MCP-Setup.md · mcp/templates/linear/
 id: linear
+display_name: Linear
+purpose: Create and update issues, manage projects and cycles, add comments, query sprints
+implementation:
+  provenance: official
+  package: "https://mcp.linear.app/mcp"
+  repository: https://linear.app/docs/mcp
+  license: proprietary
+  version_policy: remote hosted
+transport:
+  supported: [streamable_http, sse]
+  preferred: streamable_http
+auth:
+  supported: [oauth]
+  preferred: oauth
+  env: []
+tools:
+  read:
+    - list_issues
+    - get_issue
+    - list_projects
+    - list_cycles
+  write:
+    - create_issue
+    - update_issue
+    - create_comment
+  destructive: []
+approval:
+  default: read-only
+healthcheck:
+  strategy: tools-list
+  timeout_ms: 8000
+platforms:
+  claude-code: native
+  cursor: native
+  opencode: bridged
+  copilot-cli: unknown-blocked
+  gemini-cli: bridged
+  windsurf: manual
+  pi: bridged
+  codex: unknown-blocked
+security:
+  network_hosts: [mcp.linear.app, linear.app]
+  secret_storage: oauth browser flow
+  notes: Official Linear MCP uses OAuth; no API token required for streamable HTTP

--- a/mcp/registry/notion.yaml
+++ b/mcp/registry/notion.yaml
@@ -1,3 +1,48 @@
 # MCP Provider: notion
-# Research: docs/research/platform-capability-matrix.md (2026-08-04)
+# Research: docs/wiki/MCP-Setup.md · mcp/templates/notion/
 id: notion
+display_name: Notion
+purpose: Read and write Notion pages and databases, query blocks, and create content
+implementation:
+  provenance: community
+  package: mcp-notion-server
+  repository: https://github.com/suekou/mcp-notion-server
+  license: MIT
+  version_policy: pin to minor
+transport:
+  supported: [stdio]
+  preferred: stdio
+auth:
+  supported: [bearer-env]
+  preferred: bearer-env
+  env: [NOTION_API_TOKEN]
+tools:
+  read:
+    - notion_retrieve_page
+    - notion_retrieve_database
+    - notion_query_database
+    - notion_retrieve_block_children
+  write:
+    - notion_create_page
+    - notion_update_page
+    - notion_append_block_children
+  destructive:
+    - notion_delete_block
+approval:
+  default: read-only
+healthcheck:
+  strategy: tools-list
+  timeout_ms: 5000
+platforms:
+  claude-code: native
+  cursor: native
+  opencode: bridged
+  copilot-cli: unknown-blocked
+  gemini-cli: bridged
+  windsurf: manual
+  pi: bridged
+  codex: unknown-blocked
+security:
+  network_hosts: [api.notion.com]
+  secret_storage: environment variable
+  notes: Integration can only access pages/databases explicitly shared with it

--- a/mcp/registry/slack.yaml
+++ b/mcp/registry/slack.yaml
@@ -1,3 +1,46 @@
 # MCP Provider: slack
-# Research: docs/research/platform-capability-matrix.md (2026-08-04)
+# Research: docs/wiki/MCP-Setup.md · mcp/templates/slack/
 id: slack
+display_name: Slack
+purpose: Read channel history, post messages, add reactions, and browse Slack canvases
+implementation:
+  provenance: official
+  package: "@anthropic-ai/mcp-server-slack"
+  repository: https://github.com/anthropics/mcp-servers
+  license: MIT
+  version_policy: pin to minor
+transport:
+  supported: [stdio]
+  preferred: stdio
+auth:
+  supported: [bearer-env]
+  preferred: bearer-env
+  env: [SLACK_BOT_TOKEN, SLACK_APP_TOKEN]
+tools:
+  read:
+    - conversations_history
+    - conversations_list
+    - users_list
+    - canvases_sections_lookup
+  write:
+    - chat_post_message
+    - reactions_add
+  destructive: []
+approval:
+  default: read-only
+healthcheck:
+  strategy: tools-list
+  timeout_ms: 5000
+platforms:
+  claude-code: native
+  cursor: native
+  opencode: bridged
+  copilot-cli: unknown-blocked
+  gemini-cli: bridged
+  windsurf: manual
+  pi: bridged
+  codex: unknown-blocked
+security:
+  network_hosts: [slack.com, api.slack.com]
+  secret_storage: environment variable
+  notes: Requires both bot token (API) and app token (Socket Mode); invite bot to channels

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -37,6 +37,22 @@ def test_github_provider_fields():
     assert len(gh.write_tools) > 0
 
 
+def test_all_providers_have_complete_metadata():
+    """Regression: stubs with only `id` must not count as complete providers (#73)."""
+    providers = load_registry(REGISTRY_DIR)
+    required = {"github", "slack", "notion", "linear", "figma", "clickup"}
+    for pid in required:
+        p = providers[pid]
+        assert p.display_name and p.display_name != pid, f"{pid}: missing display_name"
+        assert p.purpose, f"{pid}: missing purpose"
+        assert p.package, f"{pid}: missing implementation.package"
+        assert p.provenance and p.provenance != "unknown", f"{pid}: missing provenance"
+        assert p.read_tools, f"{pid}: missing read tools"
+        # OAuth-only remotes (e.g. Linear) may omit env vars; token-based must list them.
+        if pid != "linear":
+            assert p.env_vars, f"{pid}: missing auth.env"
+
+
 def test_no_secrets_in_registry():
     """Registry files must contain only env var names, never values."""
     for yaml_file in REGISTRY_DIR.glob("*.yaml"):


### PR DESCRIPTION
## Summary
- Replace id-only stubs for slack, notion, linear, figma, and clickup with full registry metadata aligned to `docs/wiki/MCP-Setup.md` and `mcp/templates/`.
- Add regression test requiring display_name, purpose, package, provenance, read tools, and env (except OAuth Linear).

Closes #73

## Test plan
- [x] `uv run pytest tests/test_mcp_registry.py`
- [ ] CI green on stacked base `#111`

## Notes
Stacked on #111. No secrets or private hostnames added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete MCP provider configurations for ClickUp, Figma, Linear, Notion, and Slack.
  * Added provider metadata, supported transports, authentication methods, tool capabilities, approval defaults, health checks, platform support, and security settings.
  * Added setup documentation references and implementation provenance.

* **Tests**
  * Added validation ensuring supported providers include required metadata, tools, and authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->