### PR TITLE
fix(loops): reconcile tier docs with mutation-safety semantics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,10 +117,10 @@ If any script exits non-zero, read the output carefully — it will tell you whi
 
 1. **Check existing loops** in the `loops/` directory to avoid duplication.
 
-2. **Determine the tier**:
-   - **L1** — reactive, event-driven (runs every few minutes to hours)
-   - **L2** — daily summaries, health checks, or briefings
-   - **L3** — weekly or monthly trend analysis, reports, or sweeps
+2. **Determine the tier** (mutation safety — cadence is separate):
+   - **L1** — read-only or propose-only; no mutations
+   - **L2** — PR-gated writes (comments, labels, draft PRs); merge/close forbidden
+   - **L3** — allowlisted merge/close and other high-trust writes (proven loops only)
 
 3. **Create the loop directory**:
 

--- a/README.md
+++ b/README.md
@@ -225,26 +225,26 @@ Loops are recurring agentic workflows that run on a schedule or cadence. They fo
 <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/loop-tiers.svg?raw=true" width="88%">
 </div>
 
-| Tier | Cadence | Purpose |
-|------|---------|---------|
-| **L1** | Minutes to hours | Reactive, event-driven — PR monitoring, triage, CI alerts |
-| **L2** | Daily | Summaries, health checks, security sweeps, briefings |
-| **L3** | Weekly / monthly | Trend analysis, reporting, maintenance sweeps |
+| Tier | Mutation posture | Purpose |
+|------|------------------|---------|
+| **L1** | Observe / propose | Read-only or proposal-only — no repository mutations |
+| **L2** | Controlled mutations | Allowlisted writes (label, comment, limited housekeeping) — merge/close denied |
+| **L3** | High-autonomy mutations | Mature allowlisted mutations including merge/close when explicitly permitted |
 
 ### Loop Templates
 
 | Template | Tier | Default Cadence | Description |
 |----------|------|-----------------|-------------|
-| `oss-pr-monitor` | L1 | Every 30 min | Monitor open PRs across OSS repos, flag stale or failing ones |
-| `oss-triage` | L1 | Every hour | Triage new issues, apply labels, draft responses |
-| `ci-health` | L1 | Every 15 min | Watch CI status, auto-diagnose failures |
-| `oss-daily-briefing` | L2 | Daily | Summarize activity across all tracked OSS repos |
-| `dependency-drift` | L2 | Daily | Detect outdated dependencies and open upgrade PRs |
-| `security-sweep` | L2 | Daily | Run vulnerability scan across repos |
-| `codeowner-review` | L2 | Daily | Remind code owners of pending reviews |
-| `release-notes` | L3 | Weekly | Draft release notes from merged PRs |
-| `stale-branch-cleanup` | L3 | Weekly | Identify and archive stale branches |
-| `contributor-digest` | L3 | Weekly | Generate contributor activity digest |
+| `changelog-drafter` | L1 | 1d | Draft release notes from merged PRs (L1, report-only) |
+| `ci-sweeper` | L2 | 15m | Detect CI failures and propose fixes via draft PRs (L2, cautious) |
+| `daily-triage` | L1 | 1d | Triage new issues and propose labels (report-only) |
+| `dep-sweeper` | L2 | 1d | Apply patch-level dependency updates via draft PRs (L2) |
+| `issue-triage` | L1 | 4h | Propose labels and routing for new issues (L1, propose-only) |
+| `oss-daily-briefing` | L1 | 1d | Daily read-only briefing across OSS ecosystem repos (L1) |
+| `oss-pr-monitor` | L3 | 1d | Monitor open PRs across OSS ecosystem repos and take action (L3, daily) |
+| `oss-triage` | L1 | 1d | Triage issues across OSS ecosystem repos (L1, daily) |
+| `post-merge-cleanup` | L2 | 6h | Off-peak housekeeping after merges (L2, low impact) |
+| `pr-babysitter` | L2 | 15m | Monitor open PRs and post review comments (L2, PR-gated) | L3 | Weekly | Generate contributor activity digest |
 
 Each loop template lives in `loops/<name>/` and contains a `request.md` prompt template, `report.md` output template, and `runbook.md` for human operators.
 
@@ -336,9 +336,9 @@ agent-toolkit/
 
 | Tier | Trigger | Example |
 |------|---------|---------|
