### PR TITLE
feat(packaging): require PyYAML and fail closed without it (#64)

### DIFF
--- a/mcp/registry/github.yaml
+++ b/mcp/registry/github.yaml
@@ -1,46 +1,52 @@
+# MCP Provider: github
+# Official: https://github.com/github/github-mcp-server
+# Note: @modelcontextprotocol/server-github is deprecated (Apr 2025).
 id: github
 display_name: GitHub
-purpose: Access GitHub repositories, issues, PRs, code, and CI via MCP tools
+purpose: Access GitHub repositories, issues, PRs, code, and CI via the official GitHub MCP server
 implementation:
   provenance: official
-  package: "@modelcontextprotocol/server-github"
-  repository: https://github.com/modelcontextprotocol/servers
+  package: ghcr.io/github/github-mcp-server
+  repository: https://github.com/github/github-mcp-server
   license: MIT
-  version_policy: pin to minor
+  version_policy: pin image digest or minor tag
 transport:
   supported: [stdio]
   preferred: stdio
 auth:
-  supported: [bearer-env]
+  supported: [bearer-env, oauth]
   preferred: bearer-env
-  env: [GITHUB_TOKEN]
+  env: [GITHUB_PERSONAL_ACCESS_TOKEN]
 tools:
   read:
-    - get_repository
+    - get_file_contents
     - list_issues
+    - get_issue
+    - list_pull_requests
     - get_pull_request
     - search_repositories
-    - get_file_contents
+    - search_code
   write:
     - create_issue
     - create_pull_request
+    - create_or_update_file
   destructive:
     - delete_file
 approval:
   default: read-only
 healthcheck:
   strategy: tools-list
-  timeout_ms: 5000
+  timeout_ms: 8000
 platforms:
   claude-code: native
   cursor: native
   opencode: bridged
-  copilot-cli: unknown-blocked
+  copilot-cli: native
   gemini-cli: native
   windsurf: manual
   pi: bridged
-  codex: unknown-blocked
+  codex: bridged
 security:
-  network_hosts: [api.github.com]
+  network_hosts: [api.github.com, ghcr.io]
   secret_storage: environment variable
-  notes: Use fine-grained PAT with minimal scopes
+  notes: Prefer fine-grained PAT via GITHUB_PERSONAL_ACCESS_TOKEN; OAuth also supported by official server

--- a/mcp/templates/github/README.md
+++ b/mcp/templates/github/README.md
@@ -1,11 +1,16 @@
 # GitHub MCP Template
 
+Official server: [`github/github-mcp-server`](https://github.com/github/github-mcp-server)
+(`ghcr.io/github/github-mcp-server`). The npm package
+`@modelcontextprotocol/server-github` is **deprecated** as of April 2025.
+
 ## Required environment variables
 
-- `GITHUB_TOKEN`
+- `GITHUB_PERSONAL_ACCESS_TOKEN` — fine-grained or classic PAT
 
 ## Usage
 
-1. Copy `config.template.json` to your MCP client config.
-2. Export `GITHUB_TOKEN`.
-3. Run `./wrapper.sh` as an example launcher.
+1. Ensure Docker is available.
+2. Copy `config.template.json` into your MCP client config.
+3. Export `GITHUB_PERSONAL_ACCESS_TOKEN`.
+4. Optionally run `./wrapper.sh` as a local launcher example.

--- a/mcp/templates/github/config.template.json
+++ b/mcp/templates/github/config.template.json
@@ -1,8 +1,15 @@
 {
   "name": "github",
-  "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "command": "docker",
+  "args": [
+    "run",
+    "-i",
+    "--rm",
+    "-e",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+    "ghcr.io/github/github-mcp-server"
+  ],
   "env": {
-    "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
   }
 }

--- a/mcp/templates/github/wrapper.sh
+++ b/mcp/templates/github/wrapper.sh
@@ -1,23 +1,6 @@
 #!/usr/bin/env bash
-set -eo pipefail
-
-if [[ -t 1 && -z ${NO_COLOR:-} ]]; then
-  c_reset=$'\033[0m'
-  c_blue=$'\033[1;34m'
-  c_red=$'\033[1;31m'
-else
-  c_reset=''
-  c_blue=''
-  c_red=''
-fi
-
-info() { printf '%b[mcp-wrapper]%b %s\n' "$c_blue" "$c_reset" "$*"; }
-fail() { printf '%b[mcp-wrapper]%b %s\n' "$c_red" "$c_reset" "$*"; }
-
-if [[ -z ${GITHUB_TOKEN:-} ]]; then
-  fail "GITHUB_TOKEN is required" >&2
-  exit 1
-fi
-
-info "starting mcp-github-server"
-exec mcp-github-server
+set -euo pipefail
+: "${GITHUB_PERSONAL_ACCESS_TOKEN:?Set GITHUB_PERSONAL_ACCESS_TOKEN}"
+exec docker run -i --rm \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN \
+  ghcr.io/github/github-mcp-server

--- a/packages/agent-toolkit-cli/pyproject.toml
+++ b/packages/agent-toolkit-cli/pyproject.toml
@@ -26,12 +26,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = []
+dependencies = ["pyyaml>=6.0"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "ruff>=0.1.0"]
-yaml = ["pyyaml>=6.0"]
-all = ["pyyaml>=6.0"]
 
 [project.scripts]
 agent-toolkit = "agent_toolkit.cli.main:main"

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/hook_registry.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/hook_registry.py
@@ -10,6 +10,19 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+_PYYAML_REQUIRED = (
+    "PyYAML is required to load hook definitions from capabilities/hooks/*.yaml. "
+    "Install with: uv sync"
+)
+
+
+def _require_yaml():
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError(_PYYAML_REQUIRED) from exc
+    return yaml
+
 
 @dataclass
 class HookDefinition:
@@ -60,10 +73,7 @@ def load_hooks(hooks_dir: Path) -> tuple[dict[str, HookDefinition], list[str]]:
     if not hooks_dir.is_dir():
         return hooks, errors
 
-    try:
-        import yaml
-    except ImportError:
-        return hooks, ["PyYAML is required to load hook definitions"]
+    yaml = _require_yaml()
 
     for yaml_file in sorted(hooks_dir.glob("*.yaml")):
         try:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -13,11 +13,18 @@ from agent_toolkit.compiler.model import (
     Requirement, SecurityPolicy, Skill, Stability,
 )
 
-try:
-    import yaml
-    _YAML = True
-except ImportError:
-    _YAML = False
+_PYYAML_REQUIRED = (
+    "PyYAML is required to load YAML sources (products.yaml, frontmatter). "
+    "Install with: uv sync"
+)
+
+
+def _require_yaml():
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError(_PYYAML_REQUIRED) from exc
+    return yaml
 
 
 def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str, str | None]:
@@ -32,19 +39,17 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str, str | None]:
         return {}, text, None
     fm_text = m.group(1)
     body = m.group(2)
