### PR TITLE
feat(catalogs): generate skill/agent/loop catalogs from filesystem

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,6 +92,19 @@ jobs:
       - name: Assert plugin surfaces are in sync with canonical sources
         run: python3 scripts/gen-surfaces.py --check
 
+  # ── Job 4b: Catalog drift check ───────────────────────────────────────────
+  check-catalogs:
+    name: Check Catalog Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PyYAML
+        run: pip install pyyaml==6.0.2
+
+      - name: Assert catalogs match skills/agents/loops filesystem
+        run: python3 scripts/generate-catalogs.py --check
+
   # ── Job 5: Validate loop.yaml files against loop.schema.json ──────────────
   validate-loops:
     name: Validate Loop Templates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,14 @@ Profiles translate toolkit skills into tool-specific configuration.
 | `chore/` | Maintenance: dependency update, script fix, catalog regeneration |
 | `schema/` | Changes to JSON schemas |
 
+After adding or removing skills, agents, or loop templates, regenerate catalogs:
+
+```bash
+python3 scripts/generate-catalogs.py
+```
+
+CI runs `python3 scripts/generate-catalogs.py --check` — commit catalog updates with your change.
+
 Examples:
 
 ```
@@ -213,7 +221,7 @@ Before submitting a PR, confirm the following:
 - [ ] Branch name follows the naming convention above
 - [ ] `bash scripts/validate-skills.sh` passes with exit 0
 - [ ] `bash scripts/validate-loops.sh` passes with exit 0 (if you added/modified loops)
-- [ ] `bash scripts/build-catalog.sh` was run and catalog changes are included in the commit
+- [ ] `python3 scripts/generate-catalogs.py --check` passes (if you added/removed skills, agents, or loops)
 - [ ] `SKILL.md` frontmatter is complete (name, description, author, version, tags, domain)
 - [ ] `skill.json` compatibility matrix is accurate — only mark `true` for tools you have verified
 - [ ] No secrets, API keys, or credentials in any file

--- a/catalogs/agent-catalog.yaml
+++ b/catalogs/agent-catalog.yaml
@@ -1,202 +1,75 @@
-# agent-toolkit — Agent Catalog
-# Role hierarchy and handoff map for all agent personas.
-#
-# Agents are deployed per AI tool via the toolkit installer.
-# Each entry maps to an agent definition file under agents/<name>/
-#
-# fields:
-#   name:     kebab-case identifier matching the agent's frontmatter name
-#   role:     short functional description (snake_case)
-#   domain:   orchestration | review | design | testing | ops | delivery
-#   triggers: when to invoke this agent (prefer specific over vague)
-#   handoffs: agent names this agent is expected to delegate to
-
 version: 1
-
+generated: true
+count: 16
 agents:
-
-  # ── Orchestration ────────────────────────────────────────────────────────────
-
-  - name: architect
-    role: system_design_and_adrs
-    domain: orchestration
-    triggers:
-      - System or service design task
-      - Architecture decision needed
-      - Evaluate technical tradeoffs
-      - Design distributed system component
-      - Choose between competing implementation strategies
-    handoffs:
-      - planner
-      - code-reviewer
-      - security-reviewer
-
-  - name: assistant
-    role: primary_orchestrator_and_fallback
-    domain: orchestration
-    triggers:
-      - Default entry point when no specialized agent is obvious
-      - Repo inspection and convention verification
-      - Multi-agent coordination across domains
-      - Ambiguous or cross-cutting tasks
-    handoffs:
-      - architect
-      - planner
-      - code-reviewer
-      - security-reviewer
-      - docs-lookup
-      - tech-assistant
-
-  - name: planner
-    role: feature_and_iteration_planning
-    domain: orchestration
-    triggers:
-      - Feature breakdown into tasks or stories
-      - Sprint or iteration capacity planning
-      - Estimation and story-point assignment
-      - Dependency mapping for a delivery unit
-    handoffs:
-      - code-reviewer
-      - architect
-
-  - name: client-workflow-bootstrap
-    role: client_project_onboarding
-    domain: delivery
-    triggers:
-      - Onboard a new client project
-      - Bootstrap workflow skill pair for a client
-      - Generate client-specific delivery conventions
-    handoffs:
-      - assistant
-      - planner
-
-  # ── Review ───────────────────────────────────────────────────────────────────
-
-  - name: code-reviewer
-    role: code_quality_and_correctness_review
-    domain: review
-    triggers:
-      - Review a diff or PR for correctness
-      - Identify dead code, duplication, or complexity
-      - Validate implementation against requirements
-      - Post-implementation quality gate
-    handoffs: []
-
-  - name: database-reviewer
-    role: database_schema_and_query_review
-    domain: review
-    triggers:
-      - Review database schema migration
-      - Evaluate SQL query performance
-      - PostgreSQL index or constraint review
-      - Supabase RLS policy audit
-    handoffs: []
-
-  - name: performance-optimizer
-    role: performance_analysis_and_recommendations
-    domain: review
-    triggers:
-      - Profile slow code path or query
-      - Identify memory or CPU bottlenecks
-      - Benchmark comparison between implementations
-      - Performance regression investigation
-    handoffs: []
-
-  - name: security-reviewer
-    role: security_vulnerability_audit
-    domain: review
-    triggers:
-      - Security audit of code or configuration
-      - Check for secrets, injections, or insecure patterns
-      - OWASP or CVE-related review
-      - Dependency vulnerability assessment
-    handoffs: []
-
-  - name: typescript-reviewer
-    role: typescript_type_safety_review
-    domain: review
-    triggers:
-      - TypeScript or JavaScript type audit
-      - Strict mode compliance check
-      - Type inference or generics review
-      - JS-to-TS migration review
-    handoffs: []
-
-  # ── Design ───────────────────────────────────────────────────────────────────
-
-  - name: tech-assistant
-    role: technical_procedures_and_references
-    domain: design
-    triggers:
-      - Questions about internal technical procedures
-      - Architecture or infrastructure references
-      - Career development or training plans
-      - Lookup of internal runbooks
-    handoffs:
-      - architect
-      - docs-lookup
-      - reference-lookup
-
-  # ── Testing ──────────────────────────────────────────────────────────────────
-
-  - name: e2e-runner
-    role: playwright_end_to_end_test_execution
-    domain: testing
-    triggers:
-      - Run or write Playwright end-to-end tests
-      - Reproduce a UI regression with automation
-      - Validate user flows against a live environment
-      - Set up Playwright test suite from scratch
-    handoffs: []
-
-  - name: tdd-guide
-    role: test_driven_development_coach
-    domain: testing
-    triggers:
-      - Write tests before implementation
-      - TDD cycle: red → green → refactor
-      - Coverage gap analysis
-      - Unit or integration test scaffolding
-    handoffs: []
-
-  # ── Ops ──────────────────────────────────────────────────────────────────────
-
-  - name: build-error-resolver
-    role: build_and_type_error_triage
-    domain: ops
-    triggers:
-      - Build fails with compilation or type errors
-      - CI fails on lint or type check step
-      - npm, pnpm, or yarn install errors
-      - TypeScript or bundler error diagnosis
-    handoffs: []
-
-  - name: docs-lookup
-    role: documentation_and_api_reference_search
-    domain: ops
-    triggers:
-      - Fetch current library or framework docs
-      - API usage syntax or version migration
-      - SDK setup or configuration reference
-      - "How do I use X in Y version?"
-    handoffs: []
-
-  - name: reference-lookup
-    role: public_example_and_pattern_search
-    domain: ops
-    triggers:
-      - Find real-world implementation examples
-      - Locate community patterns for a problem
-      - Compare approaches across open-source projects
-      - Validate a design against public references
-    handoffs: []
-
-  - name: refactor-cleaner
-    role: dead_code_removal_and_simplification
-    domain: ops
-    triggers:
-      - Remove dead or unused code
-      - Simplify overly complex function or module
-      - Consolidate duplicate logic
-      - Cleanup after feature flag removal
-    handoffs: []
+- id: architect
+  name: architect
+  description: Software architecture and system design specialist. Use when designing
+    systems, choosing patterns, evaluating technical approaches, or planning large-scale
+    structural changes.
+- id: assistant
+  name: assistant
+  description: agent-toolkit Dev Companion — follows internal conventions and best
+    practices. Use for any work in agent-toolkit or client repositories to ensure
+    compliance with agent-toolkit standards.
+- id: build-error-resolver
+  name: build-error-resolver
+  description: Build and TypeScript error resolution specialist. Use proactively when
+    encountering compilation errors, type errors, lint failures, or CI pipeline failures.
+- id: client-workflow-bootstrap
+  name: client-workflow-bootstrap
+  description: agent-toolkit client workflow bootstrap specialist. Use when onboarding
+    a new client project or updating an existing delivery workflow skill pair. Conducts
+    a structured interview and generates <client
+- id: code-reviewer
+  name: code-reviewer
+  description: Expert code review specialist. Proactively reviews code for quality,
+    security, and maintainability. Use immediately after writing or modifying any
+    significant code.
+- id: database-reviewer
+  name: database-reviewer
+  description: PostgreSQL and database specialist. Use for schema design, query optimization,
+    migration review, index analysis, and ORM usage questions.
+- id: docs-lookup
+  name: docs-lookup
+  description: Documentation and API reference specialist. Use when searching for
+    framework docs, library APIs, configuration options, or usage examples.
+- id: e2e-runner
+  name: e2e-runner
+  description: End-to-end testing specialist using Playwright. Use when writing, debugging,
+    or running E2E tests, or when setting up Playwright test infrastructure.
+- id: performance-optimizer
+  name: performance-optimizer
+  description: Performance analysis and optimization specialist. Use when code is
+    slow, has memory leaks, fails performance benchmarks, or needs profiling.
+- id: planner
+  name: planner
+  description: Expert planning specialist for complex features and refactoring. Use
+    before starting any significant implementation to break down work, identify risks,
+    and create an actionable plan.
+- id: refactor-cleaner
+  name: refactor-cleaner
+  description: Dead code cleanup and refactoring specialist. Use when removing dead
+    code, simplifying complex functions, reducing duplication, or improving code structure
+    without changing behavior.
+- id: reference-lookup
+  name: reference-lookup
+  description: Lookup agent-toolkit reference examples and patterns from public examples.
+    Use when looking for official agent-toolkit examples, starter templates, or established
+    patterns in the agent-toolkit ecosyst
+- id: security-reviewer
+  name: security-reviewer
+  description: Security vulnerability detection specialist. Use proactively after
+    implementing authentication, data handling, API endpoints, or any user-facing
+    functionality.
+- id: tdd-guide
+  name: tdd-guide
+  description: Test-Driven Development specialist. Enforces write-tests-first methodology.
+    Use when implementing new features to ensure proper test coverage from the start.
+- id: tech-assistant
+  name: tech-assistant
+  description: Technical operations assistant — ops specialist
+- id: typescript-reviewer
+  name: typescript-reviewer
+  description: TypeScript and JavaScript code review specialist. Use for type safety
+    improvements, modern TS/JS patterns, and resolving type complexity issues.

--- a/catalogs/loop-catalog.yaml
+++ b/catalogs/loop-catalog.yaml
@@ -1,166 +1,54 @@
-# agent-toolkit — Loop Catalog
-# Metadata for all bundled loop templates.
-# Each entry describes a loops/<name>/loop.yaml template.
-#
-# Tier definitions:
-#   L1  — read-only or propose-only; no mutations; safe to run unattended
-#   L2  — limited writes (PRs, comments, labels); PR-gated; cautious budget
-#   L3  — full write access; reserved for high-trust environments
-#
-# Scope definitions:
-#   single-repo   — operates on one repository per run
-#   multi-repo    — reads pack/config to iterate across many repositories
-#
-# cost_estimate legend: low / medium / high / very-high (relative token usage per run)
-
 version: 1
-
+generated: true
+count: 10
 loops:
-
-  # ── Single-Repo Loops ────────────────────────────────────────────────────────
-
-  - name: daily-triage
-    tier: L1
-    cadence: 1d
-    scope: single-repo
-    resumable: false
-    cost_estimate: low
-    description: >
-      Scans all open issues created in the last 24 hours and proposes labels,
-      priority scores, and a brief summary for each. Writes a report only —
-      no changes are applied. Safe to run unattended every day.
-    use_case: >
-      Maintainers who want a daily digest of new issues with proposed routing,
-      without automating label application yet.
-
-  - name: issue-triage
-    tier: L1
-    cadence: 4h
-    scope: single-repo
-    resumable: false
-    cost_estimate: low
-    description: >
-      Finds unlabeled open issues (up to 20 per run) and proposes labels,
-      type classification, and priority. Outputs proposals to report.md.
-      No labels or comments are written.
-    use_case: >
-      Repositories with high issue volume where labeling must stay human-approved
-      but proposals can be automated at higher frequency.
-
-  - name: changelog-drafter
-    tier: L1
-    cadence: 1d
-    scope: single-repo
-    resumable: false
-    cost_estimate: low
-    description: >
-      Collects all PRs merged since the latest git tag and drafts release notes
-      in keep-a-changelog format. Writes draft to report.md only — does not
-      commit, tag, or push.
-    use_case: >
-      Teams who cut releases manually but want a first-pass CHANGELOG entry
-      generated automatically from merged PR titles.
-
-  - name: dep-sweeper
-    tier: L2
-    cadence: 1d
-    scope: single-repo
-    resumable: false
-    cost_estimate: medium
-    description: >
-      Detects patch-level dependency updates across all ecosystems (npm, pip,
-      cargo, etc.), applies them in a worktree, runs the test suite, and opens
-      a draft PR per ecosystem if tests pass. Skips major and minor version bumps.
-    use_case: >
-      Projects that want patch security updates merged quickly without manual
-      PR review overhead, while keeping major/minor bumps under human control.
-
-  - name: pr-babysitter
-    tier: L2
-    cadence: 15m
-    scope: single-repo
-    resumable: false
-    cost_estimate: high
-    description: >
-      Monitors open PRs every 15 minutes. For any PR without a review in the
-      last hour, posts a constructive review comment with a summary and 1-3
-      suggestions. Does not approve or request changes.
-    use_case: >
-      Teams that want faster PR feedback loops on active branches without
-      requiring a dedicated human reviewer to be online.
-
-  - name: ci-sweeper
-    tier: L2
-    cadence: 15m
-    scope: single-repo
-    resumable: false
-    cost_estimate: very-high
-    description: >
-      Detects failing CI runs on open PRs or the main branch, diagnoses the
-      root cause by fetching run logs, and proposes a minimal fix as a draft PR.
-      Never auto-merges. Designed to run conservatively with a low max_iterations
-      budget.
-    use_case: >
-      Teams with frequent CI noise who want automated triage and proposed
-      fixes surfaced before a human engineer investigates.
-
-  - name: post-merge-cleanup
-    tier: L2
-    cadence: 6h
-    scope: single-repo
-    resumable: false
-    cost_estimate: low
-    description: >
-      Runs off-peak housekeeping after merges: deletes stale merged branches
-      (older than 7 days, excluding protected branches), closes issues resolved
-      by merged PRs, and posts a "stale?" comment on issues inactive for 90 days.
-      Never deletes branches with open PRs.
-    use_case: >
-      Repositories that accumulate merged branches and stale issues over time
-      and want automated cleanup without human toil.
-
-  # ── Multi-Repo Loops ─────────────────────────────────────────────────────────
-
-  - name: oss-pr-monitor
-    tier: L3
-    cadence: 1d
-    scope: multi-repo
-    resumable: true
-    cost_estimate: high
-    description: >
-      Monitors open PRs across all repos configured in an ecosystem pack. Merges
-      Dependabot PRs with passing CI, closes dirty Dependabot PRs that will
-      regenerate, and writes a status report for human PRs. Supports resumability
-      via STATE.md so runs can survive interruption across large repo sets.
-      Requires L3 because loop-gh-gate forbids merge/close at L2.
-    use_case: >
-      OSS maintainers managing 20-50 repositories who want automated Dependabot
-      handling and a daily PR status digest without reviewing every repo manually.
-
-  - name: oss-triage
-    tier: L1
-    cadence: 1d
-    scope: multi-repo
-    resumable: true
-    cost_estimate: medium
-    description: >
-      Scans open issues across all configured repos. Applies labels and posts
-      responses to obvious questions; reports everything else. Uses resumability
-      via STATE.md to continue from the last processed repo on interruption.
-    use_case: >
-      OSS maintainers who need consistent issue hygiene across a large ecosystem
-      without spending hours on manual triage each day.
-
-  - name: oss-daily-briefing
-    tier: L1
-    cadence: 1d
-    scope: multi-repo
-    resumable: true
-    cost_estimate: low
-    description: >
-      Read-only loop that generates a daily briefing covering new PRs, open
-      issues needing attention, and CI health across all configured repos.
-      No mutations of any kind. Writes output to report.md only.
-    use_case: >
-      Maintainers who want a single morning digest of ecosystem activity
-      without any automated actions — pure visibility.
+- id: changelog-drafter
+  name: changelog-drafter
+  tier: L1
+  cadence: 1d
+  description: Draft release notes from merged PRs (L1, report-only)
+- id: ci-sweeper
+  name: ci-sweeper
+  tier: L2
+  cadence: 15m
+  description: Detect CI failures and propose fixes via draft PRs (L2, cautious)
+- id: daily-triage
+  name: daily-triage
+  tier: L1
+  cadence: 1d
+  description: Triage new issues and propose labels (report-only)
+- id: dep-sweeper
+  name: dep-sweeper
+  tier: L2
+  cadence: 1d
+  description: Apply patch-level dependency updates via draft PRs (L2)
+- id: issue-triage
+  name: issue-triage
+  tier: L1
+  cadence: 4h
+  description: Propose labels and routing for new issues (L1, propose-only)
+- id: oss-daily-briefing
+  name: oss-daily-briefing
+  tier: L1
+  cadence: 1d
+  description: Daily read-only briefing across OSS ecosystem repos (L1)
+- id: oss-pr-monitor
+  name: oss-pr-monitor
+  tier: L3
+  cadence: 1d
+  description: Monitor open PRs across OSS ecosystem repos and take action (L3, daily)
+- id: oss-triage
+  name: oss-triage
+  tier: L1
+  cadence: 1d
+  description: Triage issues across OSS ecosystem repos (L1, daily)
+- id: post-merge-cleanup
+  name: post-merge-cleanup
+  tier: L2
+  cadence: 6h
+  description: Off-peak housekeeping after merges (L2, low impact)
+- id: pr-babysitter
+  name: pr-babysitter
+  tier: L2
+  cadence: 15m
+  description: Monitor open PRs and post review comments (L2, PR-gated)

--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,699 +1,351 @@
-# agent-toolkit — Skill Catalog
-# Source of truth for skill routing metadata.
-# skill.json holds install/compatibility info; this file holds domain,
-# responsibility, triggers, and dependency graph used by orchestrators.
-#
-# Responsibility legend:
-#   HOW  — tool skill; knows how to operate a specific CLI or API
-#   WHAT — workflow skill; knows what to do at each phase of a task
-#
-# Domain legend:
-#   core          — orchestration, session management, handshake primitives
-#   delivery      — software-delivery lifecycle (PRD → ADR → work items → PR)
-#   design        — UI/UX and Figma integration
-#   forge         — version-control forge automation (GitHub, GitLab)
-#   integrations  — third-party platform connectors (Slack, Linear, ClickUp)
-#   data          — data platform validation (dbt, Snowflake)
-#   tooling       — developer tooling (Jupyter, Playwright CLI)
-#   ops           — operational and health-check utilities
-#   loops         — recurring automation loop management
-
 version: 1
-
+generated: true
+count: 52
 skills:
-
-  # ── Core ─────────────────────────────────────────────────────────────────────
-
-  - name: assistant
-    domain: core
-    responsibility: HOW
-    role: orchestrator_and_fallback
-    triggers:
-      - Default entry point when no other skill matches
-      - Multi-domain tasks requiring cross-skill coordination
-      - Repository inspection and convention verification
-      - Conflict resolution between project and global rules
-    depends_on: []
-
-  - name: dev-companion
-    domain: core
-    responsibility: WHAT
-    role: general_dev_companion
-    triggers:
-      - General client or project delivery work
-      - Task requires L2 framing or queue delegation
-      - Unclear which workflow skill applies
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-      - name: workflow-generic-project
-        version: ">=1.0.0"
-
-  - name: output-handshake
-    domain: core
-    responsibility: WHAT
-    role: artifact_destination_gate
-    triggers:
-      - where to save
-      - final artifact
-      - deliverable destination
-      - output destination
-      - confirm human review before writing
-    depends_on: []
-
-  - name: pr-fallback
-    domain: core
-    responsibility: WHAT
-    role: default_pr_mr_body
-    triggers:
-      - no pull request template in repo
-      - default PR body
-      - PR description needed
-      - MR description when no template
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: workspace-knowledge-sync
-    domain: core
-    responsibility: HOW
-    role: workspace_knowledge_management
-    triggers:
-      - Sync workspace knowledge base
-      - Save learnings or todos to knowledge/
-      - Inject session context at start
-      - Memory management across sessions
-    depends_on: []
-
-  - name: onboarding
-    domain: core
-    responsibility: WHAT
-    role: new_user_and_project_onboarding
-    triggers:
-      - First run or fresh install
-      - Onboard a new team member
-      - Initialize workspace for a new project
-      - What do I do first?
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-
-  # ── Delivery ─────────────────────────────────────────────────────────────────
-
-  - name: adr
-    domain: delivery
-    responsibility: WHAT
-    role: adr_process
-    triggers:
-      - ADR
-      - architecture decision record
-      - technical decision record
-      - long-lasting architectural decision
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: agreement
-    domain: delivery
-    responsibility: WHAT
-    role: agreement_document
-    triggers:
-      - agreement
-      - terms and conditions
-      - explicit commitment between parties
-      - SLA or contract artifact
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: bug
-    domain: delivery
-    responsibility: WHAT
-    role: bug_report_template
-    triggers:
-      - bug
-      - defect
-      - reproduction steps
-      - unexpected behavior report
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: decision-log
-    domain: delivery
-    responsibility: WHAT
-    role: lightweight_decision_log
-    triggers:
-      - decision log
-      - lightweight decision entry
-      - log a decision
-      - decision made in meeting
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: development-workflow
-    domain: delivery
-    responsibility: WHAT
-    role: default_development_lifecycle
-    triggers:
-      - development workflow
-      - definition of ready
-      - definition of done
-      - validation model
-      - task lifecycle
-      - DoR DoD
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-
-  - name: epic
-    domain: delivery
-    responsibility: WHAT
-    role: epic_template
-    triggers:
-      - epic
-      - large body of work
-      - feature group
-      - initiative
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: planning
-        version: ">=1.0.0"
-
-  - name: incident
-    domain: delivery
-    responsibility: WHAT
-    role: incident_report_and_rca
-    triggers:
-      - incident
-      - RCA
-      - root cause analysis
-      - production outage
-      - service degradation
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: meeting-minutes
-        version: ">=1.0.0"
-
-  - name: management-unit-assessment
-    domain: delivery
-    responsibility: WHAT
-    role: management_scorecard
-    triggers:
-      - management unit assessment
-      - governance assessment
-      - delivery process assessment
-      - management scorecard
-      - ai-native management readiness
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: project-assessment-evidence
-        version: ">=1.0.0"
-
-  - name: meeting-minutes
-    domain: delivery
-    responsibility: WHAT
-    role: meeting_minutes_template
-    triggers:
-      - meeting minutes
-      - meeting notes
-      - transcript processing
-      - action items from meeting
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: planning
-    domain: delivery
-    responsibility: WHAT
-    role: planning_and_estimation
-    triggers:
-      - planning
-      - estimation
-      - sprint planning
-      - iteration capacity
-      - task breakdown
-      - story points
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: prd
-    domain: delivery
-    responsibility: WHAT
-    role: product_requirements_document
-    triggers:
-      - PRD
-      - product requirements document
-      - requirements document
-      - product spec
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: planning
-        version: ">=1.0.0"
-
-  - name: project-assessment
-    domain: delivery
-    responsibility: WHAT
-    role: project_assessment_router
-    triggers:
-      - project assessment
-      - maturity assessment
-      - quality audit
-      - project audit
-      - assessment report
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: project-assessment-evidence
-        version: ">=1.0.0"
-      - name: technical-unit-assessment
-        version: ">=1.0.0"
-      - name: management-unit-assessment
-        version: ">=1.0.0"
-
-  - name: project-assessment-evidence
-    domain: delivery
-    responsibility: WHAT
-    role: assessment_evidence_intake
-    triggers:
-      - assessment evidence
-      - evidence map
-      - audit evidence
-      - collect evidence for assessment
-      - missing evidence
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: spike
-    domain: delivery
-    responsibility: WHAT
-    role: spike_research_findings
-    triggers:
-      - spike
-      - technical exploration
-      - research findings
-      - tradeoffs analysis
-      - proof of concept writeup
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-
-  - name: task
-    domain: delivery
-    responsibility: WHAT
-    role: technical_task_template
-    triggers:
-      - task
-      - technical task
-      - operational task
-      - work item that is not a story
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: planning
-        version: ">=1.0.0"
-
-  - name: technical-unit-assessment
-    domain: delivery
-    responsibility: WHAT
-    role: technical_scorecard
-    triggers:
-      - technical unit assessment
-      - frontend assessment
-      - backend assessment
-      - infrastructure assessment
-      - technical scorecard
-      - ai-native structural readiness
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: project-assessment-evidence
-        version: ">=1.0.0"
-
-  - name: trd
-    domain: delivery
-    responsibility: WHAT
-    role: technical_requirements_document
-    triggers:
-      - TRD
-      - technical requirements document
-      - technical design document
-      - architecture spec
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: spike
-        version: ">=1.0.0"
-      - name: adr
-        version: ">=1.0.0"
-
-  - name: user-story
-    domain: delivery
-    responsibility: WHAT
-    role: user_story_template
-    triggers:
-      - user story
-      - as a ... I want ... so that
-      - user-centered requirement
-      - acceptance criteria
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: planning
-        version: ">=1.0.0"
-
-  - name: work-item
-    domain: delivery
-    responsibility: WHAT
-    role: work_item_router
-    triggers:
-      - work item
-      - classify work item
-      - route epic story task bug incident
-    depends_on:
-      - name: output-handshake
-        version: ">=1.0.0"
-      - name: planning
-        version: ">=1.0.0"
-
-  - name: workflow-client-bootstrap
-    domain: delivery
-    responsibility: WHAT
-    role: client_workflow_generator
-    triggers:
-      - onboard new client project workflow
-      - bootstrap workflow for client
-      - add client workflow
-      - generate client-specific workflow skill
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-      - name: github-cli-workflow
-        version: ">=1.0.0"
-      - name: gitlab-cli-workflow
-        version: ">=1.0.0"
-
-  - name: workflow-generic-project
-    domain: delivery
-    responsibility: WHAT
-    role: generic_client_delivery_phases
-    triggers:
-      - client delivery work
-      - plan implement review PR phases
-      - generic project workflow
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-      - name: github-cli-workflow
-        version: ">=1.0.0"
-      - name: gitlab-cli-workflow
-        version: ">=1.0.0"
-
-  # ── Design ───────────────────────────────────────────────────────────────────
-
-  - name: figma
-    domain: design
-    responsibility: HOW
-    role: figma_mcp_entry_point
-    triggers:
-      - Figma URL provided
-      - design-to-code task from Figma
-      - Figma MCP setup or usage question
-    depends_on: []
-
-  - name: figma-code-connect-components
-    domain: design
-    responsibility: HOW
-    role: figma_code_connect_mapper
-    triggers:
-      - code connect mapping
-      - link Figma component to existing code component
-      - Code Connect annotation
-    depends_on:
-      - name: figma
-        version: ">=1.0.0"
-
-  - name: figma-create-design-system-rules
-    domain: design
-    responsibility: HOW
-    role: figma_design_system_rules_generator
-    triggers:
-      - create design system rules
-      - generate AGENTS.md for design system
-      - encode unwritten Figma conventions
-    depends_on:
-      - name: figma
-        version: ">=1.0.0"
-
-  - name: figma-create-new-file
-    domain: design
-    responsibility: HOW
-    role: figma_file_bootstrap
-    triggers:
-      - new Figma file
-      - create Figma file from scratch
-      - initialize Figma canvas
-    depends_on:
-      - name: figma
-        version: ">=1.0.0"
-
-  - name: figma-implement-design
-    domain: design
-    responsibility: HOW
-    role: figma_design_to_code
-    triggers:
-      - implement Figma design
-      - generate production code from Figma node
-      - build component from Figma with pixel fidelity
-    depends_on:
-      - name: figma
-        version: ">=1.0.0"
-
-  - name: ui-ux-pro-max
-    domain: design
-    responsibility: HOW
-    role: ui_ux_design_intelligence
-    triggers:
-      - UI or UX implementation task
-      - design system token enforcement
-      - layout, palette, accessibility review
-      - UI component design without a Figma source
-    depends_on: []
-
-  # ── Forge ────────────────────────────────────────────────────────────────────
-
-  - name: github-cli-workflow
-    domain: forge
-    responsibility: HOW
-    role: github_pr_automation
-    triggers:
-      - remote origin is GitHub
-      - push branch and create draft PR
-      - gh CLI operations
-    depends_on: []
-
-  - name: gitlab-cli-workflow
-    domain: forge
-    responsibility: HOW
-    role: gitlab_mr_automation
-    triggers:
-      - remote origin is GitLab
-      - push branch and create draft MR
-      - glab CLI operations
-    depends_on: []
-
-  - name: gh-address-comments
-    domain: forge
-    responsibility: HOW
-    role: github_pr_review_comment_handler
-    triggers:
-      - address PR review comments
-      - resolve open review threads
-      - respond to PR feedback
-      - apply reviewer-requested changes
-    depends_on:
-      - name: github-cli-workflow
-        version: ">=1.0.0"
-
-  - name: gh-fix-ci
-    domain: forge
-    responsibility: HOW
-    role: github_actions_ci_triage
-    triggers:
-      - fix CI
-      - debug failing GitHub Actions checks
-      - why is the build red
-      - CI check triage
-    depends_on:
-      - name: github-cli-workflow
-        version: ">=1.0.0"
-
-  - name: gh-contribution-planner
-    domain: forge
-    responsibility: WHAT
-    role: oss_contribution_planner
-    triggers:
-      - plan OSS contribution
-      - what issues can I pick up
-      - contribution strategy for repository
-      - first good issue suggestions
-    depends_on:
-      - name: github-cli-workflow
-        version: ">=1.0.0"
-
-  # ── Integrations ─────────────────────────────────────────────────────────────
-
-  - name: clickup-cli
-    domain: integrations
-    responsibility: HOW
-    role: clickup_task_and_doc_cli
-    triggers:
-      - ClickUp task ID (CU- prefix or numeric)
-      - view ClickUp task details
-      - add comment to ClickUp task
-      - update task status in ClickUp
-    depends_on: []
-
-  - name: slack-cli
-    domain: integrations
-    responsibility: HOW
-    role: slack_app_development_cli
-    triggers:
-      - Slack app development
-      - scaffold Slack bolt app
-      - deploy Slack app via CLI
-    depends_on: []
-
-  - name: slack-assistant
-    domain: integrations
-    responsibility: HOW
-    role: slack_workspace_read_write
-    triggers:
-      - Read Slack channel or messages
-      - Send Slack message or notification
-      - Add Slack reaction
-      - Browse Slack canvases
-    depends_on: []
-
-  - name: linear
-    domain: integrations
-    responsibility: HOW
-    role: linear_mcp_issue_and_project_management
-    triggers:
-      - Linear ticket or issue
-      - sprint planning in Linear
-      - triage Linear bugs
-      - Linear project or cycle management
-    depends_on: []
-
-  # ── Data ─────────────────────────────────────────────────────────────────────
-
-  - name: dbt-validation
-    domain: data
-    responsibility: HOW
-    role: dbt_model_and_test_runner
-    triggers:
-      - dbt_project.yml present in repo
-      - run dbt parse, compile, test, or run
-      - validate dbt model changes
-    depends_on: []
-
-  - name: snowflake-validation
-    domain: data
-    responsibility: HOW
-    role: snowflake_read_only_validation
-    triggers:
-      - Snowflake referenced in repo or task
-      - validate Snowflake query or table
-      - read-only Snowflake checks
-    depends_on: []
-
-  # ── Tooling ──────────────────────────────────────────────────────────────────
-
-  - name: jupyter-notebook
-    domain: tooling
-    responsibility: HOW
-    role: jupyter_notebook_scaffold
-    triggers:
-      - new Jupyter notebook
-      - scaffold .ipynb from template
-      - convert Python script to notebook
-      - reproducible experiment notebook
-    depends_on: []
-
-  - name: playwright-cli
-    domain: tooling
-    responsibility: HOW
-    role: playwright_browser_cli_automation
-    triggers:
-      - browser automation from CLI
-      - data extraction from rendered page
-      - reproduce UI bug interactively
-      - Playwright snapshot or screenshot without test spec
-    depends_on: []
-
-  # ── Ops ──────────────────────────────────────────────────────────────────────
-
-  - name: triage
-    domain: ops
-    responsibility: HOW
-    role: workstation_and_environment_healthcheck
-    triggers:
-      - workstation health check
-      - environment diagnosis
-      - missing tool or broken config
-      - triage errors on workstation
-    depends_on: []
-
-  - name: llm-cost-advisor
-    domain: ops
-    responsibility: HOW
-    role: llm_token_and_cost_analysis
-    triggers:
-      - estimate LLM cost for workflow
-      - compare token cost across providers
-      - budget LLM calls for a loop
-      - llm cost advice
-    depends_on: []
-
-  - name: docs-generator
-    domain: ops
-    responsibility: HOW
-    role: automated_documentation_generation
-    triggers:
-      - generate docs from code
-      - auto-generate README or API docs
-      - update documentation after code change
-    depends_on:
-      - name: assistant
-        version: ">=1.0.0"
-
-  # ── Loops ────────────────────────────────────────────────────────────────────
-
-  - name: loop-runner
-    domain: loops
-    responsibility: HOW
-    role: recurring_loop_executor
-    triggers:
-      - run a recurring loop
-      - start loop template
-      - schedule loop cadence
-      - loop runner setup
-    depends_on:
-      - name: workspace-knowledge-sync
-        version: ">=1.0.0"
+- id: core/assistant
+  name: assistant
+  domain: core
+  description: Assistant — on any repo, scan README→docs→AGENTS→CONTRIBUTING→PR templates→task
+    runners→devcontainer→CI→configs before code; cite sources; prefer AGENTS.md for
+    agent behavior; portable across Cursor/C
+  stability: stable
+- id: core/dev-companion
+  name: dev-companion
+  domain: core
+  description: 'WHAT — Dev Companion (general): layered companion for client delivery;
+    modes, gates, delegation to assistant and workflow-generic-project; no CLI matrices.'
+  stability: stable
+- id: core/onboarding
+  name: onboarding
+  domain: core
+  description: Getting started guide for new users. Walks through setup validation,
+    the skill/agent hierarchy, and the three most useful commands per role (developer,
+    PM, tech lead). Use when someone is new to the w
+  stability: stable
+- id: core/output-handshake
+  name: output-handshake
+  domain: core
+  description: 'WHAT — Default gate for any deliverable: confirm where the final artifact
+    will be stored and that a human will review, before writing PRDs, TRDs, ADRs,
+    or PR bodies. Repository paths, wikis, and ticke'
+  stability: stable
+- id: core/pr-fallback
+  name: pr-fallback
+  domain: core
+  description: WHAT — When the repo has no GitHub PR template, structure the pull-request
+    body using the default in references/pr-body-default.md. Pair with output-handshake
+    and github-cli-workflow. Does not open th
+  stability: stable
+- id: core/workspace-knowledge-sync
+  name: workspace-knowledge-sync
+  domain: core
+  description: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
+    discovers new patterns, learns user preferences, or identifies information worth
+    preserving for future sessions. Integrates w
+  stability: stable
+- id: data/dbt-validation
+  name: dbt-validation
+  domain: data
+  description: HOW — Run dbt checks as documented in the target repo (parse, compile,
+    test, selective run). Does not configure Snowflake accounts or change cloud security.
+  stability: stable
+- id: data/snowflake-validation
+  name: snowflake-validation
+  domain: data
+  description: 'HOW — Read-only Snowflake validation patterns: use repo-documented
+    CLI (snowflake/sql) or SQL checks. Never claim success without working credentials
+    and evidence.'
+  stability: stable
+- id: delivery/adr
+  name: adr
+  domain: delivery
+  description: WHAT — Create and maintain Architecture Decision Records (ADRs) per
+    the process. Covers when to write an ADR, required sections, review, and linking
+    to epics/PRs. English for cross-team artifacts unle
+  stability: stable
+- id: delivery/agreement
+  name: agreement
+  domain: delivery
+  description: WHAT - Capture explicit agreements, terms, parties involved, dates,
+    validity, and linked work items using the Agreement Document structure.
+  stability: stable
+- id: delivery/bug
+  name: bug
+  domain: delivery
+  description: WHAT - Draft and review bugs using the Bug Template; classifies whether
+    an issue should be escalated to incident based on production/user impact.
+  stability: stable
+- id: delivery/decision-log
+  name: decision-log
+  domain: delivery
+  description: WHAT - Capture lightweight project, product, or operational decisions
+    that do not require a full ADR; includes rationale, date, owner, and references.
+  stability: stable
+- id: delivery/development-workflow
+  name: development-workflow
+  domain: delivery
+  description: WHAT - Default development workflow, task lifecycle, DoR, DoD, validation,
+    and evidence model when a project has no explicit override. Repository instructions
+    still take precedence.
+  stability: stable
+- id: delivery/epic
+  name: epic
+  domain: delivery
+  description: WHAT - Draft and review epics using the Best Practices Epic Template;
+    includes objectives, success criteria, related tasks, stakeholders, and effort
+    metadata.
+  stability: stable
+- id: delivery/incident
+  name: incident
+  domain: delivery
+  description: WHAT - Draft and review incident reports and RCA notes using Incident
+    Management guidance; includes detection, impact, timeline, RCA, resolution, and
+    follow-ups.
+  stability: stable
+- id: delivery/management-unit-assessment
+  name: management-unit-assessment
+  domain: delivery
+  description: WHAT - Evidence-based management unit assessment for governance, delivery,
+    collaboration, culture, and AI-native management readiness. Interactive and source-driven
+    before any score is assigned.
+  stability: stable
+- id: delivery/meeting-minutes
+  name: meeting-minutes
+  domain: delivery
+  description: WHAT - Create structured meeting minutes from notes or transcripts
+    using meeting templates, with redaction, action items, decisions, and traceability.
+  stability: stable
+- id: delivery/planning
+  name: planning
+  domain: delivery
+  description: WHAT - Planning, estimation, task breakdown, and iteration capacity
+    fallback based on Best Practices. Use before finalizing backlog scope, story/task
+    estimates, or iteration commitments.
+  stability: stable
+- id: delivery/prd
+  name: prd
+  domain: delivery
+  description: WHAT — Draft and review a Product Requirements Document (PRD) using
+    the template. Business-level requirements, acceptance criteria, and traceability.
+    Does not replace the product owner. English for ti
+  stability: stable
+- id: delivery/project-assessment
+  name: project-assessment
+  domain: delivery
+  description: 'WHAT - Interactive project assessment router: define assessment scope
+    and units, collect evidence through project-assessment-evidence, then delegate
+    to technical or management unit assessment skills. '
+  stability: stable
+- id: delivery/project-assessment-evidence
+  name: project-assessment-evidence
+  domain: delivery
+  description: 'WHAT - Interactive evidence intake for project assessments. Ask the
+    user where each evidence source lives, build an evidence map, track missing evidence,
+    assumptions, freshness, and confidence before '
+  stability: stable
+- id: delivery/spike
+  name: spike
+  domain: delivery
+  description: WHAT - Produce spike and research findings using the spike template;
+    captures purpose, findings, implementation strategy, risks, tradeoffs, open questions,
+    and references.
+  stability: stable
+- id: delivery/task
+  name: task
+  domain: delivery
+  description: WHAT - Draft and review technical tasks using the Best Practices Task
+    Template; includes summary, technical notes, AC, estimate, owner, and due date.
+  stability: stable
+- id: delivery/technical-unit-assessment
+  name: technical-unit-assessment
+  domain: delivery
+  description: WHAT - Evidence-based technical unit assessment for repositories, platforms,
+    frontend, backend, infrastructure, data, UI/UX, and AI-native structural readiness.
+  stability: stable
+- id: delivery/trd
+  name: trd
+  domain: delivery
+  description: WHAT — Draft and review a Technical Requirements Document (TRD) using
+    the template, typically from an agreed PRD. Covers architecture, data contracts,
+    technical decisions, risks, and test strategy. En
+  stability: stable
+- id: delivery/user-story
+  name: user-story
+  domain: delivery
+  description: WHAT - Draft and review user stories using the task template plus the
+    As a/I want/so that format from Best Practices examples.
+  stability: stable
+- id: delivery/work-item
+  name: work-item
+  domain: delivery
+  description: WHAT - Router for creating and refining epics, user stories, tasks,
+    bugs, and incidents using Best Practices work item hierarchy.
+  stability: stable
+- id: delivery/workflow-client-bootstrap
+  name: workflow-client-bootstrap
+  domain: delivery
+  description: WHAT — Interactive interview to capture client delivery context and
+    store it inside the user's ~/.ai-workspace (or similar) as packs + knowledge (no
+    client skills). Use when onboarding a new client pr
+  stability: stable
+- id: delivery/workflow-generic-project
+  name: workflow-generic-project
+  domain: delivery
+  description: 'WHAT — Generic client delivery: Jira or ClickUp, full repo context,
+    human gates, English traceability on tickets, draft PR via delegated forge skills.
+    Use workspace packs for client/account overlays.'
+  stability: stable
+- id: design/figma
+  name: figma
+  domain: design
+  description: Use the Figma MCP server to fetch design context, screenshots, variables,
+    and assets, and to translate Figma nodes into production code. Trigger when a
+    task involves Figma URLs, node IDs, design-to-co
+  stability: stable
+- id: design/figma-code-connect-components
+  name: figma-code-connect-components
+  domain: design
+  description: Connects Figma design components to code components using Code Connect
+    mapping tools. Use when user says "code connect", "connect this component to code",
+    "map this component", "link component to code
+  stability: stable
+- id: design/figma-create-design-system-rules
+  name: figma-create-design-system-rules
+  domain: design
+  description: Generates custom design system rules for the user's codebase. Use when
+    user says "create design system rules", "generate rules for my project", "set
+    up design rules", "customize design system guidelin
+  stability: stable
+- id: design/figma-create-new-file
+  name: figma-create-new-file
+  domain: design
+  description: 'Create a new blank Figma file. Use when the user wants to create a
+    new Figma design or FigJam file, or when you need a new file before calling use_figma.
+    Handles plan resolution via whoami if needed. '
+  stability: stable
+- id: design/figma-implement-design
+  name: figma-implement-design
+  domain: design
+  description: Translates Figma designs into production-ready application code with
+    1:1 visual fidelity. Use when implementing UI code from Figma files, when user
+    mentions "implement design", "generate code", "imple
+  stability: stable
+- id: design/ui-ux-pro-max
+  name: ui-ux-pro-max
+  domain: design
+  description: 'UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings,
+    25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter,
+    Tailwind, shadcn/ui). Actions: plan, build, crea'
+  stability: stable
+- id: forge/gh-address-comments
+  name: gh-address-comments
+  domain: forge
+  description: Triage and address open GitHub PR review and conversation comments
+    using the gh CLI. Use when the user wants to "address PR comments", "resolve review
+    threads", or "respond to reviewers" on the curren
+  stability: stable
+- id: forge/gh-contribution-planner
+  name: gh-contribution-planner
+  domain: forge
+  description: Daily GitHub contribution planner — analyzes the gh-logged-in user's
+    non-archived repos (owned + forks) and recent contributions, produces a prioritized
+    plan, halts for approval, then dispatches paral
+  stability: stable
+- id: forge/gh-fix-ci
+  name: gh-fix-ci
+  domain: forge
+  description: Diagnose failing GitHub Actions checks on a PR via gh, summarize the
+    failure context, propose a plan, and only implement after explicit user approval.
+    External CI providers (Buildkite, CircleCI, etc.)
+  stability: stable
+- id: forge/github-cli-workflow
+  name: github-cli-workflow
+  domain: forge
+  description: 'HOW — GitHub CLI (gh): push branch, create draft PR with title/body
+    from template or file; fallback untracked PR_DESCRIPTION_*.md. Use when origin
+    is GitHub.'
+  stability: stable
+- id: forge/gitlab-cli-workflow
+  name: gitlab-cli-workflow
+  domain: forge
+  description: 'HOW — GitLab CLI (glab): push branch, create draft MR with title/body;
+    fallback untracked markdown. Use when origin is GitLab.'
+  stability: stable
+- id: forge/workflow-client-bootstrap
+  name: workflow-client-bootstrap
+  domain: forge
+  description: DEPRECATED alias. Use workflow-client-bootstrap instead.
+  stability: stable
+- id: forge/workflow-generic-project
+  name: workflow-generic-project
+  domain: forge
+  description: DEPRECATED alias. Use workflow-generic-project instead.
+  stability: stable
+- id: integrations/clickup-cli
+  name: clickup-cli
+  domain: integrations
+  description: 'ClickUp CLI for managing tasks, sprints, comments, statuses, and Docs.
+    Use when the user needs to interact with ClickUp — creating/editing tasks, checking
+    sprint status, adding comments, linking PRs, '
+  stability: stable
+- id: integrations/linear
+  name: linear
+  domain: integrations
+  description: Manage Linear issues, projects and cycles via the Linear MCP server.
+    Use when the user wants to read, triage, create or update Linear tickets, plan
+    a sprint, audit Linear documentation, or rebalance t
+  stability: stable
+- id: integrations/slack-assistant
+  name: slack-assistant
+  domain: integrations
+  description: Interact with Slack workspaces for reading channels/messages, sending
+    messages, adding reactions, and browsing canvases. Use when the user asks about
+    Slack channels, messages, or notifications — NOT f
+  stability: stable
+- id: integrations/slack-cli
+  name: slack-cli
+  domain: integrations
+  description: Interact with the official Slack CLI to create, run, deploy, and manage
+    Slack apps, environments, manifests, and triggers. Use when the user asks about
+    Slack app development workflows, not workspace c
+  stability: stable
+- id: loops/loop-runner
+  name: loop-runner
+  domain: loops
+  description: Execute and manage loop engineering primitives (init, run, status,
+    audit) from an AI coding session via bin/loop CLI.
+  stability: stable
+- id: ops/docs-generator
+  name: docs-generator
+  domain: ops
+  description: 'WHAT — Generate or update documentation from code: README.md from
+    repo structure, CHANGELOG.md from git history, API reference from OpenAPI/GraphQL
+    schemas, and AGENTS.md starters for new projects.'
+  stability: stable
+- id: ops/llm-cost-advisor
+  name: llm-cost-advisor
+  domain: ops
+  description: WHAT — Recommend the most cost-effective LLM provider for a given task
+    type. Shows estimated cost per run across available providers and integrates with
+    devcompanion llm-status to show what is actuall
+  stability: stable
+- id: ops/triage
+  name: triage
+  domain: ops
+  description: Workstation health triage — validate tooling, directory layout, and
+    run doctor with remediation suggestions.
+  stability: stable
+- id: tooling/jupyter-notebook
+  name: jupyter-notebook
+  domain: tooling
+  description: Create, scaffold, or refactor Jupyter notebooks (.ipynb) for experiments
+    and tutorials. Prefer the bundled templates and the helper script (`new_notebook.py`,
+    also exposed as `newnotebook`) to generat
+  stability: stable
+- id: tooling/playwright-cli
+  name: playwright-cli
+  domain: tooling
+  description: Drive a real browser from the terminal using the Playwright CLI (snapshot,
+    click, fill, screenshots, traces). Use when the task is CLI-first browser automation
+    (data extraction, UI debugging, form fil
+  stability: stable

--- a/scripts/generate-catalogs.py
+++ b/scripts/generate-catalogs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Regenerate catalogs/{skill,agent,loop}-catalog.yaml from the filesystem (#78)."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML required", file=sys.stderr)
+    sys.exit(1)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fm(text: str) -> dict:
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.S)
+    if not m:
+        return {}
+    data = yaml.safe_load(m.group(1)) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def gen_skills() -> dict:
+    skills = []
+    for skill_md in sorted((ROOT / "skills").rglob("SKILL.md")):
+        domain = skill_md.parent.parent.name
+        name = skill_md.parent.name
+        fm = _fm(skill_md.read_text(errors="replace"))
+        skills.append({
+            "id": f"{domain}/{name}",
+            "name": fm.get("name", name),
+            "domain": domain,
+            "description": str(fm.get("description", ""))[:200],
+            "stability": fm.get("stability", "stable"),
+        })
+    return {"version": 1, "generated": True, "count": len(skills), "skills": skills}
+
+
+def gen_agents() -> dict:
+    agents = []
+    for agent_md in sorted((ROOT / "agents").rglob("AGENT.md")):
+        name = agent_md.parent.name
+        fm = _fm(agent_md.read_text(errors="replace"))
+        agents.append({
+            "id": name,
+            "name": fm.get("name", name),
+            "description": str(fm.get("description", ""))[:200],
+        })
+    return {"version": 1, "generated": True, "count": len(agents), "agents": agents}
+
+
+def gen_loops() -> dict:
+    loops = []
+    for loop_yaml in sorted((ROOT / "loops").glob("*/loop.yaml")):
+        data = yaml.safe_load(loop_yaml.read_text()) or {}
+        loops.append({
+            "id": data.get("id", loop_yaml.parent.name),
+            "name": data.get("name", loop_yaml.parent.name),
+            "tier": data.get("tier"),
+            "cadence": data.get("cadence") or data.get("schedule"),
+            "description": str(data.get("description", ""))[:200],
+        })
+    return {"version": 1, "generated": True, "count": len(loops), "loops": loops}
+
+
+def main() -> int:
+    out = ROOT / "catalogs"
+    out.mkdir(exist_ok=True)
+    mapping = {
+        "skill-catalog.yaml": gen_skills(),
+        "agent-catalog.yaml": gen_agents(),
+        "loop-catalog.yaml": gen_loops(),
+    }
+    for name, data in mapping.items():
+        path = out / name
+        path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+        print(f"wrote {path} ({data['count']} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-catalogs.py
+++ b/scripts/generate-catalogs.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
-"""Regenerate catalogs/{skill,agent,loop}-catalog.yaml from the filesystem (#78)."""
+"""Regenerate catalogs/{skill,agent,loop}-catalog.yaml from the filesystem (#78).
+
+Usage:
+    python3 scripts/generate-catalogs.py          # write catalogs/
+    python3 scripts/generate-catalogs.py --check  # fail if catalogs would change (CI)
+"""
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -41,7 +47,7 @@ def gen_skills() -> dict:
 
 def gen_agents() -> dict:
     agents = []
-    for agent_md in sorted((ROOT / "agents").rglob("AGENT.md")):
+    for agent_md in sorted((ROOT / "agents").glob("*/AGENT.md")):
         name = agent_md.parent.name
         fm = _fm(agent_md.read_text(errors="replace"))
         agents.append({
@@ -55,10 +61,11 @@ def gen_agents() -> dict:
 def gen_loops() -> dict:
     loops = []
     for loop_yaml in sorted((ROOT / "loops").glob("*/loop.yaml")):
-        data = yaml.safe_load(loop_yaml.read_text()) or {}
+        data = yaml.safe_load(loop_yaml.read_text(encoding="utf-8")) or {}
+        loop_name = data.get("name", loop_yaml.parent.name)
         loops.append({
-            "id": data.get("id", loop_yaml.parent.name),
-            "name": data.get("name", loop_yaml.parent.name),
+            "id": loop_name,
+            "name": loop_name,
             "tier": data.get("tier"),
             "cadence": data.get("cadence") or data.get("schedule"),
             "description": str(data.get("description", ""))[:200],
@@ -66,18 +73,46 @@ def gen_loops() -> dict:
     return {"version": 1, "generated": True, "count": len(loops), "loops": loops}
 
 
-def main() -> int:
-    out = ROOT / "catalogs"
-    out.mkdir(exist_ok=True)
-    mapping = {
+def _render(data: dict) -> str:
+    return yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+
+
+def _catalogs() -> dict[str, dict]:
+    return {
         "skill-catalog.yaml": gen_skills(),
         "agent-catalog.yaml": gen_agents(),
         "loop-catalog.yaml": gen_loops(),
     }
-    for name, data in mapping.items():
-        path = out / name
-        path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if on-disk catalogs differ from generated output",
+    )
+    args = parser.parse_args()
+
+    out_dir = ROOT / "catalogs"
+    out_dir.mkdir(exist_ok=True)
+    drift = False
+
+    for name, data in _catalogs().items():
+        path = out_dir / name
+        rendered = _render(data)
+        if args.check:
+            if not path.is_file() or path.read_text(encoding="utf-8") != rendered:
+                print(f"  DRIFT: {path} is out of date — run: python3 scripts/generate-catalogs.py")
+                drift = True
+            else:
+                print(f"  OK: {path} ({data['count']} entries)")
+            continue
+        path.write_text(rendered, encoding="utf-8")
         print(f"wrote {path} ({data['count']} entries)")
+
+    if args.check and drift:
+        return 1
     return 0
 
 

--- a/tests/test_catalog_generation.py
+++ b/tests/test_catalog_generation.py
@@ -1,0 +1,28 @@
+"""Catalogs must match filesystem inventory (#78)."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_generate_catalogs_matches_disk_ids():
+    subprocess.check_call([sys.executable, str(REPO / "scripts" / "generate-catalogs.py")], cwd=REPO)
+    skills = yaml.safe_load((REPO / "catalogs" / "skill-catalog.yaml").read_text())["skills"]
+    disk = {
+        f"{p.parent.parent.name}/{p.parent.name}"
+        for p in (REPO / "skills").rglob("SKILL.md")
+    }
+    assert {s["id"] for s in skills} == disk
+
+    agents = yaml.safe_load((REPO / "catalogs" / "agent-catalog.yaml").read_text())["agents"]
+    disk_a = {p.parent.name for p in (REPO / "agents").rglob("AGENT.md")}
+    assert {a["id"] for a in agents} == disk_a
+
+    loops = yaml.safe_load((REPO / "catalogs" / "loop-catalog.yaml").read_text())["loops"]
+    disk_l = {p.parent.name for p in (REPO / "loops").glob("*/loop.yaml")}
+    assert {x["id"] for x in loops} == disk_l


### PR DESCRIPTION
## Summary
- Add `scripts/generate-catalogs.py` to regenerate `catalogs/*.yaml` from `skills/`, `agents/`, and `loops/`
- Support `--check` for CI drift detection; wire into `validate.yml`
- Document regeneration workflow in CONTRIBUTING.md; add catalog sync test

Closes #78

## Test plan
- [x] `python3 scripts/generate-catalogs.py --check`
- [x] `uv run pytest tests/test_catalog_generation.py -v`