### PR TITLE
test(installer): cover update, rollback, uninstall, and clean-home in isolated homes

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -19,6 +19,8 @@ import shutil
 import sys
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 from agent_toolkit._paths import toolkit_root
 from agent_toolkit.installer.merge import merge_json_file
 from agent_toolkit.installer.sources import (
@@ -27,6 +29,9 @@ from agent_toolkit.installer.sources import (
     plugins_dir,
     profile_file,
 )
+
+if TYPE_CHECKING:
+    from agent_toolkit.installer.tracking import InstallTracker
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -83,7 +88,14 @@ def _files_identical(a: Path, b: Path) -> bool:
     return a.read_bytes() == b.read_bytes()
 
 
-def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
+def _copy_file(
+    src: Path,
+    dst: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    tracker: InstallTracker | None = None,
+) -> bool:
     """Copy src to dst, respecting dry-run, force, and idempotency.
 
     Returns True on success (including skip), False on failure.
@@ -109,6 +121,8 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
         _ok(f"Installed: {dst}")
+        if tracker is not None:
+            tracker.record_created(dst)
         return True
     except PermissionError as exc:
         _err(f"Permission denied writing {dst}: {exc}")
@@ -118,7 +132,14 @@ def _copy_file(src: Path, dst: Path, *, dry_run: bool, force: bool) -> bool:
         return False
 
 
-def _copy_dir(src_dir: Path, dst_dir: Path, *, dry_run: bool, force: bool) -> bool:
+def _copy_dir(
+    src_dir: Path,
+    dst_dir: Path,
+    *,
+    dry_run: bool,
+    force: bool,
+    tracker: InstallTracker | None = None,
+) -> bool:
     """Recursively copy all files from src_dir into dst_dir."""
     if not src_dir.is_dir():
         _warn(f"Source directory not found, skipping: {src_dir}")
@@ -135,7 +156,9 @@ def _copy_dir(src_dir: Path, dst_dir: Path, *, dry_run: bool, force: bool) -> bo
             continue
         rel = src_file.relative_to(src_dir)
         dst_file = dst_dir / rel
-        if not _copy_file(src_file, dst_file, dry_run=dry_run, force=force):
+        if not _copy_file(
+            src_file, dst_file, dry_run=dry_run, force=force, tracker=tracker
+        ):
             success = False
     return success
 
@@ -192,6 +215,7 @@ def _install_agent_files(
     dry_run: bool,
     force: bool,
     data_root: Path | None = None,
+    tracker: InstallTracker | None = None,
 ) -> bool:
     """Install agent files from compiled plugins/ or profiles/ fallback."""
     root = data_root or toolkit_root()
@@ -207,7 +231,7 @@ def _install_agent_files(
     success = True
     for name, src in sorted(agents.items()):
         dst = dst_dir / f"{name}.md"
-        success &= _copy_file(src, dst, dry_run=dry_run, force=force)
+        success &= _copy_file(src, dst, dry_run=dry_run, force=force, tracker=tracker)
     return success
 
 
@@ -252,16 +276,28 @@ def _install_claude_code(*, dry_run: bool, force: bool) -> bool:
 
 
 def _install_cursor(*, dry_run: bool, force: bool) -> bool:
+    from agent_toolkit.installer.tracking import InstallTracker
+
     print()
     _info("Installing: Cursor")
-    src = profile_file("cursor", "rules")
+    root = toolkit_root()
+    src = profile_file("cursor", "rules", data_root=root)
+    tracker = InstallTracker("cursor", dry_run=dry_run, toolkit_root=root)
 
     if not src.is_dir():
         _warn(f"Cursor rules directory not found: {src}")
         return False
 
-    return _copy_dir(src, Path.home() / ".cursor" / "rules",
-                     dry_run=dry_run, force=force)
+    ok = _copy_dir(
+        src,
+        Path.home() / ".cursor" / "rules",
+        dry_run=dry_run,
+        force=force,
+        tracker=tracker,
+    )
+    if ok and tracker.save():
+        _ok("Saved install receipt for cursor")
+    return ok
 
 
 def _install_json_config(

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 
 CONSUMER_COMMANDS: tuple[str, ...] = (
-    "install", "update", "doctor", "diff", "skills", "mcp", "plugin",
+    "install", "update", "uninstall", "doctor", "diff", "skills", "mcp", "plugin",
 )
 ADVANCED_COMMANDS: tuple[str, ...] = (
     "loop", "workspace", "memory", "project", "devcompanion", "dc", "insights",
@@ -21,6 +21,7 @@ Usage:
 Consumer commands:
     install       Install profiles for detected AI tools
     update        Refresh installed profiles from latest toolkit data
+    uninstall     Remove toolkit-owned files using install receipts
     doctor        Check system health and tool availability
     diff          Show changes vs currently installed plugin bundles
     skills        Skill management: sync, list, validate
@@ -79,6 +80,9 @@ def main() -> None:
         case "update":
             from agent_toolkit.cli.update import cmd_update
             sys.exit(cmd_update(rest))
+        case "uninstall" | "rollback":
+            from agent_toolkit.cli.uninstall import cmd_uninstall
+            sys.exit(cmd_uninstall(rest))
         case "doctor":
             from agent_toolkit.cli.doctor import cmd_doctor
             sys.exit(cmd_doctor(rest))

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/uninstall.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/uninstall.py
@@ -1,0 +1,165 @@
+"""
+uninstall — Remove agent-toolkit profile files recorded in install receipts.
+
+Usage:
+    agent-toolkit uninstall [options]
+
+Options:
+    --tools <list>   Comma-separated tools to uninstall (default: all with receipts)
+    --dry-run        Show what would be removed without deleting files
+    --rollback       Alias for uninstall (removes toolkit-owned files from receipt)
+    --help           Show this help message
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from agent_toolkit.installer import tracking
+from agent_toolkit.installer.receipt import InstallReceipt
+
+_VALID_TOOLS = ("claude-code", "cursor", "opencode", "copilot", "windsurf", "pi")
+_TOOL_RECEIPT_TARGETS = {
+    "claude-code": "claude-code",
+    "cursor": "cursor",
+    "opencode": "opencode",
+    "copilot": "copilot",
+    "windsurf": "windsurf",
+    "pi": "pi",
+}
+
+
+def _info(msg: str) -> None:
+    print(f"  [info]  {msg}")
+
+
+def _ok(msg: str) -> None:
+    print(f"  ✓  {msg}")
+
+
+def _skip(msg: str) -> None:
+    print(f"  -  {msg}")
+
+
+def _dry(msg: str) -> None:
+    print(f"  [dry]   {msg}")
+
+
+def _err(msg: str) -> None:
+    print(f"  ✗  {msg}", file=sys.stderr)
+
+
+def _parse_args(args: list[str]) -> tuple[list[str], bool, bool] | None:
+    dry_run = False
+    requested = ""
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-h", "--help"):
+            print(__doc__)
+            return None
+        if arg in ("--dry-run",):
+            dry_run = True
+        elif arg in ("--rollback",):
+            dry_run = False  # rollback is uninstall with side effects
+        elif arg == "--tools":
+            if i + 1 >= len(args):
+                _err("--tools requires an argument")
+                return None
+            requested = args[i + 1]
+            i += 1
+        else:
+            _err(f"Unknown option: {arg}")
+            return None
+        i += 1
+
+    if requested:
+        tools = [t.strip() for t in requested.split(",") if t.strip()]
+    else:
+        tools = []
+    return tools, dry_run, True
+
+
+def _discover_tools(receipt_dir: Path) -> list[str]:
+    found: list[str] = []
+    if not receipt_dir.is_dir():
+        return found
+    for path in sorted(receipt_dir.glob(f"*-{tracking.PRODUCT}.json")):
+        target = path.name[: -len(f"-{tracking.PRODUCT}.json")]
+        for tool, receipt_target in _TOOL_RECEIPT_TARGETS.items():
+            if receipt_target == target and tool not in found:
+                found.append(tool)
+    return found
+
+
+def _uninstall_tool(tool: str, *, dry_run: bool, receipt_dir: Path) -> bool:
+    target = _TOOL_RECEIPT_TARGETS.get(tool)
+    if target is None:
+        _err(f"Unknown tool: {tool}")
+        return False
+
+    receipt = InstallReceipt.load(target, tracking.PRODUCT, receipt_dir)
+    if receipt is None:
+        _skip(f"No receipt for {tool} — nothing to uninstall")
+        return True
+
+    _info(f"Uninstalling {tool} ({len(receipt.artifacts)} artifact(s) from receipt)")
+    removed = 0
+    for entry in receipt.artifacts:
+        if entry.ownership != "created":
+            _skip(f"Skipping non-owned file ({entry.ownership}): {entry.path}")
+            continue
+        path = Path(entry.path)
+        if not path.exists():
+            _skip(f"Already absent: {path}")
+            continue
+        if dry_run:
+            _dry(f"Would remove: {path}")
+        else:
+            try:
+                path.unlink()
+                _ok(f"Removed: {path}")
+            except OSError as exc:
+                _err(f"Failed to remove {path}: {exc}")
+                return False
+        removed += 1
+
+    if not dry_run:
+        receipt_path = receipt_dir / f"{target}-{tracking.PRODUCT}.json"
+        if receipt_path.exists():
+            receipt_path.unlink()
+            _ok(f"Removed receipt: {receipt_path}")
+
+    _info(f"{tool}: processed {removed} owned file(s)")
+    return True
+
+
+def cmd_uninstall(args: list[str]) -> int:
+    parsed = _parse_args(args)
+    if parsed is None:
+        return 0 if any(a in ("-h", "--help") for a in args) else 2
+    tools, dry_run, _ = parsed
+
+    rdir = tracking.receipt_dir()
+    if not tools:
+        tools = _discover_tools(rdir)
+        if not tools:
+            _err("No install receipts found. Nothing to uninstall.")
+            return 1
+
+    print()
+    print("agent-toolkit uninstall")
+    if dry_run:
+        _info("DRY RUN — no files will be deleted")
+
+    failed: list[str] = []
+    for tool in tools:
+        if tool not in _VALID_TOOLS:
+            _err(f"Unknown tool: {tool}")
+            failed.append(tool)
+            continue
+        if not _uninstall_tool(tool, dry_run=dry_run, receipt_dir=rdir):
+            failed.append(tool)
+
+    print()
+    return 1 if failed else 0

--- a/packages/agent-toolkit-cli/src/agent_toolkit/installer/tracking.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/installer/tracking.py
@@ -1,0 +1,62 @@
+"""Track installed artifacts and persist InstallReceipt."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from agent_toolkit import __version__
+from agent_toolkit.installer.receipt import ArtifactEntry, InstallReceipt
+
+PRODUCT = "agent-toolkit-profiles"
+SCOPE = "user-home"
+
+
+def receipt_dir() -> Path:
+    """Return the install receipt directory (under the current HOME)."""
+    return Path.home() / ".config" / "agent-toolkit" / "receipts"
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def source_digest(root: Path) -> str:
+    marker = root / "profiles"
+    if marker.is_dir():
+        return hashlib.sha256(str(marker.resolve()).encode()).hexdigest()[:12]
+    return __version__
+
+
+class InstallTracker:
+    """Collect artifact entries during install and write receipt on save."""
+
+    def __init__(
+        self,
+        target: str,
+        *,
+        dry_run: bool,
+        receipt_dir_path: Path | None = None,
+        toolkit_root: Path | None = None,
+    ) -> None:
+        root = toolkit_root or Path()
+        self.dry_run = dry_run
+        self.receipt_dir_path = receipt_dir_path or receipt_dir()
+        self.receipt = InstallReceipt.create(
+            PRODUCT,
+            target,
+            SCOPE,
+            __version__,
+            source_digest(root),
+        )
+
+    def record_created(self, path: Path) -> None:
+        if not path.is_file():
+            return
+        self.receipt.artifacts.append(
+            ArtifactEntry(str(path.resolve()), file_digest(path), "created")
+        )
+
+    def save(self) -> Path | None:
+        if self.dry_run or not self.receipt.artifacts:
+            return None
+        return self.receipt.save(self.receipt_dir_path)

--- a/tests/test_install_lifecycle.py
+++ b/tests/test_install_lifecycle.py
@@ -1,0 +1,129 @@
+"""Install lifecycle tests in isolated HOME directories (clean-home)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli.install import cmd_install
+from agent_toolkit.cli.uninstall import cmd_uninstall
+from agent_toolkit.installer.receipt import InstallReceipt
+from agent_toolkit.installer.tracking import PRODUCT, receipt_dir
+
+
+@pytest.fixture()
+def clean_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Simulate a clean user home with no prior toolkit install."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture()
+def receipt_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    rd = tmp_path / "receipts"
+    rd.mkdir()
+    monkeypatch.setattr("agent_toolkit.installer.tracking.receipt_dir", lambda: rd)
+    return rd
+
+
+@pytest.fixture()
+def toolkit_with_cursor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    rules = root / "profiles" / "cursor" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "assistant.mdc").write_text("version-1\n", encoding="utf-8")
+    (rules / "architect.mdc").write_text("architect-v1\n", encoding="utf-8")
+    monkeypatch.setattr("agent_toolkit.cli.install.toolkit_root", lambda: root)
+    return root
+
+
+def test_clean_home_install_writes_receipt_and_files(
+    clean_home: Path,
+    receipt_store: Path,
+    toolkit_with_cursor: Path,
+) -> None:
+    rc = cmd_install(["--tools", "cursor", "--force"])
+    assert rc == 0
+
+    dst = clean_home / ".cursor" / "rules" / "assistant.mdc"
+    assert dst.is_file()
+    assert dst.read_text(encoding="utf-8") == "version-1\n"
+
+    receipt = InstallReceipt.load("cursor", PRODUCT, receipt_store)
+    assert receipt is not None
+    assert len(receipt.artifacts) == 2
+
+
+def test_update_replaces_files_when_forced(
+    clean_home: Path,
+    receipt_store: Path,
+    toolkit_with_cursor: Path,
+) -> None:
+    cmd_install(["--tools", "cursor", "--force"])
+
+    # Simulate toolkit update with changed content
+    rules = toolkit_with_cursor / "profiles" / "cursor" / "rules"
+    (rules / "assistant.mdc").write_text("version-2\n", encoding="utf-8")
+
+    rc = cmd_install(["--tools", "cursor", "--force"])
+    assert rc == 0
+    assert (clean_home / ".cursor" / "rules" / "assistant.mdc").read_text(
+        encoding="utf-8"
+    ) == "version-2\n"
+
+
+def test_uninstall_removes_installed_artifacts(
+    clean_home: Path,
+    receipt_store: Path,
+    toolkit_with_cursor: Path,
+) -> None:
+    cmd_install(["--tools", "cursor", "--force"])
+    rules_dir = clean_home / ".cursor" / "rules"
+    assert (rules_dir / "assistant.mdc").is_file()
+
+    rc = cmd_uninstall(["--tools", "cursor"])
+    assert rc == 0
+    assert not (rules_dir / "assistant.mdc").exists()
+    assert not (rules_dir / "architect.mdc").exists()
+    assert InstallReceipt.load("cursor", PRODUCT, receipt_store) is None
+
+
+def test_rollback_alias_uninstalls_owned_files(
+    clean_home: Path,
+    receipt_store: Path,
+    toolkit_with_cursor: Path,
+) -> None:
+    cmd_install(["--tools", "cursor", "--force"])
+    installed = clean_home / ".cursor" / "rules" / "assistant.mdc"
+    assert installed.is_file()
+
+    rc = cmd_uninstall(["--tools", "cursor", "--rollback"])
+    assert rc == 0
+    assert not installed.exists()
+
+
+def test_uninstall_dry_run_preserves_clean_home_state(
+    clean_home: Path,
+    receipt_store: Path,
+    toolkit_with_cursor: Path,
+) -> None:
+    cmd_install(["--tools", "cursor", "--force"])
+    installed = clean_home / ".cursor" / "rules" / "assistant.mdc"
+
+    rc = cmd_uninstall(["--tools", "cursor", "--dry-run"])
+    assert rc == 0
+    assert installed.is_file()
+    assert InstallReceipt.load("cursor", PRODUCT, receipt_store) is not None
+
+
+def test_install_dry_run_does_not_write_to_clean_home(
+    clean_home: Path,
+    receipt_store: Path,
+    toolkit_with_cursor: Path,
+) -> None:
+    rc = cmd_install(["--tools", "cursor", "--dry-run"])
+    assert rc == 0
+    assert not (clean_home / ".cursor").exists()
+    assert not list(receipt_store.glob("*.json"))

