### PR TITLE
feat(installer): wire InstallReceipt into install and add uninstall

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -16,7 +16,12 @@ from __future__ import annotations
 import shutil
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 from agent_toolkit._paths import toolkit_root
+
+if TYPE_CHECKING:
+    from agent_toolkit.installer.tracking import InstallTracker
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -73,7 +78,14 @@ def _files_identical(a: Path, b: Path) -> bool:
     return a.read_bytes() == b.read_bytes()
 
 
-def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
+def _copy_file(
+    src: Path,
+    dst: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    tracker: InstallTracker | None = None,
+) -> bool:
     """Copy src to dst, respecting dry-run, force, and idempotency.
 
     Returns True on success (including skip), False on failure.
@@ -99,6 +111,8 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
         _ok(f"Installed: {dst}")
+        if tracker is not None:
+            tracker.record_created(dst)
         return True
     except PermissionError as exc:
         _err(f"Permission denied writing {dst}: {exc}")
@@ -108,7 +122,14 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         return False
 
 
-def _copy_dir(src_dir: Path, dst_dir: Path, *, dry_run: bool, force: bool) -> bool:
+def _copy_dir(
+    src_dir: Path,
+    dst_dir: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    tracker: InstallTracker | None = None,
+) -> bool:
     """Recursively copy all files from src_dir into dst_dir."""
     if not src_dir.is_dir():
         _warn(f"Source directory not found, skipping: {src_dir}")
@@ -125,7 +146,9 @@ def _copy_dir(src_dir: Path, dst_dir: Path, *, dry_run: bool, force: bool) -> bo
             continue
         rel = src_file.relative_to(src_dir)
         dst_file = dst_dir / rel
-        if not _copy_file(src_file, dst_file, dry_run=dry_run, force=force):
+        if not _copy_file(
+            src_file, dst_file, dry_run=dry_run, force=force, tracker=tracker
+        ):
             success = False
     return success
 
@@ -173,9 +196,12 @@ def _windsurf_config_dir() -> Path:
 # ---------------------------------------------------------------------------
 
 def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: Claude Code")
     src = toolkit_root() / "profiles" / "claude-code"
+    tracker = InstallTracker("claude-code", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"Profile directory not found: {src}")
@@ -187,7 +213,7 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
     # that file is user-owned (plugins, permissions, env). Target contract:
     # distributions/targets/claude-code.yaml → plugin_settings_scope: plugin-local.
     success &= _copy_file(src / "CLAUDE.md", home / ".claude" / "CLAUDE.md",
-                          dry_run=dry_run, force=force)
+                          dry_run=dry_run, force=force, tracker=tracker)
     settings_src = src / "settings.json"
     if settings_src.is_file():
         _info(
@@ -197,27 +223,43 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
         )
     if (src / "agents").is_dir():
         success &= _copy_dir(src / "agents", home / ".claude" / "agents",
-                             dry_run=dry_run, force=force)
+                             dry_run=dry_run, force=force, tracker=tracker)
+    if tracker.save():
+        _ok("Saved install receipt for claude-code")
     return success
 
 
 def _install_cursor(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: Cursor")
     src = toolkit_root() / "profiles" / "cursor" / "rules"
+    tracker = InstallTracker("cursor", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"Cursor rules directory not found: {src}")
         return False
 
-    return _copy_dir(src, Path.home() / ".cursor" / "rules",
-                     dry_run=dry_run, force=force)
+    ok = _copy_dir(
+        src,
+        Path.home() / ".cursor" / "rules",
+        dry_run=dry_run,
+        force=force,
+        tracker=tracker,
+    )
+    if tracker.save():
+        _ok("Saved install receipt for cursor")
+    return ok
 
 
 def _install_opencode(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: OpenCode")
     src = toolkit_root() / "profiles" / "opencode"
+    tracker = InstallTracker("opencode", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"OpenCode profile directory not found: {src}")
@@ -225,11 +267,23 @@ def _install_opencode(*, dry_run: bool, force: bool) -> bool:
 
     home = Path.home()
     success = True
-    success &= _copy_file(src / "opencode.json", home / ".config" / "opencode" / "opencode.json",
-                          dry_run=dry_run, force=force)
+    success &= _copy_file(
+        src / "opencode.json",
+        home / ".config" / "opencode" / "opencode.json",
+        dry_run=dry_run,
+        force=force,
+        tracker=tracker,
+    )
     if (src / "agents").is_dir():
-        success &= _copy_dir(src / "agents", home / ".config" / "opencode" / "agents",
-                             dry_run=dry_run, force=force)
+        success &= _copy_dir(
+            src / "agents",
+            home / ".config" / "opencode" / "agents",
+            dry_run=dry_run,
+            force=force,
+            tracker=tracker,
+        )
+    if tracker.save():
+        _ok("Saved install receipt for opencode")
     return success
 
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -7,6 +7,7 @@ Usage:
 
 Commands:
     install       Install profiles for detected AI tools
+    uninstall     Remove toolkit-owned files using install receipts
     doctor        Check system health and tool availability
     diff          Show changes vs currently installed plugin bundles
     build         Compile canonical capabilities into target-native artifacts
@@ -63,6 +64,9 @@ def main() -> None:
         case "install":
             from agent_toolkit.cli.install import cmd_install
             sys.exit(cmd_install(rest))
+        case "uninstall" | "rollback":
+            from agent_toolkit.cli.uninstall import cmd_uninstall
+            sys.exit(cmd_uninstall(rest))
         case "doctor":
             from agent_toolkit.cli.doctor import cmd_doctor
             sys.exit(cmd_doctor(rest))

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/uninstall.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/uninstall.py
@@ -1,0 +1,165 @@
+"""
+uninstall — Remove agent-toolkit profile files recorded in install receipts.
+
+Usage:
+    agent-toolkit uninstall [options]
+
+Options:
+    --tools <list>   Comma-separated tools to uninstall (default: all with receipts)
+    --dry-run        Show what would be removed without deleting files
+    --rollback       Alias for uninstall (removes toolkit-owned files from receipt)
+    --help           Show this help message
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from agent_toolkit.installer import tracking
+from agent_toolkit.installer.receipt import InstallReceipt
+
+_VALID_TOOLS = ("claude-code", "cursor", "opencode", "copilot", "windsurf", "pi")
+_TOOL_RECEIPT_TARGETS = {
+    "claude-code": "claude-code",
+    "cursor": "cursor",
+    "opencode": "opencode",
+    "copilot": "copilot",
+    "windsurf": "windsurf",
+    "pi": "pi",
+}
+
+
+def _info(msg: str) -> None:
+    print(f"  [info]  {msg}")
+
+
+def _ok(msg: str) -> None:
+    print(f"  ✓  {msg}")
+
+
+def _skip(msg: str) -> None:
+    print(f"  -  {msg}")
+
+
+def _dry(msg: str) -> None:
+    print(f"  [dry]   {msg}")
+
+
+def _err(msg: str) -> None:
+    print(f"  ✗  {msg}", file=sys.stderr)
+
+
+def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
+    dry_run = False
+    requested = ""
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-h", "--help"):
+            print(__doc__)
+            return None
+        if arg in ("--dry-run",):
+            dry_run = True
+        elif arg in ("--rollback",):
+            dry_run = False
+        elif arg == "--tools":
+            if i + 1 >= len(args):
+                _err("--tools requires an argument")
+                return None
+            requested = args[i + 1]
+            i += 1
+        else:
+            _err(f"Unknown option: {arg}")
+            return None
+        i += 1
+
+    if requested:
+        tools = [t.strip() for t in requested.split(",") if t.strip()]
+    else:
+        tools = []
+    return tools, dry_run, True
+
+
+def _discover_tools(receipt_dir: Path) -> list[str]:
+    found: list[str] = []
+    if not receipt_dir.is_dir():
+        return found
+    for path in sorted(receipt_dir.glob(f"*-{tracking.PRODUCT}.json")):
+        target = path.name[: -len(f"-{tracking.PRODUCT}.json")]
+        for tool, receipt_target in _TOOL_RECEIPT_TARGETS.items():
+            if receipt_target == target and tool not in found:
+                found.append(tool)
+    return found
+
+
+def _uninstall_tool(tool: str, *, dry_run: bool, receipt_dir: Path) -> bool:
+    target = _TOOL_RECEIPT_TARGETS.get(tool)
+    if target is None:
+        _err(f"Unknown tool: {tool}")
+        return False
+
+    receipt = InstallReceipt.load(target, tracking.PRODUCT, receipt_dir)
+    if receipt is None:
+        _skip(f"No receipt for {tool} — nothing to uninstall")
+        return True
+
+    _info(f"Uninstalling {tool} ({len(receipt.artifacts)} artifact(s) from receipt)")
+    removed = 0
+    for entry in receipt.artifacts:
+        if entry.ownership != "created":
+            _skip(f"Skipping non-owned file ({entry.ownership}): {entry.path}")
+            continue
+        path = Path(entry.path)
+        if not path.exists():
+            _skip(f"Already absent: {path}")
+            continue
+        if dry_run:
+            _dry(f"Would remove: {path}")
+        else:
+            try:
+                path.unlink()
+                _ok(f"Removed: {path}")
+            except OSError as exc:
+                _err(f"Failed to remove {path}: {exc}")
+                return False
+        removed += 1
+
+    if not dry_run:
+        receipt_path = receipt_dir / f"{target}-{tracking.PRODUCT}.json"
+        if receipt_path.exists():
+            receipt_path.unlink()
+            _ok(f"Removed receipt: {receipt_path}")
+
+    _info(f"{tool}: processed {removed} owned file(s)")
+    return True
+
+
+def cmd_uninstall(args: list[str]) -> int:
+    parsed = _parse_args(args)
+    if parsed is None:
+        return 0 if any(a in ("-h", "--help") for a in args) else 2
+    tools, dry_run, _ = parsed
+
+    rdir = tracking.receipt_dir()
+    if not tools:
+        tools = _discover_tools(rdir)
+        if not tools:
+            _err("No install receipts found. Nothing to uninstall.")
+            return 1
+
+    print()
+    print("agent-toolkit uninstall")
+    if dry_run:
+        _info("DRY RUN — no files will be deleted")
+
+    failed: list[str] = []
+    for tool in tools:
+        if tool not in _VALID_TOOLS:
+            _err(f"Unknown tool: {tool}")
+            failed.append(tool)
+            continue
+        if not _uninstall_tool(tool, dry_run=dry_run, receipt_dir=rdir):
+            failed.append(tool)
+
+    print()
+    return 1 if failed else 0

