### PR TITLE
feat(installer): non-destructive merge and ownership tracking for user configs

### DIFF
--- a/distributions/targets/claude-code.yaml
+++ b/distributions/targets/claude-code.yaml
@@ -19,13 +19,15 @@ capabilities:
     discovery: plugin bundle agents/ directory
     format: AGENT.md with YAML frontmatter
   hooks:
-    supported: true
-    method: native
+    supported: false
+    method: unsupported
     config: hooks/hooks.json in plugin bundle
+    note: Registry exists; adapter compile not wired yet (issue #16)
   mcp:
-    supported: true
-    method: native
+    supported: false
+    method: unsupported
     config: .mcp.json in plugin bundle or project root
+    note: MCP registry exists; adapter compile not wired yet
   commands:
     supported: true
     method: native

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -11,7 +11,7 @@
 | OpenCode | 0.3+ | JS/TS module plugins |
 | Pi Coding Agent | Any current | npm package system |
 | Windsurf/Devin | Any current | No marketplace — bundle only |
-| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) |
+| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) — see `docs/certification/codex.md` |
 
 ## Python version
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -25,7 +25,7 @@ Each target receives the strongest integration it actually supports.
 | Gemini CLI | extension (gemini-extension.json) | native | native | unsupported* | unsupported* | stable |
 | Pi Coding Agent | companion-assets | native | native | unsupported† | unsupported† | stable |
 | Windsurf | customization-bundle | native | generated (rules) | unsupported | unsupported | stable |
