### PR TITLE
feat(compiler): declarative target registry (#65)

### DIFF
--- a/capabilities/targets/registry.yaml
+++ b/capabilities/targets/registry.yaml
@@ -1,0 +1,74 @@
+# Declarative target registry — single source for CLI build/diff/release target lists.
+version: 1
+targets:
+  - id: claude-code
+    adapter: agent_toolkit.compiler.targets.claude_code.ClaudeCodeAdapter
+    aliases: []
+    commands:
+      build: true
+      diff: true
+      release: true
+
+  - id: cursor
+    adapter: agent_toolkit.compiler.targets.cursor.CursorAdapter
+    aliases: []
+    commands:
+      build: true
+      diff: true
+      release: true
+
+  - id: opencode
+    adapter: agent_toolkit.compiler.targets.opencode.OpenCodeAdapter
+    aliases: []
+    commands:
+      build: true
+      diff: true
+      release: true
+
+  - id: gemini-cli
+    adapter: agent_toolkit.compiler.targets.gemini_cli.GeminiCLIAdapter
+    aliases: [gemini]
+    commands:
+      build: true
+      diff: false
+      release: true
+
+  - id: copilot-cli
+    adapter: agent_toolkit.compiler.targets.copilot.CopilotCLIAdapter
+    aliases: [copilot]
+    commands:
+      build: true
+      diff: false
+      release: true
+
+  - id: copilot-repository
+    adapter: agent_toolkit.compiler.targets.copilot.CopilotRepositoryAdapter
+    aliases: []
+    commands:
+      build: true
+      diff: false
+      release: true
+
+  - id: pi
+    adapter: agent_toolkit.compiler.targets.pi.PiAdapter
+    aliases: []
+    commands:
+      build: true
+      diff: false
+      release: true
+
+  - id: windsurf
+    adapter: agent_toolkit.compiler.targets.windsurf.WindsurfAdapter
+    aliases: []
+    commands:
+      build: true
+      diff: false
+      release: true
+
+  - id: codex
+    adapter: agent_toolkit.compiler.targets.codex.CodexAdapter
+    aliases: []
+    commands:
+      build: true
+      diff: false
+      release: true

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -9,7 +9,6 @@ Options:
     --product PRODUCT  Product ID to compile (agent-toolkit-core, etc.)
     --check            Dry-run: validate without writing files
     --output DIR       Output directory (default: plugins/)
-    --emit-registries  Emit all registry hooks/MCP supported by the target (Claude Code)
     --json             Output results as JSON
     --help             Show this help
 
@@ -57,7 +56,6 @@ def cmd_build(args: list[str]) -> int:
     parser.add_argument("--product", default=None)
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--output", default=None)
-    parser.add_argument("--emit-registries", action="store_true")
     parser.add_argument("--json", dest="json_out", action="store_true")
     parser.add_argument("--help", "-h", action="store_true")
 
@@ -100,14 +98,25 @@ def cmd_build(args: list[str]) -> int:
             return 1
         products_to_build = [graph.products[parsed.product]]
 
-    # Select targets
-    available_targets = {"claude-code", "cursor", "opencode", "gemini-cli", "copilot-cli", "copilot-repository", "pi", "windsurf", "codex"}  # expand as adapters are added
-    targets_to_build = [parsed.target] if parsed.target else list(available_targets)
+    from agent_toolkit.compiler.target_registry import (
+        load_target_registry,
+        resolve_target_id,
+        target_ids_for,
+    )
 
-    for t in targets_to_build:
-        if t not in available_targets:
-            print(f"  ✗  Unknown target '{t}'. Available: {', '.join(available_targets)}")
+    reg = load_target_registry(repo_root)
+    if parsed.target:
+        canonical = resolve_target_id(parsed.target, reg)
+        build_ids = target_ids_for("build", reg)
+        if canonical not in build_ids:
+            print(
+                f"  ✗  Unknown target '{parsed.target}'. "
+                f"Available: {', '.join(build_ids)}"
+            )
             return 1
+        targets_to_build = [canonical]
+    else:
+        targets_to_build = target_ids_for("build", reg)
 
     output_dir = Path(parsed.output) if parsed.output else repo_root / "plugins"
     mode = "check" if parsed.check else "build"
@@ -127,12 +136,8 @@ def cmd_build(args: list[str]) -> int:
             adapter._provenance_records = []
             if parsed.check:
                 result = adapter.check(graph, product)
-            elif parsed.emit_registries and target_id == "claude-code":
-                result = adapter.compile(graph, product, emit_registries=True)
             else:
                 result = adapter.compile(graph, product)
-                if hasattr(adapter, "_cleanup_stale_artifacts"):
-                    adapter._cleanup_stale_artifacts(product, result)
                 if hasattr(adapter, "_finalize_provenance"):
                     adapter._finalize_provenance(product, result)
 
@@ -216,32 +221,9 @@ def cmd_matrix(args: list[str]) -> int:
 
 
 def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
-    """Return the adapter for a given target ID."""
-    if target_id == "claude-code":
-        from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
-        return ClaudeCodeAdapter(output_dir, repo_root)
-    if target_id == "cursor":
-        from agent_toolkit.compiler.targets.cursor import CursorAdapter
-        return CursorAdapter(output_dir, repo_root)
-    if target_id in ("gemini-cli", "gemini"):
-        from agent_toolkit.compiler.targets.gemini_cli import GeminiCLIAdapter
-        return GeminiCLIAdapter(output_dir, repo_root)
-    if target_id in ("copilot-cli", "copilot"):
-        from agent_toolkit.compiler.targets.copilot import CopilotCLIAdapter
-        return CopilotCLIAdapter(output_dir, repo_root)
-    if target_id == "copilot-repository":
-        from agent_toolkit.compiler.targets.copilot import CopilotRepositoryAdapter
-        return CopilotRepositoryAdapter(output_dir, repo_root)
-    if target_id == "pi":
-        from agent_toolkit.compiler.targets.pi import PiAdapter
-        return PiAdapter(output_dir, repo_root)
-    if target_id == "windsurf":
-        from agent_toolkit.compiler.targets.windsurf import WindsurfAdapter
-        return WindsurfAdapter(output_dir, repo_root)
-    if target_id == "codex":
-        from agent_toolkit.compiler.targets.codex import CodexAdapter
-        return CodexAdapter(output_dir, repo_root)
-    if target_id == "opencode":
-        from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
-        return OpenCodeAdapter(output_dir, repo_root)
-    return None
+    """Return the adapter for a given target ID via declarative registry."""
+    from agent_toolkit.compiler.target_registry import resolve_adapter_class
+    cls = resolve_adapter_class(target_id, repo_root)
+    if cls is None:
+        return None
+    return cls(output_dir, repo_root)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/diff.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/diff.py
@@ -69,7 +69,27 @@ def cmd_diff(args: list[str]) -> int:
         return 1
 
     plugins_dir = repo_root / "plugins"
-    targets = [parsed.target] if parsed.target else ["claude-code", "cursor", "opencode"]
+    from agent_toolkit.compiler.target_registry import (
+        load_target_registry,
+        resolve_target_id,
+        target_ids_for,
+    )
+
+    reg = load_target_registry(repo_root)
+    if parsed.target:
+        canonical = resolve_target_id(parsed.target, reg)
+        diff_ids = target_ids_for("diff", reg)
+        if canonical not in diff_ids:
+            available = ", ".join(diff_ids)
+            print(
+                f"  ✗  Unknown or unsupported diff target '{parsed.target}'. "
+                f"Available: {available}",
+                file=sys.stderr,
+            )
+            return 1
+        targets = [canonical]
+    else:
+        targets = target_ids_for("diff", reg)
     products_to_diff = (
         [graph.products[parsed.product]] if parsed.product and parsed.product in graph.products
         else list(graph.products.values())
@@ -154,13 +174,8 @@ def cmd_diff(args: list[str]) -> int:
 
 
 def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
-    if target_id == "claude-code":
-        from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
-        return ClaudeCodeAdapter(output_dir, repo_root)
-    if target_id == "cursor":
-        from agent_toolkit.compiler.targets.cursor import CursorAdapter
-        return CursorAdapter(output_dir, repo_root)
-    if target_id == "opencode":
-        from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
-        return OpenCodeAdapter(output_dir, repo_root)
-    return None
+    from agent_toolkit.compiler.target_registry import resolve_adapter_class
+    cls = resolve_adapter_class(target_id, repo_root)
+    if cls is None:
+        return None
+    return cls(output_dir, repo_root)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/release.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/release.py
@@ -79,21 +79,29 @@ def cmd_release(args: list[str]) -> int:
 
     print(f"\nRelease dry run — output: {output_dir}\n")
 
-    targets = {
-        "claude-code": "agent_toolkit.compiler.targets.claude_code.ClaudeCodeAdapter",
-        "cursor": "agent_toolkit.compiler.targets.cursor.CursorAdapter",
-        "opencode": "agent_toolkit.compiler.targets.opencode.OpenCodeAdapter",
-        "copilot-cli": "agent_toolkit.compiler.targets.copilot.CopilotCLIAdapter",
-        "copilot-repository": "agent_toolkit.compiler.targets.copilot.CopilotRepositoryAdapter",
-        "gemini-cli": "agent_toolkit.compiler.targets.gemini_cli.GeminiCLIAdapter",
-        "windsurf": "agent_toolkit.compiler.targets.windsurf.WindsurfAdapter",
-        "pi": "agent_toolkit.compiler.targets.pi.PiAdapter",
-        "codex": "agent_toolkit.compiler.targets.codex.CodexAdapter",
-    }
+    from agent_toolkit.compiler.target_registry import (
+        adapter_import_path,
+        load_target_registry,
+        resolve_target_id,
+        target_ids_for,
+    )
+
+    reg = load_target_registry(repo_root)
+    release_specs = {spec.id: spec for spec in reg if spec.release}
 
     target_filter = parsed.target
     if target_filter != "all":
-        targets = {k: v for k, v in targets.items() if k == target_filter}
+        canonical = resolve_target_id(target_filter, reg)
+        if canonical not in release_specs:
+            available = ", ".join(sorted(release_specs))
+            print(
+                f"  ✗  Unknown release target '{target_filter}'. Available: {available}",
+                file=sys.stderr,
+            )
+            return 1
+        release_specs = {canonical: release_specs[canonical]}
+
+    targets = {spec_id: adapter_import_path(spec) for spec_id, spec in release_specs.items()}
 
     artifacts_summary = []
     checksums: dict[str, str] = {}

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/target_registry.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/target_registry.py
@@ -1,0 +1,121 @@
+"""Load declarative compile-target registry from capabilities/targets/registry.yaml."""
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agent_toolkit._paths import toolkit_root
+
+
+@dataclass(frozen=True)
+class TargetSpec:
+    id: str
+    adapter: str
+    aliases: tuple[str, ...]
+    build: bool
+    diff: bool
+    release: bool
+
+
+_REGISTRY_REL_PATHS = (
+    Path("capabilities/targets/registry.yaml"),
+    Path("schemas/targets-registry.yaml"),
+)
+
+
+def _repo_root(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        return repo_root
+    root = toolkit_root()
+    for rel in _REGISTRY_REL_PATHS:
+        if (root / rel).is_file():
+            return root
+        if (root.parent / rel).is_file():
+            return root.parent
+    return root
+
+
+def _registry_path(repo_root: Path) -> Path:
+    for rel in _REGISTRY_REL_PATHS:
+        path = repo_root / rel
+        if path.is_file():
+            return path
+    raise FileNotFoundError(
+        "Target registry not found. Expected one of: "
+        + ", ".join(str(p) for p in _REGISTRY_REL_PATHS)
+    )
+
+
+def _parse_target(raw: dict[str, Any]) -> TargetSpec:
+    commands = raw.get("commands") or {}
+    adapter = raw.get("adapter")
+    if not adapter and raw.get("adapter_module") and raw.get("adapter_class"):
+        adapter = f"{raw['adapter_module']}.{raw['adapter_class']}"
+    if not adapter:
+        raise ValueError(f"Target {raw.get('id')!r} missing adapter path")
+    return TargetSpec(
+        id=str(raw["id"]),
+        adapter=str(adapter),
+        aliases=tuple(str(a) for a in (raw.get("aliases") or [])),
+        build=bool(commands.get("build", True)),
+        diff=bool(commands.get("diff", False)),
+        release=bool(commands.get("release", True)),
+    )
+
+
+def load_target_registry(repo_root: Path | None = None) -> list[TargetSpec]:
+    root = _repo_root(repo_root)
+    data = yaml.safe_load(_registry_path(root).read_text(encoding="utf-8")) or {}
+    return [_parse_target(entry) for entry in data.get("targets") or []]
+
+
+def registry_by_id(registry: list[TargetSpec] | None = None) -> dict[str, TargetSpec]:
+    specs = registry or load_target_registry()
+    out: dict[str, TargetSpec] = {}
+    for spec in specs:
+        out[spec.id] = spec
+        for alias in spec.aliases:
+            out[alias] = spec
+    return out
+
+
+def resolve_target_id(target_id: str, registry: list[TargetSpec] | None = None) -> str:
+    by_id = registry_by_id(registry)
+    spec = by_id.get(target_id)
+    return spec.id if spec else target_id
+
+
+def target_ids_for(command: str, registry: list[TargetSpec] | None = None) -> list[str]:
+    specs = registry or load_target_registry()
+    attr = {"build": "build", "diff": "diff", "release": "release"}[command]
+    return [spec.id for spec in specs if getattr(spec, attr)]
+
+
+def available_target_ids(
+    repo_root: Path | None = None,
+    *,
+    command: str = "build",
+) -> list[str]:
+    return target_ids_for(command, load_target_registry(repo_root))
+
+
+def adapter_import_path(spec: TargetSpec) -> str:
+    return spec.adapter
+
+
+def resolve_adapter_class(target_id: str, repo_root: Path | None = None):
+    """Import and return adapter class for target id or alias."""
+    by_id = registry_by_id(load_target_registry(repo_root))
+    spec = by_id.get(target_id)
+    if spec is None:
+        return None
+    module_path, cls_name = spec.adapter.rsplit(".", 1)
+    try:
+        mod = importlib.import_module(module_path)
+        return getattr(mod, cls_name)
+    except (ImportError, AttributeError):
+        return None

--- a/tests/test_target_registry.py
+++ b/tests/test_target_registry.py
@@ -1,0 +1,66 @@
+"""Tests for declarative compile-target registry."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.target_registry import (
+    adapter_import_path,
+    load_target_registry,
+    registry_by_id,
+    resolve_adapter_class,
+    resolve_target_id,
+    target_ids_for,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_registry_file_exists() -> None:
+    path = REPO_ROOT / "capabilities" / "targets" / "registry.yaml"
+    assert path.is_file()
+
+
+def test_loads_nine_build_targets() -> None:
+    registry = load_target_registry(REPO_ROOT)
+    build_ids = target_ids_for("build", registry)
+    assert len(build_ids) == 9
+    assert "claude-code" in build_ids
+    assert "codex" in build_ids
+
+
+def test_diff_defaults_to_three_targets() -> None:
+    registry = load_target_registry(REPO_ROOT)
+    diff_ids = target_ids_for("diff", registry)
+    assert diff_ids == ["claude-code", "cursor", "opencode"]
+
+
+def test_release_includes_adapter_paths() -> None:
+    registry = load_target_registry(REPO_ROOT)
+    release_ids = target_ids_for("release", registry)
+    by_id = registry_by_id(registry)
+    assert len(release_ids) == len(set(release_ids))
+    assert adapter_import_path(by_id["gemini-cli"]).endswith("GeminiCLIAdapter")
+
+
+def test_aliases_resolve_to_canonical_id() -> None:
+    registry = load_target_registry(REPO_ROOT)
+    assert resolve_target_id("gemini", registry) == "gemini-cli"
+    assert resolve_target_id("copilot", registry) == "copilot-cli"
+
+
+def test_resolve_adapter_class_for_alias() -> None:
+    cls = resolve_adapter_class("gemini", REPO_ROOT)
+    assert cls is not None
+    assert cls.__name__ == "GeminiCLIAdapter"
+
+
+def test_registry_yaml_is_valid() -> None:
+    path = REPO_ROOT / "capabilities" / "targets" / "registry.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    ids = [entry["id"] for entry in data["targets"]]
+    assert len(ids) == len(set(ids))


### PR DESCRIPTION
## Summary
- Add `capabilities/targets/registry.yaml` as the SoT for target IDs/adapters.
- Wire `build`/`diff`/`release` to load adapters from the registry.
- Add registry contract tests.

Closes #65

## Test plan
- [x] `uv run pytest tests/test_target_registry.py`