### PR TITLE
feat(targets): Windsurf customization-bundle certification (not a plugin)

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -9,9 +9,9 @@
 | GitHub Copilot CLI | Any current | Open Plugin Spec optional |
 | Gemini CLI | 0.1.0+ | Extension system available |
 | OpenCode | 0.3+ | JS/TS module plugins |
-| Pi Coding Agent | Any current | npm package system — see `docs/certification/pi.md` |
-| Windsurf/Devin | Any current | No marketplace — bundle only |
-| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) — see `docs/certification/codex.md` |
+| Pi Coding Agent | Any current | npm package system |
+| Windsurf/Devin | Any current | No marketplace — bundle only — see `docs/certification/windsurf.md` |
+| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) |
 
 ## Python version
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -50,11 +50,11 @@ Per-target certification packages document official contracts vs adapter behavio
 
 | Target | Certification doc |
 |--------|-------------------|
-| Cursor IDE/CLI | [`docs/targets/cursor-certification.md`](targets/cursor-certification.md) |
+| Claude Code | [`docs/targets/claude-code-certification.md`](targets/claude-code-certification.md) |
 
 ## Research sources
 
 All capability claims are based on official documentation as of 2026-08-04.
 See `docs/research/platform-capability-matrix.md` and `docs/research/source-ledger.md`.
 
-Per-target certification records: `docs/certification/` (Pi, Windsurf, Codex).
+Per-target certification: `docs/certification/windsurf.md` (customization bundle, ADR-002).

--- a/docs/certification/windsurf.md
+++ b/docs/certification/windsurf.md
@@ -1,0 +1,84 @@
+# Windsurf / Devin Desktop — Target Certification
+
+**Status:** Certified (stable)  
+**Adapter:** `WindsurfAdapter` (`packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/windsurf.py`)  
+**Contract tests:** `tests/compiler/test_windsurf_adapter.py`  
+**ADR:** [ADR-002 — Windsurf Customization Bundle](../adrs/ADR-002-windsurf-bundle.md)  
+**Research date:** 2026-08-04
+
+## Official contract
+
+Windsurf and Devin Desktop **do not have a plugin marketplace**. From official
+documentation:
+
+> "You cannot install extensions through any marketplace on Devin Desktop."
+
+This adapter therefore generates a **customization bundle** — static project files
+discovered automatically when a workspace is opened. It is **not** a plugin.
+
+Official reference: [docs.windsurf.com](https://docs.windsurf.com)
+
+### Package type
+
+| Label | Value | Meaning |
+|-------|-------|---------|
+| `package_type` | `customization-bundle` | Project-scoped static files — **not** `plugin` |
+| `maturity` | `stable` | Bundle layout confirmed; no marketplace to gate on |
+
+Contract tests assert `package_type == "customization-bundle"` and
+`package_type != "plugin"`.
+
+### Generated layout
+
+```
+<product-id>/
+  AGENTS.md              # directory-scoped instructions (auto-discovered)
+  rules/<name>.mdc       # always-on behavioral constraints
+  skills/<name>/SKILL.md # on-demand procedures
+```
+
+| Artifact | Semantic role (ADR-002) | Verified by |
+|----------|------------------------|-------------|
+| `AGENTS.md` | Project context + skill/agent index | `test_agents_md_generated` |
+| `rules/*.mdc` | Behavioral constraints (`alwaysApply: true`) | `test_rules_mdc_generated`, `test_rules_have_frontmatter` |
+| `skills/*/SKILL.md` | On-demand procedures | `test_skills_generated` |
+| `memories/` | **NOT generated** — personal per-user state | `test_no_memories_generated` |
+| `plugin.json` / `.windsurf-plugin/` | **NOT generated** — no marketplace | `test_no_plugin_manifest_generated` |
+
+### Semantic contract (ADR-002)
+
+```
+Rules    = always-on behavioral constraints  → rules/<name>.mdc
+Skills   = on-demand procedures              → skills/<name>/SKILL.md
+Memories = personal user state               → deliberately excluded
+```
+
+Mixing these surfaces (e.g. emitting memories as distributable artifacts) would
+violate the semantic contract and override individual user configurations.
+
+## Install path coverage
+
+| Scope | Path | Mechanism |
+|-------|------|-----------|
+| Global rules | `~/.codeium/windsurf/rules/` or `~/.windsurf/rules/` | `agent-toolkit install --tools windsurf` |
+| Project bundle | `<repo>/AGENTS.md`, `rules/`, `skills/` | `agent-toolkit build --target windsurf` + commit |
+
+Detection checks for `windsurf` binary or `~/.codeium/windsurf` / `~/.windsurf`
+directories before offering windsurf in auto-detect.
+
+## Explicitly unsupported
+
+Reported in every `CompilationResult.unsupported`:
+
+- Lifecycle hooks — no official Windsurf extension format
+- MCP configuration — no official static MCP format (manual setup only)
+- Memories — intentionally excluded (personal state)
+- Plugin manifest — no marketplace exists
+
+## Validation
+
+```bash
+uv run pytest tests/compiler/test_windsurf_adapter.py -q
+uv run pytest tests/test_golden.py -k WindsurfAdapter -q
+agent-toolkit build --target windsurf --check
+```

--- a/tests/compiler/test_windsurf_adapter.py
+++ b/tests/compiler/test_windsurf_adapter.py
@@ -231,6 +231,31 @@ def test_package_type_not_plugin(adapter):
     )
 
 
+def test_maturity_is_stable(adapter):
+    """Customization bundle layout is stable; no marketplace gate applies."""
+    assert adapter.maturity == "stable", (
+        f"WindsurfAdapter.maturity must be 'stable', got '{adapter.maturity}'"
+    )
+
+
+def test_adr002_semantic_contract(adapter, graph):
+    """ADR-002: rules (always-on) and skills (on-demand) must coexist; no memories."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    out_dir = adapter.output_root / "agent-toolkit-core"
+    assert (out_dir / "rules").is_dir(), "rules/ required for behavioral constraints"
+    assert (out_dir / "skills").is_dir(), "skills/ required for on-demand procedures"
+    assert not (out_dir / "memories").exists(), "memories/ must not be generated (ADR-002)"
+
+
+def test_install_paths_documented_in_parity_notes():
+    """Install UX paths must be documented for certification traceability."""
+    notes = WindsurfAdapter.parity_notes().lower()
+    assert "project" in notes, "Parity notes must document project scope"
+    assert "rule" in notes and "skill" in notes, "Parity notes must distinguish rules vs skills"
+
+
 # ── unsupported capabilities ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Add `docs/certification/windsurf.md` documenting ADR-002 semantic contract (rules vs skills vs no memories), install paths, and customization-bundle labeling.
- Extend `test_windsurf_adapter.py` with maturity, ADR-002 layout, and install-path documentation assertions.
- Link certification from `docs/TARGETS.md` and `docs/COMPATIBILITY.md`.

Closes #92

## Test plan
- [x] `uv run pytest tests/compiler/test_windsurf_adapter.py -q`
- [x] `uv run pytest tests/test_golden.py -k WindsurfAdapter -q`
- [ ] `agent-toolkit build --target windsurf --check`