### PR TITLE
feat(targets): Pi certification against official package contract

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -9,7 +9,7 @@
 | GitHub Copilot CLI | Any current | Open Plugin Spec optional |
 | Gemini CLI | 0.1.0+ | Extension system available |
 | OpenCode | 0.3+ | JS/TS module plugins |
-| Pi Coding Agent | Any current | npm package system |
+| Pi Coding Agent | Any current | npm package system — see `docs/certification/pi.md` |
 | Windsurf/Devin | Any current | No marketplace — bundle only |
 | OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) — see `docs/certification/codex.md` |
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -57,4 +57,4 @@ Per-target certification packages document official contracts vs adapter behavio
 All capability claims are based on official documentation as of 2026-08-04.
 See `docs/research/platform-capability-matrix.md` and `docs/research/source-ledger.md`.
 
-Codex certification (experimental strategy): `docs/certification/codex.md`.
+Per-target certification records: `docs/certification/` (Pi, Windsurf, Codex).

--- a/docs/certification/pi.md
+++ b/docs/certification/pi.md
@@ -1,0 +1,90 @@
+# Pi Coding Agent — Target Certification
+
+**Status:** Certified (stable)  
+**Adapter:** `PiAdapter` (`packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py`)  
+**Contract tests:** `tests/compiler/test_pi_adapter.py`  
+**Research date:** 2026-08-04
+
+## Official contract
+
+Pi Coding Agent distributes capabilities via **npm packages** with a `pi` field in
+`package.json`. There is no plugin marketplace — packages are published to npm or
+the [pi.dev registry](https://pi.dev/registry) (npm-compatible).
+
+Official reference: [badlogic/pi-mono](https://github.com/badlogic/pi-mono)
+
+### Required manifest shape
+
+The adapter emits `pi-package.json` (named to avoid colliding with an existing
+project `package.json`) with this structure:
+
+```json
+{
+  "name": "@agent-toolkit/<product-id>",
+  "version": "<semver>",
+  "description": "...",
+  "license": "MIT",
+  "pi": {
+    "skills": ["skills/<name>/SKILL.md"],
+    "agents": ["agents/<name>/AGENT.md"]
+  }
+}
+```
+
+| Field | Requirement | Verified by |
+|-------|-------------|-------------|
+| `pi` | Top-level object declaring capabilities | `test_pi_package_json_has_pi_field` |
+| `pi.skills` | Array of relative paths ending in `SKILL.md` | `test_pi_field_skills_paths_match_emitted_files` |
+| `pi.agents` | Array of relative paths ending in `AGENT.md` | `test_pi_field_agents_paths_match_emitted_files` |
+| `name`, `version`, `description`, `license` | Standard npm package fields | `test_pi_package_json_has_required_fields` |
+
+### Generated layout
+
+```
+<product-id>/
+  pi-package.json
+  skills/<name>/SKILL.md
+  agents/<name>/AGENT.md
+```
+
+Skills use the native Agent Skills `SKILL.md` format — same convention as Claude
+Code, Cursor, and OpenCode.
+
+## Maturity
+
+| Surface | Maturity | Rationale |
+|---------|----------|-----------|
+| Static companion assets (this adapter) | **stable** | npm `pi` field + SKILL.md layout confirmed in pi-mono |
+| TypeScript ExtensionAPI (hooks, tools, MCP) | unsupported | Requires runtime npm package — see `packages/pi-package/` |
+
+The adapter declares `maturity = "stable"` because the static asset contract is
+stable. Runtime features are explicitly reported in `CompilationResult.unsupported`.
+
+## Install path coverage
+
+| Scope | Path | Mechanism |
+|-------|------|-----------|
+| Global skills | `~/.pi/agent/skills/` | `agent-toolkit install --tools pi` |
+| Project extensions | `.pi/extensions/*.ts` | Manual (TypeScript runtime — not generated) |
+| Auto-discovery | `~/.pi/agent/extensions/*.ts` | Pi runtime (not generated) |
+
+The compiler target generates distributable companion assets. The installer copies
+profile skills to `~/.pi/agent/skills/` when `--tools pi` is specified.
+
+## Explicitly unsupported
+
+Reported in every `CompilationResult.unsupported` (never silently dropped):
+
+- Lifecycle hooks — TypeScript ExtensionAPI
+- Custom tools — TypeScript ExtensionAPI
+- MCP server config — no static format
+- Session state — runtime only
+- Plugin marketplace — Pi uses npm/pi.dev, not a marketplace
+
+## Validation
+
+```bash
+uv run pytest tests/compiler/test_pi_adapter.py -q
+uv run pytest tests/test_golden.py -k PiAdapter -q
+agent-toolkit build --target pi --check
+```

--- a/tests/compiler/test_pi_adapter.py
+++ b/tests/compiler/test_pi_adapter.py
@@ -184,6 +184,51 @@ def test_package_type_is_companion_assets(adapter):
     )
 
 
+def test_maturity_is_stable(adapter):
+    """Static companion assets are stable; runtime TypeScript features are unsupported."""
+    assert adapter.maturity == "stable", (
+        f"PiAdapter.maturity must be 'stable' for static assets, got '{adapter.maturity}'"
+    )
+
+
+def test_pi_field_skills_paths_match_emitted_files(adapter, graph):
+    """pi.skills paths must reference emitted SKILL.md files (official package contract)."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    pkg = adapter.output_root / "agent-toolkit-core" / "pi-package.json"
+    data = json.loads(pkg.read_text())
+    pi_skills = data.get("pi", {}).get("skills", [])
+
+    assert pi_skills, "pi.skills must be non-empty after compile"
+    for skill_path in pi_skills:
+        assert skill_path.endswith("/SKILL.md"), (
+            f"pi.skills entry must end with /SKILL.md, got '{skill_path}'"
+        )
+        assert (adapter.output_root / "agent-toolkit-core" / skill_path).exists(), (
+            f"pi.skills references missing file: {skill_path}"
+        )
+
+
+def test_pi_field_agents_paths_match_emitted_files(adapter, graph):
+    """pi.agents paths must reference emitted AGENT.md files (official package contract)."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    pkg = adapter.output_root / "agent-toolkit-core" / "pi-package.json"
+    data = json.loads(pkg.read_text())
+    pi_agents = data.get("pi", {}).get("agents", [])
+
+    assert pi_agents, "pi.agents must be non-empty after compile"
+    for agent_path in pi_agents:
+        assert agent_path.endswith("/AGENT.md"), (
+            f"pi.agents entry must end with /AGENT.md, got '{agent_path}'"
+        )
+        assert (adapter.output_root / "agent-toolkit-core" / agent_path).exists(), (
+            f"pi.agents references missing file: {agent_path}"
+        )
+
+
 # ── check mode ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Add `docs/certification/pi.md` documenting the official npm `pi` field contract, install paths, and stable maturity rationale.
- Extend `test_pi_adapter.py` with maturity assertions and contract tests verifying `pi.skills` / `pi.agents` paths match emitted files.
- Link certification from `docs/TARGETS.md` and `docs/COMPATIBILITY.md`.

Closes #91

## Test plan
- [x] `uv run pytest tests/compiler/test_pi_adapter.py -q`
- [x] `uv run pytest tests/test_golden.py -k PiAdapter -q`
- [ ] `agent-toolkit build --target pi --check`