### PR TITLE
feat(agents): complete abstract tool requirements and delegation

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/loader.py
@@ -9,8 +9,22 @@ from pathlib import Path
 from typing import Any
 
 from agent_toolkit.compiler.model import (
-    Agent, CanonicalGraph, ModelClass, Product, Provenance,
-    Requirement, SecurityPolicy, Skill, Stability,
+    AbstractTool,
+    Agent,
+    CanonicalGraph,
+    ModelClass,
+    Product,
+    Provenance,
+    Requirement,
+    SecurityPolicy,
+    Skill,
+    Stability,
+)
+from agent_toolkit.compiler.tool_mapping import (
+    infer_read_only,
+    map_claude_tools,
+    parse_abstract_tool_list,
+    parse_claude_tool_names,
 )
 
 try:
@@ -113,6 +127,22 @@ def load_skills(skills_root: Path) -> tuple[dict[str, Skill], list[str]]:
     return skills, errors
 
 
+def _parse_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [v.strip() for v in str(value).split(",") if v.strip()]
+
+
+def _parse_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("true", "yes", "1")
+
+
 def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
     """Load all AGENT.md files from agents/<name>/AGENT.md."""
     agents: dict[str, Agent] = {}
@@ -131,10 +161,27 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
                 f"Agent name mismatch: directory '{agent_name}' vs "
                 f"frontmatter name '{declared_name}' in {agent_md}"
             )
+            continue
 
-        # Map tools string to list
-        tools_str = fm.get("tools", "")
-        # abstract_tools = []  # TODO: map from Claude-specific to abstract
+        if fm.get("allowed_tools") is not None:
+            allowed_tools, invalid_allowed = parse_abstract_tool_list(fm.get("allowed_tools"))
+            if invalid_allowed:
+                errors.append(f"{agent_md}: invalid allowed_tools: {', '.join(invalid_allowed)}")
+                continue
+        else:
+            allowed_tools, unknown_tools = map_claude_tools(parse_claude_tool_names(fm.get("tools")))
+            if unknown_tools:
+                errors.append(f"{agent_md}: unknown Claude tool(s): {', '.join(unknown_tools)}")
+                continue
+
+        denied_tools, invalid_denied = parse_abstract_tool_list(fm.get("denied_tools"))
+        if invalid_denied:
+            errors.append(f"{agent_md}: invalid denied_tools: {', '.join(invalid_denied)}")
+            continue
+
+        delegates_to = _parse_string_list(fm.get("delegates_to"))
+        read_only = _parse_bool(fm.get("read_only")) if "read_only" in fm else infer_read_only(allowed_tools)
+        background_eligible = _parse_bool(fm.get("background_eligible"))
 
         mc_str = fm.get("model_class", "inherit")
         mc = ModelClass(mc_str) if mc_str in ("fast", "balanced", "deep", "inherit") else ModelClass.INHERIT
@@ -145,11 +192,35 @@ def load_agents(agents_root: Path) -> tuple[dict[str, Agent], list[str]]:
             description=str(fm.get("description", ""))[:200],
             instructions=body.strip(),
             model_class=mc,
+            allowed_tools=allowed_tools,
+            denied_tools=denied_tools,
+            delegates_to=delegates_to,
+            read_only=read_only,
+            background_eligible=background_eligible,
             source_path=agent_md,
             metadata=fm,
         )
 
     return agents, errors
+
+
+def validate_agent_contracts(graph: CanonicalGraph) -> None:
+    """Validate agent tool requirements and delegation references."""
+    agent_ids = set(graph.agents)
+    for agent_id, agent in graph.agents.items():
+        overlap = {t.value for t in agent.allowed_tools} & {t.value for t in agent.denied_tools}
+        if overlap:
+            graph.errors.append(
+                f"Agent '{agent_id}' lists the same tool in allowed_tools and denied_tools: "
+                f"{', '.join(sorted(overlap))}"
+            )
+        for delegate_id in agent.delegates_to:
+            if delegate_id not in agent_ids:
+                graph.errors.append(
+                    f"Agent '{agent_id}' delegates_to unknown agent '{delegate_id}'"
+                )
+            elif delegate_id == agent_id:
+                graph.errors.append(f"Agent '{agent_id}' cannot delegate_to itself")
 
 
 def load_products(products_yaml: Path) -> tuple[dict[str, Product], list[str]]:
@@ -210,7 +281,9 @@ def load_graph(repo_root: Path) -> CanonicalGraph:
     graph.products.update(products)
     graph.errors.extend(errs)
 
-    # Validate references
+    validate_agent_contracts(graph)
+
+    # Validate product references
     for pid, product in graph.products.items():
         for skill_id in product.included_skills:
             if skill_id not in graph.skills:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/model.py
@@ -95,6 +95,7 @@ class Agent:
     max_turns: int = 0               # 0 = platform default
     allowed_tools: list[AbstractTool] = field(default_factory=list)
     denied_tools: list[AbstractTool] = field(default_factory=list)
