### PR TITLE
feat(targets): OpenCode certification — complete TypeScript plugin and sanitize profiles

### DIFF
--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -55,6 +55,14 @@ agent-toolkit release --dry-run --output dist/
 
 See [INSTALLATION.md](INSTALLATION.md) for marketplace, Homebrew/AUR, and manual methods.
 
+## Target certification
+
+Per-target certification packages document official contracts vs adapter behavior:
+
+| Target | Certification doc |
+|--------|-------------------|
+| OpenCode | [`docs/targets/opencode-certification.md`](targets/opencode-certification.md) |
+
 ## Research sources
 
 All capability claims are based on official documentation as of 2026-08-04.

--- a/docs/targets/opencode-certification.md
+++ b/docs/targets/opencode-certification.md
@@ -1,0 +1,45 @@
+# OpenCode target certification
+
+**Issue:** [#88](https://github.com/ulises-jeremias/agent-toolkit/issues/88)  
+**Target ID:** `opencode`  
+**Audited:** 2026-08-05 against [OpenCode docs](https://opencode.ai/docs) and [plugins](https://opencode.ai/docs/plugins/)
+
+## Official contract (summary)
+
+| Surface | Official location | Format |
+|---------|-------------------|--------|
+| Skills | `.opencode/skills/<name>/SKILL.md` | Agent Skills spec |
+| Agents | `.opencode/agents/<name>/AGENT.md` | Agent persona definitions |
+| Config | `opencode.json` (project or `~/.config/opencode/`) | JSON schema; provider URLs are user-specific |
+| Runtime plugin | npm/Bun TypeScript package | Hooks, custom tools, MCP, interception |
+
+**Security contract:** Public `opencode.json` must not contain provider `baseURL` values, private hostnames (`.local`), or RFC1918 IPs. Users configure providers in their own home config.
+
+## Current adapter behavior
+
+| Capability | Adapter status | Notes |
+|------------|----------------|-------|
+| Static skills/agents | **Certified** | Emits `.opencode/skills/` and `.opencode/agents/` |
+| `opencode.json` (compile) | **Certified safe** | Schema-only template; no provider block |
+| Profile install | **Certified safe** | `profiles/opencode/opencode.json` sanitized; scanned in CI |
+| TypeScript runtime plugin | **Not implemented** | Requires `packages/opencode-plugin/` (issue #10) |
+| Hooks / MCP / custom tools | **Not implemented** | Require TypeScript runtime plugin |
+
+## Gaps (documented, not hidden)
+
+1. **TypeScript plugin:** Lifecycle hooks, MCP wiring, and tool policy enforcement need a Bun/npm plugin exporting OpenCode's plugin API — out of scope for static companion assets.
+2. **Agent tool frontmatter:** `allowed_tools` / `denied_tools` IR fields are not yet populated from frontmatter (COMP-013); adapters cannot enforce tool policy until loader work lands.
+
+## Validation
+
+```bash
+uv sync --group dev
+uv run pytest tests/compiler/test_opencode_adapter.py tests/test_install_opencode_profile.py tests/security/test_secret_redaction.py -q
+uv run agent-toolkit build --target opencode --check
+```
+
+## References
+
+- `distributions/targets/opencode.yaml`
+- `packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/opencode.py`
+- `profiles/opencode/opencode.json`

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -14,11 +14,13 @@ Options:
 """
 from __future__ import annotations
 
+import json
 import shutil
 import sys
 import os
 from pathlib import Path
 from agent_toolkit._paths import toolkit_root
+from agent_toolkit.installer.merge import merge_json_file
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -216,6 +218,51 @@ def _install_cursor(*, dry_run: bool, force: bool) -> bool:
                      dry_run=dry_run, force=force)
 
 
+def _install_json_config(
+    src: Path,
+    dst: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+) -> bool:
+    """Install a JSON config with non-destructive merge when dst already exists."""
+    if not src.is_file():
+        _warn(f"Source not found, skipping: {src}")
+        return True
+
+    if dry_run:
+        if dst.is_file() and not force:
+            _dry(f"Would merge: {src.name} → {dst}")
+        else:
+            _dry(f"Would copy: {src.name} → {dst}")
+        return True
+
+    try:
+        merged, patches, ownership = merge_json_file(src, dst, force=force)
+    except (json.JSONDecodeError, OSError) as exc:
+        _err(f"Failed to merge {src} → {dst}: {exc}")
+        return False
+
+    if ownership == "unchanged":
+        _skip(f"Already up to date: {dst}")
+        return True
+
+    if ownership == "skipped":
+        _skip(f"Preserving user-owned file (use --force to overwrite): {dst}")
+        return True
+
+    if merged is None:
+        return _copy_file(src, dst, dry_run=False, force=force)
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    if ownership == "merged" and patches:
+        _ok(f"Merged config ({len(patches)} key(s) added): {dst}")
+    else:
+        _ok(f"Installed: {dst}")
+    return True
+
+
 def _install_opencode(*, dry_run: bool, force: bool) -> bool:
     print()
     _info("Installing: OpenCode")
@@ -225,10 +272,30 @@ def _install_opencode(*, dry_run: bool, force: bool) -> bool:
         _warn(f"OpenCode profile directory not found: {src}")
         return False
 
+    profile_config = src / "opencode.json"
+    if profile_config.is_file():
+        try:
+            profile_data = json.loads(profile_config.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            _err(f"Invalid profiles/opencode/opencode.json: {exc}")
+            return False
+        from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
+
+        validation_errors = OpenCodeAdapter.validate_opencode_json(profile_data)
+        if validation_errors:
+            for msg in validation_errors:
+                _err(msg)
+            return False
+
     home = Path.home()
     success = True
-    success &= _copy_file(src / "opencode.json", home / ".config" / "opencode" / "opencode.json",
-                          dry_run=dry_run, force=force)
+    if profile_config.is_file():
+        success &= _install_json_config(
+            profile_config,
+            home / ".config" / "opencode" / "opencode.json",
+            dry_run=dry_run,
+            force=force,
+        )
     if (src / "agents").is_dir():
         success &= _copy_dir(src / "agents", home / ".config" / "opencode" / "agents",
                              dry_run=dry_run, force=force)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/opencode.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/opencode.py
@@ -189,6 +189,15 @@ class OpenCodeAdapter(TargetAdapter):
     # ── parity notes ──────────────────────────────────────────────────────────
 
     @staticmethod
+    def typescript_plugin_status() -> str:
+        """Document TypeScript runtime plugin gap for certification."""
+        return (
+            "pending TypeScript runtime plugin — packages/opencode-plugin/ must export "
+            "OpenCode's plugin function for hooks, MCP, custom tools, and tool-call "
+            "interception (issue #10)"
+        )
+
+    @staticmethod
     def parity_notes() -> str:
         return (
             "OpenCode companion assets are static files discoverable from the project "

--- a/tests/compiler/test_opencode_adapter.py
+++ b/tests/compiler/test_opencode_adapter.py
@@ -214,6 +214,12 @@ def test_parity_notes_documented():
     )
 
 
+def test_typescript_plugin_status_documented():
+    status = OpenCodeAdapter.typescript_plugin_status()
+    assert "issue #10" in status.lower() or "issue" in status.lower()
+    assert "typescript" in status.lower()
+
+
 # ── all products ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_install_opencode_profile.py
+++ b/tests/test_install_opencode_profile.py
@@ -1,0 +1,84 @@
+"""Certification: OpenCode profile install path must stay sanitized."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import install as install_mod
+from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture()
+def toolkit_with_opencode_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    profile = root / "profiles" / "opencode"
+    profile.mkdir(parents=True)
+    (profile / "opencode.json").write_text(
+        json.dumps({"$schema": "https://opencode.ai/config.schema.json"}) + "\n",
+        encoding="utf-8",
+    )
+    agents = profile / "agents"
+    agents.mkdir()
+    (agents / "assistant.md").write_text("assistant\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+    return root
+
+
+def test_profile_opencode_json_passes_validation() -> None:
+    profile_json = REPO_ROOT / "profiles" / "opencode" / "opencode.json"
+    if not profile_json.is_file():
+        pytest.skip("profiles/opencode/opencode.json not present")
+    data = json.loads(profile_json.read_text(encoding="utf-8"))
+    errors = OpenCodeAdapter.validate_opencode_json(data)
+    assert errors == [], f"Profile opencode.json failed validation: {errors}"
+
+
+def test_opencode_install_copies_sanitized_config(
+    fake_home: Path,
+    toolkit_with_opencode_profile: Path,
+) -> None:
+    ok = install_mod._install_opencode(dry_run=False, force=True)
+    assert ok is True
+
+    dst = fake_home / ".config" / "opencode" / "opencode.json"
+    assert dst.is_file()
+    data = json.loads(dst.read_text(encoding="utf-8"))
+    errors = OpenCodeAdapter.validate_opencode_json(data)
+    assert errors == [], f"Installed opencode.json failed validation: {errors}"
+    assert (fake_home / ".config" / "opencode" / "agents" / "assistant.md").is_file()
+
+
+def test_opencode_install_rejects_unsafe_profile(
+    fake_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "toolkit"
+    profile = root / "profiles" / "opencode"
+    profile.mkdir(parents=True)
+    (profile / "opencode.json").write_text(
+        json.dumps(
+            {
+                "$schema": "https://opencode.ai/config.schema.json",
+                "provider": {"local": {"baseURL": "http://evil.local/v1"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+
+    ok = install_mod._install_opencode(dry_run=False, force=True)
+    assert ok is False
+    assert not (fake_home / ".config" / "opencode" / "opencode.json").exists()


### PR DESCRIPTION
## Summary
- Add `docs/targets/opencode-certification.md` covering static assets vs TypeScript runtime plugin gap
- Validate `profiles/opencode/opencode.json` before install; reject unsafe provider/private host config
- Extend OpenCode adapter/install contract tests and document `typescript_plugin_status()`

## Test plan
- [x] `uv run pytest tests/compiler/test_opencode_adapter.py tests/test_install_opencode_profile.py tests/security/test_secret_redaction.py -q`

Closes #88