-| **L1** | Event / short interval | `oss-pr-monitor`, `ci-health` |
-| **L1.5** | Scheduled short-cadence | `oss-triage`, `dependency-drift` |
-| **L3** | Weekly / monthly | `release-notes`, `contributor-digest` |
+| **L1** | Observe / propose | `oss-triage`, `oss-daily-briefing`, `issue-triage` |
+| **L2** | Controlled mutations | `ci-sweeper`, `pr-babysitter`, `dep-sweeper` |
+| **L3** | High-autonomy (merge/close allowlist) | `oss-pr-monitor` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Full catalog: [`catalogs/agent-catalog.yaml`](catalogs/agent-catalog.yaml)
 
 ## 🔄 Loop Engineering
 
-Loops are recurring agentic workflows that run on a schedule or cadence. They follow a three-tier model:
+Loops are recurring agentic workflows that run on a schedule or cadence. They follow a three-tier **mutation-safety** model enforced by `loop-gh-gate` (cadence is independent of tier):
 
 <div align="center">
 <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/loop-tiers.svg?raw=true" width="88%">
@@ -244,9 +244,9 @@ Loops are recurring agentic workflows that run on a schedule or cadence. They fo
 | `oss-pr-monitor` | L3 | 1d | Monitor open PRs across OSS ecosystem repos and take action (L3, daily) |
 | `oss-triage` | L1 | 1d | Triage issues across OSS ecosystem repos (L1, daily) |
 | `post-merge-cleanup` | L2 | 6h | Off-peak housekeeping after merges (L2, low impact) |
-| `pr-babysitter` | L2 | 15m | Monitor open PRs and post review comments (L2, PR-gated) | L3 | Weekly | Generate contributor activity digest |
+| `pr-babysitter` | L2 | 15m | Monitor open PRs and post review comments (L2, PR-gated) |
 
-Each loop template lives in `loops/<name>/` and contains a `request.md` prompt template, `report.md` output template, and `runbook.md` for human operators.
+Each loop template lives in `loops/<name>/` with a `loop.yaml` definition (prompt in `request:`). At runtime the runner writes `STATE.md` and `report.md` under that directory.
 
 ---
 

--- a/catalogs/loop-catalog.yaml
+++ b/catalogs/loop-catalog.yaml
@@ -2,10 +2,10 @@
 # Metadata for all bundled loop templates.
 # Each entry describes a loops/<name>/loop.yaml template.
 #
-# Tier definitions:
+# Tier definitions (mutation safety — enforced by loop-gh-gate):
 #   L1  — read-only or propose-only; no mutations; safe to run unattended
-#   L2  — limited writes (PRs, comments, labels); PR-gated; cautious budget
-#   L3  — full write access; reserved for high-trust environments
+#   L2  — limited writes (comment, label, draft PR); merge/close forbidden at L2
+#   L3  — merge/close allowed when explicitly allowlisted (e.g. oss-pr-monitor)
 #
 # Scope definitions:
 #   single-repo   — operates on one repository per run

--- a/docs/HOW_TO_CREATE_LOOP.md
+++ b/docs/HOW_TO_CREATE_LOOP.md
@@ -30,9 +30,9 @@ Prerequisite: the equivalent L1 loop has run reliably for at least 3 clean runs.
 
 Token budgets: 50,000 – 300,000 per run.
 
-### L3 — High-Autonomy
+### L3 — High-Autonomy (merge/close allowlisted)
 
-L3 is reserved for loops that have been running stably as L2 for an extended period. The permission set is the same as L2 — L3 is an operational maturity designation, not a different code path.
+L3 is required when a loop's allowlist includes **merge** or **close** — `loop-gh-gate` forbids those actions at L2 regardless of allowlist. Use L3 only for proven automation (for example `oss-pr-monitor` merging Dependabot PRs with passing CI). L3 loops still require explicit allowlist/deny lists and operator approval before production use.
 
 In practice, most teams run all loops at L1 or L2. Start with L1.
 

--- a/docs/LOOPS.md
+++ b/docs/LOOPS.md
@@ -60,6 +60,8 @@ request: |
 
 ## The L1 / L2 / L3 Tier System
 
+Tiers describe the **mutation/risk** level of a loop's actions (not schedule cadence). Cadence is independent of tier.
+
 Tiers describe the risk level of a loop's actions. The tier determines what a loop is allowed to do and how much human oversight is required.
 
 ### L1 — Observe and Report

--- a/docs/LOOPS.md
+++ b/docs/LOOPS.md
@@ -60,9 +60,7 @@ request: |
 
 ## The L1 / L2 / L3 Tier System
 
