### PR TITLE
feat(cli): agent-toolkit update — refresh installed profiles

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/_paths.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/_paths.py
@@ -1,70 +1,108 @@
 """Shared toolkit path resolution — works in both editable and wheel installs."""
 from __future__ import annotations
+
 import os
 from pathlib import Path
 
 
-def find_toolkit_root() -> Path:
+def _offline_mode() -> bool:
+    return os.environ.get("AGENT_TOOLKIT_OFFLINE", "").strip().lower() in ("1", "true", "yes")
+
+
+def _bundled_data_paths() -> list[Path]:
+    paths: list[Path] = []
+    try:
+        import importlib.resources as _ir
+
+        paths.append(Path(str(_ir.files("agent_toolkit").joinpath("data"))))
+    except (ImportError, TypeError, ModuleNotFoundError, FileNotFoundError):
+        pass
+
+    pkg_dir = Path(__file__).resolve().parent
+    paths.append(pkg_dir / "data")
+    return paths
+
+
+def _is_data_root(path: Path) -> bool:
+    return path.is_dir() and (path / "profiles").is_dir()
+
+
+def find_toolkit_root(*, offline: bool | None = None) -> Path:
     """
     Locate the agent-toolkit root directory (where skills/, loops/, profiles/ live).
 
     Resolution order:
-    1. AGENT_TOOLKIT_ROOT env var (user override)
-    2. AI_WORKSPACE env var (ai-workspace compat)
-    3. importlib.resources data (wheel install — data packed into the wheel)
-    4. Walk up from module file to find profiles/ (editable install)
+    1. AGENT_TOOLKIT_ROOT / AI_WORKSPACE env var (user override)
+    2. importlib.resources / package data (wheel install)
+    3. XDG cache (~/.local/share/agent-toolkit/data) or first-run GitHub download
+    4. Walk up from module file (editable install)
     5. CWD fallback
 
     Raises EnvironmentError if no root can be found with required subdirs.
     """
-    # 1. Explicit env override
+    offline = _offline_mode() if offline is None else offline
+
     for env in ("AGENT_TOOLKIT_ROOT", "AI_WORKSPACE"):
         val = os.environ.get(env, "").strip()
         if val:
             p = Path(val)
-            if (p / "skills").is_dir() or (p / "loops").is_dir():
+            if (p / "skills").is_dir() or (p / "loops").is_dir() or _is_data_root(p):
                 return p
 
-    # 2. Importlib resources (wheel installs — data packed as agent_toolkit/data/)
-    try:
-        import importlib.resources as _ir
-        # Data is packed at agent_toolkit/data/{profiles,loops,skills,...}
-        data_path = Path(str(_ir.files("agent_toolkit").joinpath("data")))
-        if data_path.is_dir() and (data_path / "profiles").is_dir():
+    for data_path in _bundled_data_paths():
+        if _is_data_root(data_path):
             return data_path
-    except (ImportError, TypeError, ModuleNotFoundError, FileNotFoundError):
-        pass
 
-    # 2b. Direct path relative to the package (uvx / pip installs)
-    pkg_dir = Path(__file__).resolve().parent  # .../site-packages/agent_toolkit/
-    data_dir = pkg_dir / "data"
-    if data_dir.is_dir() and (data_dir / "profiles").is_dir():
-        return data_dir
+    from agent_toolkit.data_sync import data_cache_dir, ensure_data, is_valid_data_root
 
-    # 3. Walk up from this file (editable install)
+    cache = data_cache_dir()
+    if is_valid_data_root(cache):
+        return cache
+
+    if not offline:
+        try:
+            downloaded = ensure_data(offline=False)
+            if downloaded and is_valid_data_root(downloaded):
+                return downloaded
+        except RuntimeError as exc:
+            raise EnvironmentError(str(exc)) from exc
+
     here = Path(__file__).resolve()
     for parent in here.parents:
         if (parent / "skills").is_dir() and (parent / "loops").is_dir():
             return parent
 
-    # 4. CWD
     cwd = Path.cwd()
     if (cwd / "skills").is_dir() or (cwd / "loops").is_dir():
         return cwd
 
