### PR TITLE
feat(targets): GitHub Copilot CLI and repository surface certification

### DIFF
--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -62,6 +62,8 @@ Per-target certification packages document official contracts vs adapter behavio
 | Target | Certification doc |
 |--------|-------------------|
 | OpenCode | [`docs/targets/opencode-certification.md`](targets/opencode-certification.md) |
+| Copilot CLI | [`docs/targets/copilot-certification.md`](targets/copilot-certification.md) |
+| Copilot Repository | [`docs/targets/copilot-certification.md`](targets/copilot-certification.md) |
 
 ## Research sources
 

--- a/docs/targets/copilot-certification.md
+++ b/docs/targets/copilot-certification.md
@@ -1,0 +1,57 @@
+# GitHub Copilot CLI and repository surface certification
+
+**Issue:** [#89](https://github.com/ulises-jeremias/agent-toolkit/issues/89)  
+**Target IDs:** `copilot-cli`, `copilot-repository`  
+**Audited:** 2026-08-05 against [Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference) and [customizing Copilot](https://docs.github.com/en/copilot/customizing-copilot)
+
+## Official contract (summary)
+
+### Copilot CLI plugin (`copilot plugin install`)
+
+| Surface | Official location | Format |
+|---------|-------------------|--------|
+| Manifest | **Root** `plugin.json` | Not `.copilot-plugin/` (unlike Claude/Cursor) |
+| Skills | `skills/<name>/SKILL.md` | Agent Skills spec |
+| Agents | `agents/<name>.agent.md` | `.agent.md` extension (not `AGENT.md`) |
+| Hooks | `hooks.json` | Cross-platform Bash + PowerShell handlers |
+
+### Repository customization (committed to project)
+
+| Surface | Official location | Format |
+|---------|-------------------|--------|
+| Instructions | `.github/copilot-instructions.md` | Global repo instructions |
+| Agents | `.github/agents/<name>.agent.md` | Agent personas |
+| Skills | `.github/skills/<name>/SKILL.md` | On-demand skills |
+
+## Current adapter behavior
+
+| Surface | Adapter | Status |
+|---------|---------|--------|
+| CLI `plugin.json` | `CopilotCLIAdapter` | **Certified** — root-level manifest with `skills`/`agents` paths |
+| CLI agents | `CopilotCLIAdapter` | **Certified** — `.agent.md` naming |
+| CLI skills | `CopilotCLIAdapter` | **Certified** |
+| Repo instructions | `CopilotRepositoryAdapter` | **Certified** |
+| Repo agents/skills | `CopilotRepositoryAdapter` | **Certified** under `.github/` |
+| Hooks | Both adapters | **Not implemented** — reported unsupported |
+| MCP | Both adapters | **unknown-blocked** — not confirmed in official docs |
+
+## Gaps (documented, not hidden)
+
+1. Hooks require canonical hook model with Bash + PowerShell handlers (#16).
+2. MCP support for Copilot CLI/repository surfaces is not confirmed from official documentation.
+3. Profile install copies `copilot-instructions.md` to a user-specified project path only — not a global home-directory overwrite.
+
+## Validation
+
+```bash
+uv sync --group dev
+uv run pytest tests/compiler/test_copilot_adapter.py -q
+uv run agent-toolkit build --target copilot-cli --check
+uv run agent-toolkit build --target copilot-repository --check
+```
+
+## References
+
+- `packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/copilot.py`
+- `profiles/copilot/copilot-instructions.md`
+- `docs/TARGETS.md`

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/copilot.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/copilot.py
@@ -162,6 +162,14 @@ class CopilotCLIAdapter(TargetAdapter):
         self._write_file(dst / f"{agent.name}.agent.md", content, result)
         result.emitted.append(f"agent:{agent.id}")
 
+    @staticmethod
+    def parity_notes() -> str:
+        return (
+            "Copilot CLI plugins use root-level plugin.json (not .copilot-plugin/). "
+            "Agents use the .agent.md extension. Hooks and MCP are not generated — "
+            "hooks need cross-platform handlers; MCP is unknown-blocked pending official docs."
+        )
+
 
 class CopilotRepositoryAdapter(TargetAdapter):
     """Generates GitHub Copilot repository-scoped assets.
@@ -260,3 +268,11 @@ class CopilotRepositoryAdapter(TargetAdapter):
         content = agent.source_path.read_text(encoding="utf-8", errors="replace")
         self._write_file(dst / f"{agent.name}.agent.md", content, result)
         result.emitted.append(f"agent:{agent.id}")
+
+    @staticmethod
+    def parity_notes() -> str:
+        return (
+            "Repository surface emits .github/copilot-instructions.md, "
+            ".github/agents/*.agent.md, and .github/skills/*/SKILL.md. "
+            "Hooks and MCP are not generated for the repository surface."
+        )

--- a/tests/compiler/test_copilot_adapter.py
+++ b/tests/compiler/test_copilot_adapter.py
@@ -218,3 +218,26 @@ def test_repo_all_products(repo_adapter, graph, product_id):
         pytest.skip(f"Product {product_id} not defined")
     result = repo_adapter.compile(graph, graph.products[product_id])
     assert result.errors == []
+
+
+def test_cli_manifest_includes_skill_agent_paths(cli_adapter, graph):
+    """Official Copilot CLI plugin.json references skills/ and agents/ directories."""
+    product = graph.products["agent-toolkit-core"]
+    cli_adapter.compile(graph, product)
+    data = json.loads(
+        (cli_adapter.output_root / "agent-toolkit-core" / "plugin.json").read_text()
+    )
+    assert data.get("skills") == "skills/"
+    assert data.get("agents") == "agents/"
+
+
+def test_cli_parity_notes_documented():
+    notes = CopilotCLIAdapter.parity_notes()
+    assert ".agent.md" in notes
+    assert "plugin.json" in notes
+
+
+def test_repo_parity_notes_document_copilot_instructions():
+    notes = CopilotRepositoryAdapter.parity_notes()
+    assert "copilot-instructions" in notes
+    assert ".github" in notes


### PR DESCRIPTION
## Summary
- Add `docs/targets/copilot-certification.md` for CLI plugin and repository surfaces
- Add `parity_notes()` on both Copilot adapters
- Extend contract tests for root `plugin.json` paths and `.github/` repository layout

## Test plan
- [x] `uv run pytest tests/compiler/test_copilot_adapter.py -q`

Closes #89