-Tiers describe the **mutation/risk** level of a loop's actions (not schedule cadence). Cadence is independent of tier.
-
-Tiers describe the risk level of a loop's actions. The tier determines what a loop is allowed to do and how much human oversight is required.
+Tiers describe the **mutation/risk** level of a loop's actions (not schedule cadence). Cadence is independent of tier. The tier determines what a loop is allowed to do and how much human oversight is required.
 
 ### L1 — Observe and Report
 
@@ -74,17 +72,17 @@ Token budgets: 20,000 – 150,000 per run.
 
 ### L2 — Controlled Mutations
 
-L2 loops can make changes, but only within a tightly scoped allowlist. Common L2 actions include merging Dependabot PRs with passing CI, applying labels, posting comments, closing merged branches, or opening draft PRs. Every L2 loop has an explicit deny list that prevents high-risk actions (force-push, approve, push to main).
+L2 loops can make changes, but only within a tightly scoped allowlist. Common L2 actions include applying labels, posting comments, opening draft PRs, and branch housekeeping — but **`loop-gh-gate` forbids merge and close at L2**. Every L2 loop has an explicit deny list that prevents high-risk actions (force-push, approve, push to main).
 
 L2 loops typically require human review of their report before the next run. They are suitable for daily automation once the L1 equivalent has been running reliably.
 
 Token budgets: 50,000 – 300,000 per run.
 
-### L3 — High-Autonomy
+### L3 — High-Autonomy (merge/close allowlisted)
 
-L3 loops are reserved for well-understood, low-risk housekeeping tasks that have been running stably as L2 for some time. The distinction from L2 is operational maturity, not a fundamentally different permission set. A loop graduates to L3 when its pattern is well understood and its error rate is acceptably low.
+L3 is required when a loop's allowlist includes **merge** or **close** — for example `oss-pr-monitor`, which auto-merges Dependabot PRs with passing CI. Beyond that gate difference, L3 follows the same allowlist/deny discipline as L2. Promote a loop to L3 only after stable L2 (or L1) runs and explicit operator approval.
 
-In practice, most teams run all loops at L1 or L2. L3 is a designation, not a different code path.
+In practice, most teams run all loops at L1 or L2. Reserve L3 for proven, tightly scoped automation.
 
 ---
 

--- a/docs/wiki/Loop-Engineering.md
+++ b/docs/wiki/Loop-Engineering.md
@@ -109,25 +109,22 @@ Token budgets: 20,000 – 150,000 per run.
 
 ### L2 — Controlled Mutations
 
-L2 loops can make changes within a tightly scoped `allowlist`. Common L2 actions: merge Dependabot
-PRs with passing CI, apply labels, post comments, close merged branches, open draft PRs.
+L2 loops can make changes within a tightly scoped `allowlist`. Common L2 actions: apply labels, post comments, open draft PRs, branch housekeeping.
 
+- **`loop-gh-gate` forbids merge and close at L2** regardless of allowlist
 - Every L2 loop has an explicit `deny` list that prevents high-risk actions
-- Typical denies: `force-push`, `approve`, `push-to-main`, `delete-unmerged-branch`
 - Prerequisite: the equivalent L1 loop has run reliably for at least 3 clean runs
 - Human should review the `report.md` after each run
 
 Token budgets: 50,000 – 300,000 per run.
 
-### L3 — High-Autonomy
+### L3 — High-Autonomy (merge/close allowlisted)
 
-L3 is reserved for loops that have been running stably as L2 for an extended period. The
-permission set is the same as L2 — L3 is an operational maturity designation, not a different
-code path.
+L3 is required when a loop's allowlist includes **merge** or **close** — for example `oss-pr-monitor`, which auto-merges Dependabot PRs with passing CI. Beyond that gate difference, L3 follows the same allowlist/deny discipline as L2. Promote a loop to L3 only after stable L1/L2 runs and explicit operator approval.
 
-In practice, most teams run all loops at L1 or L2. L3 should be rare.
+In practice, most teams run all loops at L1 or L2. Reserve L3 for proven, tightly scoped automation.
 
-**Graduation sequence:** L1 (3+ clean runs) → L2 (1+ week stable) → L3 (operational maturity)
+**Graduation sequence:** L1 (3+ clean runs) → L2 (stable controlled mutations) → L3 (only when merge/close are required)
 
 ---
 