+    delegates_to: list[str] = field(default_factory=list)
     read_only: bool = False
     background_eligible: bool = False
     dependent_skills: list[str] = field(default_factory=list)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/tool_mapping.py
@@ -1,0 +1,68 @@
+"""Map Claude Code tool names to the platform-neutral AbstractTool vocabulary."""
+from __future__ import annotations
+
+from agent_toolkit.compiler.model import AbstractTool
+
+CLAUDE_TOOL_MAP: dict[str, AbstractTool] = {
+    "Read": AbstractTool.FS_READ,
+    "Grep": AbstractTool.FS_SEARCH,
+    "Glob": AbstractTool.FS_SEARCH,
+    "Write": AbstractTool.FS_WRITE,
+    "Edit": AbstractTool.FS_WRITE,
+    "Bash": AbstractTool.SHELL_EXECUTE,
+    "WebSearch": AbstractTool.WEB_SEARCH,
+    "WebFetch": AbstractTool.WEB_FETCH,
+    "Task": AbstractTool.AGENT_DELEGATE,
+    "AskUserQuestion": AbstractTool.USER_ASK,
+    "Git": AbstractTool.GIT_READ,
+    "GitCommit": AbstractTool.GIT_WRITE,
+    "GitPush": AbstractTool.GIT_WRITE,
+}
+
+_WRITE_TOOLS = frozenset(
+    {AbstractTool.FS_WRITE, AbstractTool.SHELL_EXECUTE, AbstractTool.GIT_WRITE}
+)
+
+
+def parse_claude_tool_names(tools_value: str | list[str] | None) -> list[str]:
+    if tools_value is None:
+        return []
+    if isinstance(tools_value, list):
+        return [str(t).strip() for t in tools_value if str(t).strip()]
+    return [t.strip() for t in str(tools_value).split(",") if t.strip()]
+
+
+def map_claude_tools(names: list[str]) -> tuple[list[AbstractTool], list[str]]:
+    mapped: list[AbstractTool] = []
+    unknown: list[str] = []
+    seen: set[AbstractTool] = set()
+    for name in names:
+        abstract = CLAUDE_TOOL_MAP.get(name)
+        if abstract is None:
+            unknown.append(name)
+            continue
+        if abstract not in seen:
+            mapped.append(abstract)
+            seen.add(abstract)
+    return mapped, unknown
+
+
+def parse_abstract_tool_list(value: str | list[str] | None) -> tuple[list[AbstractTool], list[str]]:
+    if value is None:
+        return [], []
+    raw_items = value if isinstance(value, list) else [v.strip() for v in str(value).split(",")]
+    mapped: list[AbstractTool] = []
+    invalid: list[str] = []
+    for item in raw_items:
+        token = str(item).strip()
+        if not token:
+            continue
+        try:
+            mapped.append(AbstractTool(token))
+        except ValueError:
+            invalid.append(token)
+    return mapped, invalid
+
+
+def infer_read_only(tools: list[AbstractTool]) -> bool:
+    return bool(tools) and not any(t in _WRITE_TOOLS for t in tools)

--- a/tests/compiler/test_agent_contracts.py
+++ b/tests/compiler/test_agent_contracts.py
@@ -1,0 +1,42 @@
+"""Tests for agent abstract tool requirements and delegation contracts."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from agent_toolkit.compiler.loader import load_agents, load_graph, validate_agent_contracts
+from agent_toolkit.compiler.model import AbstractTool, Agent, CanonicalGraph
+
+
+def test_load_agents_explicit_allowed_tools(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "planner"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        "---\nname: planner\ndescription: Plans work.\nallowed_tools:\n  - fs.read\n"
+        "read_only: true\ndelegates_to:\n  - code-reviewer\n---\n# Planner\n",
+        encoding="utf-8",
+    )
+    agents, errors = load_agents(tmp_path)
+    assert errors == []
+    assert agents["planner"].allowed_tools == [AbstractTool.FS_READ]
+    assert agents["planner"].delegates_to == ["code-reviewer"]
+
+
+def test_validate_delegates_to_unknown_agent() -> None:
+    graph = CanonicalGraph()
+    graph.agents["assistant"] = Agent(
+        id="assistant", name="assistant", description="", instructions="",
+        delegates_to=["missing-agent"],
+    )
+    validate_agent_contracts(graph)
+    assert any("delegates_to unknown agent" in e for e in graph.errors)
+
+
+def test_repo_agents_load_with_tool_mapping() -> None:
+    repo_root = Path(__file__).parent.parent.parent
+    graph = load_graph(repo_root)
+    assert graph.is_valid, graph.errors
+    assert graph.agents["code-reviewer"].allowed_tools


### PR DESCRIPTION
## Summary
- Parse `allowed_tools`, `denied_tools`, `delegates_to`, `read_only`, and `background_eligible` from agent frontmatter
- Map legacy `tools:` field via Claude→abstract mapping when explicit allowed_tools absent
- Validate delegation targets and allowed/denied overlaps in `validate_agent_contracts`

Closes #80

## Test plan
- [x] `pytest tests/compiler/test_agent_contracts.py -q`
- [x] Full repo `load_graph` remains valid