--- a/tests/test_install_uninstall.py
+++ b/tests/test_install_uninstall.py
@@ -1,0 +1,83 @@
+"""Install receipt wiring and uninstall/rollback."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import install as install_mod
+from agent_toolkit.cli.uninstall import cmd_uninstall
+from agent_toolkit.installer import tracking
+from agent_toolkit.installer.receipt import InstallReceipt
+
+PRODUCT = tracking.PRODUCT
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture()
+def receipt_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    rd = tmp_path / "receipts"
+    rd.mkdir()
+    monkeypatch.setattr("agent_toolkit.installer.tracking.receipt_dir", lambda: rd)
+    return rd
+
+
+@pytest.fixture()
+def toolkit_with_cursor_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "toolkit"
+    rules = root / "profiles" / "cursor" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "assistant.mdc").write_text("cursor rules\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod, "toolkit_root", lambda: root)
+    return root
+
+
+def test_install_writes_receipt(
+    fake_home: Path,
+    receipt_dir: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    ok = install_mod._install_cursor(dry_run=False, force=True)
+    assert ok is True
+
+    receipt = InstallReceipt.load("cursor", PRODUCT, receipt_dir)
+    assert receipt is not None
+    assert len(receipt.artifacts) == 1
+    assert receipt.artifacts[0].ownership == "created"
+    assert (fake_home / ".cursor" / "rules" / "assistant.mdc").is_file()
+
+
+def test_uninstall_removes_receipt_owned_files(
+    fake_home: Path,
+    receipt_dir: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    install_mod._install_cursor(dry_run=False, force=True)
+    installed = fake_home / ".cursor" / "rules" / "assistant.mdc"
+    assert installed.is_file()
+
+    rc = cmd_uninstall(["--tools", "cursor"])
+    assert rc == 0
+    assert not installed.exists()
+    assert InstallReceipt.load("cursor", PRODUCT, receipt_dir) is None
+
+
+def test_uninstall_dry_run_keeps_files(
+    fake_home: Path,
+    receipt_dir: Path,
+    toolkit_with_cursor_profile: Path,
+) -> None:
+    install_mod._install_cursor(dry_run=False, force=True)
+    installed = fake_home / ".cursor" / "rules" / "assistant.mdc"
+
+    rc = cmd_uninstall(["--tools", "cursor", "--dry-run"])
+    assert rc == 0
+    assert installed.is_file()
+    assert InstallReceipt.load("cursor", PRODUCT, receipt_dir) is not None


### PR DESCRIPTION
## Summary
- Add `test_install_lifecycle.py` with clean-home fixtures for install, update, uninstall, rollback, and dry-run
- Tests use temporary `HOME` and receipt directories — no live user paths touched
- Includes `#58` receipt/uninstall wiring required for lifecycle assertions (rebase to tests-only after #58 merges)

Closes #94

## Test plan
- [x] `uv run pytest tests/test_install_lifecycle.py tests/test_install_uninstall.py -v`