### PR TITLE
feat(cli): enforce parse exit-code contract across commands

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/memory.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/memory.py
@@ -425,6 +425,8 @@ def cmd_todo(args: list[str], knowledge: Path) -> int:
 
 def cmd_memory(args: list[str]) -> int:
     """Router for memory subcommands."""
+    from agent_toolkit.cli.parse_utils import reject_unknown_flags
+
     # Extract --workspace before routing
     workspace_path: str | None = None
     filtered_args: list[str] = []
@@ -440,6 +442,9 @@ def cmd_memory(args: list[str]) -> int:
     if not filtered_args or filtered_args[0] in ("-h", "--help", "help"):
         print(__doc__)
         return 0
+
+    if err := reject_unknown_flags(filtered_args[1:], {"-h", "--help", "--type", "--title", "--workspace"}):
+        return err
 
     ws = _find_workspace(workspace_path)
     if ws is None:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/parse_utils.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/parse_utils.py
@@ -1,0 +1,65 @@
+"""Shared argparse helpers for consistent CLI exit codes."""
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+PARSE_HELP = object()
+PARSE_ERROR = object()
+
+
+def make_parser(prog: str, *, description: str | None = None) -> argparse.ArgumentParser:
+    """ArgumentParser with consistent help formatting."""
+    return argparse.ArgumentParser(
+        prog=prog,
+        description=description,
+        add_help=True,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+
+def parse_known_or_error(
+    parser: argparse.ArgumentParser,
+    argv: list[str],
+) -> tuple[argparse.Namespace, list[str]] | object:
+    """Parse argv; return PARSE_HELP or PARSE_ERROR sentinel on failure."""
+    if "-h" in argv or "--help" in argv:
+        parser.print_help()
+        return PARSE_HELP
+    try:
+        return parser.parse_known_args(argv)
+    except SystemExit as exc:
+        if exc.code == 0:
+            return PARSE_HELP
+        return PARSE_ERROR
+
+
+def first_unknown_flag(argv: list[str], known: set[str]) -> str | None:
+    """Return the first unknown option token in argv, or None if all are valid."""
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in ("-h", "--help"):
+            i += 1
+            continue
+        if arg.startswith("--"):
+            flag = arg.split("=", 1)[0]
+            if flag not in known:
+                return arg
+            if "=" not in arg and flag in known and i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+                i += 2
+                continue
+        elif arg.startswith("-") and arg not in known:
+            return arg
+        i += 1
+    return None
+
+
+def reject_unknown_flags(argv: list[str], known: set[str]) -> int | None:
+    """Print and return exit code 2 when argv contains an unknown flag."""
+    bad = first_unknown_flag(argv, known)
+    if bad is None:
+        return None
+    print(f"Unknown option: {bad}", file=sys.stderr)
+    return 2

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
@@ -361,6 +361,8 @@ def cmd_scan(args: list[str], ws: Path) -> int:
 
 def cmd_project(args: list[str]) -> int:
     """Router for project subcommands."""
+    from agent_toolkit.cli.parse_utils import reject_unknown_flags
+
     # Extract --workspace before routing
     workspace_path: str | None = None
     filtered_args: list[str] = []
@@ -376,6 +378,13 @@ def cmd_project(args: list[str]) -> int:
     if not filtered_args or filtered_args[0] in ("-h", "--help", "help"):
         print(__doc__)
         return 0
+
+    if filtered_args[0].startswith("-"):
+        err = reject_unknown_flags(filtered_args, {"-h", "--help", "--workspace"})
+        return err if err is not None else 0
+
+    if err := reject_unknown_flags(filtered_args[1:], {"-h", "--help"}):
+        return err
 
     sub = filtered_args[0]
     rest = filtered_args[1:]

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -358,7 +358,7 @@ def cmd_init(args: list[str]) -> int:
                 return 0
             case _:
                 print(f"Unknown option: {args[i]}", file=sys.stderr)
-                return 1
+                return 2
 
     if name:
         target_dir = target_dir / name
@@ -426,7 +426,7 @@ def cmd_context(args: list[str]) -> int:
                 return 0
             case _:
                 print(f"Unknown option: {args[i]}", file=sys.stderr)
-                return 1
+                return 2
 
     ws = _find_workspace(workspace_path)
     if ws is None:
@@ -571,7 +571,7 @@ def cmd_sync(args: list[str]) -> int:
                 return 0
             case _:
                 print(f"Unknown option: {args[i]}", file=sys.stderr)
-                return 1
+                return 2
 
     ws = _find_workspace(workspace_path)
     if ws is None:
@@ -637,9 +637,15 @@ def cmd_sync(args: list[str]) -> int:
 
 def cmd_workspace(args: list[str]) -> int:
     """Router for workspace subcommands."""
+    from agent_toolkit.cli.parse_utils import reject_unknown_flags
+
     if not args or args[0] in ("-h", "--help", "help"):
         print(__doc__)
         return 0
+
+    if args[0].startswith("-"):
+        err = reject_unknown_flags(args, {"-h", "--help"})
+        return err if err is not None else 0
 
     sub = args[0]
     rest = args[1:]

--- a/tests/test_cli_parse_exit_codes.py
+++ b/tests/test_cli_parse_exit_codes.py
@@ -1,8 +1,11 @@
-"""CLI parse failures must exit non-zero; --help stays 0."""
+"""CLI parse failures must exit 2; --help stays 0."""
 from __future__ import annotations
 
 from agent_toolkit.cli import doctor as doctor_mod
 from agent_toolkit.cli import install as install_mod
+from agent_toolkit.cli import memory as memory_mod
+from agent_toolkit.cli import project as project_mod
+from agent_toolkit.cli import workspace as workspace_mod
 
 
 def test_install_help_exits_0() -> None:
@@ -23,3 +26,27 @@ def test_doctor_help_exits_0() -> None:
 
 def test_doctor_unknown_option_exits_2() -> None:
     assert doctor_mod.cmd_doctor(["--nope"]) == 2
+
+
+def test_workspace_help_exits_0() -> None:
+    assert workspace_mod.cmd_workspace(["--help"]) == 0
+
+
+def test_workspace_unknown_top_level_option_exits_2() -> None:
+    assert workspace_mod.cmd_workspace(["--nope"]) == 2
+
+
+def test_workspace_context_unknown_option_exits_2() -> None:
+    assert workspace_mod.cmd_workspace(["context", "--nope"]) == 2
+
+
+def test_memory_help_exits_0() -> None:
+    assert memory_mod.cmd_memory(["--help"]) == 0
+
+
+def test_project_help_exits_0() -> None:
+    assert project_mod.cmd_project(["--help"]) == 0
+
+
+def test_project_unknown_option_exits_2() -> None:
+    assert project_mod.cmd_project(["list", "--nope"]) == 2


### PR DESCRIPTION
## Summary
- Add `parse_utils.py` with shared unknown-flag detection
- Ensure unknown options exit **2** and `--help` exits **0** for workspace, memory, and project commands
- Extend `test_cli_parse_exit_codes.py` with coverage for main command routers

Closes #55

## Test plan
- [x] `uv run pytest tests/test_cli_parse_exit_codes.py -q`
- [x] `uv run pytest tests/ -q` (233 passed)