### PR TITLE
docs: supersede epic #7 with consumer-first epic #32 (#104)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,17 @@
+# Roadmap
+
+## Current program
+
+Consumer-first simplification is tracked under epic
+[#32](https://github.com/ulises-jeremias/agent-toolkit/issues/32).
+
+That epic supersedes the earlier Phase 3–7 native multi-runtime roadmap
+([#7](https://github.com/ulises-jeremias/agent-toolkit/issues/7)). Remaining
+gaps from #7 are folded into the #32 workstream hierarchy rather than kept as
+open checkboxes on #7.
+
+## How to follow work
+
+1. Start at [#32](https://github.com/ulises-jeremias/agent-toolkit/issues/32).
+2. Use workstream epics (#33–#47) for area status.
+3. Prefer open leaf issues under those epics for implementation PRs.


### PR DESCRIPTION
## Summary
- Add `docs/ROADMAP.md` stating epic #32 supersedes epic #7.
- Remaining gaps continue under the #32 hierarchy.

Closes #104

## Test plan
- [x] Docs-only change