### PR TITLE
docs: replace competing installation quickstarts with one primary consumer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@
 One toolkit. Any coding assistant. Zero duplication.
 
 ```bash
-# Get everything in one command
-npx skills add ulises-jeremias/agent-toolkit -g
+# Primary install — auto-detects your AI tools
+uvx --from agent-toolkit-cli agent-toolkit install
+agent-toolkit doctor
 ```
 
 <div align="center">
@@ -82,19 +83,28 @@ npx skills add ulises-jeremias/agent-toolkit -g
 
 ## 🚀 Quick Install
 
-### Method 1: Python CLI — `uvx` or `pip` *(works with all tools)*
+**Recommended:** use the Python CLI with [uv](https://docs.astral.sh/uv/) — one flow for every supported tool.
 
 ```bash
-# No install needed — run directly with uvx
+# No install needed — run directly (preferred)
 uvx --from agent-toolkit-cli agent-toolkit install
 
-# Or install persistently with pip
-pip install agent-toolkit-cli
-agent-toolkit install          # auto-detects Claude, Cursor, OpenCode, Windsurf, Pi
-agent-toolkit doctor           # verify everything is set up
+# Or install the CLI persistently
+uv tool install agent-toolkit-cli          # preferred over pip when using uv
+# pip install agent-toolkit-cli            # alternative
+
+agent-toolkit install    # auto-detects Claude, Cursor, OpenCode, Windsurf, Pi, Copilot
+agent-toolkit doctor     # verify everything is set up
 ```
 
-### Method 2: Claude Code Plugin Marketplace
+→ Full walkthrough: [docs/INSTALLATION.md](docs/INSTALLATION.md)
+
+### Advanced install methods
+
+Use these only when the primary CLI flow above does not fit your setup.
+
+<details>
+<summary><strong>Claude Code plugin marketplace</strong> — native plugins for Claude Code only</summary>
 
 ```
 /plugin marketplace add ulises-jeremias/agent-toolkit
@@ -103,22 +113,43 @@ agent-toolkit doctor           # verify everything is set up
 /plugin install agent-toolkit-forge@agent-toolkit
 ```
 
-### Method 3: npx skills (Agent Skills standard — skills only)
+</details>
+
+<details>
+<summary><strong>npx skills</strong> — Agent Skills standard (skills only, no agents/loops)</summary>
 
 ```bash
 npx skills add ulises-jeremias/agent-toolkit -g
 ```
 
-### Method 4: Homebrew / AUR
+</details>
+
+<details>
+<summary><strong>Homebrew / AUR</strong> — system package managers</summary>
 
 Formulas live in dedicated repos ([homebrew-tap](https://github.com/ulises-jeremias/homebrew-tap), [aur-packages](https://github.com/ulises-jeremias/aur-packages)); release workflows notify them on tag.
 
 ```bash
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
-yay -S agent-toolkit   # Arch Linux
+yay -S agent-toolkit   # Arch Linux (AUR)
 ```
 
-### Method 5: Manual install (per tool)
+</details>
+
+<details>
+<summary><strong>Git clone + install script</strong> — offline or pinned commit</summary>
+
+```bash
+git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
+bash ~/.agent-toolkit/scripts/install.sh
+```
+
+The script detects active tools and deploys profiles. Options: `--tools`, `--dry-run`, `--force`.
+
+</details>
+
+<details>
+<summary><strong>Manual per-tool copy</strong> — full control over paths</summary>
 
 ```bash
 git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
@@ -131,14 +162,9 @@ git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
 # Pi Agent — copy profiles/pi/skills/ → ~/.pi/agent/skills/
 ```
 
-### Method 4: Auto-detect install script
+Per-tool steps: [docs/INSTALLATION.md#manual-install](docs/INSTALLATION.md#manual-install)
 
-```bash
-git clone https://github.com/ulises-jeremias/agent-toolkit.git
-bash agent-toolkit/scripts/install.sh
-```
-
-The script detects your active tools and deploys the right profiles automatically.
+</details>
 
 ---
 
@@ -301,10 +327,6 @@ Browse packs: [`packs/`](packs/)
 
 | Guide | Description |
 |-------|-------------|
-| [🚀 Installation](docs/INSTALLATION.md) | Primary consumer install flow (`uvx` / CLI) |
-| [🔄 Migration](docs/MIGRATION.md) | Switch install methods without duplicate profiles |
-| [🗑️ Uninstall](docs/UNINSTALL.md) | Remove toolkit artifacts from your machine |
-| [🛡️ Trust & security](docs/TRUST.md) | What gets installed, verification, receipts |
 | [🔨 How to add a skill](docs/HOW_TO_ADD_SKILL.md) | Create a new skill with SKILL.md frontmatter |
 | [🤖 How to add an agent](docs/HOW_TO_ADD_AGENT.md) | Define a new agent persona |
 | [🔄 How to create a loop](docs/HOW_TO_CREATE_LOOP.md) | Build a recurring agentic workflow |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,80 +1,158 @@
 # Installation
 
-This guide covers how to install agent-toolkit for each supported AI coding assistant. You can use the automated install script for a guided experience, or follow the manual steps for full control.
+This guide describes the **primary consumer install flow** for agent-toolkit, then
+lists advanced methods when you need marketplace plugins, skills-only delivery, or
+manual file copies.
 
 ---
 
 ## Prerequisites
 
-- **git** — to clone the repository
-- **bash** — for the install script (bash 4+ recommended; macOS ships bash 3, install a newer version via Homebrew: `brew install bash`)
-- At least one supported AI coding assistant installed:
+- **Python** 3.10 or later — for the CLI (`uv` / `uvx` recommended)
+- At least one supported AI coding assistant:
   - [Claude Code](https://claude.ai/code) (Anthropic)
   - [Cursor](https://cursor.sh)
   - [OpenCode](https://opencode.ai)
-  - [GitHub Copilot](https://github.com/features/copilot) (requires VS Code or JetBrains + extension)
+  - [GitHub Copilot](https://github.com/features/copilot) (VS Code or JetBrains + extension)
   - [Windsurf](https://codeium.com/windsurf) (Codeium)
   - [Pi Coding Agent](https://pi.ai)
 
 Optional but recommended:
+
+- **[uv](https://docs.astral.sh/uv/)** — preferred way to run `uvx` and manage the CLI
 - **gh** (GitHub CLI) — required by forge skills (`gh-fix-ci`, `github-cli-workflow`, etc.)
 - **jq** — used by several loop templates for JSON processing
-- **node** / **npm** — for MCP server installation
+- **node** / **npm** — for MCP server installation and `npx skills`
+- **git** + **bash** — only needed for git-clone or install-script methods below
 
 ---
 
-## Quick Install
+## Primary install (recommended)
 
-Clone the repository and run the install script:
+One command auto-detects your AI tools and deploys the right profiles.
+
+```bash
+# Run without installing the CLI (preferred)
+uvx --from agent-toolkit-cli agent-toolkit install
+
+# Verify
+uvx --from agent-toolkit-cli agent-toolkit doctor
+```
+
+### Persistent CLI install
+
+```bash
+uv tool install agent-toolkit-cli    # preferred when using uv
+# pip install agent-toolkit-cli      # alternative
+
+agent-toolkit install                # auto-detect all tools
+agent-toolkit doctor                 # verify setup
+```
+
+### Install options
+
+```bash
+# Specific tools only
+agent-toolkit install --tools claude-code,cursor
+
+# Preview changes without writing files
+agent-toolkit install --dry-run
+
+# Overwrite existing toolkit-managed files
+agent-toolkit install --force
+```
+
+---
+
+## Verification
+
+After the primary install:
+
+```bash
+agent-toolkit doctor
+```
+
+Open your AI tool and ask: *"What skills do you have available?"* — responses should
+reflect the agent-toolkit skill set.
+
+To validate skill definitions from a git checkout:
+
+```bash
+bash scripts/validate-skills.sh
+```
+
+---
+
+## Advanced install methods
+
+Use these when the primary CLI flow does not fit your environment.
+
+### Claude Code plugin marketplace
+
+Native plugins for Claude Code only:
+
+```text
+/plugin marketplace add ulises-jeremias/agent-toolkit
+/plugin install agent-toolkit-core@agent-toolkit
+/plugin install agent-toolkit-agents@agent-toolkit
+/plugin install agent-toolkit-forge@agent-toolkit
+```
+
+### npx skills (skills only)
+
+Installs skills via the [Agent Skills](https://github.com/vercel-labs/skills) standard.
+Does not deploy agents, loops, or full profiles.
+
+```bash
+npx skills add ulises-jeremias/agent-toolkit -g
+```
+
+### Homebrew / AUR
+
+```bash
+brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
+yay -S agent-toolkit   # Arch Linux (AUR)
+```
+
+### Git clone + install script
+
+For offline installs or pinning a specific commit:
 
 ```bash
 git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
 bash ~/.agent-toolkit/scripts/install.sh
 ```
 
-The script will:
-1. Detect which AI tools are installed on your machine
-2. Show you what it will install and ask for confirmation
-3. Copy profiles to the correct locations for each detected tool
-4. Ask before overwriting any existing files
-5. Print a summary of what was installed
-
-### Install Options
+Script options:
 
 ```bash
-# Install for specific tools only
 bash ~/.agent-toolkit/scripts/install.sh --tools claude-code,cursor
-
-# Dry run — show what would be installed without making changes
 bash ~/.agent-toolkit/scripts/install.sh --dry-run
-
-# Force overwrite existing files without prompting
 bash ~/.agent-toolkit/scripts/install.sh --force
 ```
 
 ---
 
-## Manual Install
+## Manual install
+
+Copy profiles yourself when you need full control over paths. Clone the repo first:
+
+```bash
+git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
+```
 
 ### Claude Code
 
 ```bash
-# Create the directories if they don't exist
 mkdir -p ~/.claude/agents
-
-# Copy the global instructions
 cp ~/.agent-toolkit/profiles/claude-code/CLAUDE.md ~/.claude/CLAUDE.md
-
-# Copy the settings (plugins, agent definitions)
 cp ~/.agent-toolkit/profiles/claude-code/settings.json ~/.claude/settings.json
-
-# Copy agent persona files
 cp -r ~/.agent-toolkit/profiles/claude-code/agents/. ~/.claude/agents/
 ```
 
-Restart Claude Code. Agents are now available via `@agent-name` (e.g. `@code-reviewer`, `@planner`).
+Restart Claude Code. Agents are available via `@agent-name` (e.g. `@code-reviewer`).
 
-**Project-level install** (overrides global for a specific project):
+**Project-level** (overrides global):
 
 ```bash
 cd /path/to/your/project
@@ -83,71 +161,42 @@ cp ~/.agent-toolkit/profiles/claude-code/CLAUDE.md .claude/CLAUDE.md
 cp ~/.agent-toolkit/profiles/claude-code/settings.json .claude/settings.json
 ```
 
----
-
 ### Cursor
 
 ```bash
-# Global rules (apply to all Cursor projects)
 mkdir -p ~/.cursor/rules
 cp -r ~/.agent-toolkit/profiles/cursor/rules/. ~/.cursor/rules/
-
-# Or install per-project rules
-cd /path/to/your/project
-mkdir -p .cursor/rules
-cp -r ~/.agent-toolkit/profiles/cursor/rules/. .cursor/rules/
 ```
 
-Restart Cursor. Rules are applied automatically to all projects (global) or the current project (per-project).
-
----
+Per-project: copy to `.cursor/rules/` inside your repo instead.
 
 ### OpenCode
 
 ```bash
-# Create config directories if needed
 mkdir -p ~/.config/opencode/agents
-
-# Copy the full profile
 cp ~/.agent-toolkit/profiles/opencode/opencode.json ~/.config/opencode/opencode.json
 cp -r ~/.agent-toolkit/profiles/opencode/agents/. ~/.config/opencode/agents/
 ```
 
----
-
 ### GitHub Copilot
 
-Copilot instructions are per-project and committed to the repository:
+Per-project, committed to the repository:
 
 ```bash
 cd /path/to/your/project
 mkdir -p .github
 cp ~/.agent-toolkit/profiles/copilot/copilot-instructions.md .github/copilot-instructions.md
-
-# Edit to select which skill domains apply to your project
-$EDITOR .github/copilot-instructions.md
-
-# Commit so the whole team benefits
-git add .github/copilot-instructions.md
-git commit -m "chore: add Copilot instructions from agent-toolkit"
 ```
-
----
 
 ### Windsurf
 
 ```bash
-# Detect your Windsurf config directory (varies by version)
 WINDSURF_DIR="${HOME}/.codeium/windsurf"
 [ -d "$WINDSURF_DIR" ] || WINDSURF_DIR="${HOME}/.windsurf"
-
 mkdir -p "${WINDSURF_DIR}/rules" "${WINDSURF_DIR}/memories"
-
 cp -r ~/.agent-toolkit/profiles/windsurf/rules/. "${WINDSURF_DIR}/rules/"
 cp ~/.agent-toolkit/profiles/windsurf/memories/global_rules.md "${WINDSURF_DIR}/memories/global_rules.md"
 ```
-
----
 
 ### Pi Coding Agent
 
@@ -158,82 +207,30 @@ cp -r ~/.agent-toolkit/profiles/pi/skills/. ~/.pi/agent/skills/
 
 ---
 
-## MCP Setup
+## MCP setup
 
-MCP (Model Context Protocol) gives your AI tool access to external services like GitHub, Slack, and Linear. See [MCP.md](MCP.md) for provider-specific setup instructions.
-
-Quick start for GitHub MCP:
-
-```bash
-# Install the GitHub MCP server
-npm install -g @anthropic-ai/mcp-server-github
-
-# Set your GitHub token
-export GITHUB_TOKEN=ghp_your_token_here
-
-# Copy and reference the template in your tool's MCP config
-# See MCP.md for per-tool config file locations
-```
+MCP gives your AI tool access to external services (GitHub, Slack, Linear, etc.).
+See [MCP.md](MCP.md) for per-tool config locations and provider setup.
 
 ---
 
-## Verification
+## Staying up to date
 
-After installation, run these checks:
-
-### Check profile files are in place
+With the CLI installed:
 
 ```bash
-# Claude Code
-ls ~/.claude/CLAUDE.md ~/.claude/settings.json
-
-# Cursor
-ls ~/.cursor/rules/
-
-# OpenCode
-ls ~/.config/opencode/opencode.json
-
-# Windsurf (adjust path for your version)
-ls ~/.codeium/windsurf/rules/
-
-# Pi
-ls ~/.pi/agent/skills/
+uv tool upgrade agent-toolkit-cli   # or: pip install -U agent-toolkit-cli
+agent-toolkit install --force
 ```
 
-### Validate the skill definitions
+With a git checkout:
 
 ```bash
-bash ~/.agent-toolkit/scripts/validate-skills.sh
+cd ~/.agent-toolkit && git pull && bash scripts/install.sh --force
 ```
 
-This checks every skill directory for required files, valid frontmatter, and the absence of secret patterns. All checks should pass (exit code 0).
-
-### Test in your AI tool
-
-Open your AI tool of choice and ask:
-
-- "What skills do you have available?"
-- "What is your repository inspection order?"
-- "Walk me through the development workflow."
-
-The responses should reflect the agent-toolkit skill set.
-
----
-
-## Staying Up to Date
-
-```bash
-cd ~/.agent-toolkit
-git pull
-
-# Re-run install to update profiles
-bash scripts/install.sh
-
-# Or force-overwrite all profile files
-bash scripts/install.sh --force
-```
-
-The `--force` flag overwrites existing profile files with the latest versions. If you have customized any toolkit-managed profile files, back them up before running with `--force`. Project-level customizations (`.claude/CLAUDE.md`, `.cursor/rules/myproject.mdc`, etc.) are never touched by the install script.
+Back up customized profile files before `--force`. See [MIGRATION.md](MIGRATION.md) when
+switching from profile-copy installs to marketplace plugins.
 
 ---
 
@@ -241,84 +238,51 @@ The `--force` flag overwrites existing profile files with the latest versions. I
 
 ### Claude Code: skills not loading
 
-Check that `~/.claude/CLAUDE.md` exists and is readable:
-
 ```bash
 head -5 ~/.claude/CLAUDE.md
 ```
 
-If you have both `~/.claude/CLAUDE.md` (global) and `.claude/CLAUDE.md` (project-level), the project-level file takes precedence — make sure it includes the content you need. Restart Claude Code after making changes.
+Project-level `.claude/CLAUDE.md` overrides global. Restart Claude Code after changes.
 
 ### Cursor: rules not appearing
 
-1. Confirm `.mdc` files are in the correct directory (`~/.cursor/rules/` for global, `.cursor/rules/` for project)
-2. Verify each file has valid YAML frontmatter (opening `---`, `description:` field, closing `---`)
-3. Restart Cursor and reopen the project
+1. Confirm `.mdc` files are in `~/.cursor/rules/` (global) or `.cursor/rules/` (project)
+2. Verify YAML frontmatter (`---`, `description:`, closing `---`)
+3. Restart Cursor
 
 ### Windsurf: rules not loading
 
-Windsurf changed its config directory between versions. If `~/.codeium/windsurf/` does not work, try `~/.windsurf/`. Check the Windsurf release notes for your installed version.
+Try `~/.windsurf/` if `~/.codeium/windsurf/` does not exist for your version.
 
 ### OpenCode: agents not available
-
-Confirm the agents directory exists and contains `.md` files:
 
 ```bash
 ls ~/.config/opencode/agents/
 ```
 
-Restart OpenCode after adding new agent files.
+Restart OpenCode after adding agent files.
 
 ### MCP servers not connecting
 
-1. Verify the MCP server binary is on `$PATH`:
-   ```bash
-   which mcp-github-server
-   ```
-2. Verify the environment variable is set in the shell where your AI tool runs:
-   ```bash
-   echo $GITHUB_TOKEN
-   ```
-3. Check your AI tool's MCP logs for connection errors
-4. For HTTP-based servers (Linear, Figma), verify network access to the endpoint
+1. Confirm the server binary is on `$PATH`
+2. Confirm env vars (e.g. `GITHUB_TOKEN`) are set in the shell your AI tool uses
+3. Check MCP logs in your tool for connection errors
 
 ### validate-skills.sh fails
-
-The script prints the exact file and field that failed. Common causes and fixes:
 
 | Error | Fix |
 |-------|-----|
 | Missing `SKILL.md` | Add `SKILL.md` to the skill directory |
 | Missing frontmatter `name` | Add `name:` to the `---` block in `SKILL.md` |
 | Missing frontmatter `description` | Add `description:` to the `---` block |
-| `skill.json` present | Remove it — only `SKILL.md` frontmatter is needed (see `docs/MIGRATION.md`) |
-| Secret pattern detected | Remove the credential and use `${ENV_VAR}` placeholder instead |
+| Secret pattern detected | Remove the credential; use `${ENV_VAR}` placeholders |
 
 ---
 
-## Uninstall
+## Related guides
 
-To remove agent-toolkit profiles from a machine:
-
-```bash
-# Claude Code (global)
-rm -f ~/.claude/CLAUDE.md ~/.claude/settings.json
-rm -rf ~/.claude/agents/
-
-# Cursor (global rules)
-rm -f ~/.cursor/rules/agent-toolkit-*.mdc
-# or remove all rules: rm -rf ~/.cursor/rules/
-
-# OpenCode
-rm -f ~/.config/opencode/opencode.json
-rm -rf ~/.config/opencode/agents/
-
-# Windsurf
-rm -f ~/.codeium/windsurf/rules/agent-toolkit-*.mdc
-rm -f ~/.codeium/windsurf/memories/global_rules.md
-
-# Pi
-rm -f ~/.pi/agent/skills/*.md
-```
-
-Project-level files (`.claude/CLAUDE.md`, `.cursor/rules/`, `.github/copilot-instructions.md`) are tracked in their respective repositories — remove them with `git rm` when appropriate.
+| Guide | Description |
+|-------|-------------|
+| [TARGETS.md](TARGETS.md) | Supported compile targets and capability matrix |
+| [MIGRATION.md](MIGRATION.md) | Move from profile-copy to native plugins |
+| [MCP.md](MCP.md) | MCP provider setup |

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -25,32 +25,35 @@ Each target receives the strongest integration it actually supports.
 | Gemini CLI | extension (gemini-extension.json) | native | native | unsupported* | unsupported* | stable |
 | Pi Coding Agent | companion-assets | native | native | unsupported† | unsupported† | stable |
 | Windsurf | customization-bundle | native | generated (rules) | unsupported | unsupported | stable |
-| OpenAI Codex (experimental) | plugin (.codex-plugin/) | native | native | unknown-blocked | unknown-blocked | experimental |
+| OpenAI Codex | plugin (.codex-plugin/) | native | native | unknown-blocked | unknown-blocked | experimental |
 
 *pending canonical hook model (issue #16)
 †requires TypeScript runtime plugin
 
 ## Install commands
 
+**Primary consumer flow** (auto-detects installed tools):
+
 ```bash
+uvx --from agent-toolkit-cli agent-toolkit install
+agent-toolkit doctor
+```
+
+**Advanced** (build, selective tools, release engineering):
+
+```bash
+# Install profiles for specific tools only
+agent-toolkit install --tools cursor,claude-code
+
 # Build for a specific target
 agent-toolkit build --target claude-code --check
 agent-toolkit build --target cursor --product agent-toolkit-core
-
-# Install profiles (profiles are a fallback for non-marketplace installs)
-agent-toolkit install --tools cursor,claude-code
 
 # Release dry run (generates dist/ without publishing)
 agent-toolkit release --dry-run --output dist/
 ```
 
-## Target certification
-
-Per-target certification packages document official contracts vs adapter behavior:
-
-| Target | Certification doc |
-|--------|-------------------|
-| Claude Code | [`docs/targets/claude-code-certification.md`](targets/claude-code-certification.md) |
+See [INSTALLATION.md](INSTALLATION.md) for marketplace, Homebrew/AUR, and manual methods.
 
 ## Research sources
 


### PR DESCRIPTION
## Summary

- Consolidates README and `docs/INSTALLATION.md` around a single primary consumer flow: `uvx`/`uv` CLI install with `agent-toolkit doctor` verification
- Moves marketplace, npx skills, Homebrew/AUR, git-clone script, and manual copy paths to clearly labeled advanced sections
- Updates `docs/TARGETS.md` install commands to lead with the primary flow

Closes #100

## Test plan

- [x] README Quick Install has one primary path (no duplicate Method numbering)
- [x] Homebrew/AUR links preserved
- [x] `docs/INSTALLATION.md` defers advanced methods below primary flow
- [x] Install commands in TARGETS.md match README primary flow