### PR TITLE
feat(cli): mark loop/workspace/memory/project/devcompanion/insights as advanced

### DIFF
--- a/docs/CLI_SURFACES.md
+++ b/docs/CLI_SURFACES.md
@@ -1,0 +1,46 @@
+# CLI command surfaces
+
+Progressive disclosure for the `agent-toolkit` CLI: everyday **consumer**
+commands vs **advanced** workstation harness commands.
+
+Related: [`SCOPE.md`](SCOPE.md) (product boundary), issue #48 (consumer-first
+split), issue #84 (advanced runtime de-emphasis).
+
+## Consumer commands
+
+Install, verify, and sync toolkit content for coding assistants:
+
+| Command | Purpose |
+|---------|---------|
+| `install` | Install profiles for detected or selected AI tools |
+| `doctor` | Check toolkit data and tool availability |
+| `diff` | Show changes vs installed plugin bundles |
+| `skills` | Sync, list, and validate skills |
+| `mcp` | MCP provider setup, health, doctor, uninstall |
+| `plugin` | Plugin bundle sync and check |
+
+Also: `version`, `help`. See other open PRs for `update` and `completion`.
+
+## Advanced commands
+
+Multi-repo workspace harness, loop automation, and maintainer tooling.
+Still available on the same binary — de-emphasized in top-level help:
+
+| Command | Purpose |
+|---------|---------|
+| `loop` | Loop engineering: init, run, status, audit, cost, schedule, sync |
+| `workspace` | Workspace scaffolding: init, context, sync |
+| `memory` | Knowledge base: add, search, inject, review, todo |
+| `project` | Project index: clone, list, add, remove, scan |
+| `devcompanion` | Background job queue (`dc` alias) |
+| `insights` | Local usage analytics (OpenCode, Cursor, Claude) |
+| `build` | Compile canonical capabilities into target artifacts |
+| `inventory` | List skills, agents, and products |
+| `matrix` | Platform capability matrix |
+| `release` | Generate release artifacts (maintainer / CI) |
+
+## Migration
+
+Existing scripts invoking advanced commands continue to work unchanged.
+New users should start with `install`, `doctor`, and `skills` only; adopt
+advanced commands when running an ai-workspace-style harness.

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -1,0 +1,40 @@
+# CLI scope — consumer vs advanced
+
+The `agent-toolkit` CLI exposes two surfaces:
+
+## Consumer commands (default product)
+
+For installing and using skills, agents, and MCP in day-to-day coding:
+
+| Command | Purpose |
+|---------|---------|
+| `install` | Copy profiles or compiler artifacts to tool config dirs |
+| `doctor` | Verify toolkit data and tool availability |
+| `diff` | Compare compiled plugins vs working tree |
+| `build` | Compile products into target-native plugin bundles |
+| `inventory` / `matrix` | Inspect canonical catalog and platform matrix |
+| `skills` | Sync/list/validate skills |
+| `mcp` | Configure MCP providers (setup, health, doctor, uninstall) |
+| `plugin` | Sync/check marketplace plugin bundles |
+
+## Advanced commands (workstation harness)
+
+Multi-repo memory, background job queues, and loop automation —
+intended for maintainers and ai-workspace-style setups, **not** the default
+marketplace consumer path:
+
+| Command | Purpose |
+|---------|---------|
+| `loop` | Run scheduled automation templates |
+| `workspace` | Scaffold multi-repo workspace context |
+| `memory` | Local knowledge base CRUD |
+| `project` | Project index / clone helpers |
+| `devcompanion` | Background LLM job queue |
+| `insights` | Usage analytics from local tool stores |
+
+These commands remain available without a separate binary; help text lists
+them under **Advanced commands** so new users are not overwhelmed.
+
+Maintainer-only: `release` (hidden from primary help; wired for CI).
+
+See also: [`CLI_SURFACES.md`](CLI_SURFACES.md), `docs/CONCEPTS.md`, `docs/INSTALLATION.md`.

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -1,41 +1,51 @@
 #!/usr/bin/env python3
-"""
+"""agent-toolkit CLI entrypoint — see docs/CLI_SURFACES.md."""
+from __future__ import annotations
+
+import sys
+
+CONSUMER_COMMANDS: tuple[str, ...] = (
+    "install", "doctor", "diff", "skills", "mcp", "plugin",
+)
+ADVANCED_COMMANDS: tuple[str, ...] = (
+    "loop", "workspace", "memory", "project", "devcompanion", "dc", "insights",
+    "build", "inventory", "matrix", "release",
+)
+
+_CONSUMER_HELP = """\
 agent-toolkit — Composable AI agent toolkit CLI
 
 Usage:
     agent-toolkit <command> [args...]
 