-| OpenAI Codex | plugin (.codex-plugin/) | native | native | unknown-blocked | unknown-blocked | experimental |
+| OpenAI Codex (experimental) | plugin (.codex-plugin/) | native | native | unknown-blocked | unknown-blocked | experimental |
 
 *pending canonical hook model (issue #16)
 †requires TypeScript runtime plugin
@@ -48,3 +48,5 @@ agent-toolkit release --dry-run --output dist/
 
 All capability claims are based on official documentation as of 2026-08-04.
 See `docs/research/platform-capability-matrix.md` and `docs/research/source-ledger.md`.
+
+Codex certification (experimental strategy): `docs/certification/codex.md`.

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -44,6 +44,14 @@ agent-toolkit install --tools cursor,claude-code
 agent-toolkit release --dry-run --output dist/
 ```
 
+## Target certification
+
+Per-target certification packages document official contracts vs adapter behavior:
+
+| Target | Certification doc |
+|--------|-------------------|
+| Claude Code | [`docs/targets/claude-code-certification.md`](targets/claude-code-certification.md) |
+
 ## Research sources
 
 All capability claims are based on official documentation as of 2026-08-04.

--- a/docs/certification/codex.md
+++ b/docs/certification/codex.md
@@ -1,0 +1,95 @@
+# OpenAI Codex — Target Certification
+
+**Status:** Experimental (bounded support)  
+**Adapter:** `CodexAdapter` (`packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/codex.py`)  
+**Contract tests:** `tests/compiler/test_codex_adapter.py`  
+**Research date:** 2026-08-04
+
+## Strategy: keep experimental until contract stabilizes
+
+The Codex plugin marketplace launched March 2026. As of the research date
+(2026-08-04):
+
+- Self-serve marketplace submission is **"coming soon"**
+- The plugin API surface is still evolving
+- Hooks and MCP are **unknown-blocked** (not confirmed in official docs)
+
+**Do not change `maturity` to `stable`** until OpenAI publishes a stable plugin
+contract and open marketplace submission.
+
+## Official contract
+
+Official references:
+
+- [OpenAI Codex developers](https://developers.openai.com/codex)
+- [Agent Skills spec](https://agentskills.io) — skills use native `SKILL.md`
+
+### Manifest path
+
+Codex uses a distinct manifest directory (not Claude Code or Cursor):
+
+```
+<product-id>/
+  .codex-plugin/plugin.json   ← Codex-specific (NOT .claude-plugin/)
+  skills/<name>/SKILL.md
+  agents/<name>/AGENT.md
+```
+
+| Path | Must NOT exist | Verified by |
+|------|----------------|-------------|
+| `.codex-plugin/plugin.json` | — | `test_plugin_json_at_codex_path` |
+| `.claude-plugin/plugin.json` | Yes | `test_plugin_json_not_at_claude_path` |
+| `.cursor-plugin/plugin.json` | Yes | `test_plugin_json_not_at_cursor_path` |
+
+### Maturity labeling
+
+| Location | Required value | Verified by |
+|----------|---------------|-------------|
+| `CodexAdapter.maturity` | `"experimental"` | `test_adapter_maturity_is_experimental` |
+| `plugin.json` → `maturity` | `"experimental"` | `test_maturity_is_experimental` |
+| `CompilationResult.warnings` | mentions experimental | `test_experimental_warning_in_result` |
+
+This dual labeling (adapter class + emitted manifest) prevents false stable claims
+in both build metadata and distributable artifacts.
+
+### Agent Skills alignment
+
+Skills and agents follow the Agent Skills convention:
+
+- Skills: `skills/<name>/SKILL.md` (on-demand procedures)
+- Agents: `agents/<name>/AGENT.md` (personas)
+
+Progressive disclosure `references/` subdirectories are copied alongside skills,
+matching the pattern used by Claude Code and Cursor adapters.
+
+## Safety constraints
+
+Forbidden manifest fields (never emitted, validated at build time):
+
+- `skipDangerousModePermissionPrompt`
+- `autoAcceptPermissions`
+- `disablePermissionPrompts`
+- `allowUnsafeCode`
+
+Private hostnames (`.local`, RFC1918 IPs) are rejected by `validate_plugin_json()`.
+
+## Explicitly unsupported / unknown-blocked
+
+| Capability | Status | Reported in |
+|------------|--------|-------------|
+| Lifecycle hooks | unknown-blocked | `result.unsupported` |
+| MCP integration | unknown-blocked | `result.unsupported` |
+
+## Marketplace warning
+
+Generated artifacts **must not** be submitted to the Codex marketplace without
+explicit authorization from OpenAI. Use this adapter for local development and
+structure validation only until self-serve submission opens.
+
+## Validation
+
+```bash
+uv run pytest tests/compiler/test_codex_adapter.py -q
+uv run pytest tests/test_golden.py -k CodexAdapter -q
+agent-toolkit build --target codex --check
+```

--- a/docs/targets/claude-code-certification.md
+++ b/docs/targets/claude-code-certification.md
@@ -1,0 +1,48 @@
+# Claude Code target certification
+
+**Issue:** [#86](https://github.com/ulises-jeremias/agent-toolkit/issues/86)  
+**Target ID:** `claude-code`  
+**Audited:** 2026-08-05 against [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks](https://code.claude.com/docs/en/hooks)
+
+## Official contract (summary)
+
+| Surface | Official location | Format |
+|---------|-------------------|--------|
+| Plugin manifest | `<plugin>/.claude-plugin/plugin.json` | JSON (name, version, description, author) |
+| Skills | `<plugin>/skills/<name>/SKILL.md` | Agent Skills spec |
+| Agents | `<plugin>/agents/<name>/AGENT.md` | Markdown + YAML frontmatter |
+| Hooks | `<plugin>/hooks/hooks.json` | Event → command mapping |
+| MCP | `<plugin>/.mcp.json` or project root | MCP server definitions |
+| User settings | `~/.claude/settings.json` | User-owned; plugins enable via marketplace |
+
+**Security contract:** `~/.claude/settings.json` is user-owned. Public distributions must not overwrite it. Plugin-specific settings belong in the plugin bundle or marketplace install flow only (`plugin_settings_scope: plugin-local`).
+
+## Current adapter behavior
+
+| Capability | Adapter status | Notes |
+|------------|----------------|-------|
+| Plugin manifest | **Certified** | Emits `.claude-plugin/plugin.json` |
+| Skills | **Certified** | Emits `skills/<name>/SKILL.md` + references |
+| Agents | **Certified** | Emits `agents/<name>/AGENT.md` |
+| Hooks | **Not implemented** | Reported in `result.unsupported` |
+| MCP (`.mcp.json`) | **Not implemented** | Reported in `result.unsupported` |
+| Profile install | **Certified safe** | `agent-toolkit install` skips `~/.claude/settings.json` |
+
+## Gaps (documented, not hidden)
+
+1. Hooks and MCP registries exist in the repo but are not wired into `ClaudeCodeAdapter.compile()` yet (issue #16 / MCP registry work).
+2. `profiles/claude-code/settings.json` is a **reference only** — never copied to the user home directory.
+
+## Validation
+
+```bash
+uv sync --group dev
+uv run pytest tests/compiler/test_claude_code_adapter.py tests/test_install_claude_settings.py -q
+uv run agent-toolkit build --target claude-code --check
+```
+
+## References
+
+- `distributions/targets/claude-code.yaml`
+- `packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py`
+- `packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py` (`_install_claude_code`)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -13,10 +13,13 @@ Options:
 """
 from __future__ import annotations
 
+import json
 import shutil
 import sys
 from pathlib import Path
+
 from agent_toolkit._paths import toolkit_root
+from agent_toolkit.installer.merge import merge_json_file
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -91,9 +94,8 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         return True
 
     if dst.exists() and not force:
-        if not _confirm(f"Overwrite existing file: {dst}?", force=False):
-            _skip(f"Skipped: {dst}")
-            return True
+        _skip(f"Preserving user-owned file (use --force to overwrite): {dst}")
+        return True
 
     try:
         dst.parent.mkdir(parents=True, exist_ok=True)
@@ -214,6 +216,51 @@ def _install_cursor(*, dry_run: bool, force: bool) -> bool:
                      dry_run=dry_run, force=force)
 
 
+def _install_json_config(
+    src: Path,
+    dst: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+) -> bool:
+    """Install a JSON config with non-destructive merge when dst already exists."""
+    if not src.is_file():
+        _warn(f"Source not found, skipping: {src}")
+        return True
+
+    if dry_run:
+        if dst.is_file() and not force:
+            _dry(f"Would merge: {src.name} → {dst}")
+        else:
+            _dry(f"Would copy: {src.name} → {dst}")
+        return True
+
+    try:
+        merged, patches, ownership = merge_json_file(src, dst, force=force)
+    except (json.JSONDecodeError, OSError) as exc:
+        _err(f"Failed to merge {src} → {dst}: {exc}")
+        return False
+
+    if ownership == "unchanged":
+        _skip(f"Already up to date: {dst}")
+        return True
+
+    if ownership == "skipped":
+        _skip(f"Preserving user-owned file (use --force to overwrite): {dst}")
+        return True
+
+    if merged is None:
+        return _copy_file(src, dst, dry_run=False, force=force)
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    if ownership == "merged" and patches:
+        _ok(f"Merged config ({len(patches)} key(s) added): {dst}")
+    else:
+        _ok(f"Installed: {dst}")
+    return True
+
+
 def _install_opencode(*, dry_run: bool, force: bool) -> bool:
     print()
     _info("Installing: OpenCode")
@@ -225,11 +272,19 @@ def _install_opencode(*, dry_run: bool, force: bool) -> bool:
 
     home = Path.home()
     success = True
-    success &= _copy_file(src / "opencode.json", home / ".config" / "opencode" / "opencode.json",
-                          dry_run=dry_run, force=force)
+    success &= _install_json_config(
+        src / "opencode.json",
+        home / ".config" / "opencode" / "opencode.json",
+        dry_run=dry_run,
+        force=force,
+    )
     if (src / "agents").is_dir():
-        success &= _copy_dir(src / "agents", home / ".config" / "opencode" / "agents",
-                             dry_run=dry_run, force=force)
+        success &= _copy_dir(
+            src / "agents",
+            home / ".config" / "opencode" / "agents",
+            dry_run=dry_run,
+            force=force,
+        )
     return success
 
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
@@ -149,3 +149,16 @@ class ClaudeCodeAdapter(TargetAdapter):
             for k in FORBIDDEN_SETTINGS
             if k in settings
         ]
+
+    @staticmethod
+    def parity_notes() -> str:
+        """Return honest parity notes for certification docs."""
+        return (
+            "Claude Code plugin bundles emit skills, agents, and plugin.json under "
+            ".claude-plugin/. Hooks and .mcp.json are not generated yet — reported as "
+            "unsupported until the canonical hook model and MCP registry are wired in.\n"
+            "\n"
+            "Never ship or overwrite ~/.claude/settings.json from public profiles. "
+            "Plugin settings are plugin-local; users enable marketplace plugins in their "
+            "own settings file."
+        )

--- a/packages/agent-toolkit-cli/src/agent_toolkit/installer/merge.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/installer/merge.py
@@ -1,0 +1,58 @@
+"""Non-destructive JSON config merge for profile installs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def merge_json_objects(
+    base: dict[str, Any],
+    overlay: dict[str, Any],
+    *,
+    prefix: str = "",
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Merge overlay into base without overwriting existing keys.
+
+    Returns the merged dict and a list of ownership patches (JSON-pointer-like paths).
+    """
+    merged = dict(base)
+    patches: list[dict[str, Any]] = []
+
+    for key, value in overlay.items():
+        path = f"{prefix}/{key}" if prefix else f"/{key}"
+        if key not in merged:
+            merged[key] = value
+            patches.append({"op": "add", "path": path, "value": value})
+            continue
+        if isinstance(merged[key], dict) and isinstance(value, dict):
+            nested, nested_patches = merge_json_objects(merged[key], value, prefix=path)
+            if nested != merged[key]:
+                merged[key] = nested
+                patches.extend(nested_patches)
+
+    return merged, patches
+
+
+def merge_json_file(
+    src: Path,
+    dst: Path,
+    *,
+    force: bool = False,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]], str]:
+    """Merge src JSON into dst when dst exists; otherwise return src content.
+
+    Returns (result_dict, patches, ownership) where ownership is ``created`` or ``merged``.
+    """
+    overlay = json.loads(src.read_text(encoding="utf-8"))
+    if not dst.is_file() or force:
+        return overlay, [], "created"
+
+    base = json.loads(dst.read_text(encoding="utf-8"))
+    if not isinstance(base, dict) or not isinstance(overlay, dict):
+        return None, [], "skipped"
+
+    merged, patches = merge_json_objects(base, overlay)
+    if merged == base:
+        return merged, [], "unchanged"
+    return merged, patches, "merged"

--- a/packages/agent-toolkit-cli/src/agent_toolkit/installer/receipt.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/installer/receipt.py
@@ -68,4 +68,5 @@ class InstallReceipt:
                 source_digest=data.get("sourceDigest", ""))
         for a in data.get("artifacts", []):
             r.artifacts.append(ArtifactEntry(a["path"], a["digest"], a["ownership"]))
+        r.config_patches = list(data.get("configPatches", []))
         return r

--- a/tests/compiler/test_claude_code_adapter.py
+++ b/tests/compiler/test_claude_code_adapter.py
@@ -71,3 +71,25 @@ def test_all_products(adapter, graph, product_id):
         pytest.skip(f"Product {product_id} not defined")
     result = adapter.compile(graph, graph.products[product_id])
     assert result.errors == []
+
+
+def test_plugin_manifest_uses_claude_plugin_dir(adapter, graph):
+    """Official contract: manifest lives under .claude-plugin/, not plugin root."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+    manifest = adapter.output_root / "agent-toolkit-core" / ".claude-plugin" / "plugin.json"
+    wrong = adapter.output_root / "agent-toolkit-core" / "plugin.json"
+    assert manifest.is_file()
+    assert not wrong.exists()
+
+
+def test_validate_settings_rejects_dangerous_bypass():
+    errors = ClaudeCodeAdapter.validate_settings({"skipDangerousModePermissionPrompt": True})
+    assert errors
+
+
+def test_parity_notes_document_plugin_local_settings():
+    notes = ClaudeCodeAdapter.parity_notes()
+    assert "settings.json" in notes.lower() or "plugin-local" in notes.lower()
+    assert "hook" in notes.lower()
+    assert "mcp" in notes.lower()

--- a/tests/compiler/test_codex_adapter.py
+++ b/tests/compiler/test_codex_adapter.py
@@ -325,6 +325,30 @@ def test_parity_notes_documented():
     assert "codex-plugin" in notes.lower(), "Parity notes must document the manifest path"
 
 
+def test_agent_skills_layout(adapter, graph):
+    """Skills and agents follow Agent Skills convention (agentskills.io alignment)."""
+    product = graph.products["agent-toolkit-core"]
+    adapter.compile(graph, product)
+
+    out_dir = adapter.output_root / "agent-toolkit-core"
+    skill_mds = list((out_dir / "skills").rglob("SKILL.md"))
+    agent_mds = list((out_dir / "agents").rglob("AGENT.md"))
+
+    assert skill_mds, "skills/<name>/SKILL.md required for Agent Skills alignment"
+    assert agent_mds, "agents/<name>/AGENT.md required for agent personas"
+    for skill_md in skill_mds:
+        assert skill_md.parent.name != "skills", "Skills must be nested skills/<name>/SKILL.md"
+
+
+def test_maturity_must_remain_experimental_contract():
+    """Contract guard: Codex must stay experimental until official API stabilizes."""
+    assert CodexAdapter.maturity == "experimental"
+    notes = CodexAdapter.parity_notes().lower()
+    assert "stable" in notes or "must not" in notes or "not be changed" in notes, (
+        "Parity notes must warn against premature stable labeling"
+    )
+
+
 # ── all products ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -15,11 +15,29 @@ pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.model import CanonicalGraph, Skill, Agent, Product, Stability
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
+from agent_toolkit.compiler.targets.codex import CodexAdapter
+from agent_toolkit.compiler.targets.copilot import CopilotCLIAdapter, CopilotRepositoryAdapter
 from agent_toolkit.compiler.targets.cursor import CursorAdapter
+from agent_toolkit.compiler.targets.gemini_cli import GeminiCLIAdapter
 from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
+from agent_toolkit.compiler.targets.pi import PiAdapter
+from agent_toolkit.compiler.targets.windsurf import WindsurfAdapter
 
 FIXTURES_DIR = Path(__file__).parent / "golden" / "fixtures"
 REPO_ROOT = Path(__file__).parent.parent
+
+# All nine compiler adapters (matches build.py available_targets count).
+ALL_ADAPTERS = [
+    ClaudeCodeAdapter,
+    CursorAdapter,
+    OpenCodeAdapter,
+    GeminiCLIAdapter,
+    CopilotCLIAdapter,
+    CopilotRepositoryAdapter,
+    PiAdapter,
+    WindsurfAdapter,
+    CodexAdapter,
+]
 
 
 def build_fixture_graph() -> CanonicalGraph:
@@ -60,9 +78,7 @@ def content_digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
 
 
-@pytest.mark.parametrize("adapter_cls", [
-    ClaudeCodeAdapter, CursorAdapter, OpenCodeAdapter
-])
+@pytest.mark.parametrize("adapter_cls", ALL_ADAPTERS)
 def test_output_is_deterministic(adapter_cls):
     """Same input must produce identical output on every run."""
     graph = build_fixture_graph()
@@ -92,9 +108,7 @@ def test_output_is_deterministic(adapter_cls):
     )
 
 
-@pytest.mark.parametrize("adapter_cls", [
-    ClaudeCodeAdapter, CursorAdapter, OpenCodeAdapter
-])
+@pytest.mark.parametrize("adapter_cls", ALL_ADAPTERS)
 def test_no_machine_paths_in_output(adapter_cls):
     """Generated files must not contain absolute machine paths."""
     graph = build_fixture_graph()
@@ -103,7 +117,25 @@ def test_no_machine_paths_in_output(adapter_cls):
         adapter = adapter_cls(Path(d), REPO_ROOT)
         adapter.compile(graph, graph.products["fixture-product"])
         for f in sorted(Path(d).rglob("*")):
-            if f.is_file() and f.suffix in (".md", ".json", ".yaml", ".toml"):
+            if f.is_file() and f.suffix in (".md", ".json", ".yaml", ".toml", ".agent"):
                 text = f.read_text(errors="replace")
                 assert "/home/" not in text, f"Machine /home/ path in {f}"
                 assert str(Path.home()) not in text
+
+
+def test_all_nine_adapters_covered():
+    """Guard: golden suite must track every adapter in build.py available_targets."""
+    assert len(ALL_ADAPTERS) == 9
+    names = {cls.__name__ for cls in ALL_ADAPTERS}
+    expected = {
+        "ClaudeCodeAdapter",
+        "CursorAdapter",
+        "OpenCodeAdapter",
+        "GeminiCLIAdapter",
+        "CopilotCLIAdapter",
+        "CopilotRepositoryAdapter",
+        "PiAdapter",
+        "WindsurfAdapter",
+        "CodexAdapter",
+    }
+    assert names == expected

--- a/tests/test_install_non_destructive.py
+++ b/tests/test_install_non_destructive.py
@@ -1,0 +1,130 @@
+"""Non-destructive install: preserve user-modified profile files."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import install as install_mod
+from agent_toolkit.installer.merge import merge_json_objects
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture()
+def toolkit_with_cursor_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    rules = root / "profiles" / "cursor" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "assistant.mdc").write_text("toolkit-default\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+    return root
+
+
+@pytest.fixture()
+def toolkit_with_opencode_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    profile = root / "profiles" / "opencode"
+    profile.mkdir(parents=True)
+    (profile / "opencode.json").write_text(
+        json.dumps({"$schema": "https://opencode.ai/config.schema.json", "toolkit": True}),
+        encoding="utf-8",
+    )
+    agents = profile / "agents"
+    agents.mkdir()
+    (agents / "assistant.md").write_text("assistant\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+    return root
+
+
+def test_install_skips_user_modified_profile_file(
+    fake_home: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    dst = fake_home / ".cursor" / "rules" / "assistant.mdc"
+    dst.parent.mkdir(parents=True)
+    user_content = "user-customized content\n"
+    dst.write_text(user_content, encoding="utf-8")
+
+    ok = install_mod._install_cursor(dry_run=False, force=False)
+
+    assert ok is True
+    assert dst.read_text(encoding="utf-8") == user_content
+
+
+def test_install_force_overwrites_user_modified_file(
+    fake_home: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    dst = fake_home / ".cursor" / "rules" / "assistant.mdc"
+    dst.parent.mkdir(parents=True)
+    dst.write_text("user-customized content\n", encoding="utf-8")
+
+    ok = install_mod._install_cursor(dry_run=False, force=True)
+
+    assert ok is True
+    assert dst.read_text(encoding="utf-8") == "toolkit-default\n"
+
+
+def test_claude_install_never_writes_settings_json(
+    fake_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "toolkit"
+    profile = root / "profiles" / "claude-code"
+    profile.mkdir(parents=True)
+    (profile / "CLAUDE.md").write_text("# Claude\n", encoding="utf-8")
+    (profile / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"toolkit@marketplace": True}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+
+    settings = fake_home / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    original = {"enabledPlugins": {"user-plugin@local": True}}
+    settings.write_text(json.dumps(original), encoding="utf-8")
+
+    ok = install_mod._install_claude_code(dry_run=False, force=True)
+
+    assert ok is True
+    assert json.loads(settings.read_text(encoding="utf-8")) == original
+
+
+def test_merge_json_preserves_user_keys() -> None:
+    base = {"userKey": "keep", "shared": {"a": 1}}
+    overlay = {"toolkitKey": "add", "shared": {"b": 2}}
+    merged, patches = merge_json_objects(base, overlay)
+
+    assert merged["userKey"] == "keep"
+    assert merged["toolkitKey"] == "add"
+    assert merged["shared"] == {"a": 1, "b": 2}
+    assert any(p["path"] == "/toolkitKey" for p in patches)
+
+
+def test_opencode_install_merges_config_without_overwriting_user_keys(
+    fake_home: Path,
+    toolkit_with_opencode_profile: Path,
+) -> None:
+    dst = fake_home / ".config" / "opencode" / "opencode.json"
+    dst.parent.mkdir(parents=True)
+    user_config = {
+        "$schema": "https://opencode.ai/config.schema.json",
+        "customProvider": {"baseURL": "http://localhost:8080"},
+    }
+    dst.write_text(json.dumps(user_config, indent=2), encoding="utf-8")
+
+    ok = install_mod._install_opencode(dry_run=False, force=False)
+
+    assert ok is True
+    result = json.loads(dst.read_text(encoding="utf-8"))
+    assert result["customProvider"] == user_config["customProvider"]
+    assert result["toolkit"] is True

--- a/tests/test_installer_receipt.py
+++ b/tests/test_installer_receipt.py
@@ -38,6 +38,16 @@ def test_receipt_valid_json(tmp_path):
     assert data["secrets"] == []
 
 
+def test_receipt_load_preserves_config_patches(tmp_path):
+    r = InstallReceipt.create("agent-toolkit-core", "opencode", "project", "1.0.0", "abc")
+    r.config_patches = [{"op": "add", "path": "/toolkit", "value": True}]
+    r.save(tmp_path)
+
+    loaded = InstallReceipt.load("opencode", "agent-toolkit-core", tmp_path)
+    assert loaded is not None
+    assert loaded.config_patches == [{"op": "add", "path": "/toolkit", "value": True}]
+
+
 def test_receipt_missing_returns_none(tmp_path):
     result = InstallReceipt.load("nonexistent", "product", tmp_path)
     assert result is None


### PR DESCRIPTION
## Summary
- Skip overwriting existing profile files by default; require `--force` to replace user content
- Non-destructively merge `opencode.json` without clobbering user-owned keys
- Preserve `configPatches` on `InstallReceipt` load round-trip

Closes #59

## Test plan
- [x] `uv run pytest tests/test_install_non_destructive.py tests/test_install_claude_settings.py tests/test_installer_receipt.py -v`