### PR TITLE
feat(data): download capability data on first run from GitHub Releases

### DIFF
--- a/docs/DATA_CACHE.md
+++ b/docs/DATA_CACHE.md
@@ -1,0 +1,31 @@
+# Capability data cache
+
+The Python wheel may ship without full `skills/`, `profiles/`, and `loops/` trees.
+On first run, `agent-toolkit` downloads the matching GitHub Release source tarball
+and caches capability data under:
+
+```
+~/.local/share/agent-toolkit/data/
+```
+
+## Resolution order
+
+See `agent_toolkit._paths.find_toolkit_root()`:
+
+1. `AGENT_TOOLKIT_ROOT` / `AI_WORKSPACE`
+2. Bundled package data (full wheel)
+3. XDG cache, downloading from GitHub Releases when missing
+4. Editable monorepo checkout
+5. Current working directory
+
+## Offline installs
+
+```bash
+agent-toolkit install --offline
+```
+
+Uses only bundled wheel data or an existing cache — no network access.
+
+## Refresh
+
+Use `agent-toolkit update` to refresh cached data and re-sync installed profiles.

--- a/packages/agent-toolkit-cli/src/agent_toolkit/_paths.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/_paths.py
@@ -1,70 +1,108 @@
 """Shared toolkit path resolution — works in both editable and wheel installs."""
 from __future__ import annotations
+
 import os
 from pathlib import Path
 
 
-def find_toolkit_root() -> Path:
+def _offline_mode() -> bool:
+    return os.environ.get("AGENT_TOOLKIT_OFFLINE", "").strip().lower() in ("1", "true", "yes")
+
+
+def _bundled_data_paths() -> list[Path]:
+    paths: list[Path] = []
+    try:
+        import importlib.resources as _ir
+
+        paths.append(Path(str(_ir.files("agent_toolkit").joinpath("data"))))
+    except (ImportError, TypeError, ModuleNotFoundError, FileNotFoundError):
+        pass
+
+    pkg_dir = Path(__file__).resolve().parent
+    paths.append(pkg_dir / "data")
+    return paths
+
+
+def _is_data_root(path: Path) -> bool:
+    return path.is_dir() and (path / "profiles").is_dir()
+
+
+def find_toolkit_root(*, offline: bool | None = None) -> Path:
     """
     Locate the agent-toolkit root directory (where skills/, loops/, profiles/ live).
 
     Resolution order:
-    1. AGENT_TOOLKIT_ROOT env var (user override)
-    2. AI_WORKSPACE env var (ai-workspace compat)
-    3. importlib.resources data (wheel install — data packed into the wheel)
-    4. Walk up from module file to find profiles/ (editable install)
+    1. AGENT_TOOLKIT_ROOT / AI_WORKSPACE env var (user override)
+    2. importlib.resources / package data (wheel install)
+    3. XDG cache (~/.local/share/agent-toolkit/data) or first-run GitHub download
+    4. Walk up from module file (editable install)
     5. CWD fallback
 
     Raises EnvironmentError if no root can be found with required subdirs.
     """
-    # 1. Explicit env override
+    offline = _offline_mode() if offline is None else offline
+
     for env in ("AGENT_TOOLKIT_ROOT", "AI_WORKSPACE"):
         val = os.environ.get(env, "").strip()
         if val:
             p = Path(val)
-            if (p / "skills").is_dir() or (p / "loops").is_dir():
+            if (p / "skills").is_dir() or (p / "loops").is_dir() or _is_data_root(p):
                 return p
 
-    # 2. Importlib resources (wheel installs — data packed as agent_toolkit/data/)
-    try:
-        import importlib.resources as _ir
-        # Data is packed at agent_toolkit/data/{profiles,loops,skills,...}
-        data_path = Path(str(_ir.files("agent_toolkit").joinpath("data")))
-        if data_path.is_dir() and (data_path / "profiles").is_dir():
+    for data_path in _bundled_data_paths():
+        if _is_data_root(data_path):
             return data_path
-    except (ImportError, TypeError, ModuleNotFoundError, FileNotFoundError):
-        pass
 
