### PR TITLE
feat(targets): Claude Code certification — plugin-local settings and marketplace contract

### DIFF
--- a/distributions/targets/claude-code.yaml
+++ b/distributions/targets/claude-code.yaml
@@ -19,13 +19,15 @@ capabilities:
     discovery: plugin bundle agents/ directory
     format: AGENT.md with YAML frontmatter
   hooks:
-    supported: true
-    method: native
+    supported: false
+    method: unsupported
     config: hooks/hooks.json in plugin bundle
+    note: Registry exists; adapter compile not wired yet (issue #16)
   mcp:
-    supported: true
-    method: native
+    supported: false
+    method: unsupported
     config: .mcp.json in plugin bundle or project root
+    note: MCP registry exists; adapter compile not wired yet
   commands:
     supported: true
     method: native

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -44,6 +44,14 @@ agent-toolkit install --tools cursor,claude-code
 agent-toolkit release --dry-run --output dist/
 ```
 
+## Target certification
+
+Per-target certification packages document official contracts vs adapter behavior:
+
+| Target | Certification doc |
+|--------|-------------------|
+| Claude Code | [`docs/targets/claude-code-certification.md`](targets/claude-code-certification.md) |
+
 ## Research sources
 
 All capability claims are based on official documentation as of 2026-08-04.

--- a/docs/targets/claude-code-certification.md
+++ b/docs/targets/claude-code-certification.md
@@ -1,0 +1,48 @@
+# Claude Code target certification
+
+**Issue:** [#86](https://github.com/ulises-jeremias/agent-toolkit/issues/86)  
+**Target ID:** `claude-code`  
+**Audited:** 2026-08-05 against [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks)
+
+## Official contract (summary)
+
+| Surface | Official location | Format |
+|---------|-------------------|--------|
+| Plugin manifest | `<plugin>/.claude-plugin/plugin.json` | JSON (name, version, description, author) |
+| Skills | `<plugin>/skills/<name>/SKILL.md` | Agent Skills spec |
+| Agents | `<plugin>/agents/<name>/AGENT.md` | Markdown + YAML frontmatter |
+| Hooks | `<plugin>/hooks/hooks.json` | Event → command mapping |
+| MCP | `<plugin>/.mcp.json` or project root | MCP server definitions |
+| User settings | `~/.claude/settings.json` | User-owned; plugins enable via marketplace |
+
+**Security contract:** `~/.claude/settings.json` is user-owned. Public distributions must not overwrite it. Plugin-specific settings belong in the plugin bundle or marketplace install flow only (`plugin_settings_scope: plugin-local`).
+
+## Current adapter behavior
+
+| Capability | Adapter status | Notes |
+|------------|----------------|-------|
+| Plugin manifest | **Certified** | Emits `.claude-plugin/plugin.json` |
+| Skills | **Certified** | Emits `skills/<name>/SKILL.md` + references |
+| Agents | **Certified** | Emits `agents/<name>/AGENT.md` |
+| Hooks | **Not implemented** | Reported in `result.unsupported` |
+| MCP (`.mcp.json`) | **Not implemented** | Reported in `result.unsupported` |
+| Profile install | **Certified safe** | `agent-toolkit install` skips `~/.claude/settings.json` |
+
+## Gaps (documented, not hidden)
+
+1. Hooks and MCP registries exist in the repo but are not wired into `ClaudeCodeAdapter.compile()` yet (issue #16 / MCP registry work).
+2. `profiles/claude-code/settings.json` is a **reference only** — never copied to the user home directory.
+
+## Validation
+
+```bash
+uv sync --group dev
+uv run pytest tests/compiler/test_claude_code_adapter.py tests/test_install_claude_settings.py -q
+uv run agent-toolkit build --target claude-code --check
+```
+
+## References
+
+- `distributions/targets/claude-code.yaml`
+- `packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py`
+- `packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py` (`_install_claude_code`)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
@@ -149,3 +149,16 @@ class ClaudeCodeAdapter(TargetAdapter):
             for k in FORBIDDEN_SETTINGS
             if k in settings
         ]
+
+    @staticmethod
+    def parity_notes() -> str:
+        """Return honest parity notes for certification docs."""
+        return (
+            "Claude Code plugin bundles emit skills, agents, and plugin.json under "
+            ".claude-plugin/. Hooks and .mcp.json are not generated yet — reported as "
+            "unsupported until the canonical hook model and MCP registry are wired in.\n"
+            "\n"
+            "Never ship or overwrite ~/.claude/settings.json from public profiles. "
+            "Plugin settings are plugin-local; users enable marketplace plugins in their "
+            "own settings file."
+        )

--- a/tests/compiler/test_claude_code_adapter.py
+++ b/tests/compiler/test_claude_code_adapter.py
@@ -71,3 +71,25 @@ def test_all_products(adapter, graph, product_id):
         pytest.skip(f"Product {product_id} not defined")
     result = adapter.compile(graph, graph.products[product_id])
     assert result.errors == []
+
+
+def test_plugin_manifest_uses_claude_plugin_dir(adapter, graph):
+    """Official contract: manifest lives under .claude-plugin/, not plugin root."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+    manifest = adapter.output_root / "agent-toolkit-core" / ".claude-plugin" / "plugin.json"
+    wrong = adapter.output_root / "agent-toolkit-core" / "plugin.json"
+    assert manifest.is_file()
+    assert not wrong.exists()
+
+
+def test_validate_settings_rejects_dangerous_bypass():
+    errors = ClaudeCodeAdapter.validate_settings({"skipDangerousModePermissionPrompt": True})
+    assert errors
+
+
+def test_parity_notes_document_plugin_local_settings():
+    notes = ClaudeCodeAdapter.parity_notes()
+    assert "settings.json" in notes.lower() or "plugin-local" in notes.lower()
+    assert "hook" in notes.lower()
+    assert "mcp" in notes.lower()


### PR DESCRIPTION
## Summary
- Add `docs/targets/claude-code-certification.md` documenting official plugin contract vs adapter/install behavior
- Align `distributions/targets/claude-code.yaml` hooks/MCP claims with adapter reality (unsupported until wired)
- Extend Claude Code compiler contract tests and `parity_notes()` for plugin-local settings

## Test plan
- [x] `uv run pytest tests/compiler/test_claude_code_adapter.py tests/test_install_claude_settings.py -q`
- [x] Confirms install never writes `~/.claude/settings.json`

Closes #86