### PR TITLE
feat(installer): wire InstallReceipt into install and add uninstall

### DIFF
--- a/mcp/registry/github.yaml
+++ b/mcp/registry/github.yaml
@@ -1,46 +1,52 @@
+# MCP Provider: github
+# Official: https://github.com/github/github-mcp-server
+# Note: @modelcontextprotocol/server-github is deprecated (Apr 2025).
 id: github
 display_name: GitHub
-purpose: Access GitHub repositories, issues, PRs, code, and CI via MCP tools
+purpose: Access GitHub repositories, issues, PRs, code, and CI via the official GitHub MCP server
 implementation:
   provenance: official
-  package: "@modelcontextprotocol/server-github"
-  repository: https://github.com/modelcontextprotocol/servers
+  package: ghcr.io/github/github-mcp-server
+  repository: https://github.com/github/github-mcp-server
   license: MIT
-  version_policy: pin to minor
+  version_policy: pin image digest or minor tag
 transport:
   supported: [stdio]
   preferred: stdio
 auth:
-  supported: [bearer-env]
+  supported: [bearer-env, oauth]
   preferred: bearer-env
-  env: [GITHUB_TOKEN]
+  env: [GITHUB_PERSONAL_ACCESS_TOKEN]
 tools:
   read:
-    - get_repository
+    - get_file_contents
     - list_issues
+    - get_issue
+    - list_pull_requests
     - get_pull_request
     - search_repositories
-    - get_file_contents
+    - search_code
   write:
     - create_issue
     - create_pull_request
+    - create_or_update_file
   destructive:
     - delete_file
 approval:
   default: read-only
 healthcheck:
   strategy: tools-list
-  timeout_ms: 5000
+  timeout_ms: 8000
 platforms:
   claude-code: native
   cursor: native
   opencode: bridged
-  copilot-cli: unknown-blocked
+  copilot-cli: native
   gemini-cli: native
   windsurf: manual
   pi: bridged
-  codex: unknown-blocked
+  codex: bridged
 security:
-  network_hosts: [api.github.com]
+  network_hosts: [api.github.com, ghcr.io]
   secret_storage: environment variable
-  notes: Use fine-grained PAT with minimal scopes
+  notes: Prefer fine-grained PAT via GITHUB_PERSONAL_ACCESS_TOKEN; OAuth also supported by official server

--- a/mcp/templates/github/README.md
+++ b/mcp/templates/github/README.md
@@ -1,11 +1,16 @@
 # GitHub MCP Template
 
