### PR TITLE
feat(agents): abstract tools and delegation contracts (#80)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -9,9 +9,18 @@ from pathlib import Path
 from typing import Any
 
 from agent_toolkit.compiler.model import (
-    Agent, CanonicalGraph, ModelClass, Product, Provenance,
-    Requirement, SecurityPolicy, Skill, Stability,
+    AbstractTool,
+    Agent,
+    CanonicalGraph,
+    ModelClass,
+    Product,
+    Provenance,
+    Requirement,
+    SecurityPolicy,
+    Skill,
+    Stability,
 )
+from agent_toolkit.compiler.tool_mapping import map_claude_tools, parse_claude_tool_names
 
 try:
     import yaml
@@ -132,9 +141,16 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
                 f"frontmatter name '{declared_name}' in {agent_md}"
             )
 
-        # Map tools string to list
-        tools_str = fm.get("tools", "")
-        # abstract_tools = []  # TODO: map from Claude-specific to abstract
+        claude_names = parse_claude_tool_names(fm.get("tools"))
+        allowed_tools, unknown_tools = map_claude_tools(claude_names)
+        if unknown_tools:
+            errors.append(
+                f"{agent_md}: unknown Claude tool(s): {', '.join(unknown_tools)}"
+            )
+            continue
+
+        write_tools = {AbstractTool.FS_WRITE, AbstractTool.SHELL_EXECUTE, AbstractTool.GIT_WRITE}
+        read_only = bool(allowed_tools) and not any(t in write_tools for t in allowed_tools)
 
         mc_str = fm.get("model_class", "inherit")
         mc = ModelClass(mc_str) if mc_str in ("fast", "balanced", "deep", "inherit") else ModelClass.INHERIT
@@ -145,6 +161,8 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
             description=str(fm.get("description", ""))[:200],
             instructions=body.strip(),
             model_class=mc,
+            allowed_tools=allowed_tools,
+            read_only=read_only,
             source_path=agent_md,
             metadata=fm,
         )

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -20,7 +20,12 @@ from agent_toolkit.compiler.model import (
     Skill,
     Stability,
 )
-from agent_toolkit.compiler.tool_mapping import map_claude_tools, parse_claude_tool_names
+from agent_toolkit.compiler.tool_mapping import (
+    infer_read_only,
+    map_claude_tools,
+    parse_abstract_tool_list,
+    parse_claude_tool_names,
+)
 
 try:
     import yaml
@@ -122,6 +127,22 @@ def load_skills(skills_root: Path) -> tuple[dict[str, Skill], list[str]]:
     return skills, errors
 
 
+def _parse_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [v.strip() for v in str(value).split(",") if v.strip()]
+
+
+def _parse_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("true", "yes", "1")
+
+
 def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
     """Load all AGENT.md files from agents/<name>/AGENT.md."""
     agents: dict[str, Agent] = {}
@@ -140,17 +161,42 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
                 f"Agent name mismatch: directory '{agent_name}' vs "
                 f"frontmatter name '{declared_name}' in {agent_md}"
             )
+            continue
 
-        claude_names = parse_claude_tool_names(fm.get("tools"))
-        allowed_tools, unknown_tools = map_claude_tools(claude_names)
-        if unknown_tools:
+        allowed_tools: list[AbstractTool]
+        denied_tools: list[AbstractTool]
+
+        if fm.get("allowed_tools") is not None:
+            allowed_tools, invalid_allowed = parse_abstract_tool_list(fm.get("allowed_tools"))
+            if invalid_allowed:
+                errors.append(
+                    f"{agent_md}: invalid allowed_tools: {', '.join(invalid_allowed)}"
+                )
+                continue
+        else:
+            claude_names = parse_claude_tool_names(fm.get("tools"))
+            allowed_tools, unknown_tools = map_claude_tools(claude_names)
+            if unknown_tools:
+                errors.append(
+                    f"{agent_md}: unknown Claude tool(s): {', '.join(unknown_tools)}"
+                )
+                continue
+
+        denied_tools, invalid_denied = parse_abstract_tool_list(fm.get("denied_tools"))
+        if invalid_denied:
             errors.append(
-                f"{agent_md}: unknown Claude tool(s): {', '.join(unknown_tools)}"
+                f"{agent_md}: invalid denied_tools: {', '.join(invalid_denied)}"
             )
             continue
 