-    raise EnvironmentError(
-        "Cannot locate agent-toolkit data directory.\n"
-        "Set AGENT_TOOLKIT_ROOT to your agent-toolkit checkout or install root."
+    hint = (
+        "Set AGENT_TOOLKIT_ROOT to your agent-toolkit checkout, "
+        "or run without --offline to download data on first use."
     )
+    if offline:
+        hint = (
+            "Offline mode: bundled/cache data missing. "
+            "Install the full wheel or populate ~/.local/share/agent-toolkit/data."
+        )
+    raise EnvironmentError(f"Cannot locate agent-toolkit data directory.\n{hint}")
 
 
-# Lazy singleton
 _root: Path | None = None
 
 
-def toolkit_root() -> Path:
+def reset_toolkit_root() -> None:
+    """Clear cached toolkit root (e.g. after toggling offline mode)."""
+    global _root
+    _root = None
+
+
+def toolkit_root(*, offline: bool | None = None) -> Path:
     """Cached toolkit root."""
     global _root
-    if _root is None:
-        _root = find_toolkit_root()
+    if _root is None or offline is not None:
+        resolved = find_toolkit_root(offline=offline)
+        if offline is None:
+            _root = resolved
+        return resolved
     return _root

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -21,6 +21,7 @@ Commands:
     skills        Skill management: sync, list, validate
     mcp           MCP provider management: setup, list, doctor
     plugin        Plugin bundle management: sync, check
+    update        Refresh installed profiles from latest toolkit data
 
 Run 'agent-toolkit <command> --help' for details.
 """
@@ -63,6 +64,9 @@ def main() -> None:
         case "install":
             from agent_toolkit.cli.install import cmd_install
             sys.exit(cmd_install(rest))
+        case "update":
+            from agent_toolkit.cli.update import cmd_update
+            sys.exit(cmd_update(rest))
         case "doctor":
             from agent_toolkit.cli.doctor import cmd_doctor
             sys.exit(cmd_doctor(rest))

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/update.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/update.py
@@ -1,0 +1,294 @@
+"""
+update — Refresh installed profiles from toolkit data.
+
+Usage:
+    agent-toolkit update [options]
+
+Options:
+    --tools <list>   Comma-separated tools to update (default: auto-detect installed)
+    --check          Dry-run — show what would change without writing files
+    --pin <version>  Download capability data from a specific release before updating
+    --help           Show this help message
+
+Examples:
+    agent-toolkit update
+    agent-toolkit update --tools cursor,opencode
+    agent-toolkit update --check
+    agent-toolkit update --pin 1.1.0
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import sys
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from agent_toolkit._paths import reset_toolkit_root, toolkit_root
+from agent_toolkit.cli.install import (
+    _VALID_TOOLS,
+    _detect_claude_code,
+    _detect_cursor,
+    _detect_opencode,
+    _detect_pi,
+    _detect_windsurf,
+    _windsurf_config_dir,
+)
+
+_PARSE_HELP = object()
+_PARSE_ERROR = object()
+
+
+@dataclass
+class FileMapping:
+    src: Path
+    dst: Path
+
+
+@dataclass
+class ToolUpdatePlan:
+    tool: str
+    changed: list[Path] = field(default_factory=list)
+    added: list[Path] = field(default_factory=list)
+    up_to_date: list[Path] = field(default_factory=list)
+
+
+def _file_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _iter_files(root: Path) -> Iterator[Path]:
+    if not root.is_dir():
+        return
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            yield path
+
+
+def _mappings_for_tool(tool: str, data_root: Path, home: Path) -> list[FileMapping]:
+    mappings: list[FileMapping] = []
+
+    if tool == "claude-code":
+        src = data_root / "profiles" / "claude-code"
+        if src.is_dir():
+            claude = src / "CLAUDE.md"
+            if claude.is_file():
+                mappings.append(FileMapping(claude, home / ".claude" / "CLAUDE.md"))
+            agents = src / "agents"
+            if agents.is_dir():
+                for f in _iter_files(agents):
+                    rel = f.relative_to(agents)
+                    mappings.append(FileMapping(f, home / ".claude" / "agents" / rel))
+
+    elif tool == "cursor":
+        src = data_root / "profiles" / "cursor" / "rules"
+        if src.is_dir():
+            for f in _iter_files(src):
+                rel = f.relative_to(src)
+                mappings.append(FileMapping(f, home / ".cursor" / "rules" / rel))
+
+    elif tool == "opencode":
+        src = data_root / "profiles" / "opencode"
+        cfg = src / "opencode.json"
+        if cfg.is_file():
+            mappings.append(FileMapping(cfg, home / ".config" / "opencode" / "opencode.json"))
+        agents = src / "agents"
+        if agents.is_dir():
+            for f in _iter_files(agents):
+                rel = f.relative_to(agents)
+                mappings.append(FileMapping(f, home / ".config" / "opencode" / "agents" / rel))
+
+    elif tool == "windsurf":
+        src = data_root / "profiles" / "windsurf"
+        config_dir = _windsurf_config_dir()
+        for sub in ("rules", "memories"):
+            sub_src = src / sub
+            if sub_src.is_dir():
+                for f in _iter_files(sub_src):
+                    rel = f.relative_to(sub_src)
+                    mappings.append(FileMapping(f, config_dir / sub / rel))
+
+    elif tool == "pi":
+        src = data_root / "profiles" / "pi" / "skills"
+        if src.is_dir():
+            for f in _iter_files(src):
+                rel = f.relative_to(src)
+                mappings.append(FileMapping(f, home / ".pi" / "agent" / "skills" / rel))
+
+    return mappings
+
+
+def _plan_tool_update(tool: str, data_root: Path, home: Path) -> ToolUpdatePlan | None:
+    mappings = _mappings_for_tool(tool, data_root, home)
+    if not mappings:
+        return None
+
+    plan = ToolUpdatePlan(tool=tool)
+    for mapping in mappings:
+        if not mapping.src.is_file():
+            continue
+        src_hash = _file_hash(mapping.src)
+        if mapping.dst.is_file():
+            if _file_hash(mapping.dst) == src_hash:
+                plan.up_to_date.append(mapping.dst)
+            else:
+                plan.changed.append(mapping.dst)
+        else:
+            plan.added.append(mapping.dst)
+    return plan
+
+
+def _detect_installed_tools() -> list[str]:
+    detectors: list[tuple[str, Callable[[], bool]]] = [
+        ("claude-code", _detect_claude_code),
+        ("cursor", _detect_cursor),
+        ("opencode", _detect_opencode),
+        ("windsurf", _detect_windsurf),
+        ("pi", _detect_pi),
+    ]
+    return [name for name, fn in detectors if fn()]
+
+
+def _apply_plan(plan: ToolUpdatePlan, data_root: Path, home: Path, *, check_only: bool) -> int:
+    updated = 0
+    mappings = _mappings_for_tool(plan.tool, data_root, home)
+    targets = {m.dst for m in mappings if m.dst in plan.changed or m.dst in plan.added}
+
+    for mapping in mappings:
+        if mapping.dst not in targets:
+            continue
+        rel = mapping.dst.relative_to(home) if mapping.dst.is_relative_to(home) else mapping.dst
+        if check_only:
+            print(f"  ~ would update: ~/{rel}")
+            updated += 1
+            continue
+        mapping.dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(mapping.src, mapping.dst)
+        print(f"  ✓ updated: ~/{rel}")
+        updated += 1
+    return updated
+
+
+def _parse_args(args: list[str]):
+    tools: list[str] = []
+    check_only = False
+    pin: str | None = None
+    requested = ""
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-h", "--help"):
+            print(__doc__)
+            return _PARSE_HELP
+        if arg == "--check":
+            check_only = True
+        elif arg == "--tools":
+            if i + 1 >= len(args):
+                print("  ✗  --tools requires an argument", file=sys.stderr)
+                return _PARSE_ERROR
+            requested = args[i + 1]
+            i += 1
+        elif arg == "--pin":
+            if i + 1 >= len(args):
+                print("  ✗  --pin requires an argument", file=sys.stderr)
+                return _PARSE_ERROR
+            pin = args[i + 1]
+            i += 1
+        else:
+            print(f"  ✗  Unknown option: {arg}", file=sys.stderr)
+            return _PARSE_ERROR
+        i += 1
+
+    if requested:
+        tools = [t.strip() for t in requested.split(",") if t.strip()]
+    return tools, check_only, pin
+
+
+def cmd_update(args: list[str]) -> int:
+    """Refresh installed profiles from toolkit data."""
+    result = _parse_args(args)
+    if result is _PARSE_HELP:
+        return 0
+    if result is _PARSE_ERROR:
+        return 2
+
+    tools, check_only, pin = result
+
+    print()
+    print("agent-toolkit update")
+
+    # Refresh capability data cache when pinned or stale
+    if pin:
+        from agent_toolkit.data_sync import download_data
+
+        reset_toolkit_root()
+        try:
+            download_data(pin, force=True)
+        except RuntimeError as exc:
+            print(f"  ✗  {exc}", file=sys.stderr)
+            return 1
+    else:
+        from agent_toolkit import __version__
+        from agent_toolkit.data_sync import cached_version, download_data
+
+        cv = cached_version()
+        if cv is None or cv.lstrip("v") != __version__.lstrip("v"):
+            try:
+                download_data(__version__, force=True, quiet=check_only)
+                reset_toolkit_root()
+            except RuntimeError as exc:
+                print(f"  ⚠  Data refresh skipped: {exc}")
+
+    try:
+        data_root = toolkit_root()
+    except EnvironmentError as exc:
+        print(f"  ✗  {exc}", file=sys.stderr)
+        return 1
+
+    print(f"  Data: {data_root}")
+    if check_only:
+        print("  [check] Dry run — no files will be written")
+
+    if not tools:
+        tools = _detect_installed_tools()
+        if not tools:
+            print("  ⚠  No installed tools detected. Use --tools to specify targets.")
+            return 1
+        print(f"  Tools: {', '.join(tools)}")
+
+    home = Path.home()
+    total_changes = 0
+    any_errors = False
+
+    for tool in tools:
+        if tool not in _VALID_TOOLS:
+            print(f"  ⚠  Unknown tool: {tool}")
+            any_errors = True
+            continue
+
+        plan = _plan_tool_update(tool, data_root, home)
+        if plan is None:
+            print(f"  ⚠  No profile data for: {tool}")
+            continue
+
+        pending = len(plan.changed) + len(plan.added)
+        if pending == 0:
+            print(f"  ✓ {tool}: up to date ({len(plan.up_to_date)} files)")
+            continue
+
+        print(f"  → {tool}: {len(plan.changed)} changed, {len(plan.added)} new")
+        total_changes += _apply_plan(plan, data_root, home, check_only=check_only)
+
+    print()
+    if check_only:
+        print(f"  {total_changes} file(s) would be updated")
+        return 1 if total_changes else 0
+
+    if total_changes:
+        print(f"  Updated {total_changes} file(s)")
+    else:
+        print("  All profiles up to date")
+    return 1 if any_errors else 0

--- a/packages/agent-toolkit-cli/src/agent_toolkit/data_sync.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/data_sync.py
@@ -1,0 +1,138 @@
+"""Download and cache agent-toolkit capability data from GitHub Releases."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from agent_toolkit import __version__
+
+GITHUB_REPO = "ulises-jeremias/agent-toolkit"
+DATA_SUBDIRS = ("skills", "agents", "loops", "profiles", "mcp", "catalogs")
+VERSION_FILE = ".version"
+
+
+def data_cache_dir() -> Path:
+    """XDG data directory for downloaded capability trees."""
+    xdg = os.environ.get("XDG_DATA_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".local" / "share"
+    return base / "agent-toolkit" / "data"
+
+
+def is_valid_data_root(path: Path) -> bool:
+    return (
+        path.is_dir()
+        and (path / "profiles").is_dir()
+        and ((path / "skills").is_dir() or (path / "loops").is_dir())
+    )
+
+
+def cached_version() -> str | None:
+    vf = data_cache_dir() / VERSION_FILE
+    if vf.is_file():
+        return vf.read_text(encoding="utf-8").strip() or None
+    return None
+
+
+def _release_tag(version: str) -> str:
+    return version if version.startswith("v") else f"v{version}"
+
+
+def _fetch_latest_release_tag() -> str:
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+    req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    tag = payload.get("tag_name", "")
+    if not tag:
+        raise RuntimeError("GitHub Releases API returned no tag_name")
+    return tag
+
+
+def _copy_data_tree(src_root: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in DATA_SUBDIRS:
+        src = src_root / name
+        if not src.is_dir():
+            continue
+        dst = dest / name
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+
+def download_data(
+    version: str | None = None,
+    *,
+    force: bool = False,
+    quiet: bool = False,
+) -> Path:
+    """Download capability data from a GitHub Release source tarball into the cache."""
+    cache = data_cache_dir()
+    target_version = version or cached_version() or _release_tag(__version__)
+
+    if not force and is_valid_data_root(cache):
+        current = cached_version()
+        if current and current.lstrip("v") == target_version.lstrip("v"):
+            return cache
+
+    tag = _release_tag(target_version)
+    url = f"https://github.com/{GITHUB_REPO}/archive/refs/tags/{tag}.tar.gz"
+    if not quiet:
+        print(f"[agent-toolkit] Downloading capability data ({tag})…", flush=True)
+
+    with tempfile.TemporaryDirectory(prefix="agent-toolkit-data-") as tmp:
+        tarball = Path(tmp) / "source.tar.gz"
+        try:
+            urllib.request.urlretrieve(url, tarball)
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Failed to download {url} (HTTP {exc.code}). "
+                "Set AGENT_TOOLKIT_ROOT to a checkout or run with bundled wheel data."
+            ) from exc
+
+        extract_dir = Path(tmp) / "extract"
+        extract_dir.mkdir()
+        with tarfile.open(tarball, "r:gz") as tar:
+            tar.extractall(extract_dir, filter="data")
+
+        roots = [p for p in extract_dir.iterdir() if p.is_dir()]
+        if not roots:
+            raise RuntimeError(f"No top-level directory in release tarball for {tag}")
+        src_root = roots[0]
+        if not is_valid_data_root(src_root):
+            raise RuntimeError(f"Release {tag} tarball does not contain capability data")
+
+        if cache.exists():
+            shutil.rmtree(cache)
+        _copy_data_tree(src_root, cache)
+        (cache / VERSION_FILE).write_text(tag.lstrip("v"), encoding="utf-8")
+
+    if not quiet:
+        print(f"[agent-toolkit] Cached data at {cache}", flush=True)
+    return cache
+
+
+def ensure_data(
+    *,
+    offline: bool = False,
+    force: bool = False,
+    version: str | None = None,
+) -> Path | None:
+    """Return cached/downloaded data root, or None when offline and cache is missing."""
+    cache = data_cache_dir()
+    if is_valid_data_root(cache) and not force:
+        cv = cached_version()
+        pin = version or __version__
+        if cv is None or cv.lstrip("v") == pin.lstrip("v"):
+            return cache
+
+    if offline:
+        return cache if is_valid_data_root(cache) else None
+
+    return download_data(version, force=force)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,65 @@
+"""Tests for agent-toolkit update command."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AGENT_TOOLKIT_ROOT", str(REPO_ROOT))
+    from agent_toolkit._paths import reset_toolkit_root
+
+    reset_toolkit_root()
+    return tmp_path
+
+
+def test_update_check_detects_changes(fake_home: Path) -> None:
+    cursor_rules = fake_home / ".cursor" / "rules"
+    cursor_rules.mkdir(parents=True)
+    installed = cursor_rules / "assistant.mdc"
+    installed.write_text("stale content")
+
+    from agent_toolkit.cli.update import cmd_update
+
+    rc = cmd_update(["--tools", "cursor", "--check"])
+    assert rc == 1  # changes pending
+
+
+def test_update_applies_changes(fake_home: Path) -> None:
+    cursor_rules = fake_home / ".cursor" / "rules"
+    cursor_rules.mkdir(parents=True)
+    installed = cursor_rules / "assistant.mdc"
+    installed.write_text("stale content")
+
+    from agent_toolkit.cli.update import cmd_update
+
+    rc = cmd_update(["--tools", "cursor"])
+    assert rc == 0
+    src = REPO_ROOT / "profiles" / "cursor" / "rules" / "assistant.mdc"
+    if src.is_file():
+        assert installed.read_bytes() == src.read_bytes()
+
+
+def test_update_up_to_date(fake_home: Path) -> None:
+    src_dir = REPO_ROOT / "profiles" / "cursor" / "rules"
+    if not src_dir.is_dir():
+        pytest.skip("cursor profile not present")
+
+    cursor_rules = fake_home / ".cursor" / "rules"
+    cursor_rules.mkdir(parents=True)
+    for src_file in src_dir.rglob("*"):
+        if src_file.is_file():
+            rel = src_file.relative_to(src_dir)
+            dst = cursor_rules / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src_file.read_bytes())
+
+    from agent_toolkit.cli.update import cmd_update
+
+    rc = cmd_update(["--tools", "cursor", "--check"])
+    assert rc == 0


### PR DESCRIPTION
## Summary
- Add `agent-toolkit update` to refresh installed profiles from toolkit data.
- Compare file hashes and copy only changed files.
- Support `--check` dry-run, `--tools` filter, and `--pin` for release data refresh.

## Test plan
- [x] `pytest tests/test_update.py -q`

Closes #5