### PR TITLE
feat(loop): workspace init + HARNESS_DIR (#200 #201 #202 #207)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/_paths.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/_paths.py
@@ -114,3 +114,31 @@ def toolkit_root(*, offline: bool | None = None) -> Path:
             _root = resolved
         return resolved
     return _root
+
+
+def find_workspace_root(*, override: str | None = None) -> Path | None:
+    """Locate the user harness / AI workspace root (not toolkit package data).
+
+    Resolution order (#207):
+    1. Explicit override (CLI ``--workspace``)
+    2. ``AGENT_TOOLKIT_WORKSPACE``
+    3. ``HARNESS_DIR`` (agentic-harness compatibility)
+    4. Walk up from CWD for ``AGENTS.md`` or ``knowledge/``
+    """
+    if override:
+        p = Path(override).expanduser().resolve()
+        return p if p.is_dir() else None
+
+    for env in ("AGENT_TOOLKIT_WORKSPACE", "HARNESS_DIR"):
+        val = os.environ.get(env, "").strip()
+        if val:
+            p = Path(val).expanduser().resolve()
+            if p.is_dir():
+                return p
+
+    current = Path.cwd()
+    for candidate in [current, *current.parents]:
+        if (candidate / "AGENTS.md").exists() or (candidate / "knowledge").is_dir():
+            return candidate
+
+    return None

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
@@ -12,7 +12,6 @@ Aliases: dc
 """
 from __future__ import annotations
 
-import json
 import os
 import re
 import shutil
@@ -28,6 +27,20 @@ if _sys.platform == 'win32':
         _sys.stderr.reconfigure(encoding='utf-8', errors='replace')
     except Exception:
         pass
+
+from agent_toolkit.cli.devcompanion_queue import (
+    DCConfig,
+    find_job_path,
+    get_dc_config,
+    iter_jobs,
+    job_project_name,
+    job_project_path,
+    mark_job_done,
+    pending_jobs,
+    queue_job_path,
+    read_job,
+    write_job,
+)
 
 
 # ── workspace detection ───────────────────────────────────────────────────────
@@ -48,13 +61,27 @@ def _find_workspace() -> Path:
 
 
 WORKSPACE_ROOT: Path = _find_workspace()
-PROJECTS_DIR: Path   = WORKSPACE_ROOT / "projects"
-TEMPLATES_DIR: Path  = WORKSPACE_ROOT / "templates" / "jobs"
-KNOWLEDGE_TODOS: Path = WORKSPACE_ROOT / "knowledge" / "todos" / "pending.md"
 
-_DC_HOME: Path = WORKSPACE_ROOT / ".devcompanion"
-QUEUE_DIR: Path  = _DC_HOME / "queue"
-RUNS_DIR: Path   = _DC_HOME / "runs"
+
+def _workspace() -> Path:
+    """Fresh workspace root (respects env changes in tests)."""
+    return _find_workspace()
+
+
+def _projects_dir() -> Path:
+    return _workspace() / "projects"
+
+
+def _templates_dir() -> Path:
+    return _workspace() / "templates" / "jobs"
+
+
+def _knowledge_todos() -> Path:
+    return _workspace() / "knowledge" / "todos" / "pending.md"
+
+
+def _cfg() -> DCConfig:
+    return get_dc_config(_workspace())
 
 
 # ── colors ────────────────────────────────────────────────────────────────────
@@ -85,42 +112,28 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-# ── job I/O ───────────────────────────────────────────────────────────────────
-
-def _read_job(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _write_job(path: Path, data: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-
-
-def _job_path(job_id: str) -> Path:
-    return QUEUE_DIR / f"{job_id}.json"
-
-
 # ── project resolution ────────────────────────────────────────────────────────
 
 def _resolve_project(name: str) -> Path | None:
     """Resolve project name → real repo path via projects/ symlinks."""
-    if not PROJECTS_DIR.is_dir():
+    projects_dir = _projects_dir()
+    if not projects_dir.is_dir():
         return None
-    link = PROJECTS_DIR / name
+    link = projects_dir / name
     if link.is_symlink():
         return link.resolve()
-    # Fuzzy: partial match
-    for entry in PROJECTS_DIR.iterdir():
+    for entry in projects_dir.iterdir():
         if entry.is_symlink() and name in entry.name:
             return entry.resolve()
     return None
 
 
 def _list_projects() -> list[tuple[str, Path | None]]:
-    if not PROJECTS_DIR.is_dir():
+    projects_dir = _projects_dir()
+    if not projects_dir.is_dir():
         return []
     result = []
-    for entry in sorted(PROJECTS_DIR.iterdir()):
+    for entry in sorted(projects_dir.iterdir()):
         if entry.is_symlink():
             target = entry.resolve() if entry.resolve().is_dir() else None
             result.append((entry.name, target))
@@ -130,9 +143,10 @@ def _list_projects() -> list[tuple[str, Path | None]]:
 # ── template loading ──────────────────────────────────────────────────────────
 
 def _load_template(name: str) -> dict:
-    tpl_file = TEMPLATES_DIR / f"{name}.yaml"
+    templates_dir = _templates_dir()
+    tpl_file = templates_dir / f"{name}.yaml"
     if not tpl_file.exists():
-        _err(f"Template not found: {name}  (looked in {TEMPLATES_DIR}/)")
+        _err(f"Template not found: {name}  (looked in {templates_dir}/)")
         sys.exit(1)
 
     text = tpl_file.read_text(encoding="utf-8")
@@ -169,8 +183,9 @@ def _load_template(name: str) -> dict:
 def _sync_todos() -> None:
     """Scan done job plans for checklist items and sync to knowledge/todos/pending.md."""
     todos: list[str] = []
+    cfg = _cfg()
+    runs_dir = cfg.runs_dir
 
-    runs_dir = RUNS_DIR
     if runs_dir.is_dir():
         for plan_md in sorted(runs_dir.rglob("plan.md")):
             try:
@@ -180,39 +195,75 @@ def _sync_todos() -> None:
             except Exception:
                 pass
 
-    KNOWLEDGE_TODOS.parent.mkdir(parents=True, exist_ok=True)
+    knowledge_todos = _knowledge_todos()
+    knowledge_todos.parent.mkdir(parents=True, exist_ok=True)
     existing = ""
-    if KNOWLEDGE_TODOS.exists():
-        existing = KNOWLEDGE_TODOS.read_text(encoding="utf-8")
+    if knowledge_todos.exists():
+        existing = knowledge_todos.read_text(encoding="utf-8")
 
-    # Build a new section
     if todos:
         block = "\n## Synced from devcompanion runs\n\n" + "\n".join(todos) + "\n"
-        # Replace existing synced section if present, else append
         marker = "\n## Synced from devcompanion runs\n"
         if marker in existing:
             pre = existing[: existing.index(marker)]
-            KNOWLEDGE_TODOS.write_text(pre + block, encoding="utf-8")
+            knowledge_todos.write_text(pre + block, encoding="utf-8")
         else:
-            KNOWLEDGE_TODOS.write_text((existing.rstrip() + "\n" + block) if existing else block, encoding="utf-8")
-        _ok(f"Synced {len(todos)} todo(s) → {KNOWLEDGE_TODOS}")
+            knowledge_todos.write_text((existing.rstrip() + "\n" + block) if existing else block, encoding="utf-8")
+        _ok(f"Synced {len(todos)} todo(s) → {knowledge_todos}")
     else:
         _ok("No '- [ ]' items found in run plans.")
 
 
 # ── runners ───────────────────────────────────────────────────────────────────
 
+def _import_harness_runner():
+    """Try to import the harness workstation runner."""
+    runner_root = os.environ.get("HARNESS_RUNNER_DIR", "").strip()
+    if not runner_root:
+        runner_root = str(Path.home() / ".local" / "share" / "agentic-harness" / "runner")
+    runner_dir = Path(runner_root) / "runner"
+    if not runner_dir.is_dir():
+        return None, f"runner dir not found: {runner_dir}"
+    if str(runner_dir) not in sys.path:
+        sys.path.insert(0, str(runner_dir))
+    try:
+        import dots_ai_devcompanion_runner as runner_mod
+        return runner_mod, None
+    except ImportError as exc:
+        return None, str(exc)
+
+
 def _has_loops(repo_path: str) -> bool:
-    """Check if project has agent-toolkit loops configured."""
     if not repo_path:
         return False
     loops_dir = Path(repo_path) / "loops"
     return loops_dir.is_dir() and any(loops_dir.iterdir())
 
 
+def _try_harness_runner(job_file: Path, out_dir: Path) -> bool:
+    runner, _reason = _import_harness_runner()
+    if runner is None:
+        return False
+
+    argv = ["--job", str(job_file), "--out", str(out_dir)]
+    try:
+        rc = runner.main(argv)
+    except Exception as exc:
+        _warn(f"Harness runner failed: {exc}")
+        return False
+
+    if rc is None:
+        rc = 0
+    if rc == 0:
+        _ok("Harness runner completed")
+        return True
+
+    _warn(f"Harness runner exited {rc}")
+    return False
+
+
 def _try_loop_runner(job: dict, out_dir: Path) -> bool:
-    """Try agent-toolkit loop run for the project."""
-    repo_path = job.get("project_path", "")
+    repo_path = job_project_path(job)
     if not _has_loops(repo_path):
         return False
 
@@ -246,18 +297,17 @@ def _try_loop_runner(job: dict, out_dir: Path) -> bool:
 
 
 def _try_claude_runner(job: dict, out_dir: Path) -> bool:
-    """Try claude --print as a runner."""
     claude_bin = shutil.which("claude")
     if not claude_bin:
         return False
 
-    repo_path = job.get("project_path", "")
+    repo_path = job_project_path(job)
     request = job.get("request", "")
     context = f"Repository: {repo_path}\n" if repo_path else ""
 
     prompt = (
         f"You are an AI assistant executing a background job.\n"
-        f"Workspace root: {WORKSPACE_ROOT}\n"
+        f"Workspace root: {_workspace()}\n"
         f"{context}"
         f"Output directory: {out_dir}\n\n"
         f"{request}\n\n"
@@ -271,7 +321,7 @@ def _try_claude_runner(job: dict, out_dir: Path) -> bool:
             input=prompt,
             capture_output=True,
             text=True,
-            cwd=str(WORKSPACE_ROOT),
+            cwd=str(_workspace()),
             timeout=1800,
         )
     except subprocess.TimeoutExpired:
@@ -290,13 +340,51 @@ def _try_claude_runner(job: dict, out_dir: Path) -> bool:
     return False
 
 
+def _try_opencode_runner(job: dict, out_dir: Path) -> bool:
+    opencode_bin = shutil.which("opencode")
+    if not opencode_bin:
+        return False
+
+    request = job.get("request", "")
+    prompt = (
+        f"You are executing an autonomous loop run in an agentic-harness workspace.\n"
+        f"Workspace root: {_workspace()}\n"
+        f"Output directory: {out_dir}\n\n"
+        f"{request}\n\n"
+        f"Write your final report to {out_dir}/report.md and your plan to "
+        f"{out_dir}/plan.md. Work from the workspace root shown above."
+    )
+    try:
+        result = subprocess.run(
+            [opencode_bin, "run", "--print-logs"],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            cwd=str(_workspace()),
+            timeout=900,
+        )
+    except subprocess.TimeoutExpired:
+        _warn("opencode runner timed out (900s)")
+        return False
+
+    if result.returncode == 0:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        report_md = out_dir / "report.md"
+        if not report_md.exists() and result.stdout.strip():
+            report_md.write_text(result.stdout, encoding="utf-8")
+        _ok("opencode runner completed")
+        return True
+
+    _warn(f"opencode runner exited {result.returncode}: {result.stderr[:200]}")
+    return False
+
+
 def _skeleton_run(job: dict, out_dir: Path) -> int:
-    """Built-in skeleton runner — generates a plan stub without LLM."""
     out_dir.mkdir(parents=True, exist_ok=True)
     try:
-        job_id   = job.get("id", "unknown")
-        project  = job.get("project", "unknown")
-        request  = job.get("request", "(no request)")
+        job_id = job.get("id", "unknown")
+        project = job_project_name(job)
+        request = job.get("request", "(no request)")
 
         plan = f"""# Plan — {job_id}
 
@@ -322,7 +410,7 @@ def _skeleton_run(job: dict, out_dir: Path) -> int:
 ## Notes
 
 - Job ID: {job_id}
-- Project path: {job.get("project_path", "not set")}
+- Project path: {job_project_path(job) or "not set"}
 """
         (out_dir / "plan.md").write_text(plan, encoding="utf-8")
         _ok(f"Skeleton plan written → {out_dir / 'plan.md'}")
@@ -330,6 +418,34 @@ def _skeleton_run(job: dict, out_dir: Path) -> int:
     except Exception as exc:
         _err(f"Skeleton runner failed: {exc}")
         return 1
+
+
+def _dispatch_run(cfg: DCConfig, job_file: Path, job: dict, out_dir: Path, no_llm: bool) -> int:
+    if no_llm:
+        _log("--no-llm flag set, using skeleton runner.")
+        return _skeleton_run(job, out_dir)
+
+    if cfg.harness_mode:
+        runner, reason = _import_harness_runner()
+        if runner is not None:
+            if _try_harness_runner(job_file, out_dir):
+                return 0
+        elif reason:
+            _warn(f"Harness runner not available ({reason}). Trying fallbacks.")
+
+        if _try_claude_runner(job, out_dir):
+            return 0
+        if _try_opencode_runner(job, out_dir):
+            return 0
+        _warn("No LLM runner found, falling back to skeleton plan.")
+        return _skeleton_run(job, out_dir)
+
+    if _try_loop_runner(job, out_dir):
+        return 0
+    if _try_claude_runner(job, out_dir):
+        return 0
+    _warn("No LLM runner found, falling back to skeleton plan.")
+    return _skeleton_run(job, out_dir)
 
 
 # ── subcommands ───────────────────────────────────────────────────────────────
@@ -348,7 +464,6 @@ def _cmd_queue(argv: list[str]) -> int:
         _err("Usage: agent-toolkit devcompanion queue <project> [--template NAME] [--request \"...\"]")
         return 1
 
-    # Resolve project path
     project_path = _resolve_project(args.project)
     if project_path is None:
         _err(f"Project not found: '{args.project}'")
@@ -362,7 +477,6 @@ def _cmd_queue(argv: list[str]) -> int:
             print("  (no projects indexed)")
         return 1
 
-    # Build request
     request = ""
     if args.template:
         tpl = _load_template(args.template)
@@ -375,19 +489,32 @@ def _cmd_queue(argv: list[str]) -> int:
         _err("Provide --request or --template")
         return 1
 
+    cfg = _cfg()
     job_id = args.id or f"{args.project}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
-    job: dict = {
-        "id":           job_id,
-        "created_at":   _utc_now(),
-        "project":      args.project,
-        "project_path": str(project_path),
-        "request":      request,
-        "template":     args.template or "",
-        "status":       "pending",
-    }
 
-    job_file = _job_path(job_id)
-    _write_job(job_file, job)
+    if cfg.harness_mode:
+        job: dict = {
+            "id":              job_id,
+            "created_at":      _utc_now(),
+            "request":         request,
+            "repo_path":       str(project_path),
+            "llm":             True,
+            "limits":          {"timeout_sec": 1800, "max_steps": 25},
+            "actions_allowed": ["plan_only"],
+        }
+    else:
+        job = {
+            "id":           job_id,
+            "created_at":   _utc_now(),
+            "project":      args.project,
+            "project_path": str(project_path),
+            "request":      request,
+            "template":     args.template or "",
+            "status":       "pending",
+        }
+
+    job_file = queue_job_path(cfg, job_id)
+    write_job(job_file, job)
 
     _log(f"Project : {args.project}")
     _log(f"Path    : {project_path}")
@@ -395,8 +522,8 @@ def _cmd_queue(argv: list[str]) -> int:
     _ok(f"Job written → {job_file}")
     print()
     print(_cyan("Plan stub:"))
-    print(f"  Run 'agent-toolkit devcompanion run-once' to execute")
-    print(f"  Run 'agent-toolkit devcompanion status' to check progress")
+    print("  Run 'agent-toolkit devcompanion run-once' to execute")
+    print("  Run 'agent-toolkit devcompanion status' to check progress")
     return 0
 
 
@@ -407,53 +534,41 @@ def _cmd_run_once(argv: list[str]) -> int:
     p.add_argument("--no-llm", action="store_true", help="Always use skeleton plan, skip LLM")
     args = p.parse_args(argv)
 
-    QUEUE_DIR.mkdir(parents=True, exist_ok=True)
-
-    # Find the oldest pending job
-    pending = sorted(
-        (f for f in QUEUE_DIR.glob("*.json")),
-        key=lambda f: f.stat().st_mtime,
-    )
-    # Filter to pending status only
-    pending = [f for f in pending if _read_job(f).get("status") == "pending"]
+    cfg = _cfg()
+    pending = pending_jobs(cfg)
 
     if not pending:
         _ok("No pending jobs.")
         return 0
 
-    job_file = pending[0]
-    job = _read_job(job_file)
+    job_file, job = pending[0]
     job_id = job["id"]
-    out_dir = RUNS_DIR / job_id
+    out_dir = cfg.runs_dir / job_id
 
     _log(f"Running job: {job_id}")
-    _log(f"Project    : {job.get('project', '?')}")
+    _log(f"Project    : {job_project_name(job)}")
     _log(f"Artifacts  → {out_dir}")
 
-    # Mark as running
-    job["status"] = "running"
-    _write_job(job_file, job)
-
-    rc = 1
-    if args.no_llm:
-        _log("--no-llm flag set, using skeleton runner.")
-        rc = _skeleton_run(job, out_dir)
+    if cfg.harness_mode:
+        cfg.queue_processing.mkdir(parents=True, exist_ok=True)
+        processing_file = cfg.queue_processing / job_file.name
+        job_file.rename(processing_file)
+        job_file = processing_file
     else:
-        # 1. agent-toolkit loop run (if project has loops)
-        if _try_loop_runner(job, out_dir):
-            rc = 0
-        # 2. claude --print
-        elif _try_claude_runner(job, out_dir):
-            rc = 0
-        # 3. Skeleton fallback
-        else:
-            _warn("No LLM runner found, falling back to skeleton plan.")
-            rc = _skeleton_run(job, out_dir)
+        job["status"] = "running"
+        write_job(job_file, job)
 
-    # Update status
-    job["status"] = "done" if rc == 0 else "failed"
-    job["completed_at"] = _utc_now()
-    _write_job(job_file, job)
+    rc = _dispatch_run(cfg, job_file, job, out_dir, args.no_llm)
+
+    if cfg.harness_mode:
+        dest_dir = cfg.queue_done if rc == 0 else cfg.queue_failed
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        if job_file.exists():
+            job_file.rename(dest_dir / job_file.name)
+    else:
+        job["status"] = "done" if rc == 0 else "failed"
+        job["completed_at"] = _utc_now()
+        write_job(job_file, job)
 
     if rc == 0:
         _ok(f"Job done: {job_id}")
@@ -469,21 +584,41 @@ def _cmd_run_once(argv: list[str]) -> int:
 
 
 def _cmd_status(_argv: list[str]) -> int:
+    cfg = _cfg()
     print()
     print(_blue("=== devcompanion queue status ==="))
     print()
 
-    QUEUE_DIR.mkdir(parents=True, exist_ok=True)
-    all_jobs = sorted(QUEUE_DIR.glob("*.json"), key=lambda f: f.stat().st_mtime)
-
-    if not all_jobs:
+    jobs = iter_jobs(cfg)
+    if not jobs:
         print("  (queue is empty)")
         print()
         return 0
 
-    col_id      = 42
+    if cfg.harness_mode:
+        for state, directory, color in (
+            ("pending", cfg.queue_pending, _yellow),
+            ("processing", cfg.queue_processing, _cyan),
+            ("done", cfg.queue_done, _green),
+            ("failed", cfg.queue_failed, _red),
+        ):
+            if not directory.is_dir():
+                continue
+            state_jobs = [item for item in jobs if item[0] == state]
+            print(f"{color(f'{state:<12}')} {len(state_jobs)} job(s)")
+            for _, jf, job in state_jobs[:5]:
+                jid = job.get("id", jf.stem)
+                project = job_project_name(job)
+                request = job.get("request", "").split("\n")[0][:60]
+                print(f"  {_cyan(f'{jid:<45}')} [{project}] {request}")
+            if len(state_jobs) > 5:
+                print(f"  … and {len(state_jobs) - 5} more")
+            print()
+        return 0
+
+    col_id = 42
     col_project = 20
-    col_status  = 12
+    col_status = 12
     col_created = 20
 
     header = (
@@ -498,18 +633,16 @@ def _cmd_status(_argv: list[str]) -> int:
     status_color = {
         "pending": _yellow,
         "running": _cyan,
-        "done":    _green,
-        "failed":  _red,
+        "done": _green,
+        "failed": _red,
     }
 
-    for jf in all_jobs:
+    for status, jf, job in jobs:
         try:
-            job = _read_job(jf)
-            jid      = job.get("id", jf.stem)[:col_id]
-            project  = job.get("project", "?")[:col_project]
-            status   = job.get("status", "?")
-            created  = job.get("created_at", "")[:19]
-            color    = status_color.get(status, lambda x: x)
+            jid = job.get("id", jf.stem)[:col_id]
+            project = job_project_name(job)[:col_project]
+            created = job.get("created_at", "")[:19]
+            color = status_color.get(status, lambda x: x)
             print(
                 f"{jid:<{col_id}}  "
                 f"{project:<{col_project}}  "
@@ -534,18 +667,26 @@ def _cmd_done(argv: list[str]) -> int:
         _err("Usage: agent-toolkit devcompanion done <job-id>")
         return 1
 
-    job_file = _job_path(args.job_id)
-    if not job_file.exists():
-        _warn(f"Job file not found: {args.job_id}.json")
+    cfg = _cfg()
+    job_id = args.job_id
+
+    if cfg.harness_mode:
+        if mark_job_done(cfg, job_id, _utc_now()):
+            _ok(f"Marked as done: {job_id}")
+            return 0
+        _warn(f"Job file not found: {job_id}.job")
         return 1
 
-    job = _read_job(job_file)
+    job_file = find_job_path(cfg, job_id)
+    if job_file is None:
+        _warn(f"Job file not found: {job_id}.json")
+        return 1
+
+    job = read_job(job_file)
     job["status"] = "done"
     job["completed_at"] = _utc_now()
-    _write_job(job_file, job)
-    _ok(f"Marked as done: {args.job_id}")
-
-    # Archive: move to runs dir (informational only — file stays in queue with status=done)
+    write_job(job_file, job)
+    _ok(f"Marked as done: {job_id}")
     return 0
 
 
@@ -555,6 +696,9 @@ def _cmd_sync_todos(_argv: list[str]) -> int:
 
 
 def _cmd_help(_argv: list[str]) -> int:
+    cfg = _cfg()
+    queue_loc = str(cfg.dc_home / "queue") if cfg.harness_mode else str(cfg.queue_dir)
+    mode = "harness (.job files)" if cfg.harness_mode else "workspace (.json files)"
     print(f"""
 {_blue('agent-toolkit devcompanion')} — background job queue for AI Workspace
 
@@ -573,11 +717,15 @@ def _cmd_help(_argv: list[str]) -> int:
 {_cyan('Workspace detection:')}
   AGENT_TOOLKIT_WORKSPACE env var, or walk up from CWD looking for .devcompanion/
 
+{_cyan('Queue mode:')}
+  {mode}
+  HARNESS_DC_HOME or HARNESS_DIR → harness queue under ~/.local/share/agentic-harness/dev-companion
+
 {_cyan('Queue location:')}
-  {QUEUE_DIR}
+  {queue_loc}
 
 {_cyan('Runs location:')}
-  {RUNS_DIR}
+  {cfg.runs_dir}
 
 {_cyan('Examples:')}
   agent-toolkit devcompanion queue my-api --template code-review
@@ -593,8 +741,6 @@ def _cmd_help(_argv: list[str]) -> int:
 """)
     return 0
 
-
-# ── entry point ───────────────────────────────────────────────────────────────
 
 def cmd_devcompanion(argv: list[str]) -> int:
     if not argv or argv[0] in ("-h", "--help", "help"):

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
@@ -33,16 +33,16 @@ if _sys.platform == 'win32':
 # ── workspace detection ───────────────────────────────────────────────────────
 
 def _find_workspace() -> Path:
-    """Return workspace root: AGENT_TOOLKIT_WORKSPACE env, or walk up from CWD."""
-    env = os.environ.get("AGENT_TOOLKIT_WORKSPACE")
-    if env:
-        return Path(env).resolve()
-    # Walk up looking for a marker (.devcompanion dir, AGENTS.md, or CLAUDE.md)
+    """Return workspace root: AGENT_TOOLKIT_WORKSPACE / HARNESS_DIR / walk-up / cwd."""
+    from agent_toolkit._paths import find_workspace_root
+
+    ws = find_workspace_root()
+    if ws is not None:
+        return ws
+    # Devcompanion also accepts .devcompanion as a marker
     cwd = Path.cwd().resolve()
     for parent in [cwd, *cwd.parents]:
         if (parent / ".devcompanion").is_dir():
-            return parent
-        if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
             return parent
     return cwd
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion_queue.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion_queue.py
@@ -1,0 +1,234 @@
+"""Queue storage backends for devcompanion (#203).
+
+Legacy (workspace-local):
+    WORKSPACE/.devcompanion/queue/<job-id>.json  (status field)
+
+Harness-compatible:
+    $HARNESS_DC_HOME/queue/{pending,processing,done,failed}/<job-id>.job
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def default_harness_dc_home() -> Path:
+    return Path.home() / ".local" / "share" / "agentic-harness" / "dev-companion"
+
+
+def resolve_harness_dc_home() -> Path | None:
+    """Return harness DC home when HARNESS_DC_HOME or HARNESS_DIR is set."""
+    explicit = os.environ.get("HARNESS_DC_HOME", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    if os.environ.get("HARNESS_DIR", "").strip():
+        return default_harness_dc_home()
+    return None
+
+
+@dataclass(frozen=True)
+class DCConfig:
+    harness_mode: bool
+    dc_home: Path
+    queue_dir: Path
+    runs_dir: Path
+    queue_pending: Path
+    queue_processing: Path
+    queue_done: Path
+    queue_failed: Path
+
+
+def get_dc_config(workspace_root: Path) -> DCConfig:
+    harness_home = resolve_harness_dc_home()
+    if harness_home is not None:
+        queue_root = harness_home / "queue"
+        artifacts = queue_root / "artifacts"
+        return DCConfig(
+            harness_mode=True,
+            dc_home=harness_home,
+            queue_dir=queue_root,
+            runs_dir=artifacts,
+            queue_pending=queue_root / "pending",
+            queue_processing=queue_root / "processing",
+            queue_done=queue_root / "done",
+            queue_failed=queue_root / "failed",
+        )
+
+    dc_home = workspace_root / ".devcompanion"
+    queue_dir = dc_home / "queue"
+    return DCConfig(
+        harness_mode=False,
+        dc_home=dc_home,
+        queue_dir=queue_dir,
+        runs_dir=dc_home / "runs",
+        queue_pending=queue_dir,
+        queue_processing=queue_dir,
+        queue_done=queue_dir,
+        queue_failed=queue_dir,
+    )
+
+
+def read_job(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_job(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def job_project_path(job: dict) -> str:
+    return str(job.get("project_path") or job.get("repo_path") or "")
+
+
+def job_project_name(job: dict) -> str:
+    if job.get("project"):
+        return str(job["project"])
+    repo = job_project_path(job)
+    return Path(repo).name if repo else "?"
+
+
+def job_status(cfg: DCConfig, job_id: str) -> str | None:
+    """Return queue state for a job id (harness dirs or legacy status field)."""
+    if cfg.harness_mode:
+        for state, directory in (
+            ("pending", cfg.queue_pending),
+            ("processing", cfg.queue_processing),
+            ("done", cfg.queue_done),
+            ("failed", cfg.queue_failed),
+        ):
+            if (directory / f"{job_id}.job").exists():
+                return state
+        return None
+
+    path = cfg.queue_dir / f"{job_id}.json"
+    if not path.exists():
+        return None
+    return read_job(path).get("status")
+
+
+def find_job_path(cfg: DCConfig, job_id: str) -> Path | None:
+    if cfg.harness_mode:
+        for directory in (
+            cfg.queue_pending,
+            cfg.queue_processing,
+            cfg.queue_done,
+            cfg.queue_failed,
+        ):
+            path = directory / f"{job_id}.job"
+            if path.exists():
+                return path
+        return None
+
+    path = cfg.queue_dir / f"{job_id}.json"
+    return path if path.exists() else None
+
+
+def iter_jobs(cfg: DCConfig) -> list[tuple[str, Path, dict]]:
+    """Return (status, path, job_dict) sorted by file mtime."""
+    items: list[tuple[str, Path, dict]] = []
+
+    if cfg.harness_mode:
+        for state, directory in (
+            ("pending", cfg.queue_pending),
+            ("processing", cfg.queue_processing),
+            ("done", cfg.queue_done),
+            ("failed", cfg.queue_failed),
+        ):
+            if not directory.is_dir():
+                continue
+            for path in directory.glob("*.job"):
+                try:
+                    items.append((state, path, read_job(path)))
+                except Exception:
+                    pass
+    else:
+        if cfg.queue_dir.is_dir():
+            for path in cfg.queue_dir.glob("*.json"):
+                try:
+                    job = read_job(path)
+                    items.append((str(job.get("status", "?")), path, job))
+                except Exception:
+                    pass
+
+    items.sort(key=lambda item: item[1].stat().st_mtime)
+    return items
+
+
+def pending_jobs(cfg: DCConfig) -> list[tuple[Path, dict]]:
+    if cfg.harness_mode:
+        cfg.queue_pending.mkdir(parents=True, exist_ok=True)
+        jobs: list[tuple[Path, dict]] = []
+        for path in sorted(cfg.queue_pending.glob("*.job"), key=lambda p: p.stat().st_mtime):
+            try:
+                jobs.append((path, read_job(path)))
+            except Exception:
+                pass
+        return jobs
+
+    cfg.queue_dir.mkdir(parents=True, exist_ok=True)
+    jobs = []
+    for path in sorted(cfg.queue_dir.glob("*.json"), key=lambda p: p.stat().st_mtime):
+        try:
+            job = read_job(path)
+            if job.get("status") == "pending":
+                jobs.append((path, job))
+        except Exception:
+            pass
+    return jobs
+
+
+def queue_job_path(cfg: DCConfig, job_id: str) -> Path:
+    if cfg.harness_mode:
+        return cfg.queue_pending / f"{job_id}.job"
+    return cfg.queue_dir / f"{job_id}.json"
+
+
+def move_job(cfg: DCConfig, job_id: str, dest_state: str) -> Path | None:
+    """Move a job file to done/failed/processing/pending (harness) or update status (legacy)."""
+    if cfg.harness_mode:
+        source = find_job_path(cfg, job_id)
+        if source is None:
+            return None
+        dest_dir = {
+            "pending": cfg.queue_pending,
+            "processing": cfg.queue_processing,
+            "done": cfg.queue_done,
+            "failed": cfg.queue_failed,
+        }.get(dest_state)
+        if dest_dir is None:
+            return None
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"{job_id}.job"
+        source.rename(dest)
+        return dest
+
+    path = cfg.queue_dir / f"{job_id}.json"
+    if not path.exists():
+        return None
+    job = read_job(path)
+    job["status"] = dest_state
+    write_job(path, job)
+    return path
+
+
+def mark_job_done(cfg: DCConfig, job_id: str, completed_at: str) -> bool:
+    if cfg.harness_mode:
+        for src_dir in (cfg.queue_pending, cfg.queue_processing, cfg.queue_failed):
+            src = src_dir / f"{job_id}.job"
+            if src.exists():
+                cfg.queue_done.mkdir(parents=True, exist_ok=True)
+                src.rename(cfg.queue_done / f"{job_id}.job")
+                return True
+        return (cfg.queue_done / f"{job_id}.job").exists()
+
+    path = cfg.queue_dir / f"{job_id}.json"
+    if not path.exists():
+        return False
+    job = read_job(path)
+    job["status"] = "done"
+    job["completed_at"] = completed_at
+    write_job(path, job)
+    return True

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/memory.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/memory.py
@@ -62,21 +62,9 @@ def _dim(t: str) -> str:    return _c("0;37", t)
 
 def _find_workspace(override: str | None = None) -> Path | None:
     """Locate workspace root via env, override, or walking up from CWD."""
-    if override:
-        p = Path(override).expanduser().resolve()
-        return p if p.is_dir() else None
+    from agent_toolkit._paths import find_workspace_root
 
-    env = os.environ.get("AGENT_TOOLKIT_WORKSPACE")
-    if env:
-        p = Path(env).expanduser().resolve()
-        return p if p.is_dir() else None
-
-    current = Path.cwd()
-    for candidate in [current, *current.parents]:
-        if (candidate / "AGENTS.md").exists() or (candidate / "knowledge").is_dir():
-            return candidate
-
-    return None
+    return find_workspace_root(override=override)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
@@ -59,21 +59,9 @@ def _dim(t: str) -> str:    return _c("0;37", t)
 
 def _find_workspace(override: str | None = None) -> Path | None:
     """Locate workspace root via env, override, or walking up from CWD."""
-    if override:
-        p = Path(override).expanduser().resolve()
-        return p if p.is_dir() else None
+    from agent_toolkit._paths import find_workspace_root
 
-    env = os.environ.get("AGENT_TOOLKIT_WORKSPACE")
-    if env:
-        p = Path(env).expanduser().resolve()
-        return p if p.is_dir() else None
-
-    current = Path.cwd()
-    for candidate in [current, *current.parents]:
-        if (candidate / "AGENTS.md").exists() or (candidate / "knowledge").is_dir():
-            return candidate
-
-    return None
+    return find_workspace_root(override=override)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
@@ -5,7 +5,8 @@ Usage:
     agent-toolkit project <subcommand> [args]
 
 Subcommands:
-    clone owner/repo [--workspace PATH]   Clone a GitHub repo and create a symlink
+    init [--workspace PATH]               Create repos/ and projects/ scaffolding
+    clone owner/repo [--ssh] [--workspace PATH]   Clone a GitHub repo and create a symlink
     list [--workspace PATH]               List all symlinked projects
     add <path> [--workspace PATH]         Symlink an already-cloned repo
     remove <name> [--workspace PATH]      Remove symlink (keeps the actual repo)
@@ -133,13 +134,46 @@ def _upsert_project(ws: Path, name: str, path: str, source: str = "") -> None:
 # Subcommands
 # ---------------------------------------------------------------------------
 
+def _gitignore_append(ws: Path, entries: list[str]) -> None:
+    gi = ws / ".gitignore"
+    existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
+    lines = existing.splitlines()
+    changed = False
+    for entry in entries:
+        if entry not in lines:
+            lines.append(entry)
+            changed = True
+    if changed or not gi.exists():
+        text = "\n".join(lines)
+        if text and not text.endswith("\n"):
+            text += "\n"
+        gi.write_text(text, encoding="utf-8")
+
+
+def cmd_init(args: list[str], ws: Path) -> int:
+    """Create repos/ and projects/ scaffolding (#208)."""
+    if args and args[0] in ("--help", "-h"):
+        print("Usage: agent-toolkit project init [--workspace PATH]")
+        print("Creates repos/github.com/ and projects/, updates .gitignore.")
+        return 0
+
+    (ws / "repos" / "github.com").mkdir(parents=True, exist_ok=True)
+    (ws / "projects").mkdir(parents=True, exist_ok=True)
+    _gitignore_append(ws, ["repos/", "projects/"])
+    print(_green("Initialized project directories"))
+    print(f"  {ws / 'repos' / 'github.com'}")
+    print(f"  {ws / 'projects'}")
+    return 0
+
+
 def cmd_clone(args: list[str], ws: Path) -> int:
     """Clone a GitHub repo and create a symlink in projects/."""
     if not args or args[0] in ("--help", "-h"):
-        print("Usage: agent-toolkit project clone owner/repo [--workspace PATH]")
+        print("Usage: agent-toolkit project clone owner/repo [--ssh] [--workspace PATH]")
         return 0
 
     repo_slug = args[0]
+    use_ssh = "--ssh" in args
     if "/" not in repo_slug:
         print(f"Error: expected owner/repo, got: {repo_slug}", file=sys.stderr)
         return 1
@@ -155,8 +189,11 @@ def cmd_clone(args: list[str], ws: Path) -> int:
         print(f"{_yellow('Already cloned:')} {target_dir}")
     else:
         repos_dir.mkdir(parents=True, exist_ok=True)
-        # Prefer `gh repo clone` if available, fall back to git clone HTTPS
-        if shutil.which("gh"):
+        if use_ssh:
+            url = f"git@github.com:{owner}/{repo_name}.git"
+            cmd = ["git", "clone", url, str(target_dir)]
+            verb = "git clone (ssh)"
+        elif shutil.which("gh"):
             cmd = ["gh", "repo", "clone", f"{owner}/{repo_name}", str(target_dir)]
             verb = "gh repo clone"
         else:
@@ -166,7 +203,7 @@ def cmd_clone(args: list[str], ws: Path) -> int:
 
         print(f"Cloning {owner}/{repo_name} via {verb} ...")
         try:
-            result = subprocess.run(cmd, check=True)
+            subprocess.run(cmd, check=True)
         except subprocess.CalledProcessError as exc:
             print(f"Error: clone failed (exit {exc.returncode})", file=sys.stderr)
             return 1
@@ -375,6 +412,8 @@ def cmd_project(args: list[str]) -> int:
         return 1
 
     match sub:
+        case "init":
+            return cmd_init(rest, ws)
         case "clone":
             return cmd_clone(rest, ws)
         case "list":

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
@@ -156,6 +156,10 @@ def cmd_init(args: list[str], ws: Path) -> int:
         print("Usage: agent-toolkit project init [--workspace PATH]")
         print("Creates repos/github.com/ and projects/, updates .gitignore.")
         return 0
+    if args:
+        print(f"Error: unexpected arguments for project init: {' '.join(args)}", file=sys.stderr)
+        print("Usage: agent-toolkit project init [--workspace PATH]", file=sys.stderr)
+        return 1
 
     (ws / "repos" / "github.com").mkdir(parents=True, exist_ok=True)
     (ws / "projects").mkdir(parents=True, exist_ok=True)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -73,6 +73,126 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
+def _require_workspace(override: str | None = None) -> Path | None:
+    ws = _find_workspace(override)
+    if ws is None:
+        print("Error: workspace not found.", file=sys.stderr)
+        print("Set AGENT_TOOLKIT_WORKSPACE or run from inside a workspace directory.", file=sys.stderr)
+    return ws
+
+
+def _parse_frontmatter_text(content: str) -> dict:
+    """Parse YAML frontmatter from markdown text."""
+    from agent_toolkit.loop.runner import _parse_simple_yaml
+
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = next((i for i, l in enumerate(lines[1:], 1) if l.strip() == "---"), None)
+    if end is None:
+        return {}
+    yaml_block = "\n".join(lines[1:end])
+    try:
+        import yaml  # type: ignore
+        loaded = yaml.safe_load(yaml_block)
+        return loaded if isinstance(loaded, dict) else {}
+    except ImportError:
+        return _parse_simple_yaml(yaml_block)
+
+
+def _parse_yaml_file(path: Path) -> dict:
+    """Parse a YAML file (PyYAML when available, else minimal parser)."""
+    from agent_toolkit.loop.runner import _parse_simple_yaml
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+        loaded = yaml.safe_load(text)
+        return loaded if isinstance(loaded, dict) else {}
+    except ImportError:
+        return _parse_simple_yaml(text)
+
+
+def _persona_path(ws: Path, name: str) -> Path:
+    return ws / "personas" / f"{name}.md"
+
+
+def _load_persona_meta(ws: Path, name: str) -> dict | None:
+    path = _persona_path(ws, name)
+    if not path.exists():
+        return None
+    return _parse_frontmatter_text(path.read_text(encoding="utf-8"))
+
+
+def _append_persona_history(ws: Path, line: str) -> None:
+    history = ws / ".persona-history"
+    with history.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _format_persona_constraints(persona_name: str, meta: dict) -> str:
+    allow = meta.get("allow") or []
+    deny = meta.get("deny") or []
+    handoffs = meta.get("handoffs") or []
+    output_fmt = meta.get("output_format", "")
+
+    lines = ["  <persona-constraints>", f"    persona: {persona_name}"]
+    if allow:
+        lines.append(f"    allow: [{', '.join(str(x) for x in allow)}]")
+    if deny:
+        lines.append(f"    deny: [{', '.join(str(x) for x in deny)}]")
+    if output_fmt:
+        lines.append(f"    output_format: {output_fmt}")
+    if handoffs:
+        lines.append("    handoffs:")
+        for h in handoffs:
+            if not isinstance(h, dict):
+                continue
+            when = h.get("when", "")
+            to = h.get("to", "")
+            lines.append(f'      - when: "{when}"')
+            lines.append(f"        to: {to}")
+    lines.append("  </persona-constraints>")
+    return "\n".join(lines)
+
+
+def _pack_notes(ws: Path, pack_ref: str) -> str:
+    """Return notes field from an active pack, if any."""
+    pack_path = Path(pack_ref)
+    if not pack_path.is_absolute():
+        pack_path = ws / pack_ref
+    if not pack_path.exists():
+        return ""
+    data = _parse_yaml_file(pack_path)
+    notes = data.get("notes")
+    if isinstance(notes, str) and notes.strip():
+        return notes.strip()
+    return ""
+
+
+def _resolve_pack_file(ws: Path, pack_arg: str) -> Path | None:
+    """Resolve a pack path relative to workspace root."""
+    candidate = Path(pack_arg)
+    if candidate.is_absolute():
+        return candidate if candidate.is_file() else None
+    for rel in (pack_arg, f"packs/{pack_arg}", f"packs/{pack_arg}.yaml"):
+        path = ws / rel
+        if path.is_file():
+            return path
+    return None
+
+
+def _pack_rel_path(ws: Path, pack_path: Path) -> str:
+    try:
+        return str(pack_path.relative_to(ws))
+    except ValueError:
+        return str(pack_path)
+
+
 # ---------------------------------------------------------------------------
 # Templates
 # ---------------------------------------------------------------------------
@@ -521,6 +641,11 @@ def cmd_context(args: list[str]) -> int:
         pack = active_pack_file.read_text(encoding="utf-8").strip()
         print(_blue("── Active Pack ────────────────────────────────────────────"))
         print(f"  {pack}")
+        notes = _pack_notes(ws, pack)
+        if notes:
+            print()
+            for line in notes.splitlines():
+                print(f"  {line}")
         print()
 
     # Active persona
@@ -528,7 +653,11 @@ def cmd_context(args: list[str]) -> int:
     if active_persona_file.exists():
         persona = active_persona_file.read_text(encoding="utf-8").strip()
         print(_blue("── Active Persona ─────────────────────────────────────────"))
-        print(f"  {persona}")
+        print(f"  Persona: {persona}")
+        print()
+        meta = _load_persona_meta(ws, persona)
+        if meta:
+            print(_format_persona_constraints(persona, meta))
         print()
 
     # AGENTS.md hash
@@ -618,6 +747,519 @@ def cmd_sync(args: list[str]) -> int:
     return 0
 
 
+def cmd_use_persona(args: list[str]) -> int:
+    """Activate a persona work mode."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace use-persona <name> [--workspace PATH]")
+                return 0
+            case _:
+                break
+
+    if i >= len(args):
+        print("Usage: agent-toolkit workspace use-persona <name>", file=sys.stderr)
+        return 1
+
+    persona = args[i]
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    persona_file = _persona_path(ws, persona)
+    if not persona_file.exists():
+        print(f"Persona not found: {persona}", file=sys.stderr)
+        cmd_personas([])
+        return 1
+
+    active_file = ws / ".active-persona"
+    from_persona = active_file.read_text(encoding="utf-8").strip() if active_file.exists() else ""
+    ts = _utc_timestamp()
+    if from_persona and from_persona != persona:
+        _append_persona_history(ws, f"{ts} transition: {from_persona} → {persona}")
+    elif not from_persona:
+        _append_persona_history(ws, f"{ts} activate: → {persona}")
+
+    _write(active_file, persona + "\n")
+    print(_green(f"Activated persona: {persona}"))
+    return 0
+
+
+def cmd_handoff(args: list[str]) -> int:
+    """Transition from active persona to another (validates handoff rules)."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace handoff <name> [--workspace PATH]")
+                return 0
+            case _:
+                break
+
+    if i >= len(args):
+        print("Usage: agent-toolkit workspace handoff <name>", file=sys.stderr)
+        return 1
+
+    to_persona = args[i]
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    active_file = ws / ".active-persona"
+    if not active_file.exists():
+        print("No active persona to handoff from. Use 'workspace use-persona <name>' first.", file=sys.stderr)
+        return 1
+
+    from_persona = active_file.read_text(encoding="utf-8").strip()
+    if not _persona_path(ws, to_persona).exists():
+        print(f"Target persona not found: {to_persona}", file=sys.stderr)
+        cmd_personas([])
+        return 1
+
+    meta = _load_persona_meta(ws, from_persona) or {}
+    handoffs = meta.get("handoffs") or []
+    allowed = {h.get("to") for h in handoffs if isinstance(h, dict) and h.get("to")}
+    if allowed and to_persona not in allowed:
+        allowed_str = ", ".join(sorted(allowed))
+        print(
+            f"Invalid handoff from '{from_persona}' to '{to_persona}'. "
+            f"Allowed targets: {allowed_str}",
+            file=sys.stderr,
+        )
+        return 1
+
+    ts = _utc_timestamp()
+    _append_persona_history(ws, f"{ts} handoff: {from_persona} → {to_persona}")
+    _write(active_file, to_persona + "\n")
+    print(_green(f"Handoff: {from_persona} → {to_persona}"))
+    return 0
+
+
+def cmd_history(args: list[str]) -> int:
+    """Show recent persona transitions."""
+    workspace_path: str | None = None
+    count = 10
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace history [count] [--workspace PATH]")
+                return 0
+            case arg if arg.isdigit():
+                count = int(arg)
+                i += 1
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    history_file = ws / ".persona-history"
+    if not history_file.exists():
+        print("No persona transitions recorded yet.")
+        return 0
+
+    lines = history_file.read_text(encoding="utf-8").splitlines()
+    recent = lines[-count:] if count else lines
+    print(f"Recent persona transitions (last {len(recent)}):")
+    print()
+    for line in recent:
+        print(f"  {line}")
+    return 0
+
+
+def cmd_personas(args: list[str]) -> int:
+    """List available personas."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace personas [--workspace PATH]")
+                return 0
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    personas_dir = ws / "personas"
+    print(_blue("── Available Personas ─────────────────────────────────────"))
+    if not personas_dir.is_dir():
+        print(_dim("  (no personas directory)"))
+        print()
+        return 0
+
+    found = False
+    for path in sorted(personas_dir.glob("*.md")):
+        found = True
+        name = path.stem
+        meta = _parse_frontmatter_text(path.read_text(encoding="utf-8"))
+        allow = meta.get("allow") or []
+        deny = meta.get("deny") or []
+        output_fmt = meta.get("output_format", "")
+        allow_s = ", ".join(str(x) for x in allow) if allow else "-"
+        deny_s = ", ".join(str(x) for x in deny) if deny else "-"
+        fmt_s = output_fmt or "-"
+        print(f"  {name:20s} allow=[{allow_s}] deny=[{deny_s}] format={fmt_s}")
+
+    if not found:
+        print(_dim("  (no personas defined)"))
+    print()
+    print("Usage: agent-toolkit workspace use-persona <name>")
+    return 0
+
+
+def cmd_load(args: list[str]) -> int:
+    """Load a context pack or composable profile."""
+    workspace_path: str | None = None
+    profile_name: str | None = None
+    pack_arg: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--profile" if i + 1 < len(args):
+                profile_name = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace load <pack-path> | --profile <name>")
+                return 0
+            case arg if not arg.startswith("-"):
+                pack_arg = arg
+                i += 1
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    if profile_name:
+        return _load_profile(ws, profile_name)
+    if not pack_arg:
+        print("Usage: agent-toolkit workspace load <pack-path> | --profile <name>", file=sys.stderr)
+        return 1
+    return _load_pack(ws, pack_arg)
+
+
+def _load_pack(ws: Path, pack_arg: str) -> int:
+    pack_path = _resolve_pack_file(ws, pack_arg)
+    if pack_path is None:
+        print(f"Pack not found: {pack_arg}", file=sys.stderr)
+        packs_dir = ws / "packs"
+        if packs_dir.is_dir():
+            available = sorted(
+                str(p.relative_to(ws))
+                for p in packs_dir.rglob("*.yaml")
+                if p.is_file()
+            )
+            if available:
+                print("\nAvailable packs:", file=sys.stderr)
+                for item in available:
+                    print(f"  {item}", file=sys.stderr)
+        return 1
+
+    rel = _pack_rel_path(ws, pack_path)
+    _write(ws / ".active-pack", rel + "\n")
+    data = _parse_yaml_file(pack_path)
+    print(_green(f"Loaded pack: {rel}"))
+    desc = data.get("description")
+    if desc:
+        print(f"  {desc}")
+    return 0
+
+
+def _load_profile(ws: Path, profile_name: str) -> int:
+    profile_path = ws / "profiles" / f"{profile_name}.yaml"
+    if not profile_path.exists():
+        print(f"Profile not found: {profile_name}", file=sys.stderr)
+        print(f"Looked in: {profile_path}", file=sys.stderr)
+        return 1
+
+    data = _parse_yaml_file(profile_path)
+    _write(ws / ".active-profile", profile_name + "\n")
+    print(_green(f"Profile loaded: {profile_name}"))
+    desc = data.get("description")
+    if desc:
+        print(f"  {desc}")
+
+    pack_ref = data.get("pack")
+    if pack_ref:
+        pack_path = _resolve_pack_file(ws, str(pack_ref))
+        if pack_path is None:
+            print(f"  (pack '{pack_ref}' not found — skipped)", file=sys.stderr)
+        else:
+            rel = _pack_rel_path(ws, pack_path)
+            _write(ws / ".active-pack", rel + "\n")
+            print(_green(f"  Pack: {rel}"))
+
+    persona = data.get("persona")
+    if persona:
+        if not _persona_path(ws, str(persona)).exists():
+            print(f"  (persona '{persona}' not found — skipped)", file=sys.stderr)
+        else:
+            active_file = ws / ".active-persona"
+            from_persona = active_file.read_text(encoding="utf-8").strip() if active_file.exists() else ""
+            ts = _utc_timestamp()
+            if from_persona and from_persona != persona:
+                _append_persona_history(ws, f"{ts} profile: {from_persona} → {persona}")
+            elif not from_persona:
+                _append_persona_history(ws, f"{ts} profile: → {persona}")
+            _write(active_file, str(persona) + "\n")
+            print(_green(f"  Persona: {persona}"))
+
+    return 0
+
+
+def cmd_profiles(args: list[str]) -> int:
+    """List available profiles."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace profiles [--workspace PATH]")
+                return 0
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    profiles_dir = ws / "profiles"
+    print(_blue("── Available Profiles ─────────────────────────────────────"))
+    if not profiles_dir.is_dir():
+        print(_dim("  (no profiles/ directory)"))
+        print()
+        return 0
+
+    found = False
+    for path in sorted(profiles_dir.glob("*.yaml")):
+        found = True
+        data = _parse_yaml_file(path)
+        name = data.get("name") or path.stem
+        pack = data.get("pack") or "-"
+        persona = data.get("persona") or "-"
+        desc = data.get("description") or ""
+        print(f"  {name:25s} pack={pack} persona={persona}")
+        if desc:
+            print(_dim(f"    {desc}"))
+
+    if not found:
+        print(_dim("  (no profiles defined)"))
+    print()
+    print("Usage: agent-toolkit workspace load --profile <name>")
+    return 0
+
+
+def _validate_packs(ws: Path) -> list[str]:
+    errors: list[str] = []
+    packs_dir = ws / "packs"
+    if not packs_dir.is_dir():
+        return errors
+    for path in sorted(packs_dir.glob("*.yaml")):
+        try:
+            data = _parse_yaml_file(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid YAML ({exc})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path.name}: root must be a mapping")
+            continue
+        for field in ("name", "description"):
+            if not data.get(field):
+                errors.append(f"{path.name}: missing required field '{field}'")
+    return errors
+
+
+def _validate_loops(ws: Path) -> list[str]:
+    errors: list[str] = []
+    loops_dir = ws / "loops"
+    if not loops_dir.is_dir():
+        return errors
+    for loop_dir in sorted(loops_dir.iterdir()):
+        if not loop_dir.is_dir():
+            continue
+        loop_md = loop_dir / "LOOP.md"
+        if not loop_md.exists():
+            continue
+        meta = _parse_frontmatter_text(loop_md.read_text(encoding="utf-8"))
+        if not meta:
+            errors.append(f"{loop_dir.name}/LOOP.md: missing or invalid frontmatter")
+            continue
+        for field in ("name", "tier", "cadence", "request"):
+            if not meta.get(field):
+                errors.append(f"{loop_dir.name}/LOOP.md: missing required field '{field}'")
+    return errors
+
+
+def _validate_personas(ws: Path) -> list[str]:
+    errors: list[str] = []
+    personas_dir = ws / "personas"
+    if not personas_dir.is_dir():
+        return errors
+    for path in sorted(personas_dir.glob("*.md")):
+        meta = _parse_frontmatter_text(path.read_text(encoding="utf-8"))
+        if not meta:
+            errors.append(f"{path.name}: missing or invalid YAML frontmatter")
+            continue
+        for field in ("allow", "deny"):
+            val = meta.get(field)
+            if val is not None and not isinstance(val, list):
+                errors.append(f"{path.name}: '{field}' must be a list")
+    return errors
+
+
+def _validate_profiles(ws: Path) -> list[str]:
+    errors: list[str] = []
+    profiles_dir = ws / "profiles"
+    if not profiles_dir.is_dir():
+        return errors
+    for path in sorted(profiles_dir.glob("*.yaml")):
+        try:
+            data = _parse_yaml_file(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid YAML ({exc})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path.name}: root must be a mapping")
+            continue
+        if not data.get("name") and not path.stem:
+            errors.append(f"{path.name}: missing required field 'name'")
+        pack_ref = data.get("pack")
+        if pack_ref and _resolve_pack_file(ws, str(pack_ref)) is None:
+            errors.append(f"{path.name}: referenced pack '{pack_ref}' not found")
+        persona = data.get("persona")
+        if persona and not _persona_path(ws, str(persona)).exists():
+            errors.append(f"{path.name}: referenced persona '{persona}' not found")
+    return errors
+
+
+def _validate_knowledge(ws: Path) -> list[str]:
+    errors: list[str] = []
+    knowledge = ws / "knowledge"
+    if not knowledge.is_dir():
+        errors.append("knowledge/: directory not found")
+        return errors
+    for sub in ("learnings", "todos", "processes"):
+        if not (knowledge / sub).is_dir():
+            errors.append(f"knowledge/{sub}/: required directory missing")
+    return errors
+
+
+def _validate_jobs(ws: Path) -> list[str]:
+    errors: list[str] = []
+    jobs_dir = ws / "templates" / "jobs"
+    if not jobs_dir.is_dir():
+        return errors
+    for path in sorted(jobs_dir.glob("*.yaml")):
+        try:
+            data = _parse_yaml_file(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid YAML ({exc})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path.name}: root must be a mapping")
+            continue
+        for field in ("name", "request"):
+            if not data.get(field):
+                errors.append(f"{path.name}: missing required field '{field}'")
+    return errors
+
+
+_SURFACES = {
+    "packs": _validate_packs,
+    "loops": _validate_loops,
+    "personas": _validate_personas,
+    "profiles": _validate_profiles,
+    "knowledge": _validate_knowledge,
+    "jobs": _validate_jobs,
+}
+
+
+def cmd_validate(args: list[str]) -> int:
+    """Validate workspace schema integrity."""
+    workspace_path: str | None = None
+    surface = "all"
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace validate [surface] [--workspace PATH]")
+                print("Surfaces: all, packs, loops, personas, profiles, knowledge, jobs")
+                return 0
+            case arg if not arg.startswith("-"):
+                surface = arg
+                i += 1
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    if surface != "all" and surface not in _SURFACES:
+        print(f"Unknown surface: {surface}", file=sys.stderr)
+        print("Valid surfaces: all, packs, loops, personas, profiles, knowledge, jobs", file=sys.stderr)
+        return 1
+
+    print()
+    print("Context Validation")
+    print("------------------")
+
+    surfaces = list(_SURFACES.keys()) if surface == "all" else [surface]
+    all_errors: list[str] = []
+    for name in surfaces:
+        print(_blue(f"Validating {name}/ ..."))
+        errors = _SURFACES[name](ws)
+        if errors:
+            for err in errors:
+                print(f"  {_yellow('✗')}  {err}", file=sys.stderr)
+            all_errors.extend(errors)
+        else:
+            print(f"  {_green('✓')}  {name}/ OK")
+
+    print()
+    if all_errors:
+        print(f"  {_yellow(str(len(all_errors)))} violation(s) found.", file=sys.stderr)
+        return 1
+    print(f"  {_green('All context files valid.')}")
+    print()
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -638,6 +1280,20 @@ def cmd_workspace(args: list[str]) -> int:
             return cmd_context(rest)
         case "sync":
             return cmd_sync(rest)
+        case "use-persona":
+            return cmd_use_persona(rest)
+        case "handoff":
+            return cmd_handoff(rest)
+        case "history":
+            return cmd_history(rest)
+        case "personas":
+            return cmd_personas(rest)
+        case "load":
+            return cmd_load(rest)
+        case "profiles":
+            return cmd_profiles(rest)
+        case "validate":
+            return cmd_validate(rest)
         case _:
             print(f"Unknown workspace subcommand: {sub}", file=sys.stderr)
             print("Run 'agent-toolkit workspace --help' for usage.", file=sys.stderr)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -55,22 +55,9 @@ def _dim(t: str) -> str:    return _c("0;37", t)
 
 def _find_workspace(override: str | None = None) -> Path | None:
     """Locate workspace root via env, override, or walking up from CWD."""
-    if override:
-        p = Path(override).expanduser().resolve()
-        return p if p.is_dir() else None
+    from agent_toolkit._paths import find_workspace_root
 
-    env = os.environ.get("AGENT_TOOLKIT_WORKSPACE")
-    if env:
-        p = Path(env).expanduser().resolve()
-        return p if p.is_dir() else None
-
-    # Walk up from CWD looking for AGENTS.md or knowledge/
-    current = Path.cwd()
-    for candidate in [current, *current.parents]:
-        if (candidate / "AGENTS.md").exists() or (candidate / "knowledge").is_dir():
-            return candidate
-
-    return None
+    return find_workspace_root(override=override)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
@@ -187,35 +187,53 @@ signal.signal(signal.SIGTERM, _handle_sig)
 
 # ── paths ─────────────────────────────────────────────────────────────────────
 
-# WORKSPACE_ROOT resolution (in priority order):
-# 1. AGENT_TOOLKIT_ROOT env var — explicit user override / ai-workspace session
-# 2. AI_WORKSPACE env var — compatibility with ai-workspace sessions
-# 3. Package data dir (pip/uvx/brew installs) — agent_toolkit/data/ in wheel
-# 4. Walk up from this file — editable/source installs
-# 5. CWD fallback
 def _find_toolkit_root() -> Path:
-    """Locate the directory that contains loops/, profiles/, skills/, etc."""
-    # Try package data directory first (pip/uvx wheel installs)
+    """Locate toolkit data (bundled loops/profiles). Prefer shared toolkit_root()."""
+    try:
+        from agent_toolkit._paths import toolkit_root
+        return toolkit_root()
+    except Exception:
+        pass
     try:
         pkg_data = Path(__file__).resolve().parent.parent / "data"
         if pkg_data.is_dir() and (pkg_data / "loops").is_dir():
             return pkg_data
     except Exception:
         pass
-    # Walk up from this file (editable/source installs)
     here = Path(__file__).resolve().parent
     for candidate in [here.parent.parent.parent, here.parent.parent, here.parent]:
         if (candidate / "loops").is_dir():
             return candidate
     return Path.cwd()
 
-WORKSPACE_ROOT = Path(
-    os.environ.get("AGENT_TOOLKIT_ROOT", "")
-    or os.environ.get("AI_WORKSPACE", "")
-    or _find_toolkit_root()
-)
-LOOPS_DIR = WORKSPACE_ROOT / "loops"
-TEMPLATES_DIR = WORKSPACE_ROOT / "loops"  # templates are the loops/ dir itself
+
+def workspace_root() -> Path:
+    """User workspace root for loop instances (#200 / #207)."""
+    from agent_toolkit._paths import find_workspace_root
+    ws = find_workspace_root()
+    if ws is not None:
+        return ws
+    for env in ("AGENT_TOOLKIT_ROOT", "AI_WORKSPACE"):
+        val = os.environ.get(env, "").strip()
+        if val:
+            return Path(val).expanduser().resolve()
+    return Path.cwd()
+
+
+def loops_dir() -> Path:
+    """User-created loop instances live under workspace/loops/ (#200)."""
+    return workspace_root() / "loops"
+
+
+def toolkit_loops_dir() -> Path:
+    """Bundled reference templates under toolkit data/loops/."""
+    return _find_toolkit_root() / "loops"
+
+
+# Back-compat aliases (recomputed each access via functions preferred)
+WORKSPACE_ROOT = Path.cwd()  # placeholder; prefer workspace_root()
+LOOPS_DIR = Path.cwd() / "loops"
+TEMPLATES_DIR = Path.cwd() / "loops"
 WORKTREES_HOME = Path(
     os.environ.get("HARNESS_WORKTREES_DIR", "")
     or Path.home() / ".local" / "share" / "agent-toolkit" / "worktrees"
@@ -417,27 +435,83 @@ def write_state_md(loop_dir: Path, state: dict[str, Any]) -> None:
 
 
 def list_loops() -> list[Path]:
-    """Return all loop directories sorted by name. Supports both LOOP.md and loop.yaml."""
-    if not LOOPS_DIR.is_dir():
+    """Return user loop instances under workspace/loops/ (#201).
+
+    Prefers directories with LOOP.md (init output). Also accepts loop.yaml for
+    compatibility. Bundled templates are not listed here — use list_templates().
+    """
+    if not loops_dir().is_dir():
         return []
     return sorted([
-        d for d in LOOPS_DIR.iterdir()
+        d for d in loops_dir().iterdir()
         if d.is_dir() and ((d / "LOOP.md").exists() or (d / "loop.yaml").exists())
     ])
 
 
 def list_templates() -> list[Path]:
-    """Return available loop templates from loops/ directory."""
-    if not TEMPLATES_DIR.is_dir():
-        return []
-    # Each loop dir contains a loop.yaml — use those as templates
-    results = []
-    for d in TEMPLATES_DIR.iterdir():
-        if d.is_dir() and (d / "loop.yaml").exists():
-            results.append(d / "loop.yaml")
-    # Also check for flat *.yaml files (legacy format)
-    results.extend(f for f in TEMPLATES_DIR.glob("*.yaml") if f not in results)
-    return sorted(results)
+    """Return available loop templates (workspace overrides + bundled) (#200/#202)."""
+    results: list[Path] = []
+    seen: set[str] = set()
+
+    ws = workspace_root()
+    user_flat = ws / "templates" / "loops"
+    if user_flat.is_dir():
+        for f in sorted(user_flat.glob("*.yaml")):
+            results.append(f)
+            seen.add(f.stem)
+        for d in sorted(user_flat.iterdir()):
+            if d.is_dir() and (d / "loop.yaml").exists() and d.name not in seen:
+                results.append(d / "loop.yaml")
+                seen.add(d.name)
+
+    bundled = toolkit_loops_dir()
+    if bundled.is_dir():
+        for d in sorted(bundled.iterdir()):
+            if d.is_dir() and (d / "loop.yaml").exists() and d.name not in seen:
+                results.append(d / "loop.yaml")
+                seen.add(d.name)
+        for f in sorted(bundled.glob("*.yaml")):
+            if f.stem not in seen:
+                results.append(f)
+                seen.add(f.stem)
+    return results
+
+
+def resolve_template(pattern: str) -> Path | None:
+    """Resolve a loop template path (#200 / #202).
+
+    Order:
+    1. ``$WORKSPACE/templates/loops/<pattern>.yaml``
+    2. ``$WORKSPACE/templates/loops/<pattern>/loop.yaml``
+    3. Bundled ``data/loops/<pattern>/loop.yaml``
+    4. Bundled flat ``data/loops/<pattern>.yaml``
+    """
+    ws = workspace_root()
+    candidates = [
+        ws / "templates" / "loops" / f"{pattern}.yaml",
+        ws / "templates" / "loops" / pattern / "loop.yaml",
+        toolkit_loops_dir() / pattern / "loop.yaml",
+        toolkit_loops_dir() / f"{pattern}.yaml",
+    ]
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+def resolve_loop_dir(name: str) -> Path | None:
+    """Resolve a runnable loop directory (#201).
+
+    Prefer user instance ``$WORKSPACE/loops/<name>/`` (LOOP.md or loop.yaml).
+    Fall back to bundled toolkit ``loops/<name>/`` when present.
+    """
+    user = loops_dir() / name
+    if user.is_dir() and ((user / "LOOP.md").exists() or (user / "loop.yaml").exists()):
+        return user
+    bundled = toolkit_loops_dir() / name
+    if bundled.is_dir() and ((bundled / "LOOP.md").exists() or (bundled / "loop.yaml").exists()):
+        return bundled
+    return None
 
 
 # ── autonomy / prompt assembly ────────────────────────────────────────────────
@@ -545,7 +619,7 @@ def _build_runner_prompt(
     contract = _autonomy_contract(meta, loop_dir)
     return (
         "You are executing an autonomous loop run in an agent-toolkit workspace.\n"
-        f"Workspace root: {WORKSPACE_ROOT}\n"
+        f"Workspace root: {workspace_root()}\n"
         f"Loop directory: {loop_dir}\n"
         f"Output directory: {run_dir}\n\n"
         f"{contract}\n\n"
@@ -626,7 +700,7 @@ def _try_claude_runner(
             [claude_bin, "--print",
              "--allowedTools", "Bash,Read,Write,Edit,Glob,Grep"],
             input_text=prompt,
-            cwd=str(WORKSPACE_ROOT),
+            cwd=str(workspace_root()),
             env=env,
             trace_file=trace_file or (run_dir / "trace.jsonl"),
         )
@@ -666,7 +740,7 @@ def _try_opencode_runner(
         result = _run_with_live_output(
             [opencode_bin, "run", "--print-logs"],
             input_text=prompt,
-            cwd=str(WORKSPACE_ROOT),
+            cwd=str(workspace_root()),
             env=env,
             trace_file=trace_file or (run_dir / "trace.jsonl"),
         )
@@ -719,7 +793,7 @@ def _queue_via_devcompanion(
         "id": job_id,
         "created_at": utc_now(),
         "request": request,
-        "repo_path": str(WORKSPACE_ROOT),
+        "repo_path": str(workspace_root()),
         "loop_run_dir": str(run_dir),
         "llm": True,
         "limits": {
@@ -749,52 +823,73 @@ def _queue_via_devcompanion(
 # ── commands ──────────────────────────────────────────────────────────────────
 
 def cmd_init(args: list[str]) -> int:
-    """Scaffold a new loop from a starter template."""
-    if not args:
-        err("Usage: loop init <pattern>")
+    """Scaffold a new loop from a starter template (#200)."""
+    if not args or args[0] in ("-h", "--help"):
+        err("Usage: agent-toolkit loop init <pattern> [--name <custom-name>]")
         print("\nAvailable patterns:")
         for t in list_templates():
-            print(f"  {t.stem}")
-        return 1
+            label = t.parent.name if t.name == "loop.yaml" else t.stem
+            print(f"  {label}")
+        return 0 if args and args[0] in ("-h", "--help") else 1
 
     pattern = args[0]
-    template_file = TEMPLATES_DIR / f"{pattern}.yaml"
-    if not template_file.exists():
+    loop_name = pattern
+    i = 1
+    while i < len(args):
+        if args[i] == "--name" and i + 1 < len(args):
+            loop_name = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    template_file = resolve_template(pattern)
+    if template_file is None:
         err(f"Template '{pattern}' not found.")
         print("\nAvailable patterns:")
         for t in list_templates():
-            print(f"  {t.stem}")
+            label = t.parent.name if t.name == "loop.yaml" else t.stem
+            print(f"  {label}")
         return 1
 
-    # Parse the template for defaults
     text = template_file.read_text(encoding="utf-8")
     name_match = re.search(r"^name:\s+(\S+)", text, re.MULTILINE)
-    loop_name = name_match.group(1) if name_match else pattern
+    if loop_name == pattern and name_match:
+        loop_name = name_match.group(1)
 
-    loop_dir = LOOPS_DIR / loop_name
+    loop_dir = loops_dir() / loop_name
     if loop_dir.exists():
         warn(f"Loop '{loop_name}' already exists at {loop_dir}")
         return 1
 
     loop_dir.mkdir(parents=True)
-    runs_dir = loop_dir / "runs"
-    runs_dir.mkdir()
+    (loop_dir / "runs").mkdir()
 
-    # Build LOOP.md from template
-    loop_md = loop_dir / "LOOP.md"
-    loop_md.write_text(
+    # Body of frontmatter: drop full-line comments from template YAML
+    fm_lines = [
+        line for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    # Ensure name matches instance directory
+    rewritten: list[str] = []
+    saw_name = False
+    for line in fm_lines:
+        if re.match(r"^name:\s+", line):
+            rewritten.append(f"name: {loop_name}")
+            saw_name = True
+        else:
+            rewritten.append(line)
+    if not saw_name:
+        rewritten.insert(0, f"name: {loop_name}")
+
+    (loop_dir / "LOOP.md").write_text(
         "---\n"
-        + "\n".join(
-            line for line in text.splitlines()
-            if not line.startswith("#") or line.strip() == "#"
-        )
+        + "\n".join(rewritten)
         + "\n---\n\n"
         f"# {loop_name.replace('-', ' ').title()} Loop\n\n"
         "<!-- Describe the goal, constraints, and escalation rules here. -->\n",
         encoding="utf-8",
     )
 
-    # Build initial STATE.md
     write_state_md(
         loop_dir,
         {
@@ -807,9 +902,10 @@ def cmd_init(args: list[str]) -> int:
         },
     )
 
-    ok(f"Initialized loop '{loop_name}' at {loop_dir.relative_to(WORKSPACE_ROOT)}")
-    print(f"\n  Edit {loop_dir.relative_to(WORKSPACE_ROOT)}/LOOP.md to customize.")
-    print(f"  Then run: ./bin/loop run {loop_name}")
+    rel = loop_dir.relative_to(workspace_root())
+    ok(f"Initialized loop '{loop_name}' at {rel}")
+    print(f"\n  Edit {rel}/LOOP.md to customize.")
+    print(f"  Then run: agent-toolkit loop run {loop_name}")
     return 0
 
 
@@ -833,9 +929,9 @@ def cmd_run(args: list[str]) -> int:
         err("Usage: loop run <loop-name> [--force] [--quiet]")
         return 1
 
-    loop_dir = LOOPS_DIR / loop_name
-    if not loop_dir.exists():
-        err(f"Loop '{loop_name}' not found. Run: ./bin/loop init {loop_name}")
+    loop_dir = resolve_loop_dir(loop_name)
+    if loop_dir is None:
+        err(f"Loop '{loop_name}' not found. Run: agent-toolkit loop init {loop_name}")
         return 1
 
     meta = parse_loop_md(loop_dir)
@@ -875,7 +971,7 @@ def cmd_run(args: list[str]) -> int:
 
     if runs_today >= max_runs and not force:
         warn(f"Budget: max_runs_per_day ({max_runs}) reached for today. Skipping.")
-        warn("  Re-run with: ./bin/loop run <loop> --force")
+        warn("  Re-run with: agent-toolkit loop run <loop> --force")
         return 0
     if force and runs_today >= max_runs:
         warn(f"Budget gate bypassed via --force (runs_today={runs_today}, max={max_runs})")
@@ -886,7 +982,7 @@ def cmd_run(args: list[str]) -> int:
     run_dir.mkdir(parents=True)
 
     log(f"Starting run {rid} for '{loop_name}' (tier={tier})")
-    log(f"Run artifacts: {run_dir.relative_to(WORKSPACE_ROOT)}")
+    log(f"Run artifacts: {run_dir.relative_to(workspace_root())}")
     allow = _as_str_list(meta.get("allowlist"))
     deny = _as_str_list(meta.get("deny"))
     log(
@@ -896,7 +992,7 @@ def cmd_run(args: list[str]) -> int:
     )
 
     # Write initial trace entry with AGENTS.md spec hash
-    agents_md = WORKSPACE_ROOT / "AGENTS.md"
+    agents_md = workspace_root() / "AGENTS.md"
     agents_md_hash = hashlib.sha256(agents_md.read_bytes()).hexdigest()[:12] if agents_md.exists() else "?"
 
     trace_file = run_dir / "trace.jsonl"
@@ -918,13 +1014,13 @@ def cmd_run(args: list[str]) -> int:
     # Create git worktree (if in a git repo)
     worktree_path: Path | None = None
     if subprocess.run(
-        ["git", "-C", str(WORKSPACE_ROOT), "rev-parse", "--git-dir"],
+        ["git", "-C", str(workspace_root()), "rev-parse", "--git-dir"],
         capture_output=True,
     ).returncode == 0:
         worktree_base = WORKTREES_HOME / loop_name / rid
         worktree_base.mkdir(parents=True, exist_ok=True)
         result = subprocess.run(
-            ["git", "-C", str(WORKSPACE_ROOT), "worktree", "add",
+            ["git", "-C", str(workspace_root()), "worktree", "add",
              str(worktree_base), "HEAD"],
             capture_output=True,
             text=True,
@@ -1067,7 +1163,7 @@ def cmd_run(args: list[str]) -> int:
         # Clean up worktree — the devcompanion worker runs independently
         if worktree_path and worktree_path.is_dir():
             subprocess.run(
-                ["git", "-C", str(WORKSPACE_ROOT), "worktree", "remove",
+                ["git", "-C", str(workspace_root()), "worktree", "remove",
                  str(worktree_path), "--force"],
                 capture_output=True,
             )
@@ -1078,7 +1174,7 @@ def cmd_run(args: list[str]) -> int:
     # Cleanup worktree on inline completion
     if worktree_path and worktree_path.is_dir():
         subprocess.run(
-            ["git", "-C", str(WORKSPACE_ROOT), "worktree", "remove",
+            ["git", "-C", str(workspace_root()), "worktree", "remove",
              str(worktree_path), "--force"],
             capture_output=True,
         )
@@ -1103,7 +1199,7 @@ def finalize_run(
     # Cleanup worktree
     if worktree_path and worktree_path.is_dir():
         subprocess.run(
-            ["git", "-C", str(WORKSPACE_ROOT), "worktree", "remove",
+            ["git", "-C", str(workspace_root()), "worktree", "remove",
              str(worktree_path), "--force"],
             capture_output=True,
         )
@@ -1118,7 +1214,7 @@ def finalize_run(
     if status == "completed":
         # Loop closure: extract learning events from trace and sync to knowledge
         _close_loop(run_dir, rid)
-        ok(f"Run {rid} complete. Artifacts at: {run_dir.relative_to(WORKSPACE_ROOT)}")
+        ok(f"Run {rid} complete. Artifacts at: {run_dir.relative_to(workspace_root())}")
     else:
         warn(f"Run {rid} finished with status: {status}")
 
@@ -1138,7 +1234,7 @@ def _close_loop(run_dir: Path, rid: str) -> None:
         if event.get("kind") == "decision" and event.get("tag") == "learning":
             content = event.get("content", "")
             if content:
-                add_script = WORKSPACE_ROOT / "bin" / "assistant-memory"
+                add_script = workspace_root() / "bin" / "assistant-memory"
                 if add_script.exists():
                     subprocess.run(
                         [sys.executable, str(add_script), "add",
@@ -1158,10 +1254,10 @@ def _close_loop(run_dir: Path, rid: str) -> None:
 def cmd_status(args: list[str]) -> int:
     """Show loop status."""
     target = args[0] if args else None
-    loops = [LOOPS_DIR / target] if target else list_loops()
+    loops = ([resolve_loop_dir(target)] if target else list_loops())
 
     if not loops:
-        print("No loops found. Run: ./bin/loop init <pattern>")
+        print("No loops found. Run: agent-toolkit loop init <pattern>")
         return 0
 
     print("")
@@ -1199,7 +1295,7 @@ def cmd_status(args: list[str]) -> int:
 def cmd_audit(args: list[str]) -> int:
     """Summarize past runs."""
     target = args[0] if args else None
-    loops = [LOOPS_DIR / target] if target else list_loops()
+    loops = ([resolve_loop_dir(target)] if target else list_loops())
 
     print("")
     print(blue("── Loop Audit ───────────────────────────────────────────"))
@@ -1255,7 +1351,10 @@ def cmd_cost(args: list[str]) -> int:
         return 1
 
     loop_name = args[0]
-    loop_dir = LOOPS_DIR / loop_name
+    loop_dir = resolve_loop_dir(loop_name)
+    if loop_dir is None:
+        err(f"Loop '{loop_name}' not found. Run: agent-toolkit loop init {loop_name}")
+        return 1
     meta = parse_loop_md(loop_dir) if loop_dir.exists() else {}
 
     tier = meta.get("tier", "L1")
@@ -1311,19 +1410,22 @@ def cmd_schedule(args: list[str]) -> int:
     if remove_mode:
         loop_name = next((a for a in args if not a.startswith("-") and a != "schedule"), None)
         if not loop_name:
-            err("Usage: bin/loop schedule <name> --remove")
+            err("Usage: agent-toolkit loop schedule <name> --remove")
             return 1
         return _schedule_remove(loop_name, dry_run)
 
     # schedule <name>: install timer
     loop_name = next((a for a in args if not a.startswith("-") and a != "schedule"), None)
     if not loop_name:
-        err("Usage: bin/loop schedule <name> [--cron EXPR] [--dry-run]")
+        err("Usage: agent-toolkit loop schedule <name> [--cron EXPR] [--dry-run]")
         return 1
 
-    loop_dir = LOOPS_DIR / loop_name
+    loop_dir = resolve_loop_dir(loop_name)
+    if loop_dir is None:
+        err(f"Loop '{loop_name}' not found. Run: agent-toolkit loop init {loop_name}")
+        return 1
     if not loop_dir.is_dir():
-        err(f"Loop not found: {loop_name} (run 'bin/loop init {loop_name}' first)")
+        err(f"Loop not found: {loop_name} (run 'agent-toolkit loop init {loop_name}' first)")
         return 1
 
     loopyaml = loop_dir / "LOOP.md"
@@ -1345,7 +1447,7 @@ def cmd_schedule(args: list[str]) -> int:
 def _schedule_dry_run(loop_name: str, cron: str) -> int:
     """Print timer files without installing."""
     system = platform.system()
-    harness_dir = WORKSPACE_ROOT
+    harness_dir = workspace_root()
     loop_cmd = f"{harness_dir}/bin/loop run {loop_name}"
 
     print(f"\n{blue('[loop]')} Would schedule: {loop_name}")
@@ -1379,7 +1481,7 @@ def _schedule_dry_run(loop_name: str, cron: str) -> int:
 def _schedule_install(loop_name: str, cron: str) -> int:
     """Install systemd timer (Linux) or launchd plist (macOS)."""
     system = platform.system()
-    harness_dir = WORKSPACE_ROOT
+    harness_dir = workspace_root()
     loop_cmd = f"{harness_dir}/bin/loop run {loop_name}"
 
     if system == "Linux":
@@ -1625,7 +1727,7 @@ def _launchd_plist(loop_name: str, cron: str) -> str:
     <string>com.agent-toolkit.{loop_name}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>{WORKSPACE_ROOT}/bin/loop</string>
+        <string>{workspace_root()}/bin/loop</string>
         <string>run</string>
         <string>{loop_name}</string>
     </array>
@@ -1640,12 +1742,12 @@ def _launchd_plist(loop_name: str, cron: str) -> str:
 
 def cmd_sync() -> int:
     """Regenerate knowledge todos from completed loop runs."""
-    knowledge_todos = WORKSPACE_ROOT / "knowledge" / "todos" / "pending.md"
-    if not LOOPS_DIR.is_dir():
+    knowledge_todos = workspace_root() / "knowledge" / "todos" / "pending.md"
+    if not loops_dir().is_dir():
         return 0
 
     entries = []
-    for loop_dir in sorted(LOOPS_DIR.iterdir()):
+    for loop_dir in sorted(loops_dir().iterdir()):
         if not (loop_dir / "STATE.md").exists():
             continue
         state = parse_state_md(loop_dir)
@@ -1667,7 +1769,7 @@ def cmd_sync() -> int:
         else:
             existing += f"\n{header}\n{block}<!-- /loop-escalations -->\n"
         knowledge_todos.write_text(existing, encoding="utf-8")
-        ok(f"Synced {len(entries)} escalation(s) to {knowledge_todos.relative_to(WORKSPACE_ROOT)}")
+        ok(f"Synced {len(entries)} escalation(s) to {knowledge_todos.relative_to(workspace_root())}")
 
     return 0
 
@@ -1703,7 +1805,7 @@ def main() -> None:
                 print(f"  {t.stem}")
         case _:
             err(f"Unknown command: {command}")
-            print("Run 'bin/loop help' for usage.")
+            print("Run 'agent-toolkit loop help' for usage.")
             sys.exit(1)
 
 

--- a/tests/test_devcompanion_queue.py
+++ b/tests/test_devcompanion_queue.py
@@ -1,0 +1,172 @@
+"""Tests for devcompanion harness queue storage (#203)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import agent_toolkit.cli.devcompanion_queue as dq
+
+
+@pytest.fixture(autouse=True)
+def _clear_harness_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HARNESS_DC_HOME", raising=False)
+    monkeypatch.delenv("HARNESS_DIR", raising=False)
+
+
+def test_resolve_harness_dc_home_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    custom = tmp_path / "dc-home"
+    monkeypatch.setenv("HARNESS_DC_HOME", str(custom))
+    assert dq.resolve_harness_dc_home() == custom
+
+
+def test_resolve_harness_dc_home_from_harness_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HARNESS_DIR", "/tmp/my-harness")
+    assert dq.resolve_harness_dc_home() == dq.default_harness_dc_home()
+
+
+def test_resolve_harness_dc_home_unset() -> None:
+    assert dq.resolve_harness_dc_home() is None
+
+
+def test_get_dc_config_legacy(tmp_path: Path) -> None:
+    cfg = dq.get_dc_config(tmp_path)
+    assert cfg.harness_mode is False
+    assert cfg.queue_dir == tmp_path / ".devcompanion" / "queue"
+    assert cfg.runs_dir == tmp_path / ".devcompanion" / "runs"
+
+
+def test_get_dc_config_harness_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dc_home = tmp_path / "harness-dc"
+    monkeypatch.setenv("HARNESS_DC_HOME", str(dc_home))
+    cfg = dq.get_dc_config(tmp_path / "workspace")
+    assert cfg.harness_mode is True
+    assert cfg.dc_home == dc_home
+    assert cfg.queue_pending == dc_home / "queue" / "pending"
+    assert cfg.queue_processing == dc_home / "queue" / "processing"
+    assert cfg.queue_done == dc_home / "queue" / "done"
+    assert cfg.queue_failed == dc_home / "queue" / "failed"
+    assert cfg.runs_dir == dc_home / "queue" / "artifacts"
+
+
+def test_harness_queue_write_and_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dc_home = tmp_path / "dc"
+    monkeypatch.setenv("HARNESS_DC_HOME", str(dc_home))
+    cfg = dq.get_dc_config(tmp_path)
+
+    job = {
+        "id": "test-job",
+        "created_at": "2026-08-05T12:00:00Z",
+        "request": "do something",
+        "repo_path": "/repo/path",
+        "llm": True,
+        "limits": {"timeout_sec": 1800, "max_steps": 25},
+        "actions_allowed": ["plan_only"],
+    }
+    job_path = dq.queue_job_path(cfg, "test-job")
+    dq.write_job(job_path, job)
+
+    assert job_path == dc_home / "queue" / "pending" / "test-job.job"
+    assert job_path.exists()
+    assert "status" not in json.loads(job_path.read_text(encoding="utf-8"))
+    assert dq.job_status(cfg, "test-job") == "pending"
+
+
+def test_harness_move_to_done(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dc_home = tmp_path / "dc"
+    monkeypatch.setenv("HARNESS_DC_HOME", str(dc_home))
+    cfg = dq.get_dc_config(tmp_path)
+
+    job_path = dq.queue_job_path(cfg, "move-me")
+    dq.write_job(job_path, {"id": "move-me", "request": "x", "repo_path": "/p"})
+
+    assert dq.mark_job_done(cfg, "move-me", "2026-08-05T12:00:00Z")
+    assert not job_path.exists()
+    assert (cfg.queue_done / "move-me.job").exists()
+    assert dq.job_status(cfg, "move-me") == "done"
+
+
+def test_harness_run_once_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate run-once state transitions: pending → processing → done."""
+    dc_home = tmp_path / "dc"
+    monkeypatch.setenv("HARNESS_DC_HOME", str(dc_home))
+    cfg = dq.get_dc_config(tmp_path)
+
+    pending_path = dq.queue_job_path(cfg, "run-me")
+    dq.write_job(pending_path, {"id": "run-me", "request": "x", "repo_path": "/p"})
+
+    pending = dq.pending_jobs(cfg)
+    assert len(pending) == 1
+    job_file, job = pending[0]
+
+    cfg.queue_processing.mkdir(parents=True, exist_ok=True)
+    processing_file = cfg.queue_processing / job_file.name
+    job_file.rename(processing_file)
+
+    cfg.queue_done.mkdir(parents=True, exist_ok=True)
+    processing_file.rename(cfg.queue_done / processing_file.name)
+
+    assert dq.job_status(cfg, "run-me") == "done"
+    assert dq.pending_jobs(cfg) == []
+
+
+def test_legacy_queue_uses_json_with_status(tmp_path: Path) -> None:
+    cfg = dq.get_dc_config(tmp_path)
+    job_path = dq.queue_job_path(cfg, "legacy-job")
+    dq.write_job(
+        job_path,
+        {
+            "id": "legacy-job",
+            "created_at": "2026-08-05T12:00:00Z",
+            "project": "my-api",
+            "project_path": "/projects/my-api",
+            "request": "review code",
+            "status": "pending",
+        },
+    )
+
+    assert job_path.suffix == ".json"
+    assert dq.job_status(cfg, "legacy-job") == "pending"
+
+    dq.move_job(cfg, "legacy-job", "running")
+    assert dq.job_status(cfg, "legacy-job") == "running"
+
+
+def test_job_project_path_normalizes_repo_path() -> None:
+    assert dq.job_project_path({"repo_path": "/a/b/c"}) == "/a/b/c"
+    assert dq.job_project_path({"project_path": "/x/y"}) == "/x/y"
+    assert dq.job_project_name({"project": "foo"}) == "foo"
+    assert dq.job_project_name({"repo_path": "/repos/bar"}) == "bar"
+
+
+def test_devcompanion_queue_integration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end queue + run-once with harness layout (--no-llm)."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    projects = workspace / "projects"
+    projects.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (projects / "demo").symlink_to(repo, target_is_directory=True)
+
+    dc_home = tmp_path / "harness-dc"
+    monkeypatch.setenv("HARNESS_DC_HOME", str(dc_home))
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(workspace))
+    monkeypatch.chdir(workspace)
+
+    from agent_toolkit.cli import devcompanion
+
+    assert devcompanion._cfg().harness_mode is True
+
+    rc = devcompanion._cmd_queue(["demo", "--request", "test harness queue", "--id", "demo-1"])
+    assert rc == 0
+    assert (dc_home / "queue" / "pending" / "demo-1.job").exists()
+
+    rc = devcompanion._cmd_run_once(["--no-llm"])
+    assert rc == 0
+    assert not (dc_home / "queue" / "pending" / "demo-1.job").exists()
+    assert (dc_home / "queue" / "done" / "demo-1.job").exists()
+    assert (dc_home / "queue" / "artifacts" / "demo-1" / "plan.md").exists()

--- a/tests/test_loop_init_workspace.py
+++ b/tests/test_loop_init_workspace.py
@@ -1,0 +1,74 @@
+"""Tests for loop init / template resolution / workspace loops (#200/#201/#202/#207)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit._paths import find_workspace_root
+from agent_toolkit.loop import runner
+
+
+def test_find_workspace_root_harness_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_TOOLKIT_WORKSPACE", raising=False)
+    monkeypatch.setenv("HARNESS_DIR", str(tmp_path))
+    assert find_workspace_root() == tmp_path.resolve()
+
+
+def test_find_workspace_root_prefers_agent_toolkit_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(a))
+    monkeypatch.setenv("HARNESS_DIR", str(b))
+    assert find_workspace_root() == a.resolve()
+
+
+def test_loop_init_from_bundled_template(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_TOOLKIT_ROOT", raising=False)
+    monkeypatch.delenv("AI_WORKSPACE", raising=False)
+    monkeypatch.delenv("HARNESS_DIR", raising=False)
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    # Ensure toolkit loops are discoverable via editable install / repo
+    assert runner.resolve_template("oss-pr-monitor") is not None
+    assert runner.workspace_root() == tmp_path.resolve()
+    assert runner.cmd_init(["oss-pr-monitor"]) == 0
+    loop_dir = tmp_path / "loops" / "oss-pr-monitor"
+    assert (loop_dir / "LOOP.md").is_file()
+    assert (loop_dir / "STATE.md").is_file()
+    assert (loop_dir / "runs").is_dir()
+    assert runner.cmd_init(["oss-pr-monitor"]) == 1  # already exists
+
+
+def test_loop_init_custom_name_and_user_template(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AGENT_TOOLKIT_ROOT", raising=False)
+    monkeypatch.delenv("AI_WORKSPACE", raising=False)
+    monkeypatch.delenv("HARNESS_DIR", raising=False)
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    tpl = tmp_path / "templates" / "loops"
+    tpl.mkdir(parents=True)
+    (tpl / "weekly-dep.yaml").write_text(
+        "name: weekly-dep\ntier: L2\ncadence: 7d\ngoal: keep deps fresh\n",
+        encoding="utf-8",
+    )
+    assert runner.cmd_init(["weekly-dep", "--name", "deps-acme"]) == 0
+    loop_dir = tmp_path / "loops" / "deps-acme"
+    text = (loop_dir / "LOOP.md").read_text(encoding="utf-8")
+    assert "name: deps-acme" in text
+    assert "tier: L2" in text
+
+
+def test_resolve_loop_dir_prefers_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    user = tmp_path / "loops" / "oss-pr-monitor"
+    user.mkdir(parents=True)
+    (user / "LOOP.md").write_text("---\nname: oss-pr-monitor\ntier: L3\n---\n", encoding="utf-8")
+    resolved = runner.resolve_loop_dir("oss-pr-monitor")
+    assert resolved == user

--- a/tests/test_project_init.py
+++ b/tests/test_project_init.py
@@ -73,3 +73,8 @@ def test_project_init_via_router(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 def test_project_init_unknown_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
     assert cmd_project(["nope"]) == 1
+
+
+def test_project_init_rejects_unexpected_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    assert cmd_init(["--workspace"], tmp_path) == 1

--- a/tests/test_project_init.py
+++ b/tests/test_project_init.py
@@ -1,0 +1,75 @@
+"""Tests for agent-toolkit project init (#208)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli.project import cmd_init, cmd_project
+
+
+def test_project_init_creates_dirs_and_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    assert cmd_init([], tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "Initialized project directories" in out
+
+    assert (tmp_path / "repos" / "github.com").is_dir()
+    assert (tmp_path / "projects").is_dir()
+
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert "repos/" in gitignore
+    assert "projects/" in gitignore
+
+
+def test_project_init_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    assert cmd_init([], tmp_path) == 0
+    assert cmd_init([], tmp_path) == 0
+    out = capsys.readouterr().out
+    assert out.count("Initialized project directories") == 2
+
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert gitignore.count("repos/") == 1
+    assert gitignore.count("projects/") == 1
+
+
+def test_project_init_preserves_existing_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    (tmp_path / ".gitignore").write_text("node_modules/\n", encoding="utf-8")
+
+    assert cmd_init([], tmp_path) == 0
+
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "node_modules/"
+    assert "repos/" in lines
+    assert "projects/" in lines
+
+
+def test_project_init_help_exits_0(capsys: pytest.CaptureFixture[str]) -> None:
+    assert cmd_init(["--help"], Path("/tmp")) == 0
+    assert "project init" in capsys.readouterr().out
+
+
+def test_project_init_via_router(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    assert cmd_project(["init", "--workspace", str(tmp_path)]) == 0
+    assert (tmp_path / "repos" / "github.com").is_dir()
+    assert (tmp_path / "projects").is_dir()
+
+
+def test_project_init_unknown_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    assert cmd_project(["nope"]) == 1

--- a/tests/test_workspace_commands.py
+++ b/tests/test_workspace_commands.py
@@ -1,0 +1,111 @@
+"""Tests for workspace persona, load, and validate commands (#204/#205/#206)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import workspace as ws
+
+
+def _scaffold_workspace(tmp_path: Path) -> Path:
+    ws.cmd_init(["--dir", str(tmp_path), "--name", "ws"])
+    root = tmp_path / "ws"
+    (root / "packs" / "acme.yaml").write_text(
+        "name: acme\ndescription: Acme client\nnotes: |\n  Key contact: Alice\n",
+        encoding="utf-8",
+    )
+    (root / "profiles").mkdir(exist_ok=True)
+    (root / "profiles" / "oss-contributor.yaml").write_text(
+        "name: oss-contributor\ndescription: OSS mode\npack: acme\npersona: implementer\n",
+        encoding="utf-8",
+    )
+    (root / "templates" / "jobs").mkdir(parents=True, exist_ok=True)
+    (root / "templates" / "jobs" / "code-review.yaml").write_text(
+        "name: code-review\nrequest: Review the code\n",
+        encoding="utf-8",
+    )
+    (root / "knowledge" / "processes").mkdir(exist_ok=True)
+    return root
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = _scaffold_workspace(tmp_path)
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(root))
+    monkeypatch.chdir(root)
+    return root
+
+
+def test_use_persona_and_history(workspace: Path) -> None:
+    assert ws.cmd_use_persona(["implementer"]) == 0
+    assert (workspace / ".active-persona").read_text(encoding="utf-8").strip() == "implementer"
+    assert ws.cmd_use_persona(["reviewer"]) == 0
+    assert ws.cmd_history(["5"]) == 0
+    history = (workspace / ".persona-history").read_text(encoding="utf-8")
+    assert "implementer → reviewer" in history
+
+
+def test_handoff_valid_and_invalid(workspace: Path) -> None:
+    ws.cmd_use_persona(["implementer"])
+    assert ws.cmd_handoff(["reviewer"]) == 0
+    assert (workspace / ".active-persona").read_text(encoding="utf-8").strip() == "reviewer"
+    # researcher is not in reviewer's handoff targets
+    assert ws.cmd_handoff(["researcher"]) == 1
+
+
+def test_personas_list(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert ws.cmd_personas([]) == 0
+    out = capsys.readouterr().out
+    assert "implementer" in out
+    assert "write_files" in out
+
+
+def test_load_pack(workspace: Path) -> None:
+    assert ws.cmd_load(["packs/acme.yaml"]) == 0
+    assert (workspace / ".active-pack").read_text(encoding="utf-8").strip() == "packs/acme.yaml"
+
+
+def test_load_profile(workspace: Path) -> None:
+    assert ws.cmd_load(["--profile", "oss-contributor"]) == 0
+    assert (workspace / ".active-profile").read_text(encoding="utf-8").strip() == "oss-contributor"
+    assert (workspace / ".active-pack").read_text(encoding="utf-8").strip() == "packs/acme.yaml"
+    assert (workspace / ".active-persona").read_text(encoding="utf-8").strip() == "implementer"
+
+
+def test_profiles_list(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert ws.cmd_profiles([]) == 0
+    out = capsys.readouterr().out
+    assert "oss-contributor" in out
+    assert "pack=acme" in out
+
+
+def test_context_includes_persona_constraints(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    ws.cmd_use_persona(["implementer"])
+    ws.cmd_load(["packs/acme.yaml"])
+    assert ws.cmd_context([]) == 0
+    out = capsys.readouterr().out
+    assert "<persona-constraints>" in out
+    assert "persona: implementer" in out
+    assert "Active Pack" in out
+    assert "Key contact: Alice" in out
+
+
+def test_validate_all_passes(workspace: Path) -> None:
+    assert ws.cmd_validate([]) == 0
+
+
+def test_validate_packs_missing_field(workspace: Path) -> None:
+    (workspace / "packs" / "bad.yaml").write_text("name: bad\n", encoding="utf-8")
+    assert ws.cmd_validate(["packs"]) == 1
+
+
+def test_validate_knowledge_missing_dir(workspace: Path) -> None:
+    import shutil
+
+    shutil.rmtree(workspace / "knowledge" / "processes")
+    assert ws.cmd_validate(["knowledge"]) == 1
+
+
+def test_validate_unknown_surface(workspace: Path) -> None:
+    assert ws.cmd_validate(["nope"]) == 1


### PR DESCRIPTION
## Summary
Harness compatibility for loops and workspace detection:
- **#207** — `find_workspace_root()` with `HARNESS_DIR`; wired into workspace/memory/project/devcompanion/loop
- **#200** — `loop init <pattern> [--name]` scaffolds `LOOP.md` / `STATE.md` / `runs/` under `$WORKSPACE/loops/`
- **#202** — template resolution: `templates/loops/` then bundled `data/loops/`
- **#201** — `resolve_loop_dir()` prefers user instances, falls back to bundled

## Test plan
- [x] `pytest tests/test_loop_init_workspace.py`
- [ ] `agent-toolkit loop init oss-pr-monitor` inside a temp workspace with `AGENT_TOOLKIT_WORKSPACE` set

Closes #200
Closes #201
Closes #202
Closes #207