-        write_tools = {AbstractTool.FS_WRITE, AbstractTool.SHELL_EXECUTE, AbstractTool.GIT_WRITE}
-        read_only = bool(allowed_tools) and not any(t in write_tools for t in allowed_tools)
+        delegates_to = _parse_string_list(fm.get("delegates_to"))
+
+        if "read_only" in fm:
+            read_only = _parse_bool(fm.get("read_only"))
+        else:
+            read_only = infer_read_only(allowed_tools)
+
+        background_eligible = _parse_bool(fm.get("background_eligible"))
 
         mc_str = fm.get("model_class", "inherit")
         mc = ModelClass(mc_str) if mc_str in ("fast", "balanced", "deep", "inherit") else ModelClass.INHERIT
@@ -162,12 +208,38 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
             instructions=body.strip(),
             model_class=mc,
             allowed_tools=allowed_tools,
+            denied_tools=denied_tools,
+            delegates_to=delegates_to,
             read_only=read_only,
+            background_eligible=background_eligible,
             source_path=agent_md,
             metadata=fm,
         )
 
     return agents, errors
+
+
+def validate_agent_contracts(graph: CanonicalGraph) -> None:
+    """Validate agent tool requirements and delegation references."""
+    agent_ids = set(graph.agents)
+
+    for agent_id, agent in graph.agents.items():
+        overlap = {t.value for t in agent.allowed_tools} & {t.value for t in agent.denied_tools}
+        if overlap:
+            graph.errors.append(
+                f"Agent '{agent_id}' lists the same tool in allowed_tools and denied_tools: "
+                f"{', '.join(sorted(overlap))}"
+            )
+
+        for delegate_id in agent.delegates_to:
+            if delegate_id not in agent_ids:
+                graph.errors.append(
+                    f"Agent '{agent_id}' delegates_to unknown agent '{delegate_id}'"
+                )
+            elif delegate_id == agent_id:
+                graph.errors.append(
+                    f"Agent '{agent_id}' cannot delegate_to itself"
+                )
 
 
 def load_products(products_yaml: Path) -> tuple[dict[str, Product], list[str]]:
@@ -228,7 +300,9 @@ def load_graph(repo_root: Path) -> CanonicalGraph:
     graph.products.update(products)
     graph.errors.extend(errs)
 
-    # Validate references
+    validate_agent_contracts(graph)
+
+    # Validate product references
     for pid, product in graph.products.items():
         for skill_id in product.included_skills:
             if skill_id not in graph.skills:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
@@ -95,6 +95,7 @@ class Agent:
     max_turns: int = 0               # 0 = platform default
     allowed_tools: list[AbstractTool] = field(default_factory=list)
     denied_tools: list[AbstractTool] = field(default_factory=list)
+    delegates_to: list[str] = field(default_factory=list)
     read_only: bool = False
     background_eligible: bool = False
     dependent_skills: list[str] = field(default_factory=list)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
@@ -1,0 +1,52 @@
+"""Map Claude Code tool names to the platform-neutral AbstractTool vocabulary."""
+from __future__ import annotations
+
+from agent_toolkit.compiler.model import AbstractTool
+
+CLAUDE_TOOL_MAP: dict[str, AbstractTool] = {
+    "Read": AbstractTool.FS_READ,
+    "Grep": AbstractTool.FS_SEARCH,
+    "Glob": AbstractTool.FS_SEARCH,
+    "Write": AbstractTool.FS_WRITE,
+    "Edit": AbstractTool.FS_WRITE,
+    "Bash": AbstractTool.SHELL_EXECUTE,
+    "WebSearch": AbstractTool.WEB_SEARCH,
+    "WebFetch": AbstractTool.WEB_FETCH,
+    "Task": AbstractTool.AGENT_DELEGATE,
+    "AskUserQuestion": AbstractTool.USER_ASK,
+    "Git": AbstractTool.GIT_READ,
+    "GitCommit": AbstractTool.GIT_WRITE,
+    "GitPush": AbstractTool.GIT_WRITE,
+}
+
+
+def parse_claude_tool_names(tools_value: str | list[str] | None) -> list[str]:
+    """Parse a frontmatter ``tools`` field into normalized Claude tool names."""
+    if tools_value is None:
+        return []
+    if isinstance(tools_value, list):
+        return [str(t).strip() for t in tools_value if str(t).strip()]
+    return [t.strip() for t in str(tools_value).split(",") if t.strip()]
+
+
+def map_claude_tools(
+    names: list[str],
+) -> tuple[list[AbstractTool], list[str]]:
+    """Map Claude tool names to abstract tools.
+
+    Returns (mapped_tools, unknown_names). Preserves order; deduplicates abstract tools.
+    """
+    mapped: list[AbstractTool] = []
+    unknown: list[str] = []
+    seen: set[AbstractTool] = set()
+
+    for name in names:
+        abstract = CLAUDE_TOOL_MAP.get(name)
+        if abstract is None:
+            unknown.append(name)
+            continue
+        if abstract not in seen:
+            mapped.append(abstract)
+            seen.add(abstract)
+
+    return mapped, unknown

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
@@ -19,6 +19,10 @@ CLAUDE_TOOL_MAP: dict[str, AbstractTool] = {
     "GitPush": AbstractTool.GIT_WRITE,
 }
 
