### PR TITLE
feat(compiler): wire provenance sidecar into compile (#67)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -122,10 +122,13 @@ def cmd_build(args: list[str]) -> int:
 
         for product in products_to_build:
             print(f"  Building {product.id} → {target_id}...")
+            adapter._provenance_records = []
             if parsed.check:
                 result = adapter.check(graph, product)
             else:
                 result = adapter.compile(graph, product)
+                if hasattr(adapter, "_finalize_provenance"):
+                    adapter._finalize_provenance(product, result)
 
             all_results.append(result)
             print(result.report())

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 from agent_toolkit.compiler.model import CanonicalGraph, CompilationResult, Product
+from agent_toolkit.compiler.provenance import ArtifactRecord, file_digest, write_provenance
 
 
 class TargetAdapter(ABC):
@@ -18,6 +19,7 @@ class TargetAdapter(ABC):
     def __init__(self, output_root: Path, repo_root: Path):
         self.output_root = output_root
         self.repo_root = repo_root
+        self._provenance_records: list[ArtifactRecord] = []
 
     @abstractmethod
     def compile(
@@ -25,34 +27,61 @@ class TargetAdapter(ABC):
         graph: CanonicalGraph,
         product: Product,
     ) -> CompilationResult:
-        """
-        Compile canonical IR into target-specific artifacts.
-        Must return a CompilationResult documenting all emitted, transformed,
-        omitted, and unsupported capabilities. Never silently drop a capability.
-        """
+        """Compile canonical IR into target-specific artifacts."""
 
     def check(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
-        """Dry-run: validate without writing any files to disk.
-
-        Uses a temporary directory that is discarded after compilation,
-        so the real output_root is never touched.
-        """
+        """Dry-run: validate without writing any files to disk."""
         with tempfile.TemporaryDirectory(prefix="agent-toolkit-check-") as tmpdir:
-            # Temporarily redirect output to the throwaway temp dir
             real_output_root = self.output_root
             self.output_root = Path(tmpdir)
+            self._provenance_records = []
             try:
                 result = self.compile(graph, product)
             finally:
                 self.output_root = real_output_root
-
-        # Artifacts were in the temp dir (now deleted) — report paths as relative
-        # so callers know what WOULD have been created, but clear actual paths
+                self._provenance_records = []
         result.artifacts.clear()
         return result
 
-    def _write_file(self, path: Path, content: str, result: CompilationResult) -> None:
-        """Write content to path and record it in result.artifacts."""
+    def _write_file(
+        self,
+        path: Path,
+        content: str,
+        result: CompilationResult,
+        *,
+        source_file: str | Path | None = None,
+    ) -> None:
+        """Write content to path and record it in result.artifacts (+ provenance)."""
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         result.artifacts.append(path)
+
+        source = str(source_file) if source_file is not None else "generated"
+        try:
+            rel = str(path.relative_to(self.output_root))
+        except ValueError:
+            rel = path.name
+        src_path = Path(source_file) if source_file is not None else None
+        self._provenance_records.append(
+            ArtifactRecord(
+                path=rel,
+                source_file=source,
+                source_digest=file_digest(src_path) if src_path and src_path.exists() else "n/a",
+                generated_digest=file_digest(path),
+            )
+        )
+
+    def _finalize_provenance(self, product: Product, result: CompilationResult) -> None:
+        """Write .provenance.json under the product output directory (#67)."""
+        out_dir = self.output_root / product.id
+        if not out_dir.exists():
+            return
+        path = write_provenance(
+            out_dir,
+            product.id,
+            self.target_id,
+            list(self._provenance_records),
+        )
+        result.artifacts.append(path)
+        result.emitted.append("provenance")
+        self._provenance_records = []

--- a/tests/test_provenance_wired.py
+++ b/tests/test_provenance_wired.py
@@ -1,0 +1,28 @@
+"""Provenance sidecar is emitted on compile (#67)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_compile_writes_provenance(tmp_path):
+    graph = load_graph(REPO)
+    product = graph.products["agent-toolkit-core"]
+    adapter = ClaudeCodeAdapter(tmp_path / "plugins", REPO)
+    adapter._provenance_records = []
+    result = adapter.compile(graph, product)
+    adapter._finalize_provenance(product, result)
+    prov = tmp_path / "plugins" / "agent-toolkit-core" / ".provenance.json"
+    assert prov.is_file(), "expected .provenance.json"
+    assert "provenance" in result.emitted
+    text = prov.read_text()
+    assert "generatorVersion" in text
+    assert product.id in text


### PR DESCRIPTION
## Summary
- Extend `TargetAdapter` to record artifact provenance during `_write_file`.
- `build` calls `_finalize_provenance` after compile to emit `.provenance.json`.
- Regression test for Claude Code compile path.

Closes #67

## Test plan
- [x] `uv run pytest tests/test_provenance_wired.py tests/test_provenance.py tests/compiler/test_claude_code_adapter.py`