### PR TITLE
feat(installer): align profile install path with compiler-generated artifacts

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -21,6 +21,12 @@ import os
 from pathlib import Path
 from agent_toolkit._paths import toolkit_root
 from agent_toolkit.installer.merge import merge_json_file
+from agent_toolkit.installer.sources import (
+    agent_install_sources,
+    compiled_agent_files,
+    plugins_dir,
+    profile_file,
+)
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -176,13 +182,43 @@ def _windsurf_config_dir() -> Path:
 # Per-tool installers
 # ---------------------------------------------------------------------------
 
+    return success
+
+
+def _install_agent_files(
+    tool: str,
+    dst_dir: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    data_root: Path | None = None,
+) -> bool:
+    """Install agent files from compiled plugins/ or profiles/ fallback."""
+    root = data_root or toolkit_root()
+    agents = agent_install_sources(tool, data_root=root)
+    if not agents:
+        _warn(f"No agent sources found for {tool}")
+        return True
+
+    plugins = plugins_dir(root)
+    if plugins is not None:
+        _info(f"Using compiler artifacts from {plugins}")
+
+    success = True
+    for name, src in sorted(agents.items()):
+        dst = dst_dir / f"{name}.md"
+        success &= _copy_file(src, dst, dry_run=dry_run, force=force)
+    return success
+
+
 def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
     print()
     _info("Installing: Claude Code")
-    src = toolkit_root() / "profiles" / "claude-code"
+    root = toolkit_root()
+    profile = profile_file("claude-code", data_root=root)
 
-    if not src.is_dir():
-        _warn(f"Profile directory not found: {src}")
+    if not profile.is_dir() and not compiled_agent_files(root):
+        _warn(f"Profile directory not found: {profile}")
         return False
 
     home = Path.home()
@@ -190,25 +226,35 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
     # Install instruction/agent files only. Never write ~/.claude/settings.json —
     # that file is user-owned (plugins, permissions, env). Target contract:
     # distributions/targets/claude-code.yaml → plugin_settings_scope: plugin-local.
-    success &= _copy_file(src / "CLAUDE.md", home / ".claude" / "CLAUDE.md",
-                          dry_run=dry_run, force=force)
-    settings_src = src / "settings.json"
+    claude_md = profile_file("claude-code", "CLAUDE.md", data_root=root)
+    if claude_md.is_file():
+        success &= _copy_file(
+            claude_md,
+            home / ".claude" / "CLAUDE.md",
+            dry_run=dry_run,
+            force=force,
+        )
+    settings_src = profile / "settings.json"
     if settings_src.is_file():
         _info(
             "Skipping ~/.claude/settings.json (user-owned). "
             "Use Claude Code marketplace plugins for toolkit capabilities; "
             f"reference profile kept at {settings_src}"
         )
-    if (src / "agents").is_dir():
-        success &= _copy_dir(src / "agents", home / ".claude" / "agents",
-                             dry_run=dry_run, force=force)
+    success &= _install_agent_files(
+        "claude-code",
+        home / ".claude" / "agents",
+        dry_run=dry_run,
+        force=force,
+        data_root=root,
+    )
     return success
 
 
 def _install_cursor(*, dry_run: bool, force: bool) -> bool:
     print()
     _info("Installing: Cursor")
-    src = toolkit_root() / "profiles" / "cursor" / "rules"
+    src = profile_file("cursor", "rules")
 
     if not src.is_dir():
         _warn(f"Cursor rules directory not found: {src}")
