### PR TITLE
fix(ci): indent YAML sequences for MegaLinter

### DIFF
--- a/catalogs/agent-catalog.yaml
+++ b/catalogs/agent-catalog.yaml
@@ -2,74 +2,75 @@ version: 1
 generated: true
 count: 16
 agents:
-- id: architect
-  name: architect
-  description: Software architecture and system design specialist. Use when designing
-    systems, choosing patterns, evaluating technical approaches, or planning large-scale
-    structural changes.
-- id: assistant
-  name: assistant
-  description: agent-toolkit Dev Companion — follows internal conventions and best
-    practices. Use for any work in agent-toolkit or client repositories to ensure
-    compliance with agent-toolkit standards.
-- id: build-error-resolver
-  name: build-error-resolver
-  description: Build and TypeScript error resolution specialist. Use proactively when
-    encountering compilation errors, type errors, lint failures, or CI pipeline failures.
-- id: client-workflow-bootstrap
-  name: client-workflow-bootstrap
-  description: agent-toolkit client workflow bootstrap specialist. Use when onboarding
-    a new client project or updating an existing delivery workflow skill pair. Conducts
-    a structured interview and generates <client
-- id: code-reviewer
-  name: code-reviewer
-  description: Expert code review specialist. Proactively reviews code for quality,
-    security, and maintainability. Use immediately after writing or modifying any
-    significant code.
-- id: database-reviewer
-  name: database-reviewer
-  description: PostgreSQL and database specialist. Use for schema design, query optimization,
-    migration review, index analysis, and ORM usage questions.
-- id: docs-lookup
-  name: docs-lookup
-  description: Documentation and API reference specialist. Use when searching for
-    framework docs, library APIs, configuration options, or usage examples.
-- id: e2e-runner
-  name: e2e-runner
-  description: End-to-end testing specialist using Playwright. Use when writing, debugging,
-    or running E2E tests, or when setting up Playwright test infrastructure.
-- id: performance-optimizer
-  name: performance-optimizer
-  description: Performance analysis and optimization specialist. Use when code is
-    slow, has memory leaks, fails performance benchmarks, or needs profiling.
-- id: planner
-  name: planner
-  description: Expert planning specialist for complex features and refactoring. Use
-    before starting any significant implementation to break down work, identify risks,
-    and create an actionable plan.
-- id: refactor-cleaner
-  name: refactor-cleaner
-  description: Dead code cleanup and refactoring specialist. Use when removing dead
-    code, simplifying complex functions, reducing duplication, or improving code structure
-    without changing behavior.
-- id: reference-lookup
-  name: reference-lookup
-  description: Lookup agent-toolkit reference examples and patterns from public examples.
-    Use when looking for official agent-toolkit examples, starter templates, or established
-    patterns in the agent-toolkit ecosyst
-- id: security-reviewer
-  name: security-reviewer
-  description: Security vulnerability detection specialist. Use proactively after
-    implementing authentication, data handling, API endpoints, or any user-facing
-    functionality.
-- id: tdd-guide
-  name: tdd-guide
-  description: Test-Driven Development specialist. Enforces write-tests-first methodology.
-    Use when implementing new features to ensure proper test coverage from the start.
-- id: tech-assistant
-  name: tech-assistant
-  description: Technical operations assistant — ops specialist
-- id: typescript-reviewer
-  name: typescript-reviewer
-  description: TypeScript and JavaScript code review specialist. Use for type safety
-    improvements, modern TS/JS patterns, and resolving type complexity issues.
+  - id: architect
+    name: architect
+    description: Software architecture and system design specialist. Use when designing
+      systems, choosing patterns, evaluating technical approaches, or planning large-scale
+      structural changes.
+  - id: assistant
+    name: assistant
+    description: agent-toolkit Dev Companion — follows internal conventions and best
+      practices. Use for any work in agent-toolkit or client repositories to ensure
+      compliance with agent-toolkit standards.
+  - id: build-error-resolver
+    name: build-error-resolver
+    description: Build and TypeScript error resolution specialist. Use proactively
+      when encountering compilation errors, type errors, lint failures, or CI pipeline
+      failures.
+  - id: client-workflow-bootstrap
+    name: client-workflow-bootstrap
+    description: agent-toolkit client workflow bootstrap specialist. Use when onboarding
+      a new client project or updating an existing delivery workflow skill pair. Conducts
+      a structured interview and generates <client
+  - id: code-reviewer
+    name: code-reviewer
+    description: Expert code review specialist. Proactively reviews code for quality,
+      security, and maintainability. Use immediately after writing or modifying any
+      significant code.
+  - id: database-reviewer
+    name: database-reviewer
+    description: PostgreSQL and database specialist. Use for schema design, query
+      optimization, migration review, index analysis, and ORM usage questions.
+  - id: docs-lookup
+    name: docs-lookup
+    description: Documentation and API reference specialist. Use when searching for
+      framework docs, library APIs, configuration options, or usage examples.
+  - id: e2e-runner
+    name: e2e-runner
+    description: End-to-end testing specialist using Playwright. Use when writing,
+      debugging, or running E2E tests, or when setting up Playwright test infrastructure.
+  - id: performance-optimizer
+    name: performance-optimizer
+    description: Performance analysis and optimization specialist. Use when code is
+      slow, has memory leaks, fails performance benchmarks, or needs profiling.
+  - id: planner
+    name: planner
+    description: Expert planning specialist for complex features and refactoring.
+      Use before starting any significant implementation to break down work, identify
+      risks, and create an actionable plan.
+  - id: refactor-cleaner
+    name: refactor-cleaner
+    description: Dead code cleanup and refactoring specialist. Use when removing dead
+      code, simplifying complex functions, reducing duplication, or improving code
+      structure without changing behavior.
+  - id: reference-lookup
+    name: reference-lookup
+    description: Lookup agent-toolkit reference examples and patterns from public
+      examples. Use when looking for official agent-toolkit examples, starter templates,
+      or established patterns in the agent-toolkit ecosyst
+  - id: security-reviewer
+    name: security-reviewer
+    description: Security vulnerability detection specialist. Use proactively after
+      implementing authentication, data handling, API endpoints, or any user-facing
+      functionality.
+  - id: tdd-guide
+    name: tdd-guide
+    description: Test-Driven Development specialist. Enforces write-tests-first methodology.
+      Use when implementing new features to ensure proper test coverage from the start.
+  - id: tech-assistant
+    name: tech-assistant
+    description: Technical operations assistant — ops specialist
+  - id: typescript-reviewer
+    name: typescript-reviewer
+    description: TypeScript and JavaScript code review specialist. Use for type safety
+      improvements, modern TS/JS patterns, and resolving type complexity issues.