--- a/tests/test_loop_tier_docs.py
+++ b/tests/test_loop_tier_docs.py
@@ -1,0 +1,69 @@
+"""Docs and catalog tier labels must match loop.yaml mutation-safety tiers."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOOPS_DIR = REPO_ROOT / "loops"
+CATALOG_PATH = REPO_ROOT / "catalogs" / "loop-catalog.yaml"
+
+# README loop templates table (Tier column) — mutation tier, not cadence.
+README_TIERS: dict[str, str] = {
+    "issue-triage": "L1",
+    "oss-triage": "L1",
+    "oss-daily-briefing": "L1",
+    "changelog-drafter": "L1",
+    "daily-triage": "L1",
+    "ci-sweeper": "L2",
+    "dep-sweeper": "L2",
+    "post-merge-cleanup": "L2",
+    "pr-babysitter": "L2",
+    "oss-pr-monitor": "L3",
+}
+
+
+def _loop_tiers_from_yaml() -> dict[str, str]:
+    tiers: dict[str, str] = {}
+    for path in sorted(LOOPS_DIR.glob("*/loop.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        tiers[path.parent.name] = str(data["tier"]).upper()
+    return tiers
+
+
+def test_catalog_tiers_match_loop_yaml() -> None:
+    catalog = yaml.safe_load(CATALOG_PATH.read_text(encoding="utf-8"))
+    yaml_tiers = _loop_tiers_from_yaml()
+    for entry in catalog.get("loops", []):
+        name = entry["name"]
+        assert name in yaml_tiers, f"catalog entry {name} has no loops/{name}/loop.yaml"
+        assert str(entry["tier"]).upper() == yaml_tiers[name], (
+            f"catalog tier for {name} ({entry['tier']}) != loop.yaml ({yaml_tiers[name]})"
+        )
+
+
+def test_readme_inventory_tiers_match_loop_yaml() -> None:
+    yaml_tiers = _loop_tiers_from_yaml()
+    for name, expected in README_TIERS.items():
+        assert name in yaml_tiers
+        assert yaml_tiers[name] == expected.upper(), (
+            f"{name}: README expects {expected}, loop.yaml has {yaml_tiers[name]}"
+        )
+
+
+def test_merge_close_requires_l3() -> None:
+    from agent_toolkit.loop.gh_gate import tier_forbids
+
+    for path in LOOPS_DIR.glob("*/loop.yaml"):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        allow = {str(a).lower() for a in (data.get("allowlist") or [])}
+        if allow & {"merge", "close"}:
+            tier = str(data["tier"]).upper()
+            assert tier.startswith("L3"), (
+                f"{path.parent.name} allowlists merge/close but tier is {tier}"
+            )
+            assert tier_forbids(tier, "merge") is None
+            assert tier_forbids(tier, "close") is None

--- a/tests/test_loop_tier_gate.py
+++ b/tests/test_loop_tier_gate.py
@@ -12,6 +12,18 @@ from agent_toolkit.loop.gh_gate import evaluate_action, tier_forbids
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_l1_forbids_all_mutations() -> None:
+    for action in ("merge", "close", "comment", "label"):
+        assert tier_forbids("L1", action)
+        ok, _ = evaluate_action(
+            action,
+            tier="L1",
+            allowlist=[action],
+            deny=[],
+        )
+        assert ok is False
+
+
 def test_l2_forbids_merge_and_close() -> None:
     assert tier_forbids("L2", "merge")
     assert tier_forbids("L2", "close")

--- a/tests/test_readme_loop_tiers.py
+++ b/tests/test_readme_loop_tiers.py
@@ -1,0 +1,21 @@
+"""README loop tier table must match loops/*/loop.yaml (#83)."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_readme_loop_tiers_match_yaml():
+    readme = (REPO / "README.md").read_text()
+    # Extract rows like | `name` | L3 | ...
+    listed = dict(re.findall(r"\| `([a-z0-9-]+)` \| (L[123]) \|", readme))
+    for loop_yaml in (REPO / "loops").glob("*/loop.yaml"):
+        data = yaml.safe_load(loop_yaml.read_text()) or {}
+        name = loop_yaml.parent.name
+        if name not in listed:
+            continue
+        assert listed[name] == str(data.get("tier")).upper(), name


### PR DESCRIPTION
## Summary
- Align README, `docs/LOOPS.md`, and CONTRIBUTING tier definitions with mutation-safety semantics enforced by `loop-gh-gate`
- Clarify that `oss-pr-monitor` requires L3 for merge/close allowlist actions
- Add tests ensuring loop catalog and README inventory match `loop.yaml` tiers

Closes #83

## Test plan
- [x] `uv run pytest tests/test_loop_tier_docs.py tests/test_loop_tier_gate.py -v`