### PR TITLE
feat(cli): define consumer vs advanced command surfaces (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ npx skills add ulises-jeremias/agent-toolkit -g
 
 ## 🚀 Quick Install
 
+Consumer vs advanced CLI: [`docs/CLI_SURFACES.md`](docs/CLI_SURFACES.md).
+
 ### Method 1: Python CLI — `uvx` or `pip` *(works with all tools)*
 
 ```bash

--- a/docs/CLI_SURFACES.md
+++ b/docs/CLI_SURFACES.md
@@ -1,0 +1,17 @@
+# CLI command surfaces
+
+## Consumer-first (#48)
+
+Everyday commands for installing and verifying the toolkit:
+
+- `version`, `help`, `install`, `doctor`, `diff`, `build`, `inventory`, `matrix`
+
+## Advanced (#84)
+
+Power-user / maintainer surfaces (still available, de-emphasized in top-level help):
+
+- `loop`, `workspace`, `memory`, `project`, `devcompanion`, `insights`
+- `release`, `mcp`, `update`, `uninstall`
+
+The binary keeps a single entrypoint; advanced commands remain reachable by name
+but are documented separately so new users are not overwhelmed.

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -1,19 +1,4 @@
-"""agent-toolkit CLI entrypoint.
-
-See docs/CLI_SURFACES.md for consumer vs advanced commands.
-"""
-# Public command surfaces (#48 / #84)
-CONSUMER_COMMANDS = (
-    "version", "help", "install", "doctor", "diff", "build", "inventory", "matrix",
-)
-ADVANCED_COMMANDS = (
-    "loop", "workspace", "memory", "project", "devcompanion", "insights", "release",
-    "mcp", "update", "uninstall",
-)
-
-#!/usr/bin/env python3
-"""
-agent-toolkit — Composable AI agent toolkit CLI
+"""agent-toolkit — Composable AI agent toolkit CLI
 
 Usage:
     agent-toolkit <command> [args...]
@@ -41,6 +26,15 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+
+# Public command surfaces (#48 / #84)
+CONSUMER_COMMANDS = (
+    "version", "help", "install", "doctor", "diff", "build", "inventory", "matrix",
+)
+ADVANCED_COMMANDS = (
+    "loop", "workspace", "memory", "project", "devcompanion", "insights", "release",
+    "mcp", "update", "uninstall",
+)
 
 
 def main() -> None:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -1,3 +1,16 @@
+"""agent-toolkit CLI entrypoint.
+
+See docs/CLI_SURFACES.md for consumer vs advanced commands.
+"""
+# Public command surfaces (#48 / #84)
+CONSUMER_COMMANDS = (
+    "version", "help", "install", "doctor", "diff", "build", "inventory", "matrix",
+)
+ADVANCED_COMMANDS = (
+    "loop", "workspace", "memory", "project", "devcompanion", "insights", "release",
+    "mcp", "update", "uninstall",
+)
+
 #!/usr/bin/env python3
 """
 agent-toolkit — Composable AI agent toolkit CLI


### PR DESCRIPTION
## Summary
- Add `docs/CLI_SURFACES.md` describing consumer vs advanced commands.
- Encode groupings in `cli/main.py`; link from README.

Closes #48