--- a/catalogs/loop-catalog.yaml
+++ b/catalogs/loop-catalog.yaml
@@ -2,53 +2,54 @@ version: 1
 generated: true
 count: 10
 loops:
-- id: changelog-drafter
-  name: changelog-drafter
-  tier: L1
-  cadence: 1d
-  description: Draft release notes from merged PRs (L1, report-only)
-- id: ci-sweeper
-  name: ci-sweeper
-  tier: L2
-  cadence: 15m
-  description: Detect CI failures and propose fixes via draft PRs (L2, cautious)
-- id: daily-triage
-  name: daily-triage
-  tier: L1
-  cadence: 1d
-  description: Triage new issues and propose labels (report-only)
-- id: dep-sweeper
-  name: dep-sweeper
-  tier: L2
-  cadence: 1d
-  description: Apply patch-level dependency updates via draft PRs (L2)
-- id: issue-triage
-  name: issue-triage
-  tier: L1
-  cadence: 4h
-  description: Propose labels and routing for new issues (L1, propose-only)
-- id: oss-daily-briefing
-  name: oss-daily-briefing
-  tier: L1
-  cadence: 1d
-  description: Daily read-only briefing across OSS ecosystem repos (L1)
-- id: oss-pr-monitor
-  name: oss-pr-monitor
-  tier: L3
-  cadence: 1d
-  description: Monitor open PRs across OSS ecosystem repos and take action (L3, daily)
-- id: oss-triage
-  name: oss-triage
-  tier: L1
-  cadence: 1d
-  description: Triage issues across OSS ecosystem repos (L1, daily)
-- id: post-merge-cleanup
-  name: post-merge-cleanup
-  tier: L2
-  cadence: 6h
-  description: Off-peak housekeeping after merges (L2, low impact)
-- id: pr-babysitter
-  name: pr-babysitter
-  tier: L2
-  cadence: 15m
-  description: Monitor open PRs and post review comments (L2, PR-gated)
+  - id: changelog-drafter
+    name: changelog-drafter
+    tier: L1
+    cadence: 1d
+    description: Draft release notes from merged PRs (L1, report-only)
+  - id: ci-sweeper
+    name: ci-sweeper
+    tier: L2
+    cadence: 15m
+    description: Detect CI failures and propose fixes via draft PRs (L2, cautious)
+  - id: daily-triage
+    name: daily-triage
+    tier: L1
+    cadence: 1d
+    description: Triage new issues and propose labels (report-only)
+  - id: dep-sweeper
+    name: dep-sweeper
+    tier: L2
+    cadence: 1d
+    description: Apply patch-level dependency updates via draft PRs (L2)
+  - id: issue-triage
+    name: issue-triage
+    tier: L1
+    cadence: 4h
+    description: Propose labels and routing for new issues (L1, propose-only)
+  - id: oss-daily-briefing
+    name: oss-daily-briefing
+    tier: L1
+    cadence: 1d
+    description: Daily read-only briefing across OSS ecosystem repos (L1)
+  - id: oss-pr-monitor
+    name: oss-pr-monitor
+    tier: L3
+    cadence: 1d
+    description: Monitor open PRs across OSS ecosystem repos and take action (L3,
+      daily)
+  - id: oss-triage
+    name: oss-triage
+    tier: L1
+    cadence: 1d
+    description: Triage issues across OSS ecosystem repos (L1, daily)
+  - id: post-merge-cleanup
+    name: post-merge-cleanup
+    tier: L2
+    cadence: 6h
+    description: Off-peak housekeeping after merges (L2, low impact)
+  - id: pr-babysitter
+    name: pr-babysitter
+    tier: L2
+    cadence: 15m
+    description: Monitor open PRs and post review comments (L2, PR-gated)

--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -2,350 +2,353 @@ version: 1
 generated: true
 count: 52
 skills:
-- id: core/assistant
-  name: assistant
-  domain: core
-  description: Assistant — on any repo, scan README→docs→AGENTS→CONTRIBUTING→PR templates→task
-    runners→devcontainer→CI→configs before code; cite sources; prefer AGENTS.md for
-    agent behavior; portable across Cursor/C
-  stability: stable
-- id: core/dev-companion
-  name: dev-companion
-  domain: core
-  description: 'WHAT — Dev Companion (general): layered companion for client delivery;
-    modes, gates, delegation to assistant and workflow-generic-project; no CLI matrices.'
-  stability: stable
-- id: core/onboarding
-  name: onboarding
-  domain: core
-  description: Getting started guide for new users. Walks through setup validation,
-    the skill/agent hierarchy, and the three most useful commands per role (developer,
-    PM, tech lead). Use when someone is new to the w
-  stability: stable
-- id: core/output-handshake
-  name: output-handshake
-  domain: core
-  description: 'WHAT — Default gate for any deliverable: confirm where the final artifact
-    will be stored and that a human will review, before writing PRDs, TRDs, ADRs,
-    or PR bodies. Repository paths, wikis, and ticke'
-  stability: stable
-- id: core/pr-fallback
-  name: pr-fallback
-  domain: core
-  description: WHAT — When the repo has no GitHub PR template, structure the pull-request
-    body using the default in references/pr-body-default.md. Pair with output-handshake
-    and github-cli-workflow. Does not open th
-  stability: stable
-- id: core/workspace-knowledge-sync
-  name: workspace-knowledge-sync
-  domain: core
-  description: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
-    discovers new patterns, learns user preferences, or identifies information worth
-    preserving for future sessions. Integrates w
-  stability: stable
-- id: data/dbt-validation
-  name: dbt-validation
-  domain: data
-  description: HOW — Run dbt checks as documented in the target repo (parse, compile,
-    test, selective run). Does not configure Snowflake accounts or change cloud security.
-  stability: stable
-- id: data/snowflake-validation
-  name: snowflake-validation
-  domain: data
-  description: 'HOW — Read-only Snowflake validation patterns: use repo-documented
-    CLI (snowflake/sql) or SQL checks. Never claim success without working credentials
-    and evidence.'
-  stability: stable
-- id: delivery/adr
-  name: adr
-  domain: delivery
-  description: WHAT — Create and maintain Architecture Decision Records (ADRs) per
-    the process. Covers when to write an ADR, required sections, review, and linking
-    to epics/PRs. English for cross-team artifacts unle
-  stability: stable
-- id: delivery/agreement
-  name: agreement
-  domain: delivery
-  description: WHAT - Capture explicit agreements, terms, parties involved, dates,
-    validity, and linked work items using the Agreement Document structure.
-  stability: stable
-- id: delivery/bug
-  name: bug
-  domain: delivery
-  description: WHAT - Draft and review bugs using the Bug Template; classifies whether
-    an issue should be escalated to incident based on production/user impact.
-  stability: stable
-- id: delivery/decision-log
-  name: decision-log
-  domain: delivery
-  description: WHAT - Capture lightweight project, product, or operational decisions
-    that do not require a full ADR; includes rationale, date, owner, and references.
-  stability: stable
-- id: delivery/development-workflow
-  name: development-workflow
-  domain: delivery
-  description: WHAT - Default development workflow, task lifecycle, DoR, DoD, validation,
-    and evidence model when a project has no explicit override. Repository instructions
-    still take precedence.
-  stability: stable
-- id: delivery/epic
-  name: epic
-  domain: delivery
-  description: WHAT - Draft and review epics using the Best Practices Epic Template;
-    includes objectives, success criteria, related tasks, stakeholders, and effort
-    metadata.
-  stability: stable
-- id: delivery/incident
-  name: incident
-  domain: delivery
-  description: WHAT - Draft and review incident reports and RCA notes using Incident
-    Management guidance; includes detection, impact, timeline, RCA, resolution, and
-    follow-ups.
-  stability: stable
-- id: delivery/management-unit-assessment
-  name: management-unit-assessment
-  domain: delivery
-  description: WHAT - Evidence-based management unit assessment for governance, delivery,
-    collaboration, culture, and AI-native management readiness. Interactive and source-driven
-    before any score is assigned.
-  stability: stable
-- id: delivery/meeting-minutes
-  name: meeting-minutes
-  domain: delivery
-  description: WHAT - Create structured meeting minutes from notes or transcripts
-    using meeting templates, with redaction, action items, decisions, and traceability.
-  stability: stable
-- id: delivery/planning
-  name: planning
-  domain: delivery
-  description: WHAT - Planning, estimation, task breakdown, and iteration capacity
-    fallback based on Best Practices. Use before finalizing backlog scope, story/task
-    estimates, or iteration commitments.
-  stability: stable
-- id: delivery/prd
-  name: prd
-  domain: delivery
-  description: WHAT — Draft and review a Product Requirements Document (PRD) using
-    the template. Business-level requirements, acceptance criteria, and traceability.
-    Does not replace the product owner. English for ti
-  stability: stable
-- id: delivery/project-assessment
-  name: project-assessment
-  domain: delivery
-  description: 'WHAT - Interactive project assessment router: define assessment scope
-    and units, collect evidence through project-assessment-evidence, then delegate
-    to technical or management unit assessment skills. '
-  stability: stable
-- id: delivery/project-assessment-evidence
-  name: project-assessment-evidence
-  domain: delivery
-  description: 'WHAT - Interactive evidence intake for project assessments. Ask the
-    user where each evidence source lives, build an evidence map, track missing evidence,
-    assumptions, freshness, and confidence before '
-  stability: stable
-- id: delivery/spike
-  name: spike
-  domain: delivery
-  description: WHAT - Produce spike and research findings using the spike template;
-    captures purpose, findings, implementation strategy, risks, tradeoffs, open questions,
-    and references.
-  stability: stable
-- id: delivery/task
-  name: task
-  domain: delivery
-  description: WHAT - Draft and review technical tasks using the Best Practices Task
-    Template; includes summary, technical notes, AC, estimate, owner, and due date.
-  stability: stable
-- id: delivery/technical-unit-assessment
-  name: technical-unit-assessment
-  domain: delivery
-  description: WHAT - Evidence-based technical unit assessment for repositories, platforms,
-    frontend, backend, infrastructure, data, UI/UX, and AI-native structural readiness.
-  stability: stable
-- id: delivery/trd
-  name: trd
-  domain: delivery
-  description: WHAT — Draft and review a Technical Requirements Document (TRD) using
-    the template, typically from an agreed PRD. Covers architecture, data contracts,
-    technical decisions, risks, and test strategy. En
-  stability: stable
-- id: delivery/user-story
-  name: user-story
-  domain: delivery
-  description: WHAT - Draft and review user stories using the task template plus the
-    As a/I want/so that format from Best Practices examples.
-  stability: stable
-- id: delivery/work-item
-  name: work-item
-  domain: delivery
-  description: WHAT - Router for creating and refining epics, user stories, tasks,
-    bugs, and incidents using Best Practices work item hierarchy.
-  stability: stable
-- id: delivery/workflow-client-bootstrap
-  name: workflow-client-bootstrap
-  domain: delivery
-  description: WHAT — Interactive interview to capture client delivery context and
-    store it inside the user's ~/.ai-workspace (or similar) as packs + knowledge (no
-    client skills). Use when onboarding a new client pr
-  stability: stable
-- id: delivery/workflow-generic-project
-  name: workflow-generic-project
-  domain: delivery
-  description: 'WHAT — Generic client delivery: Jira or ClickUp, full repo context,
-    human gates, English traceability on tickets, draft PR via delegated forge skills.
-    Use workspace packs for client/account overlays.'
-  stability: stable
-- id: design/figma
-  name: figma
-  domain: design
-  description: Use the Figma MCP server to fetch design context, screenshots, variables,
-    and assets, and to translate Figma nodes into production code. Trigger when a
-    task involves Figma URLs, node IDs, design-to-co
-  stability: stable
-- id: design/figma-code-connect-components
-  name: figma-code-connect-components
-  domain: design
-  description: Connects Figma design components to code components using Code Connect
-    mapping tools. Use when user says "code connect", "connect this component to code",
-    "map this component", "link component to code
-  stability: stable
-- id: design/figma-create-design-system-rules
-  name: figma-create-design-system-rules
-  domain: design
-  description: Generates custom design system rules for the user's codebase. Use when
-    user says "create design system rules", "generate rules for my project", "set
-    up design rules", "customize design system guidelin
-  stability: stable
-- id: design/figma-create-new-file
-  name: figma-create-new-file
-  domain: design
-  description: 'Create a new blank Figma file. Use when the user wants to create a
-    new Figma design or FigJam file, or when you need a new file before calling use_figma.
-    Handles plan resolution via whoami if needed. '
-  stability: stable
-- id: design/figma-implement-design
-  name: figma-implement-design
-  domain: design
-  description: Translates Figma designs into production-ready application code with
-    1:1 visual fidelity. Use when implementing UI code from Figma files, when user
-    mentions "implement design", "generate code", "imple
-  stability: stable
-- id: design/ui-ux-pro-max
-  name: ui-ux-pro-max
-  domain: design
-  description: 'UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings,
-    25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter,
-    Tailwind, shadcn/ui). Actions: plan, build, crea'
-  stability: stable
-- id: forge/gh-address-comments
-  name: gh-address-comments
-  domain: forge
-  description: Triage and address open GitHub PR review and conversation comments
-    using the gh CLI. Use when the user wants to "address PR comments", "resolve review
-    threads", or "respond to reviewers" on the curren
-  stability: stable
-- id: forge/gh-contribution-planner
-  name: gh-contribution-planner
-  domain: forge
-  description: Daily GitHub contribution planner — analyzes the gh-logged-in user's
-    non-archived repos (owned + forks) and recent contributions, produces a prioritized
-    plan, halts for approval, then dispatches paral
-  stability: stable
-- id: forge/gh-fix-ci
-  name: gh-fix-ci
-  domain: forge
-  description: Diagnose failing GitHub Actions checks on a PR via gh, summarize the
-    failure context, propose a plan, and only implement after explicit user approval.
-    External CI providers (Buildkite, CircleCI, etc.)
-  stability: stable
-- id: forge/github-cli-workflow
-  name: github-cli-workflow
-  domain: forge
-  description: 'HOW — GitHub CLI (gh): push branch, create draft PR with title/body
-    from template or file; fallback untracked PR_DESCRIPTION_*.md. Use when origin
-    is GitHub.'
-  stability: stable
-- id: forge/gitlab-cli-workflow
-  name: gitlab-cli-workflow
-  domain: forge
-  description: 'HOW — GitLab CLI (glab): push branch, create draft MR with title/body;
-    fallback untracked markdown. Use when origin is GitLab.'
-  stability: stable
-- id: forge/workflow-client-bootstrap
-  name: workflow-client-bootstrap
-  domain: forge
-  description: DEPRECATED alias. Use workflow-client-bootstrap instead.
-  stability: stable
-- id: forge/workflow-generic-project
-  name: workflow-generic-project
-  domain: forge
-  description: DEPRECATED alias. Use workflow-generic-project instead.
-  stability: stable
-- id: integrations/clickup-cli
-  name: clickup-cli
-  domain: integrations
-  description: 'ClickUp CLI for managing tasks, sprints, comments, statuses, and Docs.
-    Use when the user needs to interact with ClickUp — creating/editing tasks, checking
-    sprint status, adding comments, linking PRs, '
-  stability: stable
-- id: integrations/linear
-  name: linear
-  domain: integrations
-  description: Manage Linear issues, projects and cycles via the Linear MCP server.
-    Use when the user wants to read, triage, create or update Linear tickets, plan
-    a sprint, audit Linear documentation, or rebalance t
-  stability: stable
-- id: integrations/slack-assistant
-  name: slack-assistant
-  domain: integrations
-  description: Interact with Slack workspaces for reading channels/messages, sending
-    messages, adding reactions, and browsing canvases. Use when the user asks about
-    Slack channels, messages, or notifications — NOT f
-  stability: stable
-- id: integrations/slack-cli
-  name: slack-cli
-  domain: integrations
-  description: Interact with the official Slack CLI to create, run, deploy, and manage
-    Slack apps, environments, manifests, and triggers. Use when the user asks about
-    Slack app development workflows, not workspace c
-  stability: stable
-- id: loops/loop-runner
-  name: loop-runner
-  domain: loops
-  description: Execute and manage loop engineering primitives (init, run, status,
-    audit) from an AI coding session via bin/loop CLI.
-  stability: stable
-- id: ops/docs-generator
-  name: docs-generator
-  domain: ops
-  description: 'WHAT — Generate or update documentation from code: README.md from
-    repo structure, CHANGELOG.md from git history, API reference from OpenAPI/GraphQL
-    schemas, and AGENTS.md starters for new projects.'
-  stability: stable
-- id: ops/llm-cost-advisor
-  name: llm-cost-advisor
-  domain: ops
-  description: WHAT — Recommend the most cost-effective LLM provider for a given task
-    type. Shows estimated cost per run across available providers and integrates with
-    devcompanion llm-status to show what is actuall
-  stability: stable
-- id: ops/triage
-  name: triage
-  domain: ops
-  description: Workstation health triage — validate tooling, directory layout, and
-    run doctor with remediation suggestions.
-  stability: stable
-- id: tooling/jupyter-notebook
-  name: jupyter-notebook
-  domain: tooling
-  description: Create, scaffold, or refactor Jupyter notebooks (.ipynb) for experiments
-    and tutorials. Prefer the bundled templates and the helper script (`new_notebook.py`,
-    also exposed as `newnotebook`) to generat
-  stability: stable
-- id: tooling/playwright-cli
-  name: playwright-cli
-  domain: tooling
-  description: Drive a real browser from the terminal using the Playwright CLI (snapshot,
-    click, fill, screenshots, traces). Use when the task is CLI-first browser automation
-    (data extraction, UI debugging, form fil
-  stability: stable
+  - id: core/assistant
+    name: assistant
+    domain: core
+    description: Assistant — on any repo, scan README→docs→AGENTS→CONTRIBUTING→PR
+      templates→task runners→devcontainer→CI→configs before code; cite sources; prefer
+      AGENTS.md for agent behavior; portable across Cursor/C
+    stability: stable
+  - id: core/dev-companion
+    name: dev-companion
+    domain: core
+    description: 'WHAT — Dev Companion (general): layered companion for client delivery;
+      modes, gates, delegation to assistant and workflow-generic-project; no CLI matrices.'
+    stability: stable
+  - id: core/onboarding
+    name: onboarding
+    domain: core
+    description: Getting started guide for new users. Walks through setup validation,
+      the skill/agent hierarchy, and the three most useful commands per role (developer,
+      PM, tech lead). Use when someone is new to the w
+    stability: stable
+  - id: core/output-handshake
+    name: output-handshake
+    domain: core
+    description: 'WHAT — Default gate for any deliverable: confirm where the final
+      artifact will be stored and that a human will review, before writing PRDs, TRDs,
+      ADRs, or PR bodies. Repository paths, wikis, and ticke'
+    stability: stable
+  - id: core/pr-fallback
+    name: pr-fallback
+    domain: core
+    description: WHAT — When the repo has no GitHub PR template, structure the pull-request
+      body using the default in references/pr-body-default.md. Pair with output-handshake
+      and github-cli-workflow. Does not open th
+    stability: stable
+  - id: core/workspace-knowledge-sync
+    name: workspace-knowledge-sync
+    domain: core
+    description: Syncs knowledge to the ai-workspace knowledge base. Use when the
+      assistant discovers new patterns, learns user preferences, or identifies information
+      worth preserving for future sessions. Integrates w
+    stability: stable
+  - id: data/dbt-validation
+    name: dbt-validation
+    domain: data
+    description: HOW — Run dbt checks as documented in the target repo (parse, compile,
+      test, selective run). Does not configure Snowflake accounts or change cloud
+      security.
+    stability: stable
+  - id: data/snowflake-validation
+    name: snowflake-validation
+    domain: data
+    description: 'HOW — Read-only Snowflake validation patterns: use repo-documented
+      CLI (snowflake/sql) or SQL checks. Never claim success without working credentials
+      and evidence.'
+    stability: stable
+  - id: delivery/adr
+    name: adr
+    domain: delivery
+    description: WHAT — Create and maintain Architecture Decision Records (ADRs) per
+      the process. Covers when to write an ADR, required sections, review, and linking
+      to epics/PRs. English for cross-team artifacts unle
+    stability: stable
+  - id: delivery/agreement
+    name: agreement
+    domain: delivery
+    description: WHAT - Capture explicit agreements, terms, parties involved, dates,
+      validity, and linked work items using the Agreement Document structure.
+    stability: stable
+  - id: delivery/bug
+    name: bug
+    domain: delivery
+    description: WHAT - Draft and review bugs using the Bug Template; classifies whether
+      an issue should be escalated to incident based on production/user impact.
+    stability: stable
+  - id: delivery/decision-log
+    name: decision-log
+    domain: delivery
+    description: WHAT - Capture lightweight project, product, or operational decisions
+      that do not require a full ADR; includes rationale, date, owner, and references.
+    stability: stable
+  - id: delivery/development-workflow
+    name: development-workflow
+    domain: delivery
+    description: WHAT - Default development workflow, task lifecycle, DoR, DoD, validation,
+      and evidence model when a project has no explicit override. Repository instructions
+      still take precedence.
+    stability: stable
+  - id: delivery/epic
+    name: epic
+    domain: delivery
+    description: WHAT - Draft and review epics using the Best Practices Epic Template;
+      includes objectives, success criteria, related tasks, stakeholders, and effort
+      metadata.
+    stability: stable
+  - id: delivery/incident
+    name: incident
+    domain: delivery
+    description: WHAT - Draft and review incident reports and RCA notes using Incident
+      Management guidance; includes detection, impact, timeline, RCA, resolution,
+      and follow-ups.
+    stability: stable
+  - id: delivery/management-unit-assessment
+    name: management-unit-assessment
+    domain: delivery
+    description: WHAT - Evidence-based management unit assessment for governance,
+      delivery, collaboration, culture, and AI-native management readiness. Interactive
+      and source-driven before any score is assigned.
+    stability: stable
+  - id: delivery/meeting-minutes
+    name: meeting-minutes
+    domain: delivery
+    description: WHAT - Create structured meeting minutes from notes or transcripts
+      using meeting templates, with redaction, action items, decisions, and traceability.
+    stability: stable
+  - id: delivery/planning
+    name: planning
+    domain: delivery
+    description: WHAT - Planning, estimation, task breakdown, and iteration capacity
+      fallback based on Best Practices. Use before finalizing backlog scope, story/task
+      estimates, or iteration commitments.
+    stability: stable
+  - id: delivery/prd
+    name: prd
+    domain: delivery
+    description: WHAT — Draft and review a Product Requirements Document (PRD) using
+      the template. Business-level requirements, acceptance criteria, and traceability.
+      Does not replace the product owner. English for ti
+    stability: stable
+  - id: delivery/project-assessment
+    name: project-assessment
+    domain: delivery
+    description: 'WHAT - Interactive project assessment router: define assessment
+      scope and units, collect evidence through project-assessment-evidence, then
+      delegate to technical or management unit assessment skills. '
+    stability: stable
+  - id: delivery/project-assessment-evidence
+    name: project-assessment-evidence
+    domain: delivery
+    description: 'WHAT - Interactive evidence intake for project assessments. Ask
+      the user where each evidence source lives, build an evidence map, track missing
+      evidence, assumptions, freshness, and confidence before '
+    stability: stable
+  - id: delivery/spike
+    name: spike
+    domain: delivery
+    description: WHAT - Produce spike and research findings using the spike template;
+      captures purpose, findings, implementation strategy, risks, tradeoffs, open
+      questions, and references.
+    stability: stable
+  - id: delivery/task
+    name: task
+    domain: delivery
+    description: WHAT - Draft and review technical tasks using the Best Practices
+      Task Template; includes summary, technical notes, AC, estimate, owner, and due
+      date.
+    stability: stable
+  - id: delivery/technical-unit-assessment
+    name: technical-unit-assessment
+    domain: delivery
+    description: WHAT - Evidence-based technical unit assessment for repositories,
+      platforms, frontend, backend, infrastructure, data, UI/UX, and AI-native structural
+      readiness.
+    stability: stable
+  - id: delivery/trd
+    name: trd
+    domain: delivery
+    description: WHAT — Draft and review a Technical Requirements Document (TRD) using
+      the template, typically from an agreed PRD. Covers architecture, data contracts,
+      technical decisions, risks, and test strategy. En
+    stability: stable
+  - id: delivery/user-story
+    name: user-story
+    domain: delivery
+    description: WHAT - Draft and review user stories using the task template plus
+      the As a/I want/so that format from Best Practices examples.
+    stability: stable
+  - id: delivery/work-item
+    name: work-item
+    domain: delivery
+    description: WHAT - Router for creating and refining epics, user stories, tasks,
+      bugs, and incidents using Best Practices work item hierarchy.
+    stability: stable
+  - id: delivery/workflow-client-bootstrap
+    name: workflow-client-bootstrap
+    domain: delivery
+    description: WHAT — Interactive interview to capture client delivery context and
+      store it inside the user's ~/.ai-workspace (or similar) as packs + knowledge
+      (no client skills). Use when onboarding a new client pr
+    stability: stable
+  - id: delivery/workflow-generic-project
+    name: workflow-generic-project
+    domain: delivery
+    description: 'WHAT — Generic client delivery: Jira or ClickUp, full repo context,
+      human gates, English traceability on tickets, draft PR via delegated forge skills.
+      Use workspace packs for client/account overlays.'
+    stability: stable
+  - id: design/figma
+    name: figma
+    domain: design
+    description: Use the Figma MCP server to fetch design context, screenshots, variables,
+      and assets, and to translate Figma nodes into production code. Trigger when
+      a task involves Figma URLs, node IDs, design-to-co
+    stability: stable
+  - id: design/figma-code-connect-components
+    name: figma-code-connect-components
+    domain: design
+    description: Connects Figma design components to code components using Code Connect
+      mapping tools. Use when user says "code connect", "connect this component to
+      code", "map this component", "link component to code
+    stability: stable
+  - id: design/figma-create-design-system-rules
+    name: figma-create-design-system-rules
+    domain: design
+    description: Generates custom design system rules for the user's codebase. Use
+      when user says "create design system rules", "generate rules for my project",
+      "set up design rules", "customize design system guidelin
+    stability: stable
+  - id: design/figma-create-new-file
+    name: figma-create-new-file
+    domain: design
+    description: 'Create a new blank Figma file. Use when the user wants to create
+      a new Figma design or FigJam file, or when you need a new file before calling
+      use_figma. Handles plan resolution via whoami if needed. '
+    stability: stable
+  - id: design/figma-implement-design
+    name: figma-implement-design
+    domain: design
+    description: Translates Figma designs into production-ready application code with
+      1:1 visual fidelity. Use when implementing UI code from Figma files, when user
+      mentions "implement design", "generate code", "imple
+    stability: stable
+  - id: design/ui-ux-pro-max
+    name: ui-ux-pro-max
+    domain: design
+    description: 'UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings,
+      25 charts, 13 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter,
+      Tailwind, shadcn/ui). Actions: plan, build, crea'
+    stability: stable
+  - id: forge/gh-address-comments
+    name: gh-address-comments
+    domain: forge
+    description: Triage and address open GitHub PR review and conversation comments
+      using the gh CLI. Use when the user wants to "address PR comments", "resolve
+      review threads", or "respond to reviewers" on the curren
+    stability: stable
+  - id: forge/gh-contribution-planner
+    name: gh-contribution-planner
+    domain: forge
+    description: Daily GitHub contribution planner — analyzes the gh-logged-in user's
+      non-archived repos (owned + forks) and recent contributions, produces a prioritized
+      plan, halts for approval, then dispatches paral
+    stability: stable
+  - id: forge/gh-fix-ci
+    name: gh-fix-ci
+    domain: forge
+    description: Diagnose failing GitHub Actions checks on a PR via gh, summarize
+      the failure context, propose a plan, and only implement after explicit user
+      approval. External CI providers (Buildkite, CircleCI, etc.)
+    stability: stable
+  - id: forge/github-cli-workflow
+    name: github-cli-workflow
+    domain: forge
+    description: 'HOW — GitHub CLI (gh): push branch, create draft PR with title/body
+      from template or file; fallback untracked PR_DESCRIPTION_*.md. Use when origin
+      is GitHub.'
+    stability: stable
+  - id: forge/gitlab-cli-workflow
+    name: gitlab-cli-workflow
+    domain: forge
+    description: 'HOW — GitLab CLI (glab): push branch, create draft MR with title/body;
+      fallback untracked markdown. Use when origin is GitLab.'
+    stability: stable
+  - id: forge/workflow-client-bootstrap
+    name: workflow-client-bootstrap
+    domain: forge
+    description: DEPRECATED alias. Use workflow-client-bootstrap instead.
+    stability: stable
+  - id: forge/workflow-generic-project
+    name: workflow-generic-project
+    domain: forge
+    description: DEPRECATED alias. Use workflow-generic-project instead.
+    stability: stable
+  - id: integrations/clickup-cli
+    name: clickup-cli
+    domain: integrations
+    description: 'ClickUp CLI for managing tasks, sprints, comments, statuses, and
+      Docs. Use when the user needs to interact with ClickUp — creating/editing tasks,
+      checking sprint status, adding comments, linking PRs, '
+    stability: stable
+  - id: integrations/linear
+    name: linear
+    domain: integrations
+    description: Manage Linear issues, projects and cycles via the Linear MCP server.
+      Use when the user wants to read, triage, create or update Linear tickets, plan
+      a sprint, audit Linear documentation, or rebalance t
+    stability: stable
+  - id: integrations/slack-assistant
+    name: slack-assistant
+    domain: integrations
+    description: Interact with Slack workspaces for reading channels/messages, sending
+      messages, adding reactions, and browsing canvases. Use when the user asks about
+      Slack channels, messages, or notifications — NOT f
+    stability: stable
+  - id: integrations/slack-cli
+    name: slack-cli
+    domain: integrations
+    description: Interact with the official Slack CLI to create, run, deploy, and
+      manage Slack apps, environments, manifests, and triggers. Use when the user
+      asks about Slack app development workflows, not workspace c
+    stability: stable
+  - id: loops/loop-runner
+    name: loop-runner
+    domain: loops
+    description: Execute and manage loop engineering primitives (init, run, status,
+      audit) from an AI coding session via bin/loop CLI.
+    stability: stable
+  - id: ops/docs-generator
+    name: docs-generator
+    domain: ops
+    description: 'WHAT — Generate or update documentation from code: README.md from
+      repo structure, CHANGELOG.md from git history, API reference from OpenAPI/GraphQL
+      schemas, and AGENTS.md starters for new projects.'
+    stability: stable
+  - id: ops/llm-cost-advisor
+    name: llm-cost-advisor
+    domain: ops
+    description: WHAT — Recommend the most cost-effective LLM provider for a given
+      task type. Shows estimated cost per run across available providers and integrates
+      with devcompanion llm-status to show what is actuall
+    stability: stable
+  - id: ops/triage
+    name: triage
+    domain: ops
+    description: Workstation health triage — validate tooling, directory layout, and
+      run doctor with remediation suggestions.
+    stability: stable
+  - id: tooling/jupyter-notebook
+    name: jupyter-notebook
+    domain: tooling
+    description: Create, scaffold, or refactor Jupyter notebooks (.ipynb) for experiments
+      and tutorials. Prefer the bundled templates and the helper script (`new_notebook.py`,
+      also exposed as `newnotebook`) to generat
+    stability: stable
+  - id: tooling/playwright-cli
+    name: playwright-cli
+    domain: tooling
+    description: Drive a real browser from the terminal using the Playwright CLI (snapshot,
+      click, fill, screenshots, traces). Use when the task is CLI-first browser automation
+      (data extraction, UI debugging, form fil
+    stability: stable

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -1,169 +1,165 @@
 version: '1.0'
 generated_from: distributions/products.yaml
 products:
-- id: agent-toolkit-core
-  name: Agent Toolkit Core
-  description: Core orchestration skills, dev companion, output handshake, PR fallback,
-    and code-reviewer agent. The baseline install for any project.
-  version_source: src/agent_toolkit/__init__.py
-  stability: stable
-  includes:
-    skills:
-    - core/assistant
-    - core/dev-companion
-    - core/output-handshake
-    - core/pr-fallback
-    - core/workspace-knowledge-sync
-    - core/onboarding
-    agents:
-    - code-reviewer
-    hooks:
-    - session-start-context
-    mcp:
-    - github
-  excludes: []
-  targets:
-    claude-code:
-      plugin_id: agent-toolkit-core
-      manifest: plugins/agent-toolkit-core/.claude-plugin/plugin.json
-    cursor:
-      plugin_id: agent-toolkit-core
-      manifest: plugins/agent-toolkit-core/.cursor-plugin/plugin.json
-  requires:
-    executables: []
-    env: []
-  security:
-    approval_required: false
-    default_enabled: true
-    rationale: Core skills are read-only instruction files with no side effects.
-- id: agent-toolkit-agents
-  name: Agent Toolkit Agents
-  description: 'Full set of 16 AI agent personas: architect, code-reviewer, security-reviewer,
-    planner, database-reviewer, TypeScript-reviewer, and more.'
-  version_source: src/agent_toolkit/__init__.py
-  stability: stable
-  includes:
-    skills: []
-    agents:
-    - architect
-    - assistant
-    - build-error-resolver
-    - client-workflow-bootstrap
-    - code-reviewer
-    - database-reviewer
-    - docs-lookup
-    - e2e-runner
-    - performance-optimizer
-    - planner
-    - refactor-cleaner
-    - reference-lookup
-    - security-reviewer
-    - tdd-guide
-    - tech-assistant
-    - typescript-reviewer
-    hooks: []
-    mcp: []
-  targets:
-    claude-code:
-      plugin_id: agent-toolkit-agents
-      manifest: plugins/agent-toolkit-agents/.claude-plugin/plugin.json
-    cursor:
-      plugin_id: agent-toolkit-agents
-      manifest: plugins/agent-toolkit-agents/.cursor-plugin/plugin.json
-- id: agent-toolkit-forge
-  name: Agent Toolkit Forge
-  description: 'GitHub and GitLab automation skills: PR workflows, CI fixes, comment
-    resolution, and contribution planning.'
-  version_source: src/agent_toolkit/__init__.py
-  stability: stable
-  includes:
-    skills:
-    - forge/github-cli-workflow
-    - forge/gitlab-cli-workflow
-    - forge/gh-address-comments
-    - forge/gh-fix-ci
-    - forge/gh-contribution-planner
-    - forge/workflow-client-bootstrap
-    - forge/workflow-generic-project
-    agents: []
-    hooks: []
-    mcp: []
-  requires:
-    executables:
-    - name: gh
-      description: GitHub CLI
-      install_url: https://cli.github.com/
-      required: false
-  targets:
-    claude-code:
-      plugin_id: agent-toolkit-forge
-      manifest: plugins/agent-toolkit-forge/.claude-plugin/plugin.json
-    cursor:
-      plugin_id: agent-toolkit-forge
-      manifest: plugins/agent-toolkit-forge/.cursor-plugin/plugin.json
-- id: agent-toolkit-complete
-  name: Agent Toolkit Complete
-  description: Full stable skill catalog coverage for consumers who want everything
-    (#50)
-  stability: experimental
-  includes:
-    skills:
-    - core/assistant
-    - core/dev-companion
-    - core/onboarding
-    - core/output-handshake
-    - core/pr-fallback
-    - core/workspace-knowledge-sync
-    - data/dbt-validation
-    - data/snowflake-validation
-    - delivery/adr
-    - delivery/agreement
-    - delivery/bug
-    - delivery/decision-log
-    - delivery/development-workflow
-    - delivery/epic
-    - delivery/incident
-    - delivery/management-unit-assessment
-    - delivery/meeting-minutes
-    - delivery/planning
-    - delivery/prd
-    - delivery/project-assessment
-    - delivery/project-assessment-evidence
-    - delivery/spike
-    - delivery/task
-    - delivery/technical-unit-assessment
-    - delivery/trd
-    - delivery/user-story
-    - delivery/work-item
-    - delivery/workflow-client-bootstrap
-    - delivery/workflow-generic-project
-    - design/figma
-    - design/figma-code-connect-components
-    - design/figma-create-design-system-rules
-    - design/figma-create-new-file
-    - design/figma-implement-design
-    - design/ui-ux-pro-max
-    - forge/gh-address-comments
-    - forge/gh-contribution-planner
-    - forge/gh-fix-ci
-    - forge/github-cli-workflow
-    - forge/gitlab-cli-workflow
-    - forge/workflow-client-bootstrap
-    - forge/workflow-generic-project
-    - integrations/clickup-cli
-    - integrations/linear
-    - integrations/slack-assistant
-    - integrations/slack-cli
-    - loops/loop-runner
-    - ops/docs-generator
-    - ops/llm-cost-advisor
-    - ops/triage
-    - tooling/jupyter-notebook
-    - tooling/playwright-cli
-    agents: []
-    hooks: []
-    mcp: []
-  security:
-    approval_required: false
-    default_enabled: true
-    rationale: opt-in complete catalog
+  - id: agent-toolkit-core
+    name: Agent Toolkit Core
+    description: Core orchestration skills, dev companion, output handshake, PR fallback, and code-reviewer agent. The baseline install for any project.
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - core/assistant
+        - core/dev-companion
+        - core/output-handshake
+        - core/pr-fallback
+        - core/workspace-knowledge-sync
+        - core/onboarding
+      agents:
+        - code-reviewer
+      hooks:
+        - session-start-context
+      mcp:
+        - github
+    excludes: []
+    targets:
+      claude-code:
+        plugin_id: agent-toolkit-core
+        manifest: plugins/agent-toolkit-core/.claude-plugin/plugin.json
+      cursor:
+        plugin_id: agent-toolkit-core
+        manifest: plugins/agent-toolkit-core/.cursor-plugin/plugin.json
+    requires:
+      executables: []
+      env: []
+    security:
+      approval_required: false
+      default_enabled: true
+      rationale: Core skills are read-only instruction files with no side effects.
+  - id: agent-toolkit-agents
+    name: Agent Toolkit Agents
+    description: 'Full set of 16 AI agent personas: architect, code-reviewer, security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.'
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills: []
+      agents:
+        - architect
+        - assistant
+        - build-error-resolver
+        - client-workflow-bootstrap
+        - code-reviewer
+        - database-reviewer
+        - docs-lookup
+        - e2e-runner
+        - performance-optimizer
+        - planner
+        - refactor-cleaner
+        - reference-lookup
+        - security-reviewer
+        - tdd-guide
+        - tech-assistant
+        - typescript-reviewer
+      hooks: []
+      mcp: []
+    targets:
+      claude-code:
+        plugin_id: agent-toolkit-agents
+        manifest: plugins/agent-toolkit-agents/.claude-plugin/plugin.json
+      cursor:
+        plugin_id: agent-toolkit-agents
+        manifest: plugins/agent-toolkit-agents/.cursor-plugin/plugin.json
+  - id: agent-toolkit-forge
+    name: Agent Toolkit Forge
+    description: 'GitHub and GitLab automation skills: PR workflows, CI fixes, comment resolution, and contribution planning.'
+    version_source: src/agent_toolkit/__init__.py
+    stability: stable
+    includes:
+      skills:
+        - forge/github-cli-workflow
+        - forge/gitlab-cli-workflow
+        - forge/gh-address-comments
+        - forge/gh-fix-ci
+        - forge/gh-contribution-planner
+        - forge/workflow-client-bootstrap
+        - forge/workflow-generic-project
+      agents: []
+      hooks: []
+      mcp: []
+    requires:
+      executables:
+        - name: gh
+          description: GitHub CLI
+          install_url: https://cli.github.com/
+          required: false
+    targets:
+      claude-code:
+        plugin_id: agent-toolkit-forge
+        manifest: plugins/agent-toolkit-forge/.claude-plugin/plugin.json
+      cursor:
+        plugin_id: agent-toolkit-forge
+        manifest: plugins/agent-toolkit-forge/.cursor-plugin/plugin.json
+  - id: agent-toolkit-complete
+    name: Agent Toolkit Complete
+    description: Full stable skill catalog coverage for consumers who want everything (#50)
+    stability: experimental
+    includes:
+      skills:
+        - core/assistant
+        - core/dev-companion
+        - core/onboarding
+        - core/output-handshake
+        - core/pr-fallback
+        - core/workspace-knowledge-sync
+        - data/dbt-validation
+        - data/snowflake-validation
+        - delivery/adr
+        - delivery/agreement
+        - delivery/bug
+        - delivery/decision-log
+        - delivery/development-workflow
+        - delivery/epic
+        - delivery/incident
+        - delivery/management-unit-assessment
+        - delivery/meeting-minutes
+        - delivery/planning
+        - delivery/prd
+        - delivery/project-assessment
+        - delivery/project-assessment-evidence
+        - delivery/spike
+        - delivery/task
+        - delivery/technical-unit-assessment
+        - delivery/trd
+        - delivery/user-story
+        - delivery/work-item
+        - delivery/workflow-client-bootstrap
+        - delivery/workflow-generic-project
+        - design/figma
+        - design/figma-code-connect-components
+        - design/figma-create-design-system-rules
+        - design/figma-create-new-file
+        - design/figma-implement-design
+        - design/ui-ux-pro-max
+        - forge/gh-address-comments
+        - forge/gh-contribution-planner
+        - forge/gh-fix-ci
+        - forge/github-cli-workflow
+        - forge/gitlab-cli-workflow
+        - forge/workflow-client-bootstrap
+        - forge/workflow-generic-project
+        - integrations/clickup-cli
+        - integrations/linear
+        - integrations/slack-assistant
+        - integrations/slack-cli
+        - loops/loop-runner
+        - ops/docs-generator
+        - ops/llm-cost-advisor
+        - ops/triage
+        - tooling/jupyter-notebook
+        - tooling/playwright-cli
+      agents: []
+      hooks: []
+      mcp: []
+    security:
+      approval_required: false
+      default_enabled: true
+      rationale: opt-in complete catalog

--- a/scripts/generate-catalogs.py
+++ b/scripts/generate-catalogs.py
@@ -15,6 +15,14 @@ except ImportError:
 ROOT = Path(__file__).resolve().parents[1]
 
 
+class IndentDumper(yaml.SafeDumper):
+    """Force indented sequences so yamllint indentation rule passes."""
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, False)
+
+
+
 def _fm(text: str) -> dict:
     m = re.match(r"^---\s*\n(.*?)\n---", text, re.S)
     if not m:
@@ -76,7 +84,7 @@ def main() -> int:
     }
     for name, data in mapping.items():
         path = out / name
-        path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+        path.write_text(yaml.dump(data, Dumper=IndentDumper, sort_keys=False, allow_unicode=True, default_flow_style=False))
         print(f"wrote {path} ({data['count']} entries)")
     return 0
 


### PR DESCRIPTION
## Summary
- MegaLinter was failing on `main` because yamllint's indentation rule rejects unindented sequences in catalogs and `products.yaml`.
- Update `scripts/generate-catalogs.py` to dump with indented sequences and regenerate catalogs.
- Normalize `distributions/products.yaml` to the same style.

## Test plan
- [x] Local `yamllint` on touched YAML (errors only; line-length warnings OK)
- [x] `pytest` catalog/product coverage tests
- [ ] Validate + MegaLinter green on PR
- [ ] MegaLinter green on `main` after merge