### PR TITLE
feat(compiler): emit hooks and MCP from registries into Claude Code adapter

### DIFF
--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -25,8 +25,10 @@ products:
         - core/onboarding
       agents:
         - code-reviewer
-      hooks: []
-      mcp: []
+      hooks:
+        - session-start-context
+      mcp:
+        - github
     excludes: []
     targets:
       claude-code:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -9,6 +9,7 @@ Options:
     --product PRODUCT  Product ID to compile (agent-toolkit-core, etc.)
     --check            Dry-run: validate without writing files
     --output DIR       Output directory (default: plugins/)
+    --emit-registries  Emit all registry hooks/MCP supported by the target (Claude Code)
     --json             Output results as JSON
     --help             Show this help
 
@@ -56,6 +57,7 @@ def cmd_build(args: list[str]) -> int:
     parser.add_argument("--product", default=None)
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--output", default=None)
+    parser.add_argument("--emit-registries", action="store_true")
     parser.add_argument("--json", dest="json_out", action="store_true")
     parser.add_argument("--help", "-h", action="store_true")
 
@@ -124,6 +126,8 @@ def cmd_build(args: list[str]) -> int:
             print(f"  Building {product.id} → {target_id}...")
             if parsed.check:
                 result = adapter.check(graph, product)
+            elif parsed.emit_registries and target_id == "claude-code":
+                result = adapter.compile(graph, product, emit_registries=True)
             else:
                 result = adapter.compile(graph, product)
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -186,6 +186,8 @@ def load_products(products_yaml: Path) -> tuple[dict[str, Product], list[str]]:
             stability=Stability(p.get("stability", "stable")) if p.get("stability") in ("stable", "experimental", "deprecated") else Stability.STABLE,
             included_skills=inc.get("skills", []),
             included_agents=inc.get("agents", []),
+            included_hooks=inc.get("hooks", []),
+            included_mcp=inc.get("mcp", []),
             security=sec,
             target_overrides=p.get("targets", {}),
         )
@@ -210,6 +212,14 @@ def load_graph(repo_root: Path) -> CanonicalGraph:
     graph.products.update(products)
     graph.errors.extend(errs)
 
+    from agent_toolkit.compiler.hook_registry import load_hooks
+    from agent_toolkit.compiler.mcp_registry import load_registry
+
+    hooks_registry, hook_errs = load_hooks(repo_root / "capabilities" / "hooks")
+    mcp_registry, mcp_errs = load_registry(repo_root / "mcp" / "registry")
+    graph.errors.extend(hook_errs)
+    graph.errors.extend(mcp_errs)
+
     # Validate references
     for pid, product in graph.products.items():
         for skill_id in product.included_skills:
@@ -221,6 +231,16 @@ def load_graph(repo_root: Path) -> CanonicalGraph:
             if agent_id not in graph.agents:
                 graph.warnings.append(
                     f"Product '{pid}' references agent '{agent_id}' not found in agents/"
+                )
+        for hook_id in product.included_hooks:
+            if hook_id not in hooks_registry:
+                graph.warnings.append(
+                    f"Product '{pid}' references hook '{hook_id}' not found in capabilities/hooks/"
+                )
+        for mcp_id in product.included_mcp:
+            if mcp_id not in mcp_registry:
+                graph.warnings.append(
+                    f"Product '{pid}' references MCP provider '{mcp_id}' not found in mcp/registry/"
                 )
 
     return graph

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
@@ -114,6 +114,8 @@ class Product:
     stability: Stability = Stability.STABLE
     included_skills: list[str] = field(default_factory=list)   # skill IDs
     included_agents: list[str] = field(default_factory=list)   # agent IDs
+    included_hooks: list[str] = field(default_factory=list)    # hook IDs
+    included_mcp: list[str] = field(default_factory=list)      # MCP provider IDs
     excluded: list[str] = field(default_factory=list)
     requires: list[Requirement] = field(default_factory=list)
     security: SecurityPolicy = field(default_factory=SecurityPolicy)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/registry_emit.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/registry_emit.py
