### PR TITLE
feat(compiler): map Claude-specific tools to abstract model (#70)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -9,9 +9,18 @@ from pathlib import Path
 from typing import Any
 
 from agent_toolkit.compiler.model import (
-    Agent, CanonicalGraph, ModelClass, Product, Provenance,
-    Requirement, SecurityPolicy, Skill, Stability,
+    AbstractTool,
+    Agent,
+    CanonicalGraph,
+    ModelClass,
+    Product,
+    Provenance,
+    Requirement,
+    SecurityPolicy,
+    Skill,
+    Stability,
 )
+from agent_toolkit.compiler.tool_mapping import map_claude_tools, parse_claude_tool_names
 
 try:
     import yaml
@@ -132,9 +141,16 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
                 f"frontmatter name '{declared_name}' in {agent_md}"
             )
 
-        # Map tools string to list
-        tools_str = fm.get("tools", "")
-        # abstract_tools = []  # TODO: map from Claude-specific to abstract
+        claude_names = parse_claude_tool_names(fm.get("tools"))
+        allowed_tools, unknown_tools = map_claude_tools(claude_names)
+        if unknown_tools:
+            errors.append(
+                f"{agent_md}: unknown Claude tool(s): {', '.join(unknown_tools)}"
+            )
+            continue
+
+        write_tools = {AbstractTool.FS_WRITE, AbstractTool.SHELL_EXECUTE, AbstractTool.GIT_WRITE}
+        read_only = bool(allowed_tools) and not any(t in write_tools for t in allowed_tools)
 
         mc_str = fm.get("model_class", "inherit")
         mc = ModelClass(mc_str) if mc_str in ("fast", "balanced", "deep", "inherit") else ModelClass.INHERIT
@@ -145,6 +161,8 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
             description=str(fm.get("description", ""))[:200],
             instructions=body.strip(),
             model_class=mc,
+            allowed_tools=allowed_tools,
+            read_only=read_only,
             source_path=agent_md,
             metadata=fm,
         )

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
@@ -1,0 +1,52 @@
+"""Map Claude Code tool names to the platform-neutral AbstractTool vocabulary."""
+from __future__ import annotations
+
+from agent_toolkit.compiler.model import AbstractTool
+
+CLAUDE_TOOL_MAP: dict[str, AbstractTool] = {
+    "Read": AbstractTool.FS_READ,
+    "Grep": AbstractTool.FS_SEARCH,
+    "Glob": AbstractTool.FS_SEARCH,
+    "Write": AbstractTool.FS_WRITE,
+    "Edit": AbstractTool.FS_WRITE,
+    "Bash": AbstractTool.SHELL_EXECUTE,
+    "WebSearch": AbstractTool.WEB_SEARCH,
+    "WebFetch": AbstractTool.WEB_FETCH,
+    "Task": AbstractTool.AGENT_DELEGATE,
+    "AskUserQuestion": AbstractTool.USER_ASK,
+    "Git": AbstractTool.GIT_READ,
+    "GitCommit": AbstractTool.GIT_WRITE,
+    "GitPush": AbstractTool.GIT_WRITE,
+}
+
+
+def parse_claude_tool_names(tools_value: str | list[str] | None) -> list[str]:
+    """Parse a frontmatter ``tools`` field into normalized Claude tool names."""
+    if tools_value is None:
+        return []
+    if isinstance(tools_value, list):
+        return [str(t).strip() for t in tools_value if str(t).strip()]
+    return [t.strip() for t in str(tools_value).split(",") if t.strip()]
+
+
+def map_claude_tools(
+    names: list[str],
+) -> tuple[list[AbstractTool], list[str]]:
+    """Map Claude tool names to abstract tools.
+
+    Returns (mapped_tools, unknown_names). Preserves order; deduplicates abstract tools.
+    """
+    mapped: list[AbstractTool] = []
+    unknown: list[str] = []
+    seen: set[AbstractTool] = set()
+
+    for name in names:
+        abstract = CLAUDE_TOOL_MAP.get(name)
+        if abstract is None:
+            unknown.append(name)
+            continue
+        if abstract not in seen:
+            mapped.append(abstract)
+            seen.add(abstract)
+
+    return mapped, unknown

--- a/tests/compiler/test_tool_mapping.py
+++ b/tests/compiler/test_tool_mapping.py
@@ -1,0 +1,37 @@
+"""Tests for Claude → abstract tool mapping (#70)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_toolkit.compiler.loader import load_agents
+from agent_toolkit.compiler.model import AbstractTool
+from agent_toolkit.compiler.tool_mapping import map_claude_tools, parse_claude_tool_names
+
+
+def test_parse_and_map_standard_reviewer_tools():
+    names = parse_claude_tool_names("Read, Grep, Glob, Bash")
+    mapped, unknown = map_claude_tools(names)
+    assert unknown == []
+    assert AbstractTool.FS_READ in mapped
+    assert AbstractTool.FS_SEARCH in mapped
+    assert AbstractTool.SHELL_EXECUTE in mapped
+
+
+def test_unknown_tool_reported():
+    mapped, unknown = map_claude_tools(["Read", "NotARealTool"])
+    assert AbstractTool.FS_READ in mapped
+    assert unknown == ["NotARealTool"]
+
+
+def test_load_agents_populates_allowed_tools(tmp_path: Path):
+    agent_dir = tmp_path / "docs-lookup"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        "---\nname: docs-lookup\ndescription: Docs\ntools: Read, Grep, Glob\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    agents, errors = load_agents(tmp_path)
+    assert errors == []
+    agent = agents["docs-lookup"]
+    assert AbstractTool.FS_READ in agent.allowed_tools
+    assert agent.read_only is True


### PR DESCRIPTION
## Summary
- Add Claude → AbstractTool mapping module
- Populate `Agent.allowed_tools` and inferred `read_only` when loading agents

Closes #70

## Test plan
- [x] `uv run pytest tests/compiler/test_tool_mapping.py -q`