### PR TITLE
feat(cli): define consumer vs advanced command surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,36 @@ The script detects your active tools and deploys the right profiles automaticall
 
 ---
 
+## 🎛️ CLI: Consumer vs Advanced
+
+The Python CLI groups commands by audience so everyday workflows stay simple while power-user tooling stays discoverable.
+
+**Consumer commands** — install, verify, and get help:
+
+| Command | Purpose |
+|---------|---------|
+| `install` | Deploy profiles to detected AI tools |
+| `doctor` | Verify installation health |
+| `version` / `--version` | Show CLI version |
+| `help` / `--help` | Show command list |
+
+**Advanced commands** — workspace orchestration and compilation:
+
+| Command | Purpose |
+|---------|---------|
+| `build`, `diff`, `inventory`, `matrix` | Compile and inspect canonical capabilities |
+| `loop` | Loop engineering (init, run, status, audit, …) |
+| `workspace` | Scaffold and sync harness workspaces |
+| `memory` | Persistent knowledge base (add, search, inject, …) |
+| `project` | Project lifecycle (init, clone, list, sync, …) |
+| `devcompanion` | Background job queue for deferred work |
+| `insights` | Usage analytics for OpenCode, Cursor, Claude |
+| `skills`, `mcp`, `plugin` | Skill/MCP/plugin bundle management |
+
+Run `agent-toolkit <command> --help` for subcommand details.
+
+---
+
 ## 🖥️ Supported Tools
 
 <div align="center">

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -5,17 +5,21 @@ agent-toolkit — Composable AI agent toolkit CLI
 Usage:
     agent-toolkit <command> [args...]
 
-Commands:
+Consumer commands (install, verify, and discover):
     install       Install profiles for detected AI tools
     doctor        Check system health and tool availability
-    diff          Show changes vs currently installed plugin bundles
+    version       Show version (--version / -V)
+    help          Show this help (--help / -h)
+
+Advanced commands (workspace orchestration and power users):
     build         Compile canonical capabilities into target-native artifacts
+    diff          Show changes vs currently installed plugin bundles
     inventory     List all canonical skills, agents, and products
     matrix        Show platform capability matrix
     loop          Loop engineering: init, run, status, audit, cost, schedule, sync
     workspace     Workspace scaffolding: init, context, sync
     memory        Knowledge base: add, search, inject, review, todo
-    project       Project management: clone, list, add, remove, scan
+    project       Project lifecycle: init, clone, list, add, remove, sync, scan
     devcompanion  Background job queue: queue, run-once, status, done, sync-todos
     insights      AI tool usage insights: opencode, cursor, claude
     skills        Skill management: sync, list, validate


### PR DESCRIPTION
## Summary
- Group CLI commands into **consumer** (install, doctor, version, help) and **advanced** (loop, workspace, memory, project, devcompanion, insights, build, …) in `cli/main.py` help text
- Add a README section documenting the consumer vs advanced split

Closes #48

## Test plan
- [x] `uv run pytest tests/ -q` (227 passed)
- [ ] `agent-toolkit --help` shows consumer/advanced groupings