### PR TITLE
fix(cli): consumer/advanced surface exit codes (#48)

### DIFF
--- a/docs/CLI_SURFACES.md
+++ b/docs/CLI_SURFACES.md
@@ -13,13 +13,15 @@ Install, verify, and sync toolkit content for coding assistants:
 | Command | Purpose |
 |---------|---------|
 | `install` | Install profiles for detected or selected AI tools |
+| `update` | Refresh installed profiles from latest toolkit data |
+| `uninstall` | Remove toolkit-owned files using install receipts |
 | `doctor` | Check toolkit data and tool availability |
 | `diff` | Show changes vs installed plugin bundles |
 | `skills` | Sync, list, and validate skills |
 | `mcp` | MCP provider setup, health, doctor, uninstall |
 | `plugin` | Plugin bundle sync and check |
 
-Also: `version`, `help`. See other open PRs for `update` and `completion`.
+Also: `version`, `help`.
 
 ## Advanced commands
 
@@ -44,3 +46,10 @@ Still available on the same binary — de-emphasized in top-level help:
 Existing scripts invoking advanced commands continue to work unchanged.
 New users should start with `install`, `doctor`, and `skills` only; adopt
 advanced commands when running an ai-workspace-style harness.
+
+## Exit-code contract (#48)
+
+Consumer and advanced commands return integer status codes from their `cmd_*`
+handlers. They must not call `sys.exit` for recoverable errors (missing
+templates, unknown `--tools` values). argparse `--help` stays exit 0; bad
+flags stay exit 2.

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
@@ -129,11 +129,16 @@ def _list_projects() -> list[tuple[str, Path | None]]:
 
 # ── template loading ──────────────────────────────────────────────────────────
 
+class TemplateNotFoundError(FileNotFoundError):
+    """Raised when a job template YAML is missing (#48 / CLI-011)."""
+
+
 def _load_template(name: str) -> dict:
     tpl_file = TEMPLATES_DIR / f"{name}.yaml"
     if not tpl_file.exists():
-        _err(f"Template not found: {name}  (looked in {TEMPLATES_DIR}/)")
-        sys.exit(1)
+        raise TemplateNotFoundError(
+            f"Template not found: {name}  (looked in {TEMPLATES_DIR}/)"
+        )
 
     text = tpl_file.read_text(encoding="utf-8")
     lines = text.splitlines()
@@ -334,6 +339,16 @@ def _skeleton_run(job: dict, out_dir: Path) -> int:
 
 # ── subcommands ───────────────────────────────────────────────────────────────
 
+def _safe_parse(parser, argv: list[str]) -> tuple[object | None, int | None]:
+    """Parse argv without letting argparse SystemExit bypass cmd return codes (#48)."""
+    try:
+        return parser.parse_args(argv), None
+    except SystemExit as exc:
+        if exc.code in (0, None):
+            return None, 0
+        return None, int(exc.code) if isinstance(exc.code, int) else 2
+
+
 def _cmd_queue(argv: list[str]) -> int:
     import argparse
 
@@ -342,7 +357,9 @@ def _cmd_queue(argv: list[str]) -> int:
     p.add_argument("--template", "-t",     help="Job template name from templates/jobs/")
     p.add_argument("--request",  "-r",     help="Custom request string")
     p.add_argument("--id",                 help="Custom job ID (default: <project>-<timestamp>)")
-    args = p.parse_args(argv)
+    args, parse_err = _safe_parse(p, argv)
+    if parse_err is not None:
+        return parse_err
 
     if not args.project:
         _err("Usage: agent-toolkit devcompanion queue <project> [--template NAME] [--request \"...\"]")
@@ -365,7 +382,11 @@ def _cmd_queue(argv: list[str]) -> int:
     # Build request
     request = ""
     if args.template:
-        tpl = _load_template(args.template)
+        try:
+            tpl = _load_template(args.template)
+        except TemplateNotFoundError as exc:
+            _err(str(exc))
+            return 1
         request = tpl["request"]
         if args.request:
             request = f"{request}\n\n---\n\n{args.request}"
@@ -405,7 +426,9 @@ def _cmd_run_once(argv: list[str]) -> int:
 
     p = argparse.ArgumentParser(prog="agent-toolkit devcompanion run-once", add_help=True)
     p.add_argument("--no-llm", action="store_true", help="Always use skeleton plan, skip LLM")
-    args = p.parse_args(argv)
+    args, parse_err = _safe_parse(p, argv)
+    if parse_err is not None:
+        return parse_err
 
     QUEUE_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -528,7 +551,9 @@ def _cmd_done(argv: list[str]) -> int:
 
     p = argparse.ArgumentParser(prog="agent-toolkit devcompanion done", add_help=True)
     p.add_argument("job_id", nargs="?", help="Job ID to mark as done")
-    args = p.parse_args(argv)
+    args, parse_err = _safe_parse(p, argv)
+    if parse_err is not None:
+        return parse_err
 
     if not args.job_id:
         _err("Usage: agent-toolkit devcompanion done <job-id>")

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/skills.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/skills.py
@@ -307,6 +307,7 @@ def _cmd_sync(args: list[str], toolkit_dir: Path) -> int:
             print()
         else:
             print(f"  ⚠  Unknown tool: {tool}  (valid: {', '.join(valid_tools)})")
+            success = False  # CLI-012 / #48 — unknown --tools must fail
 
     return 0 if success else 1
 

--- a/tests/test_cli_surface_exit_codes.py
+++ b/tests/test_cli_surface_exit_codes.py
@@ -1,0 +1,47 @@
+"""#48 — consumer/advanced surface exit-code contract (CLI-011, CLI-012)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import skills as skills_mod
+from agent_toolkit.cli.devcompanion import TemplateNotFoundError, _load_template, _safe_parse, cmd_devcompanion
+
+
+def test_skills_sync_unknown_tool_exits_1(tmp_path: Path) -> None:
+    assert skills_mod._cmd_sync(["--tools", "not-a-real-tool"], tmp_path) == 1
+
+
+def test_load_template_missing_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_toolkit.cli.devcompanion as dc
+
+    monkeypatch.setattr(dc, "TEMPLATES_DIR", tmp_path)
+    with pytest.raises(TemplateNotFoundError):
+        _load_template("missing-template")
+
+
+def test_safe_parse_help_returns_0() -> None:
+    import argparse
+
+    p = argparse.ArgumentParser(prog="test")
+    args, err = _safe_parse(p, ["--help"])
+    assert args is None
+    assert err == 0
+
+
+def test_devcompanion_queue_missing_template_returns_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import agent_toolkit.cli.devcompanion as dc
+
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    (projects / "demo").symlink_to(tmp_path, target_is_directory=True)
+    monkeypatch.setattr(dc, "PROJECTS_DIR", projects)
+    monkeypatch.setattr(dc, "TEMPLATES_DIR", tmp_path / "templates")
+    monkeypatch.setattr(dc, "QUEUE_DIR", tmp_path / "queue")
+    (tmp_path / "templates").mkdir()
+    (tmp_path / "queue").mkdir()
+
+    assert cmd_devcompanion(["queue", "demo", "--template", "nope"]) == 1


### PR DESCRIPTION
## Summary
Closes remaining #48 acceptance gaps for CLI surface progressive disclosure:
- **CLI-011**: `_load_template` raises instead of `sys.exit(1)`; argparse helpers return int codes
- **CLI-012**: `skills sync --tools <unknown>` returns 1
- Docs: `docs/CLI_SURFACES.md` lists `update`/`uninstall` as consumer and documents the exit-code contract

## Test plan
- [x] `pytest tests/test_cli_surface_exit_codes.py tests/test_cli_surfaces.py tests/test_cli_help.py`
- [ ] Manual: `agent-toolkit help` shows Consumer vs Advanced
- [ ] Manual: `agent-toolkit skills sync --tools nope` exits 1

Closes #48