### PR TITLE
feat(compiler): wire provenance sidecar into compile and plugin check (#67)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -122,10 +122,12 @@ def cmd_build(args: list[str]) -> int:
 
         for product in products_to_build:
             print(f"  Building {product.id} → {target_id}...")
+            adapter._provenance_records = []
             if parsed.check:
                 result = adapter.check(graph, product)
             else:
                 result = adapter.compile(graph, product)
+                adapter._finalize_provenance(product, result)
 
             all_results.append(result)
             print(result.report())

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/plugin.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/plugin.py
@@ -177,9 +177,38 @@ def _cmd_sync(toolkit_dir: Path) -> int:
     return _run_gen_surfaces(toolkit_dir, check=False)
 
 
+def _check_provenance_sidecars(plugins_dir: Path) -> bool:
+    """Verify compiled plugin bundles include .provenance.json (#67)."""
+    ok = True
+    if not plugins_dir.is_dir():
+        return ok
+    for product_dir in sorted(p for p in plugins_dir.iterdir() if p.is_dir()):
+        prov = product_dir / ".provenance.json"
+        if not prov.is_file():
+            print(f"  ⚠  Missing provenance sidecar: {product_dir.name}/.provenance.json")
+            print("     Run: agent-toolkit build --target <target> --product <product>")
+            ok = False
+            continue
+        try:
+            import json
+
+            data = json.loads(prov.read_text(encoding="utf-8"))
+            if "artifacts" not in data or "generatorVersion" not in data:
+                print(f"  ✗  Invalid provenance manifest: {prov}")
+                ok = False
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"  ✗  Cannot read provenance: {prov} ({exc})")
+            ok = False
+    return ok
+
+
 def _cmd_check(toolkit_dir: Path) -> int:
     """Verify plugin bundles are in sync. Exit 1 if drift detected."""
-    return _run_gen_surfaces(toolkit_dir, check=True)
+    code = _run_gen_surfaces(toolkit_dir, check=True)
+    plugins_dir = toolkit_dir / "plugins"
+    if not _check_provenance_sidecars(plugins_dir):
+        return 1
+    return code
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 from agent_toolkit.compiler.model import CanonicalGraph, CompilationResult, Product
+from agent_toolkit.compiler.provenance import ArtifactRecord, file_digest, write_provenance
 
 
 class TargetAdapter(ABC):
@@ -18,6 +19,7 @@ class TargetAdapter(ABC):
     def __init__(self, output_root: Path, repo_root: Path):
         self.output_root = output_root
         self.repo_root = repo_root
+        self._provenance_records: list[ArtifactRecord] = []
 
     @abstractmethod
     def compile(
@@ -35,24 +37,88 @@ class TargetAdapter(ABC):
         """Dry-run: validate without writing any files to disk.
 
         Uses a temporary directory that is discarded after compilation,
-        so the real output_root is never touched.
+        so the real output_root is never touched. Provenance is generated
+        in the temp dir to validate the sidecar would be emitted (#67).
         """
         with tempfile.TemporaryDirectory(prefix="agent-toolkit-check-") as tmpdir:
-            # Temporarily redirect output to the throwaway temp dir
             real_output_root = self.output_root
             self.output_root = Path(tmpdir)
+            self._provenance_records = []
             try:
                 result = self.compile(graph, product)
+                self._finalize_provenance(product, result)
             finally:
                 self.output_root = real_output_root
+                self._provenance_records = []
 
         # Artifacts were in the temp dir (now deleted) — report paths as relative
         # so callers know what WOULD have been created, but clear actual paths
         result.artifacts.clear()
         return result
 
-    def _write_file(self, path: Path, content: str, result: CompilationResult) -> None:
-        """Write content to path and record it in result.artifacts."""
+    def _write_file(
+        self,
+        path: Path,
+        content: str,
+        result: CompilationResult,
+        *,
+        source_file: str | Path | None = None,
+    ) -> None:
+        """Write content to path and record it in result.artifacts (+ provenance)."""
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         result.artifacts.append(path)
+
+        source = str(source_file) if source_file is not None else "generated"
+        try:
+            rel = str(path.relative_to(self.output_root))
+        except ValueError:
+            rel = path.name
+        src_path = Path(source_file) if source_file is not None else None
+        self._provenance_records.append(
+            ArtifactRecord(
+                path=rel,
+                source_file=source,
+                source_digest=file_digest(src_path) if src_path and src_path.exists() else "n/a",
+                generated_digest=file_digest(path),
+            )
+        )
+
+    def _record_binary_artifact(
+        self,
+        path: Path,
+        result: CompilationResult,
+        *,
+        source_file: str | Path | None = None,
+    ) -> None:
+        """Record a copied binary artifact for provenance (e.g. references/)."""
+        result.artifacts.append(path)
+        source = str(source_file) if source_file is not None else "generated"
+        try:
+            rel = str(path.relative_to(self.output_root))
+        except ValueError:
+            rel = path.name
+        src_path = Path(source_file) if source_file is not None else None
+        self._provenance_records.append(
+            ArtifactRecord(
+                path=rel,
+                source_file=source,
+                source_digest=file_digest(src_path) if src_path and src_path.exists() else "n/a",
+                generated_digest=file_digest(path),
+            )
+        )
+
+    def _finalize_provenance(self, product: Product, result: CompilationResult) -> None:
+        """Write .provenance.json under the product output directory (#67)."""
+        out_dir = self.output_root / product.id
+        if not out_dir.exists():
+            return
+        path = write_provenance(
+            out_dir,
+            product.id,
+            self.target_id,
+            list(self._provenance_records),
+        )
+        result.artifacts.append(path)
+        result.emitted.append("provenance")
+        self._provenance_records = []

--- a/tests/test_provenance_wired.py
+++ b/tests/test_provenance_wired.py
@@ -1,0 +1,39 @@
+"""Provenance sidecar is emitted on compile and build --check (#67)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_compile_writes_provenance(tmp_path):
+    graph = load_graph(REPO)
+    product = graph.products["agent-toolkit-core"]
+    adapter = ClaudeCodeAdapter(tmp_path / "plugins", REPO)
+    adapter._provenance_records = []
+    result = adapter.compile(graph, product)
+    adapter._finalize_provenance(product, result)
+    prov = tmp_path / "plugins" / "agent-toolkit-core" / ".provenance.json"
+    assert prov.is_file(), "expected .provenance.json"
+    assert "provenance" in result.emitted
+    data = json.loads(prov.read_text())
+    assert data["product"] == product.id
+    assert data["target"] == "claude-code"
+    assert len(data["artifacts"]) >= 1
+
+
+def test_build_check_emits_provenance_in_temp(tmp_path):
+    graph = load_graph(REPO)
+    product = graph.products["agent-toolkit-core"]
+    adapter = ClaudeCodeAdapter(tmp_path / "plugins", REPO)
+    result = adapter.check(graph, product)
+    assert "provenance" in result.emitted
+    assert not (tmp_path / "plugins" / product.id / ".provenance.json").exists()


### PR DESCRIPTION
## Summary
- Emit `.provenance.json` on `agent-toolkit build` via `_finalize_provenance` in target adapters
- `build --check` generates provenance in a temp dir to validate the sidecar without writing to disk
- `plugin check` validates provenance sidecars exist under `plugins/<product>/`

## Test plan
- [x] `uv run pytest tests/test_provenance_wired.py tests/test_provenance.py`
- [ ] `uv run agent-toolkit build --target claude-code --product agent-toolkit-core` and confirm `.provenance.json`

Closes #67