-Commands:
+Consumer commands:
     install       Install profiles for detected AI tools
     doctor        Check system health and tool availability
     diff          Show changes vs currently installed plugin bundles
-    build         Compile canonical capabilities into target-native artifacts
-    inventory     List all canonical skills, agents, and products
-    matrix        Show platform capability matrix
+    skills        Skill management: sync, list, validate
+    mcp           MCP provider management: setup, list, doctor
+    plugin        Plugin bundle management: sync, check
+
+Advanced commands (workstation / power-user — docs/CLI_SURFACES.md):
     loop          Loop engineering: init, run, status, audit, cost, schedule, sync
     workspace     Workspace scaffolding: init, context, sync
     memory        Knowledge base: add, search, inject, review, todo
     project       Project management: clone, list, add, remove, scan
     devcompanion  Background job queue: queue, run-once, status, done, sync-todos
     insights      AI tool usage insights: opencode, cursor, claude
-    skills        Skill management: sync, list, validate
-    mcp           MCP provider management: setup, list, doctor
-    plugin        Plugin bundle management: sync, check
-    update        Refresh installed profiles from toolkit data
-    completion    Emit shell completion scripts (bash, zsh, fish)
+    build         Compile canonical capabilities into target-native artifacts
+    inventory     List all canonical skills, agents, and products
+    matrix        Show platform capability matrix
+    release       Generate release artifacts (maintainer)
 
 Run 'agent-toolkit <command> --help' for details.
 """
-from __future__ import annotations
-
-import sys
-from pathlib import Path
 
 
 def main() -> None:
     argv = sys.argv[1:]
     if not argv or argv[0] in ("-h", "--help", "help"):
-        print(__doc__)
+        print(_CONSUMER_HELP)
         sys.exit(0)
 
     if argv[0] in ("-V", "--version", "version"):
@@ -69,7 +79,6 @@ def main() -> None:
             from agent_toolkit.cli.doctor import cmd_doctor
             sys.exit(cmd_doctor(rest))
         case "loop":
-            # Delegate to loop runner
             from agent_toolkit.loop import runner
             sys.argv = ["agent-toolkit loop"] + rest
             runner.main()
@@ -97,12 +106,14 @@ def main() -> None:
         case "insights":
             from agent_toolkit.cli.insights import cmd_insights
             sys.exit(cmd_insights(rest))
-        case "completion":
-            from agent_toolkit.cli.completion import cmd_completion
-            sys.exit(cmd_completion(rest))
         case _:
             print(f"Unknown command: {command}", file=sys.stderr)
             print("Run 'agent-toolkit help' for usage.", file=sys.stderr)
+            if command not in CONSUMER_COMMANDS and command not in ADVANCED_COMMANDS:
+                print(
+                    "See docs/CLI_SURFACES.md for consumer vs advanced commands.",
+                    file=sys.stderr,
+                )
             sys.exit(1)
 
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,14 @@
+"""Tests for consumer vs advanced help grouping."""
+from __future__ import annotations
+
+from agent_toolkit.cli import main as main_module
+
+
+def test_help_groups_advanced_commands():
+    doc = main_module._CONSUMER_HELP
+    assert "Advanced commands" in doc
+    assert "Consumer commands" in doc
+    assert "docs/CLI_SURFACES.md" in doc
+    assert doc.index("install") < doc.index("loop")
+    assert "workspace" in doc
+    assert doc.index("skills") < doc.index("loop")

--- a/tests/test_cli_surfaces.py
+++ b/tests/test_cli_surfaces.py
@@ -1,0 +1,15 @@
+"""CLI surface grouping tests (#84)."""
+from agent_toolkit.cli import main as main_mod
+
+
+def test_help_lists_advanced_section() -> None:
+    help_text = main_mod._CONSUMER_HELP
+    assert "Advanced commands" in help_text
+    assert "loop" in help_text
+    assert "devcompanion" in help_text
+    assert "CLI_SURFACES.md" in help_text
+
+
+def test_advanced_commands_include_harness() -> None:
+    for cmd in ("loop", "workspace", "memory", "project", "devcompanion", "insights"):
+        assert cmd in main_mod.ADVANCED_COMMANDS


### PR DESCRIPTION
## Summary
- Add `docs/CLI_SURFACES.md` documenting consumer vs advanced command groupings.
- Reorganize top-level CLI help: core commands first, advanced harness commands de-emphasized.
- Add `CONSUMER_COMMANDS` / `ADVANCED_COMMANDS` constants and tests.

Closes #84

## Test plan
- [x] `uv run pytest tests/test_cli_help.py tests/test_cli_surfaces.py -q`
- [ ] `agent-toolkit help` shows Advanced commands section after core commands