@@ -266,16 +312,17 @@ def _install_json_config(
 def _install_opencode(*, dry_run: bool, force: bool) -> bool:
     print()
     _info("Installing: OpenCode")
-    src = toolkit_root() / "profiles" / "opencode"
+    root = toolkit_root()
+    profile = profile_file("opencode", data_root=root)
 
-    if not src.is_dir():
-        _warn(f"OpenCode profile directory not found: {src}")
+    if not profile.is_dir() and not compiled_agent_files(root):
+        _warn(f"OpenCode profile directory not found: {profile}")
         return False
 
-    profile_config = src / "opencode.json"
-    if profile_config.is_file():
+    opencode_json = profile_file("opencode", "opencode.json", data_root=root)
+    if opencode_json.is_file():
         try:
-            profile_data = json.loads(profile_config.read_text(encoding="utf-8"))
+            profile_data = json.loads(opencode_json.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             _err(f"Invalid profiles/opencode/opencode.json: {exc}")
             return False
@@ -289,16 +336,20 @@ def _install_opencode(*, dry_run: bool, force: bool) -> bool:
 
     home = Path.home()
     success = True
-    if profile_config.is_file():
+    if opencode_json.is_file():
         success &= _install_json_config(
-            profile_config,
+            opencode_json,
             home / ".config" / "opencode" / "opencode.json",
             dry_run=dry_run,
             force=force,
         )
-    if (src / "agents").is_dir():
-        success &= _copy_dir(src / "agents", home / ".config" / "opencode" / "agents",
-                             dry_run=dry_run, force=force)
+    success &= _install_agent_files(
+        "opencode",
+        home / ".config" / "opencode" / "agents",
+        dry_run=dry_run,
+        force=force,
+        data_root=root,
+    )
     return success
 
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/installer/sources.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/installer/sources.py
@@ -1,0 +1,95 @@
+"""Resolve install source paths — prefer compiler-generated plugins/ over hand profiles/."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from agent_toolkit._paths import toolkit_root
+
+# Default products whose compiled agents are installed for profile-based targets.
+_DEFAULT_AGENT_PRODUCTS = (
+    "agent-toolkit-core",
+    "agent-toolkit-agents",
+    "agent-toolkit-forge",
+)
+
+
+def find_repo_root(data_root: Path | None = None) -> Path:
+    """Return repo root containing plugins/ compiler output."""
+    root = data_root or toolkit_root()
+    if (root / "plugins").is_dir():
+        return root
+    if (root.parent / "plugins").is_dir():
+        return root.parent
+    return root
+
+
+def plugins_dir(data_root: Path | None = None) -> Path | None:
+    """Return plugins/ output directory when compiler artifacts are present."""
+    override = os.environ.get("AGENT_TOOLKIT_INSTALL_SOURCE", "").strip()
+    if override:
+        path = Path(override)
+        return path if path.is_dir() else None
+
+    repo = find_repo_root(data_root)
+    plugins = repo / "plugins"
+    return plugins if plugins.is_dir() else None
+
+
+def compiled_agent_files(
+    data_root: Path | None = None,
+    *,
+    products: tuple[str, ...] = _DEFAULT_AGENT_PRODUCTS,
+) -> dict[str, Path]:
+    """Map agent name -> AGENT.md path from compiled plugin bundles."""
+    root = data_root or toolkit_root()
+    plugins = root / "plugins"
+    if not plugins.is_dir():
+        repo_plugins = plugins_dir(data_root)
+        if repo_plugins is None:
+            return {}
+        plugins = repo_plugins
+
+    agents: dict[str, Path] = {}
+    for product_id in products:
+        agents_dir = plugins / product_id / "agents"
+        if not agents_dir.is_dir():
+            continue
+        for agent_dir in sorted(agents_dir.iterdir()):
+            if not agent_dir.is_dir():
+                continue
+            agent_md = agent_dir / "AGENT.md"
+            if agent_md.is_file():
+                agents[agent_dir.name] = agent_md
+    return agents
+
+
+def agent_install_sources(
+    tool: str,
+    data_root: Path | None = None,
+) -> dict[str, Path]:
+    """Return agent-name -> source file for a profile install target.
+
+    Prefers compiler-generated ``plugins/*/agents/*/AGENT.md`` artifacts.
+    Falls back to ``profiles/<tool>/agents/*.md`` when plugins are unavailable.
+    """
+    compiled = compiled_agent_files(data_root)
+    if compiled:
+        return compiled
+
+    root = data_root or toolkit_root()
+    profile_agents = root / "profiles" / tool / "agents"
+    if not profile_agents.is_dir():
+        return {}
+
+    return {
+        path.stem: path
+        for path in sorted(profile_agents.glob("*.md"))
+        if path.is_file()
+    }
+
+
+def profile_file(tool: str, *parts: str, data_root: Path | None = None) -> Path:
+    """Return a profile-relative path (rules, CLAUDE.md, etc.)."""
+    root = data_root or toolkit_root()
+    return root / "profiles" / tool / Path(*parts)

--- a/tests/test_install_sources.py
+++ b/tests/test_install_sources.py
@@ -1,0 +1,71 @@
+"""Install source resolution prefers compiler-generated plugins/ artifacts."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import install as install_mod
+from agent_toolkit.installer import sources
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+def test_agent_install_sources_prefers_plugins_over_profiles(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    plugins = root / "plugins" / "agent-toolkit-agents" / "agents" / "architect"
+    plugins.mkdir(parents=True)
+    compiled = "compiled architect content\n"
+    (plugins / "AGENT.md").write_text(compiled, encoding="utf-8")
+
+    profile = root / "profiles" / "claude-code" / "agents"
+    profile.mkdir(parents=True)
+    (profile / "architect.md").write_text("stale profile content\n", encoding="utf-8")
+
+    agents = sources.agent_install_sources("claude-code", data_root=root)
+    assert agents["architect"].read_text(encoding="utf-8") == compiled
+
+
+def test_claude_install_uses_compiled_agents(
+    fake_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "repo"
+    plugins = root / "plugins" / "agent-toolkit-agents" / "agents" / "tech-assistant"
+    plugins.mkdir(parents=True)
+    marker = "from plugins tech-assistant\n"
+    (plugins / "AGENT.md").write_text(marker, encoding="utf-8")
+
+    profile = root / "profiles" / "claude-code"
+    profile.mkdir(parents=True)
+    (profile / "CLAUDE.md").write_text("# Claude\n", encoding="utf-8")
+    agents = profile / "agents"
+    agents.mkdir()
+    (agents / "tech-assistant.md").write_text("stale profile\n", encoding="utf-8")
+
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+
+    ok = install_mod._install_claude_code(dry_run=False, force=True)
+
+    assert ok is True
+    installed = fake_home / ".claude" / "agents" / "tech-assistant.md"
+    assert installed.is_file()
+    assert installed.read_text(encoding="utf-8") == marker
+
+
+def test_agent_install_sources_falls_back_to_profiles(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    profile = root / "profiles" / "opencode" / "agents"
+    profile.mkdir(parents=True)
+    (profile / "assistant.md").write_text("profile assistant\n", encoding="utf-8")
+
+    agents = sources.agent_install_sources("opencode", data_root=root)
+    assert "assistant" in agents
+    assert agents["assistant"].name == "assistant.md"


### PR DESCRIPTION
## Summary
- Add `installer/sources.py` to resolve agent files from `plugins/` compiler output
- Install Claude Code and OpenCode agents from compiled `AGENT.md` artifacts when available
- Fall back to `profiles/` for rules, static configs, and environments without `plugins/`

Closes #60

## Test plan
- [x] `uv run pytest tests/test_install_sources.py tests/test_install_claude_settings.py -v`