### PR TITLE
feat(mcp): add health and uninstall CLI with offline registry validation

### DIFF
--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -17,8 +17,10 @@ products:
     - core/onboarding
     agents:
     - code-reviewer
-    hooks: []
-    mcp: []
+    hooks:
+    - session-start-context
+    mcp:
+    - github
   excludes: []
   targets:
     claude-code:
@@ -160,6 +162,7 @@ products:
     - tooling/playwright-cli
     agents: []
     hooks: []
+    mcp: []
   security:
     approval_required: false
     default_enabled: true

--- a/distributions/targets/claude-code.yaml
+++ b/distributions/targets/claude-code.yaml
@@ -19,13 +19,15 @@ capabilities:
     discovery: plugin bundle agents/ directory
     format: AGENT.md with YAML frontmatter
   hooks:
-    supported: true
-    method: native
+    supported: false
+    method: unsupported
     config: hooks/hooks.json in plugin bundle
+    note: Registry exists; adapter compile not wired yet (issue #16)
   mcp:
-    supported: true
-    method: native
+    supported: false
+    method: unsupported
     config: .mcp.json in plugin bundle or project root
+    note: MCP registry exists; adapter compile not wired yet
   commands:
     supported: true
     method: native

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -11,7 +11,7 @@
 | OpenCode | 0.3+ | JS/TS module plugins |
 | Pi Coding Agent | Any current | npm package system |
 | Windsurf/Devin | Any current | No marketplace — bundle only |
-| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) |
+| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) — see `docs/certification/codex.md` |
 
 ## Python version
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -25,7 +25,7 @@ Each target receives the strongest integration it actually supports.
 | Gemini CLI | extension (gemini-extension.json) | native | native | unsupported* | unsupported* | stable |
 | Pi Coding Agent | companion-assets | native | native | unsupported† | unsupported† | stable |
 | Windsurf | customization-bundle | native | generated (rules) | unsupported | unsupported | stable |
