### PR TITLE
feat(compiler): map Claude tools to abstract tool model

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -9,9 +9,18 @@ from pathlib import Path
 from typing import Any
 
 from agent_toolkit.compiler.model import (
-    Agent, CanonicalGraph, ModelClass, Product, Provenance,
-    Requirement, SecurityPolicy, Skill, Stability,
+    AbstractTool,
+    Agent,
+    CanonicalGraph,
+    ModelClass,
+    Product,
+    Provenance,
+    Requirement,
+    SecurityPolicy,
+    Skill,
+    Stability,
 )
+from agent_toolkit.compiler.tool_mapping import map_claude_tools, parse_claude_tool_names
 
 try:
     import yaml
@@ -132,9 +141,14 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
                 f"frontmatter name '{declared_name}' in {agent_md}"
             )
 
-        # Map tools string to list
-        tools_str = fm.get("tools", "")
-        # abstract_tools = []  # TODO: map from Claude-specific to abstract
+        claude_names = parse_claude_tool_names(fm.get("tools"))
+        allowed_tools, unknown_tools = map_claude_tools(claude_names)
+        if unknown_tools:
+            errors.append(f"{agent_md}: unknown Claude tool(s): {', '.join(unknown_tools)}")
+            continue
+
+        write_tools = {AbstractTool.FS_WRITE, AbstractTool.SHELL_EXECUTE, AbstractTool.GIT_WRITE}
+        read_only = bool(allowed_tools) and not any(t in write_tools for t in allowed_tools)
 
         mc_str = fm.get("model_class", "inherit")
         mc = ModelClass(mc_str) if mc_str in ("fast", "balanced", "deep", "inherit") else ModelClass.INHERIT
@@ -145,6 +159,8 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
             description=str(fm.get("description", ""))[:200],
             instructions=body.strip(),
             model_class=mc,
+            allowed_tools=allowed_tools,
+            read_only=read_only,
             source_path=agent_md,
             metadata=fm,
         )

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
@@ -1,0 +1,43 @@
+"""Map Claude Code tool names to the platform-neutral AbstractTool vocabulary."""
+from __future__ import annotations
+
+from agent_toolkit.compiler.model import AbstractTool
+
+CLAUDE_TOOL_MAP: dict[str, AbstractTool] = {
+    "Read": AbstractTool.FS_READ,
+    "Grep": AbstractTool.FS_SEARCH,
+    "Glob": AbstractTool.FS_SEARCH,
+    "Write": AbstractTool.FS_WRITE,
+    "Edit": AbstractTool.FS_WRITE,
+    "Bash": AbstractTool.SHELL_EXECUTE,
+    "WebSearch": AbstractTool.WEB_SEARCH,
+    "WebFetch": AbstractTool.WEB_FETCH,
+    "Task": AbstractTool.AGENT_DELEGATE,
+    "AskUserQuestion": AbstractTool.USER_ASK,
+    "Git": AbstractTool.GIT_READ,
+    "GitCommit": AbstractTool.GIT_WRITE,
+    "GitPush": AbstractTool.GIT_WRITE,
+}
+
+
+def parse_claude_tool_names(tools_value: str | list[str] | None) -> list[str]:
+    if tools_value is None:
+        return []
+    if isinstance(tools_value, list):
+        return [str(t).strip() for t in tools_value if str(t).strip()]
+    return [t.strip() for t in str(tools_value).split(",") if t.strip()]
+
+
+def map_claude_tools(names: list[str]) -> tuple[list[AbstractTool], list[str]]:
+    mapped: list[AbstractTool] = []
+    unknown: list[str] = []
+    seen: set[AbstractTool] = set()
+    for name in names:
+        abstract = CLAUDE_TOOL_MAP.get(name)
+        if abstract is None:
+            unknown.append(name)
+            continue
+        if abstract not in seen:
+            mapped.append(abstract)
+            seen.add(abstract)
+    return mapped, unknown

--- a/tests/compiler/test_loader_tool_mapping.py
+++ b/tests/compiler/test_loader_tool_mapping.py
@@ -1,0 +1,25 @@
+"""Tests that loader maps Claude tools to abstract tools on agents."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_agents
+from agent_toolkit.compiler.model import AbstractTool
+
+
+def test_load_agents_maps_claude_tools(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "code-reviewer"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        "---\nname: code-reviewer\ndescription: Review.\ntools: Read, Grep, Glob, Bash\n---\n# R\n",
+        encoding="utf-8",
+    )
+    agents, errors = load_agents(tmp_path)
+    assert errors == []
+    assert agents["code-reviewer"].allowed_tools == [
+        AbstractTool.FS_READ, AbstractTool.FS_SEARCH, AbstractTool.SHELL_EXECUTE,
+    ]

--- a/tests/compiler/test_tool_mapping.py
+++ b/tests/compiler/test_tool_mapping.py
@@ -1,0 +1,19 @@
+"""Tests for Claude → abstract tool mapping."""
+from __future__ import annotations
+
+import pytest
+
+from agent_toolkit.compiler.model import AbstractTool
+from agent_toolkit.compiler.tool_mapping import map_claude_tools, parse_claude_tool_names
+
+
+def test_map_claude_tools_deduplicates_abstract() -> None:
+    mapped, unknown = map_claude_tools(["Read", "Grep", "Glob"])
+    assert unknown == []
+    assert mapped == [AbstractTool.FS_READ, AbstractTool.FS_SEARCH]
+
+
+def test_map_claude_tools_reports_unknown() -> None:
+    mapped, unknown = map_claude_tools(["Read", "NotARealTool"])
+    assert mapped == [AbstractTool.FS_READ]
+    assert unknown == ["NotARealTool"]


### PR DESCRIPTION
## Summary
- Add `tool_mapping.py` with Claude Code → `AbstractTool` mapping table
- Populate `Agent.allowed_tools` and infer `read_only` in `load_agents`
- Fail closed on unknown Claude tool names; add mapping and loader tests

Closes #70

## Test plan
- [x] `pytest tests/compiler/test_tool_mapping.py tests/compiler/test_loader_tool_mapping.py -q`
- [x] Repo agents load via `load_graph` without errors