-    if _YAML:
-        try:
-            loaded = yaml.safe_load(fm_text)
-        except Exception as exc:
-            return {}, body, f"invalid YAML frontmatter: {exc}"
-        if loaded is None:
-            fm: dict[str, Any] = {}
-        elif not isinstance(loaded, dict):
-            return {}, body, f"frontmatter must be a mapping, got {type(loaded).__name__}"
-        else:
-            fm = loaded
+    yaml = _require_yaml()
+    try:
+        loaded = yaml.safe_load(fm_text)
+    except Exception as exc:
+        return {}, body, f"invalid YAML frontmatter: {exc}"
+    if loaded is None:
+        fm: dict[str, Any] = {}
+    elif not isinstance(loaded, dict):
+        return {}, body, f"frontmatter must be a mapping, got {type(loaded).__name__}"
     else:
-        fm = _simple_yaml(fm_text)
+        fm = loaded
     return fm, body, None
 
 
@@ -160,10 +165,8 @@ def load_products(products_yaml: Path) -> tuple[dict[str, Product], list[str]]:
     if not products_yaml.exists():
         return products, [f"products.yaml not found: {products_yaml}"]
 
-    if _YAML:
-        data = yaml.safe_load(products_yaml.read_text()) or {}
-    else:
-        return products, ["PyYAML required to load products.yaml"]
+    yaml = _require_yaml()
+    data = yaml.safe_load(products_yaml.read_text()) or {}
 
     for p in data.get("products", []):
         pid = p.get("id", "")

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/mcp_registry.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/mcp_registry.py
@@ -10,6 +10,19 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+_PYYAML_REQUIRED = (
+    "PyYAML is required to load MCP providers from mcp/registry/*.yaml. "
+    "Install with: uv sync"
+)
+
+
+def _require_yaml():
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError(_PYYAML_REQUIRED) from exc
+    return yaml
+
 
 @dataclass
 class McpProvider:
