### PR TITLE
feat(installer): non-destructive install for user profile files

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -91,9 +91,8 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         return True
 
     if dst.exists() and not force:
-        if not _confirm(f"Overwrite existing file: {dst}?", force=False):
-            _skip(f"Skipped: {dst}")
-            return True
+        _skip(f"Preserving user-owned file (use --force to overwrite): {dst}")
+        return True
 
     try:
         dst.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_install_non_destructive.py
+++ b/tests/test_install_non_destructive.py
@@ -1,0 +1,82 @@
+"""Non-destructive install: preserve user-modified profile files."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import install as install_mod
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture()
+def toolkit_with_cursor_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    rules = root / "profiles" / "cursor" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "assistant.mdc").write_text("toolkit-default\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+    return root
+
+
+def test_install_skips_user_modified_profile_file(
+    fake_home: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    dst = fake_home / ".cursor" / "rules" / "assistant.mdc"
+    dst.parent.mkdir(parents=True)
+    user_content = "user-customized content\n"
+    dst.write_text(user_content, encoding="utf-8")
+
+    ok = install_mod._install_cursor(dry_run=False, force=False)
+
+    assert ok is True
+    assert dst.read_text(encoding="utf-8") == user_content
+
+
+def test_install_force_overwrites_user_modified_file(
+    fake_home: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    dst = fake_home / ".cursor" / "rules" / "assistant.mdc"
+    dst.parent.mkdir(parents=True)
+    dst.write_text("user-customized content\n", encoding="utf-8")
+
+    ok = install_mod._install_cursor(dry_run=False, force=True)
+
+    assert ok is True
+    assert dst.read_text(encoding="utf-8") == "toolkit-default\n"
+
+
+def test_claude_install_never_writes_settings_json(
+    fake_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "toolkit"
+    profile = root / "profiles" / "claude-code"
+    profile.mkdir(parents=True)
+    (profile / "CLAUDE.md").write_text("# Claude\n", encoding="utf-8")
+    (profile / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"toolkit@marketplace": True}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+
+    settings = fake_home / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    original = {"enabledPlugins": {"user-plugin@local": True}}
+    settings.write_text(json.dumps(original), encoding="utf-8")
+
+    ok = install_mod._install_claude_code(dry_run=False, force=True)
+
+    assert ok is True
+    assert json.loads(settings.read_text(encoding="utf-8")) == original


### PR DESCRIPTION
## Summary
- Skip overwriting existing profile files by default; require `--force` to replace user content
- Preserve Claude `settings.json` (already skipped) with explicit tmp-HOME regression tests
- Add tests for skip vs force behavior on Cursor profile copies

Closes #59

## Test plan
- [x] `uv run pytest tests/test_install_non_destructive.py tests/test_install_claude_settings.py -v`