### PR TITLE
fix(mcp): align GitHub provider with official github-mcp-server (#74)

### DIFF
--- a/mcp/registry/github.yaml
+++ b/mcp/registry/github.yaml
@@ -1,46 +1,52 @@
+# MCP Provider: github
+# Official: https://github.com/github/github-mcp-server
+# Note: @modelcontextprotocol/server-github is deprecated (Apr 2025).
 id: github
 display_name: GitHub
-purpose: Access GitHub repositories, issues, PRs, code, and CI via MCP tools
+purpose: Access GitHub repositories, issues, PRs, code, and CI via the official GitHub MCP server
 implementation:
   provenance: official
-  package: "@modelcontextprotocol/server-github"
-  repository: https://github.com/modelcontextprotocol/servers
+  package: ghcr.io/github/github-mcp-server
+  repository: https://github.com/github/github-mcp-server
   license: MIT
-  version_policy: pin to minor
+  version_policy: pin image digest or minor tag
 transport:
   supported: [stdio]
   preferred: stdio
 auth:
-  supported: [bearer-env]
+  supported: [bearer-env, oauth]
   preferred: bearer-env
-  env: [GITHUB_TOKEN]
+  env: [GITHUB_PERSONAL_ACCESS_TOKEN]
 tools:
   read:
-    - get_repository
+    - get_file_contents
     - list_issues
+    - get_issue
+    - list_pull_requests
     - get_pull_request
     - search_repositories
-    - get_file_contents
+    - search_code
   write:
     - create_issue
     - create_pull_request
+    - create_or_update_file
   destructive:
     - delete_file
 approval:
   default: read-only
 healthcheck:
   strategy: tools-list
-  timeout_ms: 5000
+  timeout_ms: 8000
 platforms:
   claude-code: native
   cursor: native
   opencode: bridged
-  copilot-cli: unknown-blocked
+  copilot-cli: native
   gemini-cli: native
   windsurf: manual
   pi: bridged
-  codex: unknown-blocked
+  codex: bridged
 security:
-  network_hosts: [api.github.com]
+  network_hosts: [api.github.com, ghcr.io]
   secret_storage: environment variable
-  notes: Use fine-grained PAT with minimal scopes
+  notes: Prefer fine-grained PAT via GITHUB_PERSONAL_ACCESS_TOKEN; OAuth also supported by official server

--- a/mcp/templates/github/README.md
+++ b/mcp/templates/github/README.md
@@ -1,11 +1,16 @@
 # GitHub MCP Template
 
+Official server: [`github/github-mcp-server`](https://github.com/github/github-mcp-server)
+(`ghcr.io/github/github-mcp-server`). The npm package
+`@modelcontextprotocol/server-github` is **deprecated** as of April 2025.
+
 ## Required environment variables
 
-- `GITHUB_TOKEN`
+- `GITHUB_PERSONAL_ACCESS_TOKEN` — fine-grained or classic PAT
 
 ## Usage
 
-1. Copy `config.template.json` to your MCP client config.
-2. Export `GITHUB_TOKEN`.
-3. Run `./wrapper.sh` as an example launcher.
+1. Ensure Docker is available.
+2. Copy `config.template.json` into your MCP client config.
+3. Export `GITHUB_PERSONAL_ACCESS_TOKEN`.
+4. Optionally run `./wrapper.sh` as a local launcher example.

--- a/mcp/templates/github/config.template.json
+++ b/mcp/templates/github/config.template.json
@@ -1,8 +1,15 @@
 {
   "name": "github",
-  "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "command": "docker",
+  "args": [
+    "run",
+    "-i",
+    "--rm",
+    "-e",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+    "ghcr.io/github/github-mcp-server"
+  ],
   "env": {
-    "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
   }
 }

--- a/mcp/templates/github/wrapper.sh
+++ b/mcp/templates/github/wrapper.sh
@@ -1,23 +1,6 @@
 #!/usr/bin/env bash
-set -eo pipefail
-
-if [[ -t 1 && -z ${NO_COLOR:-} ]]; then
-  c_reset=$'\033[0m'
-  c_blue=$'\033[1;34m'
-  c_red=$'\033[1;31m'
-else
-  c_reset=''
-  c_blue=''
-  c_red=''
-fi
-
-info() { printf '%b[mcp-wrapper]%b %s\n' "$c_blue" "$c_reset" "$*"; }
-fail() { printf '%b[mcp-wrapper]%b %s\n' "$c_red" "$c_reset" "$*"; }
-
-if [[ -z ${GITHUB_TOKEN:-} ]]; then
-  fail "GITHUB_TOKEN is required" >&2
-  exit 1
-fi
-
-info "starting mcp-github-server"
-exec mcp-github-server
+set -euo pipefail
+: "${GITHUB_PERSONAL_ACCESS_TOKEN:?Set GITHUB_PERSONAL_ACCESS_TOKEN}"
+exec docker run -i --rm \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN \
+  ghcr.io/github/github-mcp-server

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -33,9 +33,19 @@ def test_github_provider_fields():
     assert gh.id == "github"
     assert gh.display_name == "GitHub"
     assert gh.provenance == "official"
-    assert "GITHUB_TOKEN" in gh.env_vars
+    assert gh.package == "ghcr.io/github/github-mcp-server"
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in gh.env_vars
+    assert "GITHUB_TOKEN" not in gh.env_vars
     assert len(gh.read_tools) > 0
     assert len(gh.write_tools) > 0
+
+
+def test_github_template_matches_official_server():
+    """Regression #74: template must not reference deprecated npm package."""
+    template = (REPO_ROOT / "mcp" / "templates" / "github" / "config.template.json").read_text()
+    assert "ghcr.io/github/github-mcp-server" in template
+    assert "@modelcontextprotocol/server-github" not in template
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in template
 
 
 def test_all_providers_have_complete_metadata():


### PR DESCRIPTION
## Summary
- Point registry + template at official `ghcr.io/github/github-mcp-server`.
- Switch auth env to `GITHUB_PERSONAL_ACCESS_TOKEN` (deprecated npm package removed).
- Regression tests assert package/env/template alignment.

Closes #74

## Test plan
- [x] `uv run pytest tests/test_mcp_registry.py`