+_WRITE_TOOLS = frozenset(
+    {AbstractTool.FS_WRITE, AbstractTool.SHELL_EXECUTE, AbstractTool.GIT_WRITE}
+)
+
 
 def parse_claude_tool_names(tools_value: str | list[str] | None) -> list[str]:
     """Parse a frontmatter ``tools`` field into normalized Claude tool names."""
@@ -50,3 +54,28 @@ def map_claude_tools(
             seen.add(abstract)
 
     return mapped, unknown
+
+
+def parse_abstract_tool_list(
+    value: str | list[str] | None,
+) -> tuple[list[AbstractTool], list[str]]:
+    """Parse explicit abstract tool IDs from frontmatter."""
+    if value is None:
+        return [], []
+    raw_items = value if isinstance(value, list) else [v.strip() for v in str(value).split(",")]
+    mapped: list[AbstractTool] = []
+    invalid: list[str] = []
+    for item in raw_items:
+        token = str(item).strip()
+        if not token:
+            continue
+        try:
+            mapped.append(AbstractTool(token))
+        except ValueError:
+            invalid.append(token)
+    return mapped, invalid
+
+
+def infer_read_only(tools: list[AbstractTool]) -> bool:
+    """True when the agent has tools but none that mutate state."""
+    return bool(tools) and not any(t in _WRITE_TOOLS for t in tools)

--- a/tests/compiler/test_agent_contracts.py
+++ b/tests/compiler/test_agent_contracts.py
@@ -1,0 +1,88 @@
+"""Tests for agent abstract tool requirements and delegation contracts."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_agents, load_graph, validate_agent_contracts
+from agent_toolkit.compiler.model import AbstractTool, Agent, CanonicalGraph
+
+
+def test_load_agents_explicit_allowed_tools(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "planner"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        "---\n"
+        "name: planner\n"
+        "description: Plans work.\n"
+        "allowed_tools:\n"
+        "  - fs.read\n"
+        "  - fs.search\n"
+        "read_only: true\n"
+        "delegates_to:\n"
+        "  - code-reviewer\n"
+        "---\n"
+        "# Planner\n",
+        encoding="utf-8",
+    )
+
+    agents, errors = load_agents(tmp_path)
+    assert errors == []
+    agent = agents["planner"]
+    assert agent.allowed_tools == [AbstractTool.FS_READ, AbstractTool.FS_SEARCH]
+    assert agent.read_only is True
+    assert agent.delegates_to == ["code-reviewer"]
+
+
+def test_validate_delegates_to_unknown_agent() -> None:
+    graph = CanonicalGraph()
+    graph.agents["assistant"] = Agent(
+        id="assistant",
+        name="assistant",
+        description="Routes work.",
+        instructions="",
+        delegates_to=["missing-agent"],
+    )
+
+    validate_agent_contracts(graph)
+    assert any("delegates_to unknown agent" in e for e in graph.errors)
+
+
+def test_validate_delegates_to_self_is_error() -> None:
+    graph = CanonicalGraph()
+    graph.agents["assistant"] = Agent(
+        id="assistant",
+        name="assistant",
+        description="Routes work.",
+        instructions="",
+        delegates_to=["assistant"],
+    )
+
+    validate_agent_contracts(graph)
+    assert any("cannot delegate_to itself" in e for e in graph.errors)
+
+
+def test_validate_allowed_denied_overlap() -> None:
+    graph = CanonicalGraph()
+    graph.agents["reviewer"] = Agent(
+        id="reviewer",
+        name="reviewer",
+        description="Review.",
+        instructions="",
+        allowed_tools=[AbstractTool.FS_READ],
+        denied_tools=[AbstractTool.FS_READ],
+    )
+
+    validate_agent_contracts(graph)
+    assert any("allowed_tools and denied_tools" in e for e in graph.errors)
+
+
+def test_repo_agents_load_with_tool_mapping() -> None:
+    repo_root = Path(__file__).parent.parent.parent
+    graph = load_graph(repo_root)
+    assert graph.is_valid, graph.errors
+    assert graph.agents["code-reviewer"].allowed_tools
+    assert graph.agents["code-reviewer"].read_only is False

--- a/tests/compiler/test_tool_mapping.py
+++ b/tests/compiler/test_tool_mapping.py
@@ -1,0 +1,37 @@
+"""Tests for Claude → abstract tool mapping (#70)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_toolkit.compiler.loader import load_agents
+from agent_toolkit.compiler.model import AbstractTool
+from agent_toolkit.compiler.tool_mapping import map_claude_tools, parse_claude_tool_names
+
+
+def test_parse_and_map_standard_reviewer_tools():
+    names = parse_claude_tool_names("Read, Grep, Glob, Bash")
+    mapped, unknown = map_claude_tools(names)
+    assert unknown == []
+    assert AbstractTool.FS_READ in mapped
+    assert AbstractTool.FS_SEARCH in mapped
+    assert AbstractTool.SHELL_EXECUTE in mapped
+
+
+def test_unknown_tool_reported():
+    mapped, unknown = map_claude_tools(["Read", "NotARealTool"])
+    assert AbstractTool.FS_READ in mapped
+    assert unknown == ["NotARealTool"]
+
+
+def test_load_agents_populates_allowed_tools(tmp_path: Path):
+    agent_dir = tmp_path / "docs-lookup"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        "---\nname: docs-lookup\ndescription: Docs\ntools: Read, Grep, Glob\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    agents, errors = load_agents(tmp_path)
+    assert errors == []
+    agent = agents["docs-lookup"]
+    assert AbstractTool.FS_READ in agent.allowed_tools
+    assert agent.read_only is True

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -121,11 +121,12 @@ def test_all_hooks_validate_against_schema():
 def test_registry_loads_all_hook_files():
     """load_hooks must not silently skip broken definitions."""
     yaml_files = _hook_yaml_files()
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, errors = load_hooks(HOOKS_DIR)
     assert len(hooks) == len(yaml_files), (
         f"Expected {len(yaml_files)} hooks loaded, got {len(hooks)} — "
         "check for silent parse failures in hook_registry.load_hooks"
     )
+    assert errors == []
 
 
 def test_registry_loads_hooks():
@@ -143,7 +144,7 @@ def test_hooks_have_required_fields():
 
 def test_no_placeholder_handlers_in_default_enabled_hooks():
     """Production hooks (default_enabled) must not use stub/placeholder commands."""
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     for hook in hooks.values():
         if not hook.default_enabled:
             continue
@@ -159,7 +160,7 @@ def test_no_placeholder_handlers_in_default_enabled_hooks():
 
 def test_opt_in_hooks_with_placeholders_are_documented():
     """Opt-in hooks may stub handlers but must stay disabled by default."""
-    hooks = load_hooks(HOOKS_DIR)
+    hooks, _errs = load_hooks(HOOKS_DIR)
     for hook in hooks.values():
         if hook.default_enabled:
             continue
@@ -222,5 +223,6 @@ def test_broken_canonical_hook_would_fail_file_count_check(tmp_path):
     (tmp_path / "good-hook.yaml").write_text(good.read_text(encoding="utf-8"), encoding="utf-8")
 
     yaml_files = sorted(tmp_path.glob("*.yaml"))
-    hooks = load_hooks(tmp_path)
+    hooks, errors = load_hooks(tmp_path)
     assert len(hooks) < len(yaml_files), "Broken hook YAML must not load silently without detection"
+    assert errors, "Broken hook YAML must be reported in errors"


### PR DESCRIPTION
## Summary
- Parse `allowed_tools` / `denied_tools` / `delegates_to` on agents
- Map Claude `tools:` frontmatter via abstract tool vocabulary
- Validate delegation targets and allow/deny overlaps in the graph loader

Closes #80

## Test plan
- [x] `uv run pytest tests/compiler/test_agent_contracts.py -q`