-    # 2b. Direct path relative to the package (uvx / pip installs)
-    pkg_dir = Path(__file__).resolve().parent  # .../site-packages/agent_toolkit/
-    data_dir = pkg_dir / "data"
-    if data_dir.is_dir() and (data_dir / "profiles").is_dir():
-        return data_dir
+    from agent_toolkit.data_sync import data_cache_dir, ensure_data, is_valid_data_root
 
-    # 3. Walk up from this file (editable install)
+    cache = data_cache_dir()
+    if is_valid_data_root(cache):
+        return cache
+
+    if not offline:
+        try:
+            downloaded = ensure_data(offline=False)
+            if downloaded and is_valid_data_root(downloaded):
+                return downloaded
+        except RuntimeError as exc:
+            raise EnvironmentError(str(exc)) from exc
+
     here = Path(__file__).resolve()
     for parent in here.parents:
         if (parent / "skills").is_dir() and (parent / "loops").is_dir():
             return parent
 
-    # 4. CWD
     cwd = Path.cwd()
     if (cwd / "skills").is_dir() or (cwd / "loops").is_dir():
         return cwd
 
-    raise EnvironmentError(
-        "Cannot locate agent-toolkit data directory.\n"
-        "Set AGENT_TOOLKIT_ROOT to your agent-toolkit checkout or install root."
+    hint = (
+        "Set AGENT_TOOLKIT_ROOT to your agent-toolkit checkout, "
+        "or run without --offline to download data on first use."
     )
+    if offline:
+        hint = (
+            "Offline mode: bundled/cache data missing. "
+            "Install the full wheel or populate ~/.local/share/agent-toolkit/data."
+        )
+    raise EnvironmentError(f"Cannot locate agent-toolkit data directory.\n{hint}")
 
 
-# Lazy singleton
 _root: Path | None = None
 
 
-def toolkit_root() -> Path:
+def reset_toolkit_root() -> None:
+    """Clear cached toolkit root (e.g. after toggling offline mode)."""
+    global _root
+    _root = None
+
+
+def toolkit_root(*, offline: bool | None = None) -> Path:
     """Cached toolkit root."""
     global _root
-    if _root is None:
-        _root = find_toolkit_root()
+    if _root is None or offline is not None:
+        resolved = find_toolkit_root(offline=offline)
+        if offline is None:
+            _root = resolved
+        return resolved
     return _root

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -9,6 +9,7 @@ Options:
                     Valid: claude-code, cursor, opencode, copilot, windsurf, pi
     --dry-run       Show what would happen without making changes
     --force         Overwrite existing files without prompting
+    --offline       Use only bundled/cached data (no network download)
     --help          Show this help message
 """
 from __future__ import annotations
@@ -16,7 +17,7 @@ from __future__ import annotations
 import shutil
 import sys
 from pathlib import Path
-from agent_toolkit._paths import toolkit_root
+from agent_toolkit._paths import reset_toolkit_root, toolkit_root
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -322,9 +323,10 @@ _PARSE_ERROR = object()
 
 
 def _parse_args(args: list[str]):
-    """Return (tools, dry_run, force), _PARSE_HELP, or _PARSE_ERROR."""
+    """Return (tools, dry_run, force, offline), _PARSE_HELP, or _PARSE_ERROR."""
     dry_run = False
     force = False
+    offline = False
     requested: str = ""
 
     i = 0
@@ -337,6 +339,8 @@ def _parse_args(args: list[str]):
             dry_run = True
         elif arg == "--force":
             force = True
+        elif arg == "--offline":
+            offline = True
         elif arg == "--tools":
             if i + 1 >= len(args):
                 _err("--tools requires an argument")
@@ -351,7 +355,7 @@ def _parse_args(args: list[str]):
     tools: list[str] = []
     if requested:
         tools = [t.strip() for t in requested.split(",") if t.strip()]
-    return tools, dry_run, force
+    return tools, dry_run, force, offline
 
 
 # ---------------------------------------------------------------------------
@@ -369,11 +373,22 @@ def cmd_install(args: list[str]) -> int:
     if result is _PARSE_ERROR:
         return 2
 
-    tools, dry_run, force = result
+    tools, dry_run, force, offline = result
+
+    if offline:
+        os.environ["AGENT_TOOLKIT_OFFLINE"] = "1"
+        reset_toolkit_root()
 
     print()
     print("agent-toolkit installer")
-    print(f"Toolkit: {toolkit_root()}")
+    try:
+        root = toolkit_root(offline=offline)
+    except EnvironmentError as exc:
+        _err(str(exc))
+        return 1
+    print(f"Toolkit: {root}")
+    if offline:
+        _info("Offline mode — using bundled/cached data only")
 
     if dry_run:
         print()

--- a/packages/agent-toolkit-cli/src/agent_toolkit/data_sync.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/data_sync.py
@@ -1,0 +1,138 @@
+"""Download and cache agent-toolkit capability data from GitHub Releases."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from agent_toolkit import __version__
+
+GITHUB_REPO = "ulises-jeremias/agent-toolkit"
+DATA_SUBDIRS = ("skills", "agents", "loops", "profiles", "mcp", "catalogs")
+VERSION_FILE = ".version"
+
+
+def data_cache_dir() -> Path:
+    """XDG data directory for downloaded capability trees."""
+    xdg = os.environ.get("XDG_DATA_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".local" / "share"
+    return base / "agent-toolkit" / "data"
+
+
+def is_valid_data_root(path: Path) -> bool:
+    return (
+        path.is_dir()
+        and (path / "profiles").is_dir()
+        and ((path / "skills").is_dir() or (path / "loops").is_dir())
+    )
+
+
+def cached_version() -> str | None:
+    vf = data_cache_dir() / VERSION_FILE
+    if vf.is_file():
+        return vf.read_text(encoding="utf-8").strip() or None
+    return None
+
+
+def _release_tag(version: str) -> str:
+    return version if version.startswith("v") else f"v{version}"
+
+
+def _fetch_latest_release_tag() -> str:
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+    req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    tag = payload.get("tag_name", "")
+    if not tag:
+        raise RuntimeError("GitHub Releases API returned no tag_name")
+    return tag
+
+
+def _copy_data_tree(src_root: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in DATA_SUBDIRS:
+        src = src_root / name
+        if not src.is_dir():
+            continue
+        dst = dest / name
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+
+def download_data(
+    version: str | None = None,
+    *,
+    force: bool = False,
+    quiet: bool = False,
+) -> Path:
+    """Download capability data from a GitHub Release source tarball into the cache."""
+    cache = data_cache_dir()
+    target_version = version or cached_version() or _release_tag(__version__)
+
+    if not force and is_valid_data_root(cache):
+        current = cached_version()
+        if current and current.lstrip("v") == target_version.lstrip("v"):
+            return cache
+
+    tag = _release_tag(target_version)
+    url = f"https://github.com/{GITHUB_REPO}/archive/refs/tags/{tag}.tar.gz"
+    if not quiet:
+        print(f"[agent-toolkit] Downloading capability data ({tag})…", flush=True)
+
+    with tempfile.TemporaryDirectory(prefix="agent-toolkit-data-") as tmp:
+        tarball = Path(tmp) / "source.tar.gz"
+        try:
+            urllib.request.urlretrieve(url, tarball)
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Failed to download {url} (HTTP {exc.code}). "
+                "Set AGENT_TOOLKIT_ROOT to a checkout or run with bundled wheel data."
+            ) from exc
+
+        extract_dir = Path(tmp) / "extract"
+        extract_dir.mkdir()
+        with tarfile.open(tarball, "r:gz") as tar:
+            tar.extractall(extract_dir, filter="data")
+
+        roots = [p for p in extract_dir.iterdir() if p.is_dir()]
+        if not roots:
+            raise RuntimeError(f"No top-level directory in release tarball for {tag}")
+        src_root = roots[0]
+        if not is_valid_data_root(src_root):
+            raise RuntimeError(f"Release {tag} tarball does not contain capability data")
+
+        if cache.exists():
+            shutil.rmtree(cache)
+        _copy_data_tree(src_root, cache)
+        (cache / VERSION_FILE).write_text(tag.lstrip("v"), encoding="utf-8")
+
+    if not quiet:
+        print(f"[agent-toolkit] Cached data at {cache}", flush=True)
+    return cache
+
+
+def ensure_data(
+    *,
+    offline: bool = False,
+    force: bool = False,
+    version: str | None = None,
+) -> Path | None:
+    """Return cached/downloaded data root, or None when offline and cache is missing."""
+    cache = data_cache_dir()
+    if is_valid_data_root(cache) and not force:
+        cv = cached_version()
+        pin = version or __version__
+        if cv is None or cv.lstrip("v") == pin.lstrip("v"):
+            return cache
+
+    if offline:
+        return cache if is_valid_data_root(cache) else None
+
+    return download_data(version, force=force)

--- a/tests/test_data_sync.py
+++ b/tests/test_data_sync.py
@@ -1,0 +1,67 @@
+"""Tests for GitHub Release data download and cache resolution."""
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from agent_toolkit import data_sync
+
+
+def _make_fake_release_tarball(path: Path) -> None:
+    root = path.parent / "agent-toolkit-9.9.9"
+    (root / "profiles" / "cursor" / "rules").mkdir(parents=True)
+    (root / "profiles" / "cursor" / "rules" / "assistant.mdc").write_text("rule")
+    (root / "skills" / "core").mkdir(parents=True)
+    (root / "skills" / "core" / "SKILL.md").write_text("skill")
+    with tarfile.open(path, "w:gz") as tar:
+        tar.add(root, arcname=root.name)
+
+
+def test_is_valid_data_root(tmp_path: Path) -> None:
+    assert not data_sync.is_valid_data_root(tmp_path)
+    (tmp_path / "profiles").mkdir()
+    (tmp_path / "skills").mkdir()
+    assert data_sync.is_valid_data_root(tmp_path)
+
+
+def test_download_data_extracts_to_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(data_sync, "data_cache_dir", lambda: cache)
+
+    fake_tar = tmp_path / "release.tar.gz"
+    _make_fake_release_tarball(fake_tar)
+
+    def fake_urlretrieve(url: str, dest: str) -> None:
+        Path(dest).write_bytes(fake_tar.read_bytes())
+
+    monkeypatch.setattr(data_sync.urllib.request, "urlretrieve", fake_urlretrieve)
+
+    out = data_sync.download_data("9.9.9", force=True, quiet=True)
+    assert out == cache
+    assert (cache / "profiles" / "cursor" / "rules" / "assistant.mdc").is_file()
+    assert data_sync.cached_version() == "9.9.9"
+
+
+def test_ensure_data_offline_without_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(data_sync, "data_cache_dir", lambda: cache)
+    assert data_sync.ensure_data(offline=True) is None
+
+
+def test_find_toolkit_root_uses_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_toolkit import _paths
+
+    cache = tmp_path / "cache"
+    (cache / "profiles").mkdir(parents=True)
+    (cache / "skills").mkdir()
+    monkeypatch.setattr(data_sync, "data_cache_dir", lambda: cache)
+    monkeypatch.setattr(data_sync, "is_valid_data_root", lambda p: p == cache)
+    monkeypatch.setattr(_paths, "_bundled_data_paths", lambda: [])
+    monkeypatch.delenv("AGENT_TOOLKIT_ROOT", raising=False)
+    monkeypatch.delenv("AI_WORKSPACE", raising=False)
+    monkeypatch.setenv("AGENT_TOOLKIT_OFFLINE", "1")
+    _paths.reset_toolkit_root()
+    assert _paths.find_toolkit_root(offline=True) == cache


### PR DESCRIPTION
## Summary
- Add `data_sync` module to download GitHub Release source tarballs into `~/.local/share/agent-toolkit/data/`.
- Extend `_paths.py` resolution with XDG cache + first-run download hook.
- Add `agent-toolkit install --offline` to skip network fetch.
- Document cache behavior in `docs/DATA_CACHE.md`.

## Test plan
- [x] `pytest tests/test_data_sync.py -q`
- [ ] `agent-toolkit install --offline` with empty cache reports clear error
- [ ] First run without bundled data downloads and caches profiles/skills

Closes #3