### PR TITLE
feat(targets): Cursor certification — rules, skills, plugin manifest vs official docs

### DIFF
--- a/distributions/targets/cursor.yaml
+++ b/distributions/targets/cursor.yaml
@@ -23,10 +23,12 @@ capabilities:
     note: Rules are persistent constraints; skills are on-demand procedures
   mcp:
     supported: true
-    method: native
+    method: manual
+    note: User configures ~/.cursor/mcp.json; not bundled in plugin compile output
   hooks:
-    supported: native-experimental
-    note: Hook support available in recent versions; verify event names
+    supported: false
+    method: unsupported
+    note: Platform supports hooks; toolkit pending canonical hook model (#16)
   commands:
     supported: unknown-blocked
     note: Need to verify if Cursor plugin format supports slash commands

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -50,7 +50,7 @@ Per-target certification packages document official contracts vs adapter behavio
 
 | Target | Certification doc |
 |--------|-------------------|
-| Claude Code | [`docs/targets/claude-code-certification.md`](targets/claude-code-certification.md) |
+| Cursor IDE/CLI | [`docs/targets/cursor-certification.md`](targets/cursor-certification.md) |
 
 ## Research sources
 

--- a/docs/targets/cursor-certification.md
+++ b/docs/targets/cursor-certification.md
@@ -1,0 +1,48 @@
+# Cursor target certification
+
+**Issue:** [#87](https://github.com/ulises-jeremias/agent-toolkit/issues/87)  
+**Target ID:** `cursor`  
+**Audited:** 2026-08-05 against [Cursor docs](https://cursor.com/docs) and [rules](https://cursor.com/docs/context/rules)
+
+## Official contract (summary)
+
+| Surface | Official location | Format |
+|---------|-------------------|--------|
+| Plugin manifest | `<plugin>/.cursor-plugin/plugin.json` | JSON (shared schema with Claude Code plugins) |
+| Skills | `<plugin>/skills/<name>/SKILL.md` | Agent Skills spec (on-demand procedures) |
+| Agents | `<plugin>/agents/<name>/AGENT.md` | Agent persona definitions |
+| Rules | `~/.cursor/rules/*.mdc` or `.cursor/rules/` | `.mdc` with YAML frontmatter (`description`, `alwaysApply`) |
+| MCP | `~/.cursor/mcp.json` | User-configured; not bundled in plugin |
+| Hooks | Cursor lifecycle events | Platform supports hooks; toolkit pending canonical hook model (#16) |
+
+**Semantic distinction:** Rules are persistent session constraints; skills are on-demand procedures. The compiler emits skills/agents in the plugin bundle; rules ship via the separate `profiles/cursor/rules/` profile surface.
+
+## Current adapter behavior
+
+| Capability | Adapter status | Notes |
+|------------|----------------|-------|
+| Plugin manifest | **Certified** | Emits `.cursor-plugin/plugin.json` |
+| Skills | **Certified** | Emits `skills/<name>/SKILL.md` |
+| Agents | **Certified** | Emits `agents/<name>/AGENT.md` |
+| Rules (`.mdc`) | **Profile surface** | Installed to `~/.cursor/rules/` via `agent-toolkit install`; not duplicated in plugin bundle |
+| MCP | **Manual** | User configures `~/.cursor/mcp.json`; reported as unsupported in plugin compile |
+| Hooks | **Not implemented** | Reported in `result.unsupported` |
+
+## Gaps (documented, not hidden)
+
+1. Plugin compile does not emit `.mdc` rules — by design (different semantic from skills).
+2. MCP and hooks are not generated from canonical IR until registry/hook model lands.
+
+## Validation
+
+```bash
+uv sync --group dev
+uv run pytest tests/compiler/test_cursor_adapter.py tests/test_cursor_profile_rules.py -q
+uv run agent-toolkit build --target cursor --check
+```
+
+## References
+
+- `distributions/targets/cursor.yaml`
+- `packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/cursor.py`
+- `profiles/cursor/rules/*.mdc`

--- a/tests/compiler/test_cursor_adapter.py
+++ b/tests/compiler/test_cursor_adapter.py
@@ -228,6 +228,17 @@ def test_parity_notes_documented():
     assert "rule" in notes.lower(), "Parity notes must explain rules vs skills"
     assert "mcp" in notes.lower(), "Parity notes must explain MCP status"
     assert "hook" in notes.lower(), "Parity notes must explain hooks status"
+    assert "plugin bundle" in notes.lower() or "profile" in notes.lower()
+
+
+def test_plugin_manifest_uses_cursor_plugin_dir(adapter, graph):
+    """Official contract: manifest lives under .cursor-plugin/."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+    manifest = adapter.output_root / "agent-toolkit-core" / ".cursor-plugin" / "plugin.json"
+    wrong = adapter.output_root / "agent-toolkit-core" / "plugin.json"
+    assert manifest.is_file()
+    assert not wrong.exists()
 
 
 # ── all products ──────────────────────────────────────────────────────────────

--- a/tests/test_cursor_profile_rules.py
+++ b/tests/test_cursor_profile_rules.py
@@ -1,0 +1,65 @@
+"""Certification: Cursor profile rules (.mdc) match official frontmatter contract."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+RULES_DIR = REPO_ROOT / "profiles" / "cursor" / "rules"
+
+
+@pytest.fixture(scope="module")
+def rule_files() -> list[Path]:
+    if not RULES_DIR.is_dir():
+        pytest.skip("profiles/cursor/rules not present")
+    files = sorted(RULES_DIR.glob("*.mdc"))
+    if not files:
+        pytest.skip("no .mdc rule files")
+    return files
+
+
+def test_rules_use_mdc_extension(rule_files: list[Path]) -> None:
+    for path in rule_files:
+        assert path.suffix == ".mdc", f"Cursor rules must use .mdc: {path}"
+
+
+def test_rules_have_yaml_frontmatter(rule_files: list[Path]) -> None:
+    for path in rule_files:
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith("---\n"), f"Missing frontmatter opener in {path.name}"
+        assert "\n---\n" in text[4:], f"Missing frontmatter closer in {path.name}"
+
+
+def test_rules_frontmatter_has_description(rule_files: list[Path]) -> None:
+    for path in rule_files:
+        text = path.read_text(encoding="utf-8")
+        fm = text.split("\n---\n", 1)[0]
+        assert re.search(r"^description:\s*.+", fm, re.M), (
+            f"Missing description in {path.name} frontmatter"
+        )
+
+
+def test_rules_frontmatter_has_always_apply(rule_files: list[Path]) -> None:
+    for path in rule_files:
+        text = path.read_text(encoding="utf-8")
+        fm = text.split("\n---\n", 1)[0]
+        assert re.search(r"^alwaysApply:\s*(true|false)\s*$", fm, re.M), (
+            f"Missing alwaysApply in {path.name} frontmatter"
+        )
+
+
+def test_plugin_compile_does_not_emit_mdc_in_bundle(tmp_path) -> None:
+    """Rules are a profile surface — plugin bundle must not silently include .mdc files."""
+    pytest.importorskip("yaml")
+    from agent_toolkit.compiler.loader import load_graph
+    from agent_toolkit.compiler.targets.cursor import CursorAdapter
+
+    graph = load_graph(REPO_ROOT)
+    adapter = CursorAdapter(tmp_path / "plugins", REPO_ROOT)
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    mdc_files = list((adapter.output_root / product.id).rglob("*.mdc"))
+    assert mdc_files == [], f"Plugin bundle must not emit .mdc rules: {mdc_files}"


### PR DESCRIPTION
## Summary
- Add `docs/targets/cursor-certification.md` for rules (.mdc), skills, agents, and plugin manifest
- Correct `distributions/targets/cursor.yaml` MCP (manual) and hooks (unsupported) claims
- Add profile `.mdc` frontmatter contract tests and plugin manifest path lock tests

## Test plan
- [x] `uv run pytest tests/compiler/test_cursor_adapter.py tests/test_cursor_profile_rules.py -q`

Closes #87