### PR TITLE
feat(distributions): expand product catalog skill coverage

### DIFF
--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -111,3 +111,128 @@ products:
       cursor:
         plugin_id: agent-toolkit-forge
         manifest: plugins/agent-toolkit-forge/.cursor-plugin/plugin.json
+
+  - id: agent-toolkit-delivery
+    name: "Agent Toolkit Delivery"
+    description: >-
+      Product-delivery skills: PRDs, user stories, epics, bugs, incidents,
+      assessments, ADRs, and workflow templates for client engagements.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - delivery/adr
+        - delivery/agreement
+        - delivery/bug
+        - delivery/decision-log
+        - delivery/development-workflow
+        - delivery/epic
+        - delivery/incident
+        - delivery/management-unit-assessment
+        - delivery/meeting-minutes
+        - delivery/planning
+        - delivery/prd
+        - delivery/project-assessment
+        - delivery/project-assessment-evidence
+        - delivery/spike
+        - delivery/task
+        - delivery/technical-unit-assessment
+        - delivery/trd
+        - delivery/user-story
+        - delivery/workflow-client-bootstrap
+        - delivery/workflow-generic-project
+        - delivery/work-item
+      agents: []
+      hooks: []
+      mcp: []
+
+  - id: agent-toolkit-design
+    name: "Agent Toolkit Design"
+    description: >-
+      UI/UX and Figma skills for design-system rules, code connect,
+      and design-to-code workflows.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - design/figma
+        - design/figma-code-connect-components
+        - design/figma-create-design-system-rules
+        - design/figma-create-new-file
+        - design/figma-implement-design
+        - design/ui-ux-pro-max
+      agents: []
+      hooks: []
+      mcp: []
+
+  - id: agent-toolkit-integrations
+    name: "Agent Toolkit Integrations"
+    description: >-
+      Third-party integrations: Slack, ClickUp, and Linear CLI assistants.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - integrations/clickup-cli
+        - integrations/linear
+        - integrations/slack-assistant
+        - integrations/slack-cli
+      agents: []
+      hooks: []
+      mcp: []
+
+  - id: agent-toolkit-data
+    name: "Agent Toolkit Data"
+    description: >-
+      Data engineering validation skills for dbt and Snowflake pipelines.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - data/dbt-validation
+        - data/snowflake-validation
+      agents: []
+      hooks: []
+      mcp: []
+
+  - id: agent-toolkit-ops
+    name: "Agent Toolkit Ops"
+    description: >-
+      Operational skills: workstation triage, LLM cost advisory, and docs generation.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - ops/docs-generator
+        - ops/llm-cost-advisor
+        - ops/triage
+      agents: []
+      hooks: []
+      mcp: []
+
+  - id: agent-toolkit-tooling
+    name: "Agent Toolkit Tooling"
+    description: >-
+      Developer tooling skills: Playwright CLI and Jupyter notebook workflows.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - tooling/jupyter-notebook
+        - tooling/playwright-cli
+      agents: []
+      hooks: []
+      mcp: []
+
+  - id: agent-toolkit-loops
+    name: "Agent Toolkit Loops"
+    description: >-
+      Loop engineering runner skill for autonomous background workflows.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - loops/loop-runner
+      agents: []
+      hooks: []
+      mcp: []

--- a/tests/test_product_skill_coverage.py
+++ b/tests/test_product_skill_coverage.py
@@ -1,0 +1,61 @@
+"""Product catalog must cover stable canonical skills."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.compiler.loader import load_graph
+
+# Skills intentionally excluded from distributable products (experimental, internal-only).
+INTENTIONAL_EXCLUSIONS: frozenset[str] = frozenset()
+
+# Minimum fraction of stable skills that must appear in at least one product.
+MIN_COVERAGE_RATIO = 1.0
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "skills").is_dir() and (parent / "distributions" / "products.yaml").is_file():
+            return parent
+    pytest.fail("Could not locate agent-toolkit repo root from tests/")
+
+
+def test_product_skill_coverage_tracked() -> None:
+    repo = _repo_root()
+    graph = load_graph(repo)
+
+    stable_skill_ids = {
+        sid for sid, skill in graph.skills.items() if skill.stability.value == "stable"
+    }
+    assert stable_skill_ids, "expected at least one stable skill in skills/"
+
+    covered: set[str] = set()
+    for product in graph.products.values():
+        covered.update(product.included_skills)
+
+    eligible = stable_skill_ids - INTENTIONAL_EXCLUSIONS
+    uncovered = sorted(eligible - covered)
+    ratio = len(eligible & covered) / len(eligible) if eligible else 1.0
+
+    assert ratio >= MIN_COVERAGE_RATIO, (
+        f"Product skill coverage {ratio:.0%} below minimum {MIN_COVERAGE_RATIO:.0%}. "
+        f"Uncovered stable skills ({len(uncovered)}): {', '.join(uncovered)}"
+    )
+
+
+def test_no_duplicate_skill_across_products() -> None:
+    repo = _repo_root()
+    graph = load_graph(repo)
+
+    seen: dict[str, str] = {}
+    duplicates: list[str] = []
+    for pid, product in graph.products.items():
+        for skill_id in product.included_skills:
+            if skill_id in seen:
+                duplicates.append(f"{skill_id}: {seen[skill_id]} + {pid}")
+            else:
+                seen[skill_id] = pid
+
+    assert not duplicates, "Skills must not appear in multiple products:\n" + "\n".join(duplicates)


### PR DESCRIPTION
## Summary
- Add domain products: delivery, design, integrations, data, ops, tooling, loops
- Cover 100% of stable canonical skills across the product catalog
- Add `test_product_skill_coverage.py` to track coverage and prevent duplicate skill assignments

Closes #50

## Test plan
- [x] `uv run pytest tests/test_product_skill_coverage.py -q`
- [x] `uv run pytest tests/ -q` (229 passed)