### PR TITLE
fix(gemini): emit real skill bodies in extension commands (#90)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/gemini_cli.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/gemini_cli.py
@@ -80,7 +80,7 @@ class GeminiCLIAdapter(TargetAdapter):
         )
         result.emitted.append("extension-manifest")
 
-        # 2. Skills → TOML commands (Gemini uses TOML, not YAML frontmatter)
+        # 2. Skills → bundled SKILL.md + TOML commands that inject the body via @{…}
         commands_toml_lines: list[str] = []
         for skill_id in product.included_skills:
             skill = graph.skills.get(skill_id)
@@ -88,7 +88,10 @@ class GeminiCLIAdapter(TargetAdapter):
                 result.warnings.append(f"Skill '{skill_id}' not found — skipping")
                 result.omitted.append(f"skill:{skill_id}")
                 continue
-            commands_toml_lines.extend(self._skill_to_toml_command(skill))
+            rel_skill = self._emit_skill_file(skill, out_dir, result)
+            if rel_skill is None:
+                continue
+            commands_toml_lines.extend(self._skill_to_toml_command(skill, rel_skill))
             result.emitted.append(f"skill:{skill_id}")
 
         if commands_toml_lines:
@@ -146,25 +149,49 @@ class GeminiCLIAdapter(TargetAdapter):
         }
         return manifest
 
-    def _skill_to_toml_command(self, skill: Skill) -> list[str]:
+    def _emit_skill_file(
+        self, skill: Skill, out_dir: Path, result: CompilationResult
+    ) -> str | None:
+        """Copy SKILL.md into the extension bundle; return path relative to out_dir."""
+        if not skill.source_path.exists():
+            result.warnings.append(f"Skill source missing: {skill.source_path}")
+            result.omitted.append(f"skill:{skill.id}")
+            return None
+
+        dst = out_dir / "skills" / skill.name
+        dst.mkdir(parents=True, exist_ok=True)
+        content = skill.source_path.read_text(encoding="utf-8", errors="replace")
+        self._write_file(dst / "SKILL.md", content, result)
+
+        refs_src = skill.source_path.parent / "references"
+        if refs_src.is_dir():
+            for ref_file in sorted(refs_src.rglob("*")):
+                if ref_file.is_file():
+                    rel = ref_file.relative_to(skill.source_path.parent)
+                    ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
+                    self._write_file(dst / rel, ref_content, result)
+
+        return f"skills/{skill.name}/SKILL.md"
+
+    def _skill_to_toml_command(self, skill: Skill, skill_relpath: str) -> list[str]:
         """Convert a canonical skill to a Gemini TOML command block.
 
-        Gemini CLI uses TOML for command definitions — different from the
-        YAML frontmatter used by Claude Code, Cursor, and Copilot.
+        Gemini CLI uses TOML for command definitions. The prompt injects the
+        bundled SKILL.md via ``@{path}`` so maturity=stable ships real body
+        content (not a stub pointer).
         """
-        # Sanitize name for TOML key (no spaces, safe chars)
         safe_name = skill.name.replace("-", "_").replace(" ", "_")
-        # Truncate description for TOML inline value
         desc = (skill.description or "").replace('"', "'")[:200]
 
         lines = [
-            f'[[commands]]',
+            "[[commands]]",
             f'name = "{safe_name}"',
             f'description = "{desc}"',
-            # Reference the SKILL.md body as the command prompt
-            f'prompt = """',
-            f'See {skill.name} skill for full instructions.',
-            f'"""',
+            'prompt = """',
+            f"Follow the `{skill.name}` skill instructions for {{{{args}}}}.",
+            "",
+            f"@{{{skill_relpath}}}",
+            '"""',
             "",
         ]
         return lines

--- a/tests/compiler/test_gemini_adapter.py
+++ b/tests/compiler/test_gemini_adapter.py
@@ -80,6 +80,22 @@ def test_commands_toml_valid_toml_like(adapter, graph):
     assert "description" in text
 
 
+def test_commands_prompt_injects_skill_body_not_stub(adapter, graph):
+    """Regression #90: prompts must @{skills/.../SKILL.md}, not stub one-liners."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+    out = adapter.output_root / "agent-toolkit-core"
+    commands = (out / "commands.toml").read_text()
+    assert "skill for full instructions" not in commands
+    assert "@{skills/" in commands
+    assert "/SKILL.md}" in commands
+    # Bundled skill files exist and contain real markdown body
+    skill_mds = list((out / "skills").rglob("SKILL.md"))
+    assert skill_mds, "expected bundled skills/*/SKILL.md"
+    body = skill_mds[0].read_text()
+    assert len(body) > 80
+
+
 def test_package_type_is_extension(adapter):
     assert adapter.package_type == "extension"
 


### PR DESCRIPTION
## Summary
- Bundle `skills/<name>/SKILL.md` (and `references/`) into Gemini extension output.
- TOML command prompts inject that content via `@{skills/<name>/SKILL.md}` instead of stub one-liners.
- Regression test asserts no \"skill for full instructions\" stubs and that bundled files exist.

Closes #90

## Test plan
- [x] `uv run pytest tests/compiler/test_gemini_adapter.py`
- [ ] CI green on stacked base `#111`

## Notes
Stacked on #111. Maturity remains `stable` now that skill emission includes body content.