--- a/packages/agent-toolkit-cli/src/agent_toolkit/installer/tracking.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/installer/tracking.py
@@ -1,0 +1,62 @@
+"""Track installed artifacts and persist InstallReceipt."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from agent_toolkit import __version__
+from agent_toolkit.installer.receipt import ArtifactEntry, InstallReceipt
+
+PRODUCT = "agent-toolkit-profiles"
+SCOPE = "user-home"
+
+
+def receipt_dir() -> Path:
+    """Return the install receipt directory (under the current HOME)."""
+    return Path.home() / ".config" / "agent-toolkit" / "receipts"
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def source_digest(root: Path) -> str:
+    marker = root / "profiles"
+    if marker.is_dir():
+        return hashlib.sha256(str(marker.resolve()).encode()).hexdigest()[:12]
+    return __version__
+
+
+class InstallTracker:
+    """Collect artifact entries during install and write receipt on save."""
+
+    def __init__(
+        self,
+        target: str,
+        *,
+        dry_run: bool,
+        receipt_dir_path: Path | None = None,
+        toolkit_root: Path | None = None,
+    ) -> None:
+        root = toolkit_root or Path()
+        self.dry_run = dry_run
+        self.receipt_dir_path = receipt_dir_path or receipt_dir()
+        self.receipt = InstallReceipt.create(
+            PRODUCT,
+            target,
+            SCOPE,
+            __version__,
+            source_digest(root),
+        )
+
+    def record_created(self, path: Path) -> None:
+        if not path.is_file():
+            return
+        self.receipt.artifacts.append(
+            ArtifactEntry(str(path.resolve()), file_digest(path), "created")
+        )
+
+    def save(self) -> Path | None:
+        if self.dry_run or not self.receipt.artifacts:
+            return None
+        return self.receipt.save(self.receipt_dir_path)

--- a/tests/test_install_cli_receipt.py
+++ b/tests/test_install_cli_receipt.py
@@ -1,0 +1,61 @@
+"""Install/uninstall integration tests using a temporary HOME."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli.install import cmd_install
+from agent_toolkit.cli.uninstall import cmd_uninstall
+from agent_toolkit.installer.receipt import InstallReceipt
+from agent_toolkit.installer.tracking import PRODUCT, receipt_dir
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".cursor" / "rules").mkdir(parents=True)
+    return tmp_path
+
+
+def test_install_writes_receipt(isolated_home):
+    rc = cmd_install(["--tools", "cursor", "--force"])
+    assert rc == 0
+
+    rdir = receipt_dir()
+    receipt_path = rdir / f"cursor-{PRODUCT}.json"
+    assert receipt_path.is_file()
+
+    data = json.loads(receipt_path.read_text())
+    assert data["product"] == PRODUCT
+    assert data["target"] == "cursor"
+    assert len(data["artifacts"]) >= 1
+
+
+def test_uninstall_removes_receipt_artifacts(isolated_home):
+    cmd_install(["--tools", "cursor", "--force"])
+    rdir = receipt_dir()
+    receipt = InstallReceipt.load("cursor", PRODUCT, rdir)
+    assert receipt is not None
+    artifact_paths = [Path(a.path) for a in receipt.artifacts]
+    assert all(p.is_file() for p in artifact_paths)
+
+    rc = cmd_uninstall(["--tools", "cursor"])
+    assert rc == 0
+    assert not (rdir / f"cursor-{PRODUCT}.json").exists()
+    for path in artifact_paths:
+        assert not path.exists()
+
+
+def test_uninstall_dry_run_keeps_files(isolated_home):
+    cmd_install(["--tools", "cursor", "--force"])
+    rdir = receipt_dir()
+    receipt = InstallReceipt.load("cursor", PRODUCT, rdir)
+    assert receipt is not None
+    paths = [Path(a.path) for a in receipt.artifacts]
+
+    rc = cmd_uninstall(["--tools", "cursor", "--dry-run"])
+    assert rc == 0
+    assert (rdir / f"cursor-{PRODUCT}.json").is_file()
+    assert all(p.is_file() for p in paths)


### PR DESCRIPTION
## Summary
- Wire `InstallReceipt` into `agent-toolkit install` for claude-code, cursor, and opencode
- Add `agent-toolkit uninstall` / `rollback` to remove toolkit-owned files from receipts
- Add tmp-HOME integration tests for install → receipt → uninstall flow

## Test plan
- [x] `uv run pytest tests/test_install_cli_receipt.py tests/test_installer_receipt.py -q`

Closes #58