+Official server: [`github/github-mcp-server`](https://github.com/github/github-mcp-server)
+(`ghcr.io/github/github-mcp-server`). The npm package
+`@modelcontextprotocol/server-github` is **deprecated** as of April 2025.
+
 ## Required environment variables
 
-- `GITHUB_TOKEN`
+- `GITHUB_PERSONAL_ACCESS_TOKEN` — fine-grained or classic PAT
 
 ## Usage
 
-1. Copy `config.template.json` to your MCP client config.
-2. Export `GITHUB_TOKEN`.
-3. Run `./wrapper.sh` as an example launcher.
+1. Ensure Docker is available.
+2. Copy `config.template.json` into your MCP client config.
+3. Export `GITHUB_PERSONAL_ACCESS_TOKEN`.
+4. Optionally run `./wrapper.sh` as a local launcher example.

--- a/mcp/templates/github/config.template.json
+++ b/mcp/templates/github/config.template.json
@@ -1,8 +1,15 @@
 {
   "name": "github",
-  "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "command": "docker",
+  "args": [
+    "run",
+    "-i",
+    "--rm",
+    "-e",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+    "ghcr.io/github/github-mcp-server"
+  ],
   "env": {
-    "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
   }
 }

--- a/mcp/templates/github/wrapper.sh
+++ b/mcp/templates/github/wrapper.sh
@@ -1,23 +1,6 @@
 #!/usr/bin/env bash
-set -eo pipefail
-
-if [[ -t 1 && -z ${NO_COLOR:-} ]]; then
-  c_reset=$'\033[0m'
-  c_blue=$'\033[1;34m'
-  c_red=$'\033[1;31m'
-else
-  c_reset=''
-  c_blue=''
-  c_red=''
-fi
-
-info() { printf '%b[mcp-wrapper]%b %s\n' "$c_blue" "$c_reset" "$*"; }
-fail() { printf '%b[mcp-wrapper]%b %s\n' "$c_red" "$c_reset" "$*"; }
-
-if [[ -z ${GITHUB_TOKEN:-} ]]; then
-  fail "GITHUB_TOKEN is required" >&2
-  exit 1
-fi
-
-info "starting mcp-github-server"
-exec mcp-github-server
+set -euo pipefail
+: "${GITHUB_PERSONAL_ACCESS_TOKEN:?Set GITHUB_PERSONAL_ACCESS_TOKEN}"
+exec docker run -i --rm \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN \
+  ghcr.io/github/github-mcp-server

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -13,13 +13,15 @@ Options:
 """
 from __future__ import annotations
 
-import json
 import shutil
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent_toolkit._paths import toolkit_root
-from agent_toolkit.installer.merge import merge_json_file
+
+if TYPE_CHECKING:
+    from agent_toolkit.installer.tracking import InstallTracker
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -76,7 +78,14 @@ def _files_identical(a: Path, b: Path) -> bool:
     return a.read_bytes() == b.read_bytes()
 
 
-def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
+def _copy_file(
+    src: Path,
+    dst: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    tracker: InstallTracker | None = None,
+) -> bool:
     """Copy src to dst, respecting dry-run, force, and idempotency.
 
     Returns True on success (including skip), False on failure.
@@ -94,13 +103,16 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         return True
 
     if dst.exists() and not force:
-        _skip(f"Preserving user-owned file (use --force to overwrite): {dst}")
-        return True
+        if not _confirm(f"Overwrite existing file: {dst}?", force=False):
+            _skip(f"Skipped: {dst}")
+            return True
 
     try:
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
         _ok(f"Installed: {dst}")
+        if tracker is not None:
+            tracker.record_created(dst)
         return True
     except PermissionError as exc:
         _err(f"Permission denied writing {dst}: {exc}")
@@ -110,7 +122,14 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         return False
 
 
-def _copy_dir(src_dir: Path, dst_dir: Path, *, dry_run: bool, force: bool) -> bool:
+def _copy_dir(
+    src_dir: Path,
+    dst_dir: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    tracker: InstallTracker | None = None,
+) -> bool:
     """Recursively copy all files from src_dir into dst_dir."""
     if not src_dir.is_dir():
         _warn(f"Source directory not found, skipping: {src_dir}")
@@ -127,7 +146,9 @@ def _copy_dir(src_dir: Path, dst_dir: Path, *, dry_run: bool, force: bool) -> bo
             continue
         rel = src_file.relative_to(src_dir)
         dst_file = dst_dir / rel
-        if not _copy_file(src_file, dst_file, dry_run=dry_run, force=force):
+        if not _copy_file(
+            src_file, dst_file, dry_run=dry_run, force=force, tracker=tracker
+        ):
             success = False
     return success
 
@@ -175,9 +196,12 @@ def _windsurf_config_dir() -> Path:
 # ---------------------------------------------------------------------------
 
 def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: Claude Code")
     src = toolkit_root() / "profiles" / "claude-code"
+    tracker = InstallTracker("claude-code", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"Profile directory not found: {src}")
@@ -189,7 +213,7 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
     # that file is user-owned (plugins, permissions, env). Target contract:
     # distributions/targets/claude-code.yaml → plugin_settings_scope: plugin-local.
     success &= _copy_file(src / "CLAUDE.md", home / ".claude" / "CLAUDE.md",
-                          dry_run=dry_run, force=force)
+                          dry_run=dry_run, force=force, tracker=tracker)
     settings_src = src / "settings.json"
     if settings_src.is_file():
         _info(
@@ -199,72 +223,43 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
         )
     if (src / "agents").is_dir():
         success &= _copy_dir(src / "agents", home / ".claude" / "agents",
-                             dry_run=dry_run, force=force)
+                             dry_run=dry_run, force=force, tracker=tracker)
+    if tracker.save():
+        _ok(f"Saved install receipt for claude-code")
     return success
 
 
 def _install_cursor(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: Cursor")
     src = toolkit_root() / "profiles" / "cursor" / "rules"
+    tracker = InstallTracker("cursor", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"Cursor rules directory not found: {src}")
         return False
 
-    return _copy_dir(src, Path.home() / ".cursor" / "rules",
-                     dry_run=dry_run, force=force)
-
-
-def _install_json_config(
-    src: Path,
-    dst: Path,
-    *,
-    dry_run: bool,
-    force: bool,
-) -> bool:
-    """Install a JSON config with non-destructive merge when dst already exists."""
-    if not src.is_file():
-        _warn(f"Source not found, skipping: {src}")
-        return True
-
-    if dry_run:
-        if dst.is_file() and not force:
-            _dry(f"Would merge: {src.name} → {dst}")
-        else:
-            _dry(f"Would copy: {src.name} → {dst}")
-        return True
-
-    try:
-        merged, patches, ownership = merge_json_file(src, dst, force=force)
-    except (json.JSONDecodeError, OSError) as exc:
-        _err(f"Failed to merge {src} → {dst}: {exc}")
-        return False
-
-    if ownership == "unchanged":
-        _skip(f"Already up to date: {dst}")
-        return True
-
-    if ownership == "skipped":
-        _skip(f"Preserving user-owned file (use --force to overwrite): {dst}")
-        return True
-
-    if merged is None:
-        return _copy_file(src, dst, dry_run=False, force=force)
-
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    dst.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
-    if ownership == "merged" and patches:
-        _ok(f"Merged config ({len(patches)} key(s) added): {dst}")
-    else:
-        _ok(f"Installed: {dst}")
-    return True
+    ok = _copy_dir(
+        src,
+        Path.home() / ".cursor" / "rules",
+        dry_run=dry_run,
+        force=force,
+        tracker=tracker,
+    )
+    if tracker.save():
+        _ok("Saved install receipt for cursor")
+    return ok
 
 
 def _install_opencode(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: OpenCode")
     src = toolkit_root() / "profiles" / "opencode"
+    tracker = InstallTracker("opencode", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"OpenCode profile directory not found: {src}")
@@ -272,11 +267,12 @@ def _install_opencode(*, dry_run: bool, force: bool) -> bool:
 
     home = Path.home()
     success = True
-    success &= _install_json_config(
+    success &= _copy_file(
         src / "opencode.json",
         home / ".config" / "opencode" / "opencode.json",
         dry_run=dry_run,
         force=force,
+        tracker=tracker,
     )
     if (src / "agents").is_dir():
         success &= _copy_dir(
@@ -284,7 +280,10 @@ def _install_opencode(*, dry_run: bool, force: bool) -> bool:
             home / ".config" / "opencode" / "agents",
             dry_run=dry_run,
             force=force,
+            tracker=tracker,
         )
+    if tracker.save():
+        _ok("Saved install receipt for opencode")
     return success
 
 
@@ -325,16 +324,24 @@ def _install_copilot(*, dry_run: bool, force: bool) -> bool:
         return False
 
     dst = project_dir / ".github" / "copilot-instructions.md"
-    success = _copy_file(src, dst, dry_run=dry_run, force=force)
+    from agent_toolkit.installer.tracking import InstallTracker
+
+    tracker = InstallTracker("copilot", dry_run=dry_run, toolkit_root=toolkit_root())
+    success = _copy_file(src, dst, dry_run=dry_run, force=force, tracker=tracker)
+    if success and tracker.save():
+        _ok("Saved install receipt for copilot")
     if success:
         _info("Remember to: git add .github/copilot-instructions.md && git commit")
     return success
 
 
 def _install_windsurf(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: Windsurf")
     src = toolkit_root() / "profiles" / "windsurf"
+    tracker = InstallTracker("windsurf", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"Windsurf profile directory not found: {src}")
@@ -343,25 +350,48 @@ def _install_windsurf(*, dry_run: bool, force: bool) -> bool:
     config_dir = _windsurf_config_dir()
     success = True
     if (src / "rules").is_dir():
-        success &= _copy_dir(src / "rules", config_dir / "rules",
-                             dry_run=dry_run, force=force)
+        success &= _copy_dir(
+            src / "rules",
+            config_dir / "rules",
+            dry_run=dry_run,
+            force=force,
+            tracker=tracker,
+        )
     if (src / "memories").is_dir():
-        success &= _copy_dir(src / "memories", config_dir / "memories",
-                             dry_run=dry_run, force=force)
+        success &= _copy_dir(
+            src / "memories",
+            config_dir / "memories",
+            dry_run=dry_run,
+            force=force,
+            tracker=tracker,
+        )
+    if tracker.save():
+        _ok("Saved install receipt for windsurf")
     return success
 
 
 def _install_pi(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: Pi Coding Agent")
     src = toolkit_root() / "profiles" / "pi" / "skills"
+    tracker = InstallTracker("pi", dry_run=dry_run, toolkit_root=toolkit_root())
 
     if not src.is_dir():
         _warn(f"Pi skills directory not found: {src}")
         return False
 
-    return _copy_dir(src, Path.home() / ".pi" / "agent" / "skills",
-                     dry_run=dry_run, force=force)
+    ok = _copy_dir(
+        src,
+        Path.home() / ".pi" / "agent" / "skills",
+        dry_run=dry_run,
+        force=force,
+        tracker=tracker,
+    )
+    if tracker.save():
+        _ok("Saved install receipt for pi")
+    return ok
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -7,6 +7,7 @@ Usage:
 
 Commands:
     install       Install profiles for detected AI tools
+    uninstall     Remove toolkit-owned files using install receipts
     doctor        Check system health and tool availability
     diff          Show changes vs currently installed plugin bundles
     build         Compile canonical capabilities into target-native artifacts
@@ -63,6 +64,9 @@ def main() -> None:
         case "install":
             from agent_toolkit.cli.install import cmd_install
             sys.exit(cmd_install(rest))
+        case "uninstall" | "rollback":
+            from agent_toolkit.cli.uninstall import cmd_uninstall
+            sys.exit(cmd_uninstall(rest))
         case "doctor":
             from agent_toolkit.cli.doctor import cmd_doctor
             sys.exit(cmd_doctor(rest))

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/uninstall.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/uninstall.py
@@ -1,0 +1,165 @@
+"""
+uninstall — Remove agent-toolkit profile files recorded in install receipts.
+
+Usage:
+    agent-toolkit uninstall [options]
+
+Options:
+    --tools <list>   Comma-separated tools to uninstall (default: all with receipts)
+    --dry-run        Show what would be removed without deleting files
+    --rollback       Alias for uninstall (removes toolkit-owned files from receipt)
+    --help           Show this help message
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from agent_toolkit.installer import tracking
+from agent_toolkit.installer.receipt import InstallReceipt
+
+_VALID_TOOLS = ("claude-code", "cursor", "opencode", "copilot", "windsurf", "pi")
+_TOOL_RECEIPT_TARGETS = {
+    "claude-code": "claude-code",
+    "cursor": "cursor",
+    "opencode": "opencode",
+    "copilot": "copilot",
+    "windsurf": "windsurf",
+    "pi": "pi",
+}
+
+
+def _info(msg: str) -> None:
+    print(f"  [info]  {msg}")
+
+
+def _ok(msg: str) -> None:
+    print(f"  ✓  {msg}")
+
+
+def _skip(msg: str) -> None:
+    print(f"  -  {msg}")
+
+
+def _dry(msg: str) -> None:
+    print(f"  [dry]   {msg}")
+
+
+def _err(msg: str) -> None:
+    print(f"  ✗  {msg}", file=sys.stderr)
+
+
+def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
+    dry_run = False
+    requested = ""
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-h", "--help"):
+            print(__doc__)
+            return None
+        if arg in ("--dry-run",):
+            dry_run = True
+        elif arg in ("--rollback",):
+            dry_run = False  # rollback is uninstall with side effects
+        elif arg == "--tools":
+            if i + 1 >= len(args):
+                _err("--tools requires an argument")
+                return None
+            requested = args[i + 1]
+            i += 1
+        else:
+            _err(f"Unknown option: {arg}")
+            return None
+        i += 1
+
+    if requested:
+        tools = [t.strip() for t in requested.split(",") if t.strip()]
+    else:
+        tools = []
+    return tools, dry_run, True
+
+
+def _discover_tools(receipt_dir: Path) -> list[str]:
+    found: list[str] = []
+    if not receipt_dir.is_dir():
+        return found
+    for path in sorted(receipt_dir.glob(f"*-{tracking.PRODUCT}.json")):
+        target = path.name[: -len(f"-{tracking.PRODUCT}.json")]
+        for tool, receipt_target in _TOOL_RECEIPT_TARGETS.items():
+            if receipt_target == target and tool not in found:
+                found.append(tool)
+    return found
+
+
+def _uninstall_tool(tool: str, *, dry_run: bool, receipt_dir: Path) -> bool:
+    target = _TOOL_RECEIPT_TARGETS.get(tool)
+    if target is None:
+        _err(f"Unknown tool: {tool}")
+        return False
+
+    receipt = InstallReceipt.load(target, tracking.PRODUCT, receipt_dir)
+    if receipt is None:
+        _skip(f"No receipt for {tool} — nothing to uninstall")
+        return True
+
+    _info(f"Uninstalling {tool} ({len(receipt.artifacts)} artifact(s) from receipt)")
+    removed = 0
+    for entry in receipt.artifacts:
+        if entry.ownership != "created":
+            _skip(f"Skipping non-owned file ({entry.ownership}): {entry.path}")
+            continue
+        path = Path(entry.path)
+        if not path.exists():
+            _skip(f"Already absent: {path}")
+            continue
+        if dry_run:
+            _dry(f"Would remove: {path}")
+        else:
+            try:
+                path.unlink()
+                _ok(f"Removed: {path}")
+            except OSError as exc:
+                _err(f"Failed to remove {path}: {exc}")
+                return False
+        removed += 1
+
+    if not dry_run:
+        receipt_path = receipt_dir / f"{target}-{tracking.PRODUCT}.json"
+        if receipt_path.exists():
+            receipt_path.unlink()
+            _ok(f"Removed receipt: {receipt_path}")
+
+    _info(f"{tool}: processed {removed} owned file(s)")
+    return True
+
+
+def cmd_uninstall(args: list[str]) -> int:
+    parsed = _parse_args(args)
+    if parsed is None:
+        return 0 if any(a in ("-h", "--help") for a in args) else 2
+    tools, dry_run, _ = parsed
+
+    rdir = tracking.receipt_dir()
+    if not tools:
+        tools = _discover_tools(rdir)
+        if not tools:
+            _err("No install receipts found. Nothing to uninstall.")
+            return 1
+
+    print()
+    print("agent-toolkit uninstall")
+    if dry_run:
+        _info("DRY RUN — no files will be deleted")
+
+    failed: list[str] = []
+    for tool in tools:
+        if tool not in _VALID_TOOLS:
+            _err(f"Unknown tool: {tool}")
+            failed.append(tool)
+            continue
+        if not _uninstall_tool(tool, dry_run=dry_run, receipt_dir=rdir):
+            failed.append(tool)
+
+    print()
+    return 1 if failed else 0

--- a/packages/agent-toolkit-cli/src/agent_toolkit/installer/tracking.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/installer/tracking.py
@@ -1,0 +1,62 @@
+"""Track installed artifacts and persist InstallReceipt."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from agent_toolkit import __version__
+from agent_toolkit.installer.receipt import ArtifactEntry, InstallReceipt
+
+PRODUCT = "agent-toolkit-profiles"
+SCOPE = "user-home"
+
+
+def receipt_dir() -> Path:
+    """Return the install receipt directory (under the current HOME)."""
+    return Path.home() / ".config" / "agent-toolkit" / "receipts"
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def source_digest(root: Path) -> str:
+    marker = root / "profiles"
+    if marker.is_dir():
+        return hashlib.sha256(str(marker.resolve()).encode()).hexdigest()[:12]
+    return __version__
+
+
+class InstallTracker:
+    """Collect artifact entries during install and write receipt on save."""
+
+    def __init__(
+        self,
+        target: str,
+        *,
+        dry_run: bool,
+        receipt_dir_path: Path | None = None,
+        toolkit_root: Path | None = None,
+    ) -> None:
+        root = toolkit_root or Path()
+        self.dry_run = dry_run
+        self.receipt_dir_path = receipt_dir_path or receipt_dir()
+        self.receipt = InstallReceipt.create(
+            PRODUCT,
+            target,
+            SCOPE,
+            __version__,
+            source_digest(root),
+        )
+
+    def record_created(self, path: Path) -> None:
+        if not path.is_file():
+            return
+        self.receipt.artifacts.append(
+            ArtifactEntry(str(path.resolve()), file_digest(path), "created")
+        )
+
+    def save(self) -> Path | None:
+        if self.dry_run or not self.receipt.artifacts:
+            return None
+        return self.receipt.save(self.receipt_dir_path)

--- a/tests/test_install_uninstall.py
+++ b/tests/test_install_uninstall.py
@@ -1,0 +1,83 @@
+"""Install receipt wiring and uninstall/rollback."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import install as install_mod
+from agent_toolkit.cli.uninstall import cmd_uninstall
+from agent_toolkit.installer import tracking
+from agent_toolkit.installer.receipt import InstallReceipt
+
+PRODUCT = tracking.PRODUCT
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture()
+def receipt_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    rd = tmp_path / "receipts"
+    rd.mkdir()
+    monkeypatch.setattr("agent_toolkit.installer.tracking.receipt_dir", lambda: rd)
+    return rd
+
+
+@pytest.fixture()
+def toolkit_with_cursor_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    rules = root / "profiles" / "cursor" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "assistant.mdc").write_text("cursor rules\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+    return root
+
+
+def test_install_writes_receipt(
+    fake_home: Path,
+    receipt_dir: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    ok = install_mod._install_cursor(dry_run=False, force=True)
+    assert ok is True
+
+    receipt = InstallReceipt.load("cursor", PRODUCT, receipt_dir)
+    assert receipt is not None
+    assert len(receipt.artifacts) == 1
+    assert receipt.artifacts[0].ownership == "created"
+    assert (fake_home / ".cursor" / "rules" / "assistant.mdc").is_file()
+
+
+def test_uninstall_removes_receipt_owned_files(
+    fake_home: Path,
+    receipt_dir: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    install_mod._install_cursor(dry_run=False, force=True)
+    installed = fake_home / ".cursor" / "rules" / "assistant.mdc"
+    assert installed.is_file()
+
+    rc = cmd_uninstall(["--tools", "cursor"])
+    assert rc == 0
+    assert not installed.exists()
+    assert InstallReceipt.load("cursor", PRODUCT, receipt_dir) is None
+
+
+def test_uninstall_dry_run_keeps_files(
+    fake_home: Path,
+    receipt_dir: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    install_mod._install_cursor(dry_run=False, force=True)
+    installed = fake_home / ".cursor" / "rules" / "assistant.mdc"
+
+    rc = cmd_uninstall(["--tools", "cursor", "--dry-run"])
+    assert rc == 0
+    assert installed.is_file()
+    assert InstallReceipt.load("cursor", PRODUCT, receipt_dir) is not None

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -33,9 +33,19 @@ def test_github_provider_fields():
     assert gh.id == "github"
     assert gh.display_name == "GitHub"
     assert gh.provenance == "official"
-    assert "GITHUB_TOKEN" in gh.env_vars
+    assert gh.package == "ghcr.io/github/github-mcp-server"
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in gh.env_vars
+    assert "GITHUB_TOKEN" not in gh.env_vars
     assert len(gh.read_tools) > 0
     assert len(gh.write_tools) > 0
+
+
+def test_github_template_matches_official_server():
+    """Regression #74: template must not reference deprecated npm package."""
+    template = (REPO_ROOT / "mcp" / "templates" / "github" / "config.template.json").read_text()
+    assert "ghcr.io/github/github-mcp-server" in template
+    assert "@modelcontextprotocol/server-github" not in template
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in template
 
 
 def test_all_providers_have_complete_metadata():


### PR DESCRIPTION
## Summary
- Wire `InstallReceipt` into `agent-toolkit install` for claude-code, cursor, and opencode
- Add `agent-toolkit uninstall` / `rollback` to remove only toolkit-owned files recorded in receipts
- Add tmp-HOME integration tests for install → receipt → uninstall flow

Closes #58

## Test plan
- [x] `uv run pytest tests/test_install_uninstall.py tests/test_installer_receipt.py tests/test_install_claude_settings.py -v`