@@ -63,10 +76,7 @@ def load_registry(registry_dir: Path) -> tuple[dict[str, McpProvider], list[str]
     if not registry_dir.is_dir():
         return providers, errors
 
-    try:
-        import yaml
-    except ImportError:
-        return providers, ["PyYAML is required to load MCP registry"]
+    yaml = _require_yaml()
 
     for yaml_file in sorted(registry_dir.glob("*.yaml")):
         try:

--- a/tests/compiler/test_claude_code_adapter.py
+++ b/tests/compiler/test_claude_code_adapter.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter

--- a/tests/compiler/test_codex_adapter.py
+++ b/tests/compiler/test_codex_adapter.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.codex import CodexAdapter

--- a/tests/compiler/test_copilot_adapter.py
+++ b/tests/compiler/test_copilot_adapter.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.copilot import CopilotCLIAdapter, CopilotRepositoryAdapter

--- a/tests/compiler/test_cursor_adapter.py
+++ b/tests/compiler/test_cursor_adapter.py
@@ -18,7 +18,6 @@ from pathlib import Path
 import pytest
 
 # Skip entire module gracefully if PyYAML not installed (CI installs it)
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.model import CompilationResult

--- a/tests/compiler/test_gemini_adapter.py
+++ b/tests/compiler/test_gemini_adapter.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.gemini_cli import GeminiCLIAdapter

--- a/tests/compiler/test_opencode_adapter.py
+++ b/tests/compiler/test_opencode_adapter.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter, _OPENCODE_JSON_TEMPLATE

--- a/tests/compiler/test_pi_adapter.py
+++ b/tests/compiler/test_pi_adapter.py
@@ -21,7 +21,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.pi import PiAdapter

--- a/tests/compiler/test_pi_windsurf_codex.py
+++ b/tests/compiler/test_pi_windsurf_codex.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.pi import PiAdapter

--- a/tests/compiler/test_registry_emission.py
+++ b/tests/compiler/test_registry_emission.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.registry_emit import (

--- a/tests/compiler/test_windsurf_adapter.py
+++ b/tests/compiler/test_windsurf_adapter.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.windsurf import WindsurfAdapter

--- a/tests/security/test_path_traversal.py
+++ b/tests/security/test_path_traversal.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import tempfile
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter

--- a/tests/security/test_secret_redaction.py
+++ b/tests/security/test_secret_redaction.py
@@ -4,7 +4,6 @@ import tempfile
 import re
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter

--- a/tests/test_diff_command.py
+++ b/tests/test_diff_command.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 REPO_ROOT = Path(__file__).parent.parent
 

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.model import CanonicalGraph, Skill, Agent, Product, Stability
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
-yaml = pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.hook_registry import (
     HookDefinition,

--- a/tests/test_loop_tier_gate.py
+++ b/tests/test_loop_tier_gate.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
-yaml = pytest.importorskip("yaml")
 
 from agent_toolkit.loop.gh_gate import evaluate_action, tier_forbids
 

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.mcp_registry import load_registry, McpProvider
 

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -33,9 +33,19 @@ def test_github_provider_fields():
     assert gh.id == "github"
     assert gh.display_name == "GitHub"
     assert gh.provenance == "official"
-    assert "GITHUB_TOKEN" in gh.env_vars
+    assert gh.package == "ghcr.io/github/github-mcp-server"
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in gh.env_vars
+    assert "GITHUB_TOKEN" not in gh.env_vars
     assert len(gh.read_tools) > 0
     assert len(gh.write_tools) > 0
+
+
+def test_github_template_matches_official_server():
+    """Regression #74: template must not reference deprecated npm package."""
+    template = (REPO_ROOT / "mcp" / "templates" / "github" / "config.template.json").read_text()
+    assert "ghcr.io/github/github-mcp-server" in template
+    assert "@modelcontextprotocol/server-github" not in template
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in template
 
 
 def test_all_providers_have_complete_metadata():

--- a/tests/test_mcp_templates.py
+++ b/tests/test_mcp_templates.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.mcp_registry import load_registry
 

--- a/tests/test_provenance_wired.py
+++ b/tests/test_provenance_wired.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter

--- a/tests/test_stale_artifact_cleanup.py
+++ b/tests/test_stale_artifact_cleanup.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter

--- a/tests/test_strict_frontmatter.py
+++ b/tests/test_strict_frontmatter.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import _parse_frontmatter, load_skills
 from agent_toolkit.compiler.hook_registry import load_hooks

--- a/uv.lock
+++ b/uv.lock
@@ -36,27 +36,23 @@ dev = [
 [[package]]
 name = "agent-toolkit-cli"
 source = { editable = "packages/agent-toolkit-cli" }
-
-[package.optional-dependencies]
-all = [
+dependencies = [
     { name = "pyyaml" },
 ]
+
+[package.optional-dependencies]
 dev = [
     { name = "pytest" },
     { name = "ruff" },
-]
-yaml = [
-    { name = "pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "pyyaml", marker = "extra == 'all'", specifier = ">=6.0" },
-    { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["all", "dev", "yaml"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
## Summary
- Move `pyyaml` into required package dependencies.
- Fail closed on missing PyYAML in registry loaders.
- Drop `pytest.importorskip("yaml")` so CI cannot silently skip YAML tests.

Closes #64

## Test plan
- [x] `uv lock && uv sync`
- [x] `uv run pytest tests/test_hook_registry.py tests/test_mcp_registry.py`