@@ -1,0 +1,144 @@
+"""Emit hooks and MCP configurations from canonical registries into target formats."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_toolkit.compiler.hook_registry import HookDefinition, load_hooks
+from agent_toolkit.compiler.mcp_registry import McpProvider, load_registry
+
+# Canonical event → Claude Code hook event name
+_CLAUDE_HOOK_EVENTS: dict[str, str] = {
+    "session.start": "SessionStart",
+    "session.end": "SessionEnd",
+    "tool.before": "PreToolUse",
+    "tool.after": "PostToolUse",
+    "prompt.before_submit": "UserPromptSubmit",
+}
+
+
+def _hooks_dict(hooks_dir: Path) -> dict[str, HookDefinition]:
+    hooks, _errors = load_hooks(hooks_dir)
+    return hooks
+
+
+def _mcp_dict(registry_dir: Path) -> dict[str, McpProvider]:
+    providers, _errors = load_registry(registry_dir)
+    return providers
+
+
+def resolve_hook_ids(
+    product_hooks: list[str],
+    *,
+    target_id: str,
+    hooks_dir: Path,
+    emit_registries: bool = False,
+) -> list[str]:
+    """Return hook IDs to emit for a product/target."""
+    registry = _hooks_dict(hooks_dir)
+    if product_hooks:
+        return [hid for hid in product_hooks if hid in registry]
+    if not emit_registries:
+        return []
+    return [
+        hook.id
+        for hook in registry.values()
+        if hook.is_supported_for(target_id)
+    ]
+
+
+def resolve_mcp_ids(
+    product_mcp: list[str],
+    *,
+    target_id: str,
+    registry_dir: Path,
+    emit_registries: bool = False,
+) -> list[str]:
+    """Return MCP provider IDs to emit for a product/target."""
+    registry = _mcp_dict(registry_dir)
+    if product_mcp:
+        return [pid for pid in product_mcp if pid in registry]
+    if not emit_registries:
+        return []
+    return [
+        provider.id
+        for provider in registry.values()
+        if provider.is_supported_for(target_id)
+    ]
+
+
+def emit_claude_hooks_json(
+    hook_ids: list[str],
+    hooks_dir: Path,
+    target_id: str = "claude-code",
+) -> dict | None:
+    """Build Claude Code hooks/hooks.json content from canonical hook IDs."""
+    registry = _hooks_dict(hooks_dir)
+    hooks_block: dict[str, list[dict]] = {}
+
+    for hook_id in hook_ids:
+        hook = registry.get(hook_id)
+        if hook is None or not hook.is_supported_for(target_id):
+            continue
+        event_name = _CLAUDE_HOOK_EVENTS.get(hook.event, hook.event)
+        if hook.handler_type != "command" or not hook.command:
+            continue
+        entry = {
+            "type": "command",
+            "command": " ".join(hook.command),
+            "timeout": hook.timeout_ms,
+        }
+        hooks_block.setdefault(event_name, []).append(entry)
+
+    if not hooks_block:
+        return None
+    return {"hooks": hooks_block}
+
+
+def emit_claude_mcp_json(
+    provider_ids: list[str],
+    registry_dir: Path,
+    target_id: str = "claude-code",
+) -> dict | None:
+    """Build Claude Code .mcp.json content from canonical MCP provider IDs."""
+    registry = _mcp_dict(registry_dir)
+    servers: dict[str, dict] = {}
+
+    for provider_id in provider_ids:
+        provider = registry.get(provider_id)
+        if provider is None or not provider.is_supported_for(target_id):
+            continue
+        env = {var: f"${{{var}}}" for var in provider.env_vars}
+        if provider.package.startswith("@"):
+            servers[provider_id] = {
+                "command": "npx",
+                "args": ["-y", provider.package],
+                "env": env,
+            }
+        else:
+            servers[provider_id] = {
+                "command": provider.package or provider_id,
+                "env": env,
+            }
+
+    if not servers:
+        return None
+    return {"mcpServers": servers}
+
+
+def hooks_json_text(hook_ids: list[str], hooks_dir: Path, target_id: str = "claude-code") -> str | None:
+    payload = emit_claude_hooks_json(hook_ids, hooks_dir, target_id)
+    if payload is None:
+        return None
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def mcp_json_text(
+    provider_ids: list[str],
+    registry_dir: Path,
+    target_id: str = "claude-code",
+) -> str | None:
+    payload = emit_claude_mcp_json(provider_ids, registry_dir, target_id)
+    if payload is None:
+        return None
+    return json.dumps(payload, indent=2) + "\n"

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
@@ -35,9 +35,17 @@ class ClaudeCodeAdapter(TargetAdapter):
     package_type = "plugin"
     maturity = "stable"
 
-    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+    def compile(
+        self,
+        graph: CanonicalGraph,
+        product: Product,
+        *,
+        emit_registries: bool = False,
+    ) -> CompilationResult:
         result = CompilationResult(target=self.target_id, product=product.id)
         out_dir = self.output_root / product.id
+        hooks_dir = self.repo_root / "capabilities" / "hooks"
+        mcp_dir = self.repo_root / "mcp" / "registry"
 
         # Emit plugin.json
         plugin_json = self._build_plugin_json(product, graph)
@@ -66,11 +74,41 @@ class ClaudeCodeAdapter(TargetAdapter):
                 continue
             self._emit_agent(agent, out_dir, result)
 
-        # Capabilities this adapter does NOT yet implement
-        result.unsupported.extend([
-            "hooks (hooks/hooks.json — pending hook canonical model)",
-            ".mcp.json (pending MCP registry implementation)",
-        ])
+        from agent_toolkit.compiler.registry_emit import (
+            hooks_json_text,
+            mcp_json_text,
+            resolve_hook_ids,
+            resolve_mcp_ids,
+        )
+
+        hook_ids = resolve_hook_ids(
+            product.included_hooks,
+            target_id=self.target_id,
+            hooks_dir=hooks_dir,
+            emit_registries=emit_registries,
+        )
+        hooks_text = hooks_json_text(hook_ids, hooks_dir, self.target_id)
+        if hooks_text:
+            self._write_file(out_dir / "hooks" / "hooks.json", hooks_text, result)
+            result.emitted.append("hooks")
+
+        mcp_ids = resolve_mcp_ids(
+            product.included_mcp,
+            target_id=self.target_id,
+            registry_dir=mcp_dir,
+            emit_registries=emit_registries,
+        )
+        mcp_text = mcp_json_text(mcp_ids, mcp_dir, self.target_id)
+        if mcp_text:
+            self._write_file(out_dir / ".mcp.json", mcp_text, result)
+            result.emitted.append("mcp")
+
+        pending: list[str] = []
+        if not hook_ids:
+            pending.append("hooks (hooks/hooks.json — none included for this product)")
+        if not mcp_ids:
+            pending.append(".mcp.json (none included for this product)")
+        result.unsupported.extend(pending)
 
         return result
 

--- a/tests/compiler/test_claude_code_adapter.py
+++ b/tests/compiler/test_claude_code_adapter.py
@@ -50,11 +50,21 @@ def test_no_dangerous_mode_bypass(adapter, graph):
             assert "skipDangerousModePermissionPrompt" not in data
 
 
-def test_unsupported_reported(adapter, graph):
+def test_hooks_and_mcp_emitted(adapter, graph):
     product = graph.products["agent-toolkit-core"]
     result = adapter.compile(graph, product)
+    out = adapter.output_root / "agent-toolkit-core"
+    assert (out / "hooks" / "hooks.json").exists()
+    assert (out / ".mcp.json").exists()
+    assert "hooks" in result.emitted
+    assert "mcp" in result.emitted
+
+
+def test_agents_product_reports_pending_registries(adapter, graph):
+    product = graph.products["agent-toolkit-agents"]
+    result = adapter.compile(graph, product)
     unsupported = " ".join(result.unsupported).lower()
-    assert "hook" in unsupported
+    assert "hooks" in unsupported
     assert "mcp" in unsupported
 
 

--- a/tests/compiler/test_registry_emission.py
+++ b/tests/compiler/test_registry_emission.py
@@ -1,0 +1,99 @@
+"""Tests for registry-based hooks/MCP emission."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.registry_emit import (
+    emit_claude_hooks_json,
+    emit_claude_mcp_json,
+    resolve_hook_ids,
+    resolve_mcp_ids,
+)
+from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+HOOKS_DIR = REPO_ROOT / "capabilities" / "hooks"
+MCP_DIR = REPO_ROOT / "mcp" / "registry"
+
+
+@pytest.fixture
+def graph():
+    return load_graph(REPO_ROOT)
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    return ClaudeCodeAdapter(tmp_path / "plugins", REPO_ROOT)
+
+
+def test_resolve_hooks_from_product():
+    ids = resolve_hook_ids(
+        ["session-start-context"],
+        target_id="claude-code",
+        hooks_dir=HOOKS_DIR,
+    )
+    assert ids == ["session-start-context"]
+
+
+def test_emit_registries_includes_supported_hooks():
+    ids = resolve_hook_ids(
+        [],
+        target_id="claude-code",
+        hooks_dir=HOOKS_DIR,
+        emit_registries=True,
+    )
+    assert "session-start-context" in ids
+
+
+def test_emit_claude_hooks_json():
+    payload = emit_claude_hooks_json(["session-start-context"], HOOKS_DIR)
+    assert payload is not None
+    assert "SessionStart" in payload["hooks"]
+    assert payload["hooks"]["SessionStart"][0]["command"] == "agent-toolkit workspace context"
+
+
+def test_emit_claude_mcp_json():
+    payload = emit_claude_mcp_json(["github"], MCP_DIR)
+    assert payload is not None
+    assert "github" in payload["mcpServers"]
+    assert payload["mcpServers"]["github"]["env"]["GITHUB_TOKEN"] == "${GITHUB_TOKEN}"
+
+
+def test_adapter_emits_hooks_and_mcp(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+    out = adapter.output_root / "agent-toolkit-core"
+    assert (out / "hooks" / "hooks.json").is_file()
+    assert (out / ".mcp.json").is_file()
+    assert "hooks" in result.emitted
+    assert "mcp" in result.emitted
+
+    hooks = json.loads((out / "hooks" / "hooks.json").read_text())
+    mcp = json.loads((out / ".mcp.json").read_text())
+    assert "SessionStart" in hooks["hooks"]
+    assert "github" in mcp["mcpServers"]
+
+
+def test_agents_product_without_hooks_mcp(adapter, graph):
+    product = graph.products["agent-toolkit-agents"]
+    result = adapter.compile(graph, product)
+    out = adapter.output_root / "agent-toolkit-agents"
+    assert not (out / "hooks" / "hooks.json").exists()
+    assert not (out / ".mcp.json").exists()
+    assert any("hooks" in u for u in result.unsupported)
+
+
+def test_emit_registries_flag(adapter, graph):
+    product = graph.products["agent-toolkit-agents"]
+    result = adapter.compile(graph, product, emit_registries=True)
+    out = adapter.output_root / "agent-toolkit-agents"
+    assert (out / "hooks" / "hooks.json").is_file()
+    assert (out / ".mcp.json").is_file()
+    mcp_ids = resolve_mcp_ids([], target_id="claude-code", registry_dir=MCP_DIR, emit_registries=True)
+    assert mcp_ids  # at least github from registry


### PR DESCRIPTION
## Summary
- Add `included_hooks` / `included_mcp` product fields and `registry_emit` helpers
- Emit `hooks/hooks.json` and `.mcp.json` from Claude Code adapter when product includes them
- Include `session-start-context` + `github` in `agent-toolkit-core`; add `--emit-registries` build flag

## Test plan
- [x] `uv run pytest tests/compiler/test_registry_emission.py tests/compiler/test_claude_code_adapter.py -q`

Closes #68