-| OpenAI Codex | plugin (.codex-plugin/) | native | native | unknown-blocked | unknown-blocked | experimental |
+| OpenAI Codex (experimental) | plugin (.codex-plugin/) | native | native | unknown-blocked | unknown-blocked | experimental |
 
 *pending canonical hook model (issue #16)
 †requires TypeScript runtime plugin
@@ -48,3 +48,5 @@ agent-toolkit release --dry-run --output dist/
 
 All capability claims are based on official documentation as of 2026-08-04.
 See `docs/research/platform-capability-matrix.md` and `docs/research/source-ledger.md`.
+
+Codex certification (experimental strategy): `docs/certification/codex.md`.

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -44,6 +44,14 @@ agent-toolkit install --tools cursor,claude-code
 agent-toolkit release --dry-run --output dist/
 ```
 
+## Target certification
+
+Per-target certification packages document official contracts vs adapter behavior:
+
+| Target | Certification doc |
+|--------|-------------------|
+| Claude Code | [`docs/targets/claude-code-certification.md`](targets/claude-code-certification.md) |
+
 ## Research sources
 
 All capability claims are based on official documentation as of 2026-08-04.

--- a/docs/certification/codex.md
+++ b/docs/certification/codex.md
@@ -1,0 +1,95 @@
+# OpenAI Codex — Target Certification
+
+**Status:** Experimental (bounded support)  
+**Adapter:** `CodexAdapter` (`packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/codex.py`)  
+**Contract tests:** `tests/compiler/test_codex_adapter.py`  
+**Research date:** 2026-08-04
+
+## Strategy: keep experimental until contract stabilizes
+
+The Codex plugin marketplace launched March 2026. As of the research date
+(2026-08-04):
+
+- Self-serve marketplace submission is **"coming soon"**
+- The plugin API surface is still evolving
+- Hooks and MCP are **unknown-blocked** (not confirmed in official docs)
+
+**Do not change `maturity` to `stable`** until OpenAI publishes a stable plugin
+contract and open marketplace submission.
+
+## Official contract
+
+Official references:
+
+- [OpenAI Codex developers](https://developers.openai.com/codex)
+- [Agent Skills spec](https://agentskills.io) — skills use native `SKILL.md`
+
+### Manifest path
+
+Codex uses a distinct manifest directory (not Claude Code or Cursor):
+
+```
+<product-id>/
+  .codex-plugin/plugin.json   ← Codex-specific (NOT .claude-plugin/)
+  skills/<name>/SKILL.md
+  agents/<name>/AGENT.md
+```
+
+| Path | Must NOT exist | Verified by |
+|------|----------------|-------------|
+| `.codex-plugin/plugin.json` | — | `test_plugin_json_at_codex_path` |
+| `.claude-plugin/plugin.json` | Yes | `test_plugin_json_not_at_claude_path` |
+| `.cursor-plugin/plugin.json` | Yes | `test_plugin_json_not_at_cursor_path` |
+
+### Maturity labeling
+
+| Location | Required value | Verified by |
+|----------|---------------|-------------|
+| `CodexAdapter.maturity` | `"experimental"` | `test_adapter_maturity_is_experimental` |
+| `plugin.json` → `maturity` | `"experimental"` | `test_maturity_is_experimental` |
+| `CompilationResult.warnings` | mentions experimental | `test_experimental_warning_in_result` |
+
+This dual labeling (adapter class + emitted manifest) prevents false stable claims
+in both build metadata and distributable artifacts.
+
+### Agent Skills alignment
+
+Skills and agents follow the Agent Skills convention:
+
+- Skills: `skills/<name>/SKILL.md` (on-demand procedures)
+- Agents: `agents/<name>/AGENT.md` (personas)
+
+Progressive disclosure `references/` subdirectories are copied alongside skills,
+matching the pattern used by Claude Code and Cursor adapters.
+
+## Safety constraints
+
+Forbidden manifest fields (never emitted, validated at build time):
+
+- `skipDangerousModePermissionPrompt`
+- `autoAcceptPermissions`
+- `disablePermissionPrompts`
+- `allowUnsafeCode`
+
+Private hostnames (`.local`, RFC1918 IPs) are rejected by `validate_plugin_json()`.
+
+## Explicitly unsupported / unknown-blocked
+
+| Capability | Status | Reported in |
+|------------|--------|-------------|
+| Lifecycle hooks | unknown-blocked | `result.unsupported` |
+| MCP integration | unknown-blocked | `result.unsupported` |
+
+## Marketplace warning
+
+Generated artifacts **must not** be submitted to the Codex marketplace without
+explicit authorization from OpenAI. Use this adapter for local development and
+structure validation only until self-serve submission opens.
+
+## Validation
+
+```bash
+uv run pytest tests/compiler/test_codex_adapter.py -q
+uv run pytest tests/test_golden.py -k CodexAdapter -q
+agent-toolkit build --target codex --check
+```

--- a/docs/targets/claude-code-certification.md
+++ b/docs/targets/claude-code-certification.md
@@ -1,0 +1,48 @@
+# Claude Code target certification
+
+**Issue:** [#86](https://github.com/ulises-jeremias/agent-toolkit/issues/86)  
+**Target ID:** `claude-code`  
+**Audited:** 2026-08-05 against [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks)
+
+## Official contract (summary)
+
+| Surface | Official location | Format |
+|---------|-------------------|--------|
+| Plugin manifest | `<plugin>/.claude-plugin/plugin.json` | JSON (name, version, description, author) |
+| Skills | `<plugin>/skills/<name>/SKILL.md` | Agent Skills spec |
+| Agents | `<plugin>/agents/<name>/AGENT.md` | Markdown + YAML frontmatter |
+| Hooks | `<plugin>/hooks/hooks.json` | Event → command mapping |
+| MCP | `<plugin>/.mcp.json` or project root | MCP server definitions |
+| User settings | `~/.claude/settings.json` | User-owned; plugins enable via marketplace |
+
+**Security contract:** `~/.claude/settings.json` is user-owned. Public distributions must not overwrite it. Plugin-specific settings belong in the plugin bundle or marketplace install flow only (`plugin_settings_scope: plugin-local`).
+
+## Current adapter behavior
+
+| Capability | Adapter status | Notes |
+|------------|----------------|-------|
+| Plugin manifest | **Certified** | Emits `.claude-plugin/plugin.json` |
+| Skills | **Certified** | Emits `skills/<name>/SKILL.md` + references |
+| Agents | **Certified** | Emits `agents/<name>/AGENT.md` |
+| Hooks | **Not implemented** | Reported in `result.unsupported` |
+| MCP (`.mcp.json`) | **Not implemented** | Reported in `result.unsupported` |
+| Profile install | **Certified safe** | `agent-toolkit install` skips `~/.claude/settings.json` |
+
+## Gaps (documented, not hidden)
+
+1. Hooks and MCP registries exist in the repo but are not wired into `ClaudeCodeAdapter.compile()` yet (issue #16 / MCP registry work).
+2. `profiles/claude-code/settings.json` is a **reference only** — never copied to the user home directory.
+
+## Validation
+
+```bash
+uv sync --group dev
+uv run pytest tests/compiler/test_claude_code_adapter.py tests/test_install_claude_settings.py -q
+uv run agent-toolkit build --target claude-code --check
+```
+
+## References
+
+- `distributions/targets/claude-code.yaml`
+- `packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py`
+- `packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py` (`_install_claude_code`)

--- a/mcp/templates/clickup/config.template.json
+++ b/mcp/templates/clickup/config.template.json
@@ -1,6 +1,7 @@
 {
   "name": "clickup",
-  "command": "mcp-clickup-server",
+  "command": "npx",
+  "args": ["-y", "mcp-clickup-server"],
   "env": {
     "CLICKUP_API_TOKEN": "${CLICKUP_API_TOKEN}"
   }

--- a/mcp/templates/github/config.template.json
+++ b/mcp/templates/github/config.template.json
@@ -1,6 +1,7 @@
 {
   "name": "github",
-  "command": "mcp-github-server",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
   "env": {
     "GITHUB_TOKEN": "${GITHUB_TOKEN}"
   }

--- a/mcp/templates/notion/config.template.json
+++ b/mcp/templates/notion/config.template.json
@@ -1,6 +1,7 @@
 {
   "name": "notion",
-  "command": "mcp-notion-server",
+  "command": "npx",
+  "args": ["-y", "mcp-notion-server"],
   "env": {
     "NOTION_API_TOKEN": "${NOTION_API_TOKEN}"
   }

--- a/mcp/templates/slack/config.template.json
+++ b/mcp/templates/slack/config.template.json
@@ -1,6 +1,7 @@
 {
   "name": "slack",
-  "command": "mcp-slack-server",
+  "command": "npx",
+  "args": ["-y", "@anthropic-ai/mcp-server-slack"],
   "env": {
     "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
     "SLACK_APP_TOKEN": "${SLACK_APP_TOKEN}"

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -9,6 +9,7 @@ Options:
     --product PRODUCT  Product ID to compile (agent-toolkit-core, etc.)
     --check            Dry-run: validate without writing files
     --output DIR       Output directory (default: plugins/)
+    --emit-registries  Emit all registry hooks/MCP supported by the target (Claude Code)
     --json             Output results as JSON
     --help             Show this help
 
@@ -56,6 +57,7 @@ def cmd_build(args: list[str]) -> int:
     parser.add_argument("--product", default=None)
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--output", default=None)
+    parser.add_argument("--emit-registries", action="store_true")
     parser.add_argument("--json", dest="json_out", action="store_true")
     parser.add_argument("--help", "-h", action="store_true")
 
@@ -125,6 +127,8 @@ def cmd_build(args: list[str]) -> int:
             adapter._provenance_records = []
             if parsed.check:
                 result = adapter.check(graph, product)
+            elif parsed.emit_registries and target_id == "claude-code":
+                result = adapter.compile(graph, product, emit_registries=True)
             else:
                 result = adapter.compile(graph, product)
                 if hasattr(adapter, "_finalize_provenance"):

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/mcp.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/mcp.py
@@ -7,10 +7,13 @@ Usage:
 Subcommands:
     list                   List available MCP providers
     setup <provider>       Interactive wizard to configure a provider
+    health [provider]      Validate registry entry and required env var names (no network)
     doctor [provider]      Check env vars and connectivity for provider(s)
+    uninstall <provider>   Remove a provider from local MCP config
 
 Options:
-    --help    Show this help message
+    --offline              Skip network connectivity checks (setup/doctor)
+    --help                 Show this help message
 """
 from __future__ import annotations
 
@@ -37,6 +40,35 @@ def _mcp_config_path() -> Path:
 
 def _templates_dir(toolkit_dir: Path) -> Path:
     return toolkit_dir / "mcp" / "templates"
+
+
+def _registry_dir(toolkit_dir: Path) -> Path:
+    return toolkit_dir / "mcp" / "registry"
+
+
+def _load_registry_provider(toolkit_dir: Path, provider: str):
+    """Load provider metadata from mcp/registry/<provider>.yaml."""
+    from agent_toolkit.compiler.mcp_registry import load_registry
+
+    registry, _errors = load_registry(_registry_dir(toolkit_dir))
+    return registry.get(provider)
+
+
+def _registry_env_vars(toolkit_dir: Path, provider: str) -> list[str]:
+    entry = _load_registry_provider(toolkit_dir, provider)
+    if entry is None:
+        template = _load_template(_templates_dir(toolkit_dir), provider)
+        return _extract_env_vars(template) if template else []
+    return list(entry.env_vars)
+
+
+def _list_known_providers(toolkit_dir: Path) -> list[str]:
+    reg_dir = _registry_dir(toolkit_dir)
+    names = {p.stem for p in reg_dir.glob("*.yaml")} if reg_dir.is_dir() else set()
+    tdir = _templates_dir(toolkit_dir)
+    if tdir.is_dir():
+        names.update(p.name for p in tdir.iterdir() if p.is_dir())
+    return sorted(names)
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +224,7 @@ def _cmd_list(toolkit_dir: Path | None) -> int:
     return 0
 
 
-def _cmd_setup(provider: str, toolkit_dir: Path | None) -> int:
+def _cmd_setup(provider: str, toolkit_dir: Path | None, *, offline: bool = False) -> int:
     """Interactive wizard to configure an MCP provider."""
     if toolkit_dir is None:
         print("  ✗  Cannot locate toolkit directory", file=sys.stderr)
@@ -200,14 +232,17 @@ def _cmd_setup(provider: str, toolkit_dir: Path | None) -> int:
 
     tdir = _templates_dir(toolkit_dir)
     template = _load_template(tdir, provider)
-    if template is None:
-        providers = sorted(p.name for p in tdir.iterdir() if p.is_dir()) if tdir.is_dir() else []
+    entry = _load_registry_provider(toolkit_dir, provider)
+    if entry is None and template is None:
+        providers = _list_known_providers(toolkit_dir)
         print(f"  ✗  Provider '{provider}' not found.", file=sys.stderr)
         if providers:
             print(f"  Available: {', '.join(providers)}", file=sys.stderr)
         return 1
 
-    env_vars = _extract_env_vars(template)
+    env_vars = _registry_env_vars(toolkit_dir, provider)
+    if not env_vars and template is not None:
+        env_vars = _extract_env_vars(template)
     readme = _load_readme(tdir, provider)
 
     print()
@@ -261,13 +296,18 @@ def _cmd_setup(provider: str, toolkit_dir: Path | None) -> int:
 
     # Validate / test connectivity
     print()
-    print("  Testing connectivity...")
-    ok, detail = _test_connectivity(provider, env_vals)
+    if offline:
+        print("  ✓  Offline mode — skipping connectivity check")
+        ok, detail = True, "registry and env var names validated"
+    else:
+        print("  Testing connectivity...")
+        ok, detail = _test_connectivity(provider, env_vals)
     if ok:
         print(f"  ✓  {detail}")
     else:
         print(f"  ⚠  Connectivity check failed: {detail}")
-        print("     Saving configuration anyway — double-check your credentials.")
+        if not offline:
+            print("     Saving configuration anyway — double-check your credentials.")
 
     # Save config: store env var names (not plaintext values)
     cfg = _load_config()
@@ -377,9 +417,72 @@ def _cmd_doctor(providers_arg: list[str], toolkit_dir: Path | None) -> int:
     return 1 if total_err else 0
 
 
+def _cmd_health(providers_arg: list[str], toolkit_dir: Path | None) -> int:
+    """Validate registry metadata and env var names without network calls."""
+    if toolkit_dir is None:
+        print("  ✗  Cannot locate toolkit directory", file=sys.stderr)
+        return 1
+
+    targets = providers_arg or _list_known_providers(toolkit_dir)
+    if not targets:
+        print("  ⚠  No MCP providers found in registry or templates")
+        return 0
+
+    print()
+    print("MCP health (offline)")
+    errors = 0
+    for provider in targets:
+        print(f"\n── {provider} ──")
+        entry = _load_registry_provider(toolkit_dir, provider)
+        if entry is None:
+            print(f"  ✗  Not in mcp/registry/ and no template directory")
+            errors += 1
+            continue
+        print(f"  ✓  registry: {entry.display_name} ({entry.id})")
+        if entry.package:
+            print(f"  ✓  package: {entry.package}")
+        env_vars = entry.env_vars
+        if env_vars:
+            print(f"  ✓  required env: {', '.join(env_vars)}")
+            for var in env_vars:
+                if os.environ.get(var):
+                    print(f"  ✓  {var}: set")
+                else:
+                    print(f"  -  {var}: not set (expected until configured)")
+        else:
+            print("  ✓  required env: (none)")
+
+    print()
+    return 1 if errors else 0
+
+
+def _cmd_uninstall(provider: str) -> int:
+    """Remove a provider from the local MCP config file."""
+    cfg = _load_config()
+    providers = cfg.get("providers", {})
+    if provider not in providers:
+        print(f"  ⚠  Provider '{provider}' is not configured")
+        return 0
+    del providers[provider]
+    cfg["providers"] = providers
+    _save_config(cfg)
+    print(f"  ✓  Removed '{provider}' from {_mcp_config_path()}")
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Argument parsing & dispatch
 # ---------------------------------------------------------------------------
+
+def _pop_offline_flag(args: list[str]) -> tuple[list[str], bool]:
+    rest: list[str] = []
+    offline = False
+    for arg in args:
+        if arg == "--offline":
+            offline = True
+        else:
+            rest.append(arg)
+    return rest, offline
 
 def cmd_mcp(args: list[str]) -> int:
     """MCP provider management entry point.
@@ -391,22 +494,38 @@ def cmd_mcp(args: list[str]) -> int:
         return 0
 
     toolkit_dir = toolkit_root()
-    subcommand = args[0]
-    rest = args[1:]
+    rest, offline = _pop_offline_flag(args)
+    if not rest or rest[0] in ("-h", "--help"):
+        print(__doc__)
+        return 0
+
+    subcommand = rest[0]
+    subargs = rest[1:]
 
     if subcommand == "list":
         return _cmd_list(toolkit_dir)
 
     elif subcommand == "setup":
-        if not rest:
+        if not subargs:
             print("  ✗  Usage: agent-toolkit mcp setup <provider>", file=sys.stderr)
             return 1
-        return _cmd_setup(rest[0], toolkit_dir)
+        return _cmd_setup(subargs[0], toolkit_dir, offline=offline)
+
+    elif subcommand == "health":
+        return _cmd_health(subargs, toolkit_dir)
 
     elif subcommand == "doctor":
-        return _cmd_doctor(rest, toolkit_dir)
+        if offline:
+            return _cmd_health(subargs, toolkit_dir)
+        return _cmd_doctor(subargs, toolkit_dir)
+
+    elif subcommand == "uninstall":
+        if not subargs:
+            print("  ✗  Usage: agent-toolkit mcp uninstall <provider>", file=sys.stderr)
+            return 1
+        return _cmd_uninstall(subargs[0])
 
     else:
         print(f"  ✗  Unknown subcommand: {subcommand}", file=sys.stderr)
-        print("  Valid subcommands: list, setup, doctor", file=sys.stderr)
+        print("  Valid subcommands: list, setup, health, doctor, uninstall", file=sys.stderr)
         return 1

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -186,6 +186,8 @@ def load_products(products_yaml: Path) -> tuple[dict[str, Product], list[str]]:
             stability=Stability(p.get("stability", "stable")) if p.get("stability") in ("stable", "experimental", "deprecated") else Stability.STABLE,
             included_skills=inc.get("skills", []),
             included_agents=inc.get("agents", []),
+            included_hooks=inc.get("hooks", []),
+            included_mcp=inc.get("mcp", []),
             security=sec,
             target_overrides=p.get("targets", {}),
         )
@@ -210,6 +212,14 @@ def load_graph(repo_root: Path) -> CanonicalGraph:
     graph.products.update(products)
     graph.errors.extend(errs)
 
+    from agent_toolkit.compiler.hook_registry import load_hooks
+    from agent_toolkit.compiler.mcp_registry import load_registry
+
+    hooks_registry, hook_errs = load_hooks(repo_root / "capabilities" / "hooks")
+    mcp_registry, mcp_errs = load_registry(repo_root / "mcp" / "registry")
+    graph.errors.extend(hook_errs)
+    graph.errors.extend(mcp_errs)
+
     # Validate references
     for pid, product in graph.products.items():
         for skill_id in product.included_skills:
@@ -221,6 +231,16 @@ def load_graph(repo_root: Path) -> CanonicalGraph:
             if agent_id not in graph.agents:
                 graph.warnings.append(
                     f"Product '{pid}' references agent '{agent_id}' not found in agents/"
+                )
+        for hook_id in product.included_hooks:
+            if hook_id not in hooks_registry:
+                graph.warnings.append(
+                    f"Product '{pid}' references hook '{hook_id}' not found in capabilities/hooks/"
+                )
+        for mcp_id in product.included_mcp:
+            if mcp_id not in mcp_registry:
+                graph.warnings.append(
+                    f"Product '{pid}' references MCP provider '{mcp_id}' not found in mcp/registry/"
                 )
 
     return graph

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
@@ -114,6 +114,8 @@ class Product:
     stability: Stability = Stability.STABLE
     included_skills: list[str] = field(default_factory=list)   # skill IDs
     included_agents: list[str] = field(default_factory=list)   # agent IDs
+    included_hooks: list[str] = field(default_factory=list)    # hook IDs
+    included_mcp: list[str] = field(default_factory=list)      # MCP provider IDs
     excluded: list[str] = field(default_factory=list)
     requires: list[Requirement] = field(default_factory=list)
     security: SecurityPolicy = field(default_factory=SecurityPolicy)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/registry_emit.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/registry_emit.py
@@ -1,0 +1,144 @@
+"""Emit hooks and MCP configurations from canonical registries into target formats."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_toolkit.compiler.hook_registry import HookDefinition, load_hooks
+from agent_toolkit.compiler.mcp_registry import McpProvider, load_registry
+
+# Canonical event → Claude Code hook event name
+_CLAUDE_HOOK_EVENTS: dict[str, str] = {
+    "session.start": "SessionStart",
+    "session.end": "SessionEnd",
+    "tool.before": "PreToolUse",
+    "tool.after": "PostToolUse",
+    "prompt.before_submit": "UserPromptSubmit",
+}
+
+
+def _hooks_dict(hooks_dir: Path) -> dict[str, HookDefinition]:
+    hooks, _errors = load_hooks(hooks_dir)
+    return hooks
+
+
+def _mcp_dict(registry_dir: Path) -> dict[str, McpProvider]:
+    providers, _errors = load_registry(registry_dir)
+    return providers
+
+
+def resolve_hook_ids(
+    product_hooks: list[str],
+    *,
+    target_id: str,
+    hooks_dir: Path,
+    emit_registries: bool = False,
+) -> list[str]:
+    """Return hook IDs to emit for a product/target."""
+    registry = _hooks_dict(hooks_dir)
+    if product_hooks:
+        return [hid for hid in product_hooks if hid in registry]
+    if not emit_registries:
+        return []
+    return [
+        hook.id
+        for hook in registry.values()
+        if hook.is_supported_for(target_id)
+    ]
+
+
+def resolve_mcp_ids(
+    product_mcp: list[str],
+    *,
+    target_id: str,
+    registry_dir: Path,
+    emit_registries: bool = False,
+) -> list[str]:
+    """Return MCP provider IDs to emit for a product/target."""
+    registry = _mcp_dict(registry_dir)
+    if product_mcp:
+        return [pid for pid in product_mcp if pid in registry]
+    if not emit_registries:
+        return []
+    return [
+        provider.id
+        for provider in registry.values()
+        if provider.is_supported_for(target_id)
+    ]
+
+
+def emit_claude_hooks_json(
+    hook_ids: list[str],
+    hooks_dir: Path,
+    target_id: str = "claude-code",
+) -> dict | None:
+    """Build Claude Code hooks/hooks.json content from canonical hook IDs."""
+    registry = _hooks_dict(hooks_dir)
+    hooks_block: dict[str, list[dict]] = {}
+
+    for hook_id in hook_ids:
+        hook = registry.get(hook_id)
+        if hook is None or not hook.is_supported_for(target_id):
+            continue
+        event_name = _CLAUDE_HOOK_EVENTS.get(hook.event, hook.event)
+        if hook.handler_type != "command" or not hook.command:
+            continue
+        entry = {
+            "type": "command",
+            "command": " ".join(hook.command),
+            "timeout": hook.timeout_ms,
+        }
+        hooks_block.setdefault(event_name, []).append(entry)
+
+    if not hooks_block:
+        return None
+    return {"hooks": hooks_block}
+
+
+def emit_claude_mcp_json(
+    provider_ids: list[str],
+    registry_dir: Path,
+    target_id: str = "claude-code",
+) -> dict | None:
+    """Build Claude Code .mcp.json content from canonical MCP provider IDs."""
+    registry = _mcp_dict(registry_dir)
+    servers: dict[str, dict] = {}
+
+    for provider_id in provider_ids:
+        provider = registry.get(provider_id)
+        if provider is None or not provider.is_supported_for(target_id):
+            continue
+        env = {var: f"${{{var}}}" for var in provider.env_vars}
+        if provider.package.startswith("@"):
+            servers[provider_id] = {
+                "command": "npx",
+                "args": ["-y", provider.package],
+                "env": env,
+            }
+        else:
+            servers[provider_id] = {
+                "command": provider.package or provider_id,
+                "env": env,
+            }
+
+    if not servers:
+        return None
+    return {"mcpServers": servers}
+
+
+def hooks_json_text(hook_ids: list[str], hooks_dir: Path, target_id: str = "claude-code") -> str | None:
+    payload = emit_claude_hooks_json(hook_ids, hooks_dir, target_id)
+    if payload is None:
+        return None
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def mcp_json_text(
+    provider_ids: list[str],
+    registry_dir: Path,
+    target_id: str = "claude-code",
+) -> str | None:
+    payload = emit_claude_mcp_json(provider_ids, registry_dir, target_id)
+    if payload is None:
+        return None
+    return json.dumps(payload, indent=2) + "\n"

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
@@ -35,9 +35,17 @@ class ClaudeCodeAdapter(TargetAdapter):
     package_type = "plugin"
     maturity = "stable"
 
-    def compile(self, graph: CanonicalGraph, product: Product) -> CompilationResult:
+    def compile(
+        self,
+        graph: CanonicalGraph,
+        product: Product,
+        *,
+        emit_registries: bool = False,
+    ) -> CompilationResult:
         result = CompilationResult(target=self.target_id, product=product.id)
         out_dir = self.output_root / product.id
+        hooks_dir = self.repo_root / "capabilities" / "hooks"
+        mcp_dir = self.repo_root / "mcp" / "registry"
 
         # Emit plugin.json
         plugin_json = self._build_plugin_json(product, graph)
@@ -66,11 +74,41 @@ class ClaudeCodeAdapter(TargetAdapter):
                 continue
             self._emit_agent(agent, out_dir, result)
 
-        # Capabilities this adapter does NOT yet implement
-        result.unsupported.extend([
-            "hooks (hooks/hooks.json — pending hook canonical model)",
-            ".mcp.json (pending MCP registry implementation)",
-        ])
+        from agent_toolkit.compiler.registry_emit import (
+            hooks_json_text,
+            mcp_json_text,
+            resolve_hook_ids,
+            resolve_mcp_ids,
+        )
+
+        hook_ids = resolve_hook_ids(
+            product.included_hooks,
+            target_id=self.target_id,
+            hooks_dir=hooks_dir,
+            emit_registries=emit_registries,
+        )
+        hooks_text = hooks_json_text(hook_ids, hooks_dir, self.target_id)
+        if hooks_text:
+            self._write_file(out_dir / "hooks" / "hooks.json", hooks_text, result)
+            result.emitted.append("hooks")
+
+        mcp_ids = resolve_mcp_ids(
+            product.included_mcp,
+            target_id=self.target_id,
+            registry_dir=mcp_dir,
+            emit_registries=emit_registries,
+        )
+        mcp_text = mcp_json_text(mcp_ids, mcp_dir, self.target_id)
+        if mcp_text:
+            self._write_file(out_dir / ".mcp.json", mcp_text, result)
+            result.emitted.append("mcp")
+
+        pending: list[str] = []
+        if not hook_ids:
+            pending.append("hooks (hooks/hooks.json — none included for this product)")
+        if not mcp_ids:
+            pending.append(".mcp.json (none included for this product)")
+        result.unsupported.extend(pending)
 
         return result
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
@@ -149,3 +149,16 @@ class ClaudeCodeAdapter(TargetAdapter):
             for k in FORBIDDEN_SETTINGS
             if k in settings
         ]
+
+    @staticmethod
+    def parity_notes() -> str:
+        """Return honest parity notes for certification docs."""
+        return (
+            "Claude Code plugin bundles emit skills, agents, and plugin.json under "
+            ".claude-plugin/. Hooks and .mcp.json are not generated yet — reported as "
+            "unsupported until the canonical hook model and MCP registry are wired in.\n"
+            "\n"
+            "Never ship or overwrite ~/.claude/settings.json from public profiles. "
+            "Plugin settings are plugin-local; users enable marketplace plugins in their "
+            "own settings file."
+        )

--- a/plugins/agent-toolkit-core/.mcp.json
+++ b/plugins/agent-toolkit-core/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/plugins/agent-toolkit-core/hooks/hooks.json
+++ b/plugins/agent-toolkit-core/hooks/hooks.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "agent-toolkit workspace context",
+        "timeout": 5000
+      }
+    ]
+  }
+}

--- a/schemas/mcp-provider.schema.yaml
+++ b/schemas/mcp-provider.schema.yaml
@@ -1,0 +1,44 @@
+# JSON Schema for canonical MCP provider definitions (mcp/registry/*.yaml)
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/mcp-provider.schema.yaml"
+title: "agent-toolkit MCP Provider"
+type: object
+required: [id, display_name, purpose, implementation, auth, platforms]
+additionalProperties: true
+properties:
+  id:
+    type: string
+    pattern: "^[a-z][a-z0-9-]*$"
+  display_name:
+    type: string
+    minLength: 1
+  purpose:
+    type: string
+  implementation:
+    type: object
+    required: [provenance, package]
+    properties:
+      provenance:
+        type: string
+        enum: [official, community, vendor, unknown]
+      package:
+        type: string
+        minLength: 1
+  auth:
+    type: object
+    properties:
+      env:
+        type: array
+        items:
+          type: string
+          pattern: "^[A-Z][A-Z0-9_]*$"
+  tools:
+    type: object
+    properties:
+      read: {type: array, items: {type: string}}
+      write: {type: array, items: {type: string}}
+      destructive: {type: array, items: {type: string}}
+  platforms:
+    type: object
+    additionalProperties:
+      type: string

--- a/tests/compiler/test_claude_code_adapter.py
+++ b/tests/compiler/test_claude_code_adapter.py
@@ -50,11 +50,21 @@ def test_no_dangerous_mode_bypass(adapter, graph):
             assert "skipDangerousModePermissionPrompt" not in data
 
 
-def test_unsupported_reported(adapter, graph):
+def test_hooks_and_mcp_emitted(adapter, graph):
     product = graph.products["agent-toolkit-core"]
     result = adapter.compile(graph, product)
+    out = adapter.output_root / "agent-toolkit-core"
+    assert (out / "hooks" / "hooks.json").exists()
+    assert (out / ".mcp.json").exists()
+    assert "hooks" in result.emitted
+    assert "mcp" in result.emitted
+
+
+def test_agents_product_reports_pending_registries(adapter, graph):
+    product = graph.products["agent-toolkit-agents"]
+    result = adapter.compile(graph, product)
     unsupported = " ".join(result.unsupported).lower()
-    assert "hook" in unsupported
+    assert "hooks" in unsupported
     assert "mcp" in unsupported
 
 

--- a/tests/compiler/test_claude_code_adapter.py
+++ b/tests/compiler/test_claude_code_adapter.py
@@ -71,3 +71,25 @@ def test_all_products(adapter, graph, product_id):
         pytest.skip(f"Product {product_id} not defined")
     result = adapter.compile(graph, graph.products[product_id])
     assert result.errors == []
+
+
+def test_plugin_manifest_uses_claude_plugin_dir(adapter, graph):
+    """Official contract: manifest lives under .claude-plugin/, not plugin root."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+    manifest = adapter.output_root / "agent-toolkit-core" / ".claude-plugin" / "plugin.json"
+    wrong = adapter.output_root / "agent-toolkit-core" / "plugin.json"
+    assert manifest.is_file()
+    assert not wrong.exists()
+
+
+def test_validate_settings_rejects_dangerous_bypass():
+    errors = ClaudeCodeAdapter.validate_settings({"skipDangerousModePermissionPrompt": True})
+    assert errors
+
+
+def test_parity_notes_document_plugin_local_settings():
+    notes = ClaudeCodeAdapter.parity_notes()
+    assert "settings.json" in notes.lower() or "plugin-local" in notes.lower()
+    assert "hook" in notes.lower()
+    assert "mcp" in notes.lower()

--- a/tests/compiler/test_codex_adapter.py
+++ b/tests/compiler/test_codex_adapter.py
@@ -325,6 +325,30 @@ def test_parity_notes_documented():
     assert "codex-plugin" in notes.lower(), "Parity notes must document the manifest path"
 
 
+def test_agent_skills_layout(adapter, graph):
+    """Skills and agents follow Agent Skills convention (agentskills.io alignment)."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    out_dir = adapter.output_root / "agent-toolkit-core"
+    skill_mds = list((out_dir / "skills").rglob("SKILL.md"))
+    agent_mds = list((out_dir / "agents").rglob("AGENT.md"))
+
+    assert skill_mds, "skills/<name>/SKILL.md required for Agent Skills alignment"
+    assert agent_mds, "agents/<name>/AGENT.md required for agent personas"
+    for skill_md in skill_mds:
+        assert skill_md.parent.name != "skills", "Skills must be nested skills/<name>/SKILL.md"
+
+
+def test_maturity_must_remain_experimental_contract():
+    """Contract guard: Codex must stay experimental until official API stabilizes."""
+    assert CodexAdapter.maturity == "experimental"
+    notes = CodexAdapter.parity_notes().lower()
+    assert "stable" in notes or "must not" in notes or "not be changed" in notes, (
+        "Parity notes must warn against premature stable labeling"
+    )
+
+
 # ── all products ──────────────────────────────────────────────────────────────
 
 

--- a/tests/compiler/test_registry_emission.py
+++ b/tests/compiler/test_registry_emission.py
@@ -1,0 +1,99 @@
+"""Tests for registry-based hooks/MCP emission."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.registry_emit import (
+    emit_claude_hooks_json,
+    emit_claude_mcp_json,
+    resolve_hook_ids,
+    resolve_mcp_ids,
+)
+from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+HOOKS_DIR = REPO_ROOT / "capabilities" / "hooks"
+MCP_DIR = REPO_ROOT / "mcp" / "registry"
+
+
+@pytest.fixture
+def graph():
+    return load_graph(REPO_ROOT)
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    return ClaudeCodeAdapter(tmp_path / "plugins", REPO_ROOT)
+
+
+def test_resolve_hooks_from_product():
+    ids = resolve_hook_ids(
+        ["session-start-context"],
+        target_id="claude-code",
+        hooks_dir=HOOKS_DIR,
+    )
+    assert ids == ["session-start-context"]
+
+
+def test_emit_registries_includes_supported_hooks():
+    ids = resolve_hook_ids(
+        [],
+        target_id="claude-code",
+        hooks_dir=HOOKS_DIR,
+        emit_registries=True,
+    )
+    assert "session-start-context" in ids
+
+
+def test_emit_claude_hooks_json():
+    payload = emit_claude_hooks_json(["session-start-context"], HOOKS_DIR)
+    assert payload is not None
+    assert "SessionStart" in payload["hooks"]
+    assert payload["hooks"]["SessionStart"][0]["command"] == "agent-toolkit workspace context"
+
+
+def test_emit_claude_mcp_json():
+    payload = emit_claude_mcp_json(["github"], MCP_DIR)
+    assert payload is not None
+    assert "github" in payload["mcpServers"]
+    assert payload["mcpServers"]["github"]["env"]["GITHUB_TOKEN"] == "${GITHUB_TOKEN}"
+
+
+def test_adapter_emits_hooks_and_mcp(adapter, graph):
+    product = graph.products["agent-toolkit-core"]
+    result = adapter.compile(graph, product)
+    out = adapter.output_root / "agent-toolkit-core"
+    assert (out / "hooks" / "hooks.json").is_file()
+    assert (out / ".mcp.json").is_file()
+    assert "hooks" in result.emitted
+    assert "mcp" in result.emitted
+
+    hooks = json.loads((out / "hooks" / "hooks.json").read_text())
+    mcp = json.loads((out / ".mcp.json").read_text())
+    assert "SessionStart" in hooks["hooks"]
+    assert "github" in mcp["mcpServers"]
+
+
+def test_agents_product_without_hooks_mcp(adapter, graph):
+    product = graph.products["agent-toolkit-agents"]
+    result = adapter.compile(graph, product)
+    out = adapter.output_root / "agent-toolkit-agents"
+    assert not (out / "hooks" / "hooks.json").exists()
+    assert not (out / ".mcp.json").exists()
+    assert any("hooks" in u for u in result.unsupported)
+
+
+def test_emit_registries_flag(adapter, graph):
+    product = graph.products["agent-toolkit-agents"]
+    result = adapter.compile(graph, product, emit_registries=True)
+    out = adapter.output_root / "agent-toolkit-agents"
+    assert (out / "hooks" / "hooks.json").is_file()
+    assert (out / ".mcp.json").is_file()
+    mcp_ids = resolve_mcp_ids([], target_id="claude-code", registry_dir=MCP_DIR, emit_registries=True)
+    assert mcp_ids  # at least github from registry

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -15,11 +15,29 @@ pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.model import CanonicalGraph, Skill, Agent, Product, Stability
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+from agent_toolkit.compiler.targets.codex import CodexAdapter
+from agent_toolkit.compiler.targets.copilot import CopilotCLIAdapter, CopilotRepositoryAdapter
 from agent_toolkit.compiler.targets.cursor import CursorAdapter
+from agent_toolkit.compiler.targets.gemini_cli import GeminiCLIAdapter
 from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
+from agent_toolkit.compiler.targets.pi import PiAdapter
+from agent_toolkit.compiler.targets.windsurf import WindsurfAdapter
 
 FIXTURES_DIR = Path(__file__).parent / "golden" / "fixtures"
 REPO_ROOT = Path(__file__).parent.parent
+
+# All nine compiler adapters (matches build.py available_targets count).
+ALL_ADAPTERS = [
+    ClaudeCodeAdapter,
+    CursorAdapter,
+    OpenCodeAdapter,
+    GeminiCLIAdapter,
+    CopilotCLIAdapter,
+    CopilotRepositoryAdapter,
+    PiAdapter,
+    WindsurfAdapter,
+    CodexAdapter,
+]
 
 
 def build_fixture_graph() -> CanonicalGraph:
@@ -60,9 +78,7 @@ def content_digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
 
 
-@pytest.mark.parametrize("adapter_cls", [
-    ClaudeCodeAdapter, CursorAdapter, OpenCodeAdapter
-])
+@pytest.mark.parametrize("adapter_cls", ALL_ADAPTERS)
 def test_output_is_deterministic(adapter_cls):
     """Same input must produce identical output on every run."""
     graph = build_fixture_graph()
@@ -92,9 +108,7 @@ def test_output_is_deterministic(adapter_cls):
     )
 
 
-@pytest.mark.parametrize("adapter_cls", [
-    ClaudeCodeAdapter, CursorAdapter, OpenCodeAdapter
-])
+@pytest.mark.parametrize("adapter_cls", ALL_ADAPTERS)
 def test_no_machine_paths_in_output(adapter_cls):
     """Generated files must not contain absolute machine paths."""
     graph = build_fixture_graph()
@@ -103,7 +117,25 @@ def test_no_machine_paths_in_output(adapter_cls):
         adapter = adapter_cls(Path(d), REPO_ROOT)
         adapter.compile(graph, graph.products["fixture-product"])
         for f in sorted(Path(d).rglob("*")):
-            if f.is_file() and f.suffix in (".md", ".json", ".yaml", ".toml"):
+            if f.is_file() and f.suffix in (".md", ".json", ".yaml", ".toml", ".agent"):
                 text = f.read_text(errors="replace")
                 assert "/home/" not in text, f"Machine /home/ path in {f}"
                 assert str(Path.home()) not in text
+
+
+def test_all_nine_adapters_covered():
+    """Guard: golden suite must track every adapter in build.py available_targets."""
+    assert len(ALL_ADAPTERS) == 9
+    names = {cls.__name__ for cls in ALL_ADAPTERS}
+    expected = {
+        "ClaudeCodeAdapter",
+        "CursorAdapter",
+        "OpenCodeAdapter",
+        "GeminiCLIAdapter",
+        "CopilotCLIAdapter",
+        "CopilotRepositoryAdapter",
+        "PiAdapter",
+        "WindsurfAdapter",
+        "CodexAdapter",
+    }
+    assert names == expected

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -121,11 +121,12 @@ def test_all_hooks_validate_against_schema():
 def test_registry_loads_all_hook_files():
     """load_hooks must not silently skip broken definitions."""
     yaml_files = _hook_yaml_files()
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, errors = load_hooks(HOOKS_DIR)
     assert len(hooks) == len(yaml_files), (
         f"Expected {len(yaml_files)} hooks loaded, got {len(hooks)} — "
         "check for silent parse failures in hook_registry.load_hooks"
     )
+    assert errors == []
 
 
 def test_registry_loads_hooks():
@@ -143,7 +144,7 @@ def test_hooks_have_required_fields():
 
 def test_no_placeholder_handlers_in_default_enabled_hooks():
     """Production hooks (default_enabled) must not use stub/placeholder commands."""
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     for hook in hooks.values():
         if not hook.default_enabled:
             continue
@@ -159,7 +160,7 @@ def test_no_placeholder_handlers_in_default_enabled_hooks():
 
 def test_opt_in_hooks_with_placeholders_are_documented():
     """Opt-in hooks may stub handlers but must stay disabled by default."""
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     for hook in hooks.values():
         if hook.default_enabled:
             continue
@@ -222,5 +223,6 @@ def test_broken_canonical_hook_would_fail_file_count_check(tmp_path):
     (tmp_path / "good-hook.yaml").write_text(good.read_text(encoding="utf-8"), encoding="utf-8")
 
     yaml_files = sorted(tmp_path.glob("*.yaml"))
-    hooks = load_hooks(tmp_path)
+    hooks, errors = load_hooks(tmp_path)
     assert len(hooks) < len(yaml_files), "Broken hook YAML must not load silently without detection"
+    assert errors, "Broken hook YAML must be reported in errors"

--- a/tests/test_mcp_cli.py
+++ b/tests/test_mcp_cli.py
@@ -1,0 +1,45 @@
+"""Tests for MCP CLI health/setup/uninstall surface."""
+from __future__ import annotations
+
+import json
+
+from agent_toolkit.cli.mcp import cmd_mcp
+
+
+def test_mcp_help_lists_health_and_uninstall(capsys):
+    rc = cmd_mcp(["--help"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "health" in out
+    assert "uninstall" in out
+    assert "setup" in out
+
+
+def test_mcp_health_github_offline(capsys):
+    rc = cmd_mcp(["health", "github"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "GITHUB_TOKEN" in out
+    assert "registry:" in out
+
+
+def test_mcp_health_unknown_provider(capsys):
+    rc = cmd_mcp(["health", "not-a-real-provider"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Not in mcp/registry" in out
+
+
+def test_mcp_uninstall_removes_provider(tmp_path, monkeypatch, capsys):
+    cfg_dir = tmp_path / ".config" / "agent-toolkit"
+    cfg_dir.mkdir(parents=True)
+    cfg_path = cfg_dir / "mcp-config.json"
+    cfg_path.write_text(
+        json.dumps({"providers": {"github": {"enabled": True, "required_env": ["GITHUB_TOKEN"]}}})
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    rc = cmd_mcp(["uninstall", "github"])
+    assert rc == 0
+    data = json.loads(cfg_path.read_text())
+    assert "github" not in data["providers"]

--- a/tests/test_mcp_templates.py
+++ b/tests/test_mcp_templates.py
@@ -1,0 +1,51 @@
+"""Validate MCP templates align with registry packages (no invented binaries)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.mcp_registry import load_registry
+
+REPO_ROOT = Path(__file__).parent.parent
+REGISTRY_DIR = REPO_ROOT / "mcp" / "registry"
+TEMPLATES_DIR = REPO_ROOT / "mcp" / "templates"
+
+
+def _stdio_templates() -> list[tuple[str, dict]]:
+    out: list[tuple[str, dict]] = []
+    for provider_dir in sorted(TEMPLATES_DIR.iterdir()):
+        if not provider_dir.is_dir():
+            continue
+        template_file = provider_dir / "config.template.json"
+        if not template_file.is_file():
+            continue
+        data = json.loads(template_file.read_text())
+        if data.get("transport") in ("streamable_http", "http"):
+            continue
+        out.append((provider_dir.name, data))
+    return out
+
+
+def test_stdio_templates_use_npx_with_registry_package():
+    providers, _ = load_registry(REGISTRY_DIR)
+    for name, template in _stdio_templates():
+        provider = providers.get(name)
+        assert provider is not None, f"Missing registry entry for template {name}"
+        assert template.get("command") == "npx", f"{name}: stdio templates must use npx"
+        args = template.get("args", [])
+        assert args[:2] == ["-y", provider.package], (
+            f"{name}: args must be ['-y', {provider.package!r}], got {args!r}"
+        )
+
+
+def test_registry_providers_have_required_fields():
+    providers, errors = load_registry(REGISTRY_DIR)
+    assert not errors, errors
+    for pid, provider in providers.items():
+        assert provider.display_name
+        assert provider.package
+        assert provider.env_vars is not None


### PR DESCRIPTION
## Summary
- Add `agent-toolkit mcp health` for offline registry + env var validation (no network)
- Add `agent-toolkit mcp uninstall <provider>` to remove providers from local config
- Add `--offline` flag for setup/doctor to skip connectivity checks
- Fix stdio MCP templates to use `npx -y <registry package>` instead of invented binaries
- Add `schemas/mcp-provider.schema.yaml` and template/registry alignment tests

Closes #75

## Test plan
- [x] `uv run pytest tests/test_mcp_cli.py tests/test_mcp_templates.py`
- [x] `uv run pytest`