### PR TITLE
docs: declare docs/ as SoT over wiki (#101)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+## Source of truth
+
+| Audience | Canonical docs | Notes |
+|----------|----------------|-------|
+| Consumers | `README.md`, `docs/INSTALLATION.md`, `docs/UNINSTALL.md`, `docs/MIGRATION.md`, `docs/TRUST_BOUNDARIES.md` | Prefer these over wiki mirrors |
+| Contributors | `CONTRIBUTING.md`, `AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/HOW_TO_ADD_SKILL.md` | |
+| Target matrix | `docs/TARGETS.md`, `docs/targets/*-certification.md` | |
+| Research / historical | `docs/research/`, `docs/wiki/` | Wiki pages may lag; treat as mirrors until sync |
+
+When `docs/` and `docs/wiki/` disagree, **`docs/` wins**. Update or delete the wiki page in the same PR (#101).

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,3 +1,5 @@
+> **Note:** Canonical documentation lives under [`docs/`](../). This wiki may lag.
+
 # agent-toolkit Wiki
 
 > Composable AI capabilities for every major coding assistant — one toolkit, any tool.


### PR DESCRIPTION
## Summary
- Add `docs/README.md` declaring `docs/` as canonical over `docs/wiki/`.
- Banner on wiki Home pointing readers to canonical docs.

Closes #101