### PR TITLE
feat(workspace): persona lifecycle, load, and validate (#204 #205 #206)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -73,6 +73,126 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
+def _require_workspace(override: str | None = None) -> Path | None:
+    ws = _find_workspace(override)
+    if ws is None:
+        print("Error: workspace not found.", file=sys.stderr)
+        print("Set AGENT_TOOLKIT_WORKSPACE or run from inside a workspace directory.", file=sys.stderr)
+    return ws
+
+
+def _parse_frontmatter_text(content: str) -> dict:
+    """Parse YAML frontmatter from markdown text."""
+    from agent_toolkit.loop.runner import _parse_simple_yaml
+
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = next((i for i, l in enumerate(lines[1:], 1) if l.strip() == "---"), None)
+    if end is None:
+        return {}
+    yaml_block = "\n".join(lines[1:end])
+    try:
+        import yaml  # type: ignore
+        loaded = yaml.safe_load(yaml_block)
+        return loaded if isinstance(loaded, dict) else {}
+    except ImportError:
+        return _parse_simple_yaml(yaml_block)
+
+
+def _parse_yaml_file(path: Path) -> dict:
+    """Parse a YAML file (PyYAML when available, else minimal parser)."""
+    from agent_toolkit.loop.runner import _parse_simple_yaml
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+        loaded = yaml.safe_load(text)
+        return loaded if isinstance(loaded, dict) else {}
+    except ImportError:
+        return _parse_simple_yaml(text)
+
+
+def _persona_path(ws: Path, name: str) -> Path:
+    return ws / "personas" / f"{name}.md"
+
+
+def _load_persona_meta(ws: Path, name: str) -> dict | None:
+    path = _persona_path(ws, name)
+    if not path.exists():
+        return None
+    return _parse_frontmatter_text(path.read_text(encoding="utf-8"))
+
+
+def _append_persona_history(ws: Path, line: str) -> None:
+    history = ws / ".persona-history"
+    with history.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _format_persona_constraints(persona_name: str, meta: dict) -> str:
+    allow = meta.get("allow") or []
+    deny = meta.get("deny") or []
+    handoffs = meta.get("handoffs") or []
+    output_fmt = meta.get("output_format", "")
+
+    lines = ["  <persona-constraints>", f"    persona: {persona_name}"]
+    if allow:
+        lines.append(f"    allow: [{', '.join(str(x) for x in allow)}]")
+    if deny:
+        lines.append(f"    deny: [{', '.join(str(x) for x in deny)}]")
+    if output_fmt:
+        lines.append(f"    output_format: {output_fmt}")
+    if handoffs:
+        lines.append("    handoffs:")
+        for h in handoffs:
+            if not isinstance(h, dict):
+                continue
+            when = h.get("when", "")
+            to = h.get("to", "")
+            lines.append(f'      - when: "{when}"')
+            lines.append(f"        to: {to}")
+    lines.append("  </persona-constraints>")
+    return "\n".join(lines)
+
+
+def _pack_notes(ws: Path, pack_ref: str) -> str:
+    """Return notes field from an active pack, if any."""
+    pack_path = Path(pack_ref)
+    if not pack_path.is_absolute():
+        pack_path = ws / pack_ref
+    if not pack_path.exists():
+        return ""
+    data = _parse_yaml_file(pack_path)
+    notes = data.get("notes")
+    if isinstance(notes, str) and notes.strip():
+        return notes.strip()
+    return ""
+
+
+def _resolve_pack_file(ws: Path, pack_arg: str) -> Path | None:
+    """Resolve a pack path relative to workspace root."""
+    candidate = Path(pack_arg)
+    if candidate.is_absolute():
+        return candidate if candidate.is_file() else None
+    for rel in (pack_arg, f"packs/{pack_arg}", f"packs/{pack_arg}.yaml"):
+        path = ws / rel
+        if path.is_file():
+            return path
+    return None
+
+
+def _pack_rel_path(ws: Path, pack_path: Path) -> str:
+    try:
+        return str(pack_path.relative_to(ws))
+    except ValueError:
+        return str(pack_path)
+
+
 # ---------------------------------------------------------------------------
 # Templates
 # ---------------------------------------------------------------------------
@@ -521,6 +641,11 @@ def cmd_context(args: list[str]) -> int:
         pack = active_pack_file.read_text(encoding="utf-8").strip()
         print(_blue("── Active Pack ────────────────────────────────────────────"))
         print(f"  {pack}")
+        notes = _pack_notes(ws, pack)
+        if notes:
+            print()
+            for line in notes.splitlines():
+                print(f"  {line}")
         print()
 
     # Active persona
@@ -528,7 +653,11 @@ def cmd_context(args: list[str]) -> int:
     if active_persona_file.exists():
         persona = active_persona_file.read_text(encoding="utf-8").strip()
         print(_blue("── Active Persona ─────────────────────────────────────────"))
-        print(f"  {persona}")
+        print(f"  Persona: {persona}")
+        print()
+        meta = _load_persona_meta(ws, persona)
+        if meta:
+            print(_format_persona_constraints(persona, meta))
         print()
 
     # AGENTS.md hash
@@ -618,6 +747,519 @@ def cmd_sync(args: list[str]) -> int:
     return 0
 
 
+def cmd_use_persona(args: list[str]) -> int:
+    """Activate a persona work mode."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace use-persona <name> [--workspace PATH]")
+                return 0
+            case _:
+                break
+
+    if i >= len(args):
+        print("Usage: agent-toolkit workspace use-persona <name>", file=sys.stderr)
+        return 1
+
+    persona = args[i]
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    persona_file = _persona_path(ws, persona)
+    if not persona_file.exists():
+        print(f"Persona not found: {persona}", file=sys.stderr)
+        cmd_personas([])
+        return 1
+
+    active_file = ws / ".active-persona"
+    from_persona = active_file.read_text(encoding="utf-8").strip() if active_file.exists() else ""
+    ts = _utc_timestamp()
+    if from_persona and from_persona != persona:
+        _append_persona_history(ws, f"{ts} transition: {from_persona} → {persona}")
+    elif not from_persona:
+        _append_persona_history(ws, f"{ts} activate: → {persona}")
+
+    _write(active_file, persona + "\n")
+    print(_green(f"Activated persona: {persona}"))
+    return 0
+
+
+def cmd_handoff(args: list[str]) -> int:
+    """Transition from active persona to another (validates handoff rules)."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace handoff <name> [--workspace PATH]")
+                return 0
+            case _:
+                break
+
+    if i >= len(args):
+        print("Usage: agent-toolkit workspace handoff <name>", file=sys.stderr)
+        return 1
+
+    to_persona = args[i]
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    active_file = ws / ".active-persona"
+    if not active_file.exists():
+        print("No active persona to handoff from. Use 'workspace use-persona <name>' first.", file=sys.stderr)
+        return 1
+
+    from_persona = active_file.read_text(encoding="utf-8").strip()
+    if not _persona_path(ws, to_persona).exists():
+        print(f"Target persona not found: {to_persona}", file=sys.stderr)
+        cmd_personas([])
+        return 1
+
+    meta = _load_persona_meta(ws, from_persona) or {}
+    handoffs = meta.get("handoffs") or []
+    allowed = {h.get("to") for h in handoffs if isinstance(h, dict) and h.get("to")}
+    if allowed and to_persona not in allowed:
+        allowed_str = ", ".join(sorted(allowed))
+        print(
+            f"Invalid handoff from '{from_persona}' to '{to_persona}'. "
+            f"Allowed targets: {allowed_str}",
+            file=sys.stderr,
+        )
+        return 1
+
+    ts = _utc_timestamp()
+    _append_persona_history(ws, f"{ts} handoff: {from_persona} → {to_persona}")
+    _write(active_file, to_persona + "\n")
+    print(_green(f"Handoff: {from_persona} → {to_persona}"))
+    return 0
+
+
+def cmd_history(args: list[str]) -> int:
+    """Show recent persona transitions."""
+    workspace_path: str | None = None
+    count = 10
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace history [count] [--workspace PATH]")
+                return 0
+            case arg if arg.isdigit():
+                count = int(arg)
+                i += 1
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    history_file = ws / ".persona-history"
+    if not history_file.exists():
+        print("No persona transitions recorded yet.")
+        return 0
+
+    lines = history_file.read_text(encoding="utf-8").splitlines()
+    recent = lines[-count:] if count else lines
+    print(f"Recent persona transitions (last {len(recent)}):")
+    print()
+    for line in recent:
+        print(f"  {line}")
+    return 0
+
+
+def cmd_personas(args: list[str]) -> int:
+    """List available personas."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace personas [--workspace PATH]")
+                return 0
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    personas_dir = ws / "personas"
+    print(_blue("── Available Personas ─────────────────────────────────────"))
+    if not personas_dir.is_dir():
+        print(_dim("  (no personas directory)"))
+        print()
+        return 0
+
+    found = False
+    for path in sorted(personas_dir.glob("*.md")):
+        found = True
+        name = path.stem
+        meta = _parse_frontmatter_text(path.read_text(encoding="utf-8"))
+        allow = meta.get("allow") or []
+        deny = meta.get("deny") or []
+        output_fmt = meta.get("output_format", "")
+        allow_s = ", ".join(str(x) for x in allow) if allow else "-"
+        deny_s = ", ".join(str(x) for x in deny) if deny else "-"
+        fmt_s = output_fmt or "-"
+        print(f"  {name:20s} allow=[{allow_s}] deny=[{deny_s}] format={fmt_s}")
+
+    if not found:
+        print(_dim("  (no personas defined)"))
+    print()
+    print("Usage: agent-toolkit workspace use-persona <name>")
+    return 0
+
+
+def cmd_load(args: list[str]) -> int:
+    """Load a context pack or composable profile."""
+    workspace_path: str | None = None
+    profile_name: str | None = None
+    pack_arg: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--profile" if i + 1 < len(args):
+                profile_name = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace load <pack-path> | --profile <name>")
+                return 0
+            case arg if not arg.startswith("-"):
+                pack_arg = arg
+                i += 1
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    if profile_name:
+        return _load_profile(ws, profile_name)
+    if not pack_arg:
+        print("Usage: agent-toolkit workspace load <pack-path> | --profile <name>", file=sys.stderr)
+        return 1
+    return _load_pack(ws, pack_arg)
+
+
+def _load_pack(ws: Path, pack_arg: str) -> int:
+    pack_path = _resolve_pack_file(ws, pack_arg)
+    if pack_path is None:
+        print(f"Pack not found: {pack_arg}", file=sys.stderr)
+        packs_dir = ws / "packs"
+        if packs_dir.is_dir():
+            available = sorted(
+                str(p.relative_to(ws))
+                for p in packs_dir.rglob("*.yaml")
+                if p.is_file()
+            )
+            if available:
+                print("\nAvailable packs:", file=sys.stderr)
+                for item in available:
+                    print(f"  {item}", file=sys.stderr)
+        return 1
+
+    rel = _pack_rel_path(ws, pack_path)
+    _write(ws / ".active-pack", rel + "\n")
+    data = _parse_yaml_file(pack_path)
+    print(_green(f"Loaded pack: {rel}"))
+    desc = data.get("description")
+    if desc:
+        print(f"  {desc}")
+    return 0
+
+
+def _load_profile(ws: Path, profile_name: str) -> int:
+    profile_path = ws / "profiles" / f"{profile_name}.yaml"
+    if not profile_path.exists():
+        print(f"Profile not found: {profile_name}", file=sys.stderr)
+        print(f"Looked in: {profile_path}", file=sys.stderr)
+        return 1
+
+    data = _parse_yaml_file(profile_path)
+    _write(ws / ".active-profile", profile_name + "\n")
+    print(_green(f"Profile loaded: {profile_name}"))
+    desc = data.get("description")
+    if desc:
+        print(f"  {desc}")
+
+    pack_ref = data.get("pack")
+    if pack_ref:
+        pack_path = _resolve_pack_file(ws, str(pack_ref))
+        if pack_path is None:
+            print(f"  (pack '{pack_ref}' not found — skipped)", file=sys.stderr)
+        else:
+            rel = _pack_rel_path(ws, pack_path)
+            _write(ws / ".active-pack", rel + "\n")
+            print(_green(f"  Pack: {rel}"))
+
+    persona = data.get("persona")
+    if persona:
+        if not _persona_path(ws, str(persona)).exists():
+            print(f"  (persona '{persona}' not found — skipped)", file=sys.stderr)
+        else:
+            active_file = ws / ".active-persona"
+            from_persona = active_file.read_text(encoding="utf-8").strip() if active_file.exists() else ""
+            ts = _utc_timestamp()
+            if from_persona and from_persona != persona:
+                _append_persona_history(ws, f"{ts} profile: {from_persona} → {persona}")
+            elif not from_persona:
+                _append_persona_history(ws, f"{ts} profile: → {persona}")
+            _write(active_file, str(persona) + "\n")
+            print(_green(f"  Persona: {persona}"))
+
+    return 0
+
+
+def cmd_profiles(args: list[str]) -> int:
+    """List available profiles."""
+    workspace_path: str | None = None
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace profiles [--workspace PATH]")
+                return 0
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    profiles_dir = ws / "profiles"
+    print(_blue("── Available Profiles ─────────────────────────────────────"))
+    if not profiles_dir.is_dir():
+        print(_dim("  (no profiles/ directory)"))
+        print()
+        return 0
+
+    found = False
+    for path in sorted(profiles_dir.glob("*.yaml")):
+        found = True
+        data = _parse_yaml_file(path)
+        name = data.get("name") or path.stem
+        pack = data.get("pack") or "-"
+        persona = data.get("persona") or "-"
+        desc = data.get("description") or ""
+        print(f"  {name:25s} pack={pack} persona={persona}")
+        if desc:
+            print(_dim(f"    {desc}"))
+
+    if not found:
+        print(_dim("  (no profiles defined)"))
+    print()
+    print("Usage: agent-toolkit workspace load --profile <name>")
+    return 0
+
+
+def _validate_packs(ws: Path) -> list[str]:
+    errors: list[str] = []
+    packs_dir = ws / "packs"
+    if not packs_dir.is_dir():
+        return errors
+    for path in sorted(packs_dir.glob("*.yaml")):
+        try:
+            data = _parse_yaml_file(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid YAML ({exc})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path.name}: root must be a mapping")
+            continue
+        for field in ("name", "description"):
+            if not data.get(field):
+                errors.append(f"{path.name}: missing required field '{field}'")
+    return errors
+
+
+def _validate_loops(ws: Path) -> list[str]:
+    errors: list[str] = []
+    loops_dir = ws / "loops"
+    if not loops_dir.is_dir():
+        return errors
+    for loop_dir in sorted(loops_dir.iterdir()):
+        if not loop_dir.is_dir():
+            continue
+        loop_md = loop_dir / "LOOP.md"
+        if not loop_md.exists():
+            continue
+        meta = _parse_frontmatter_text(loop_md.read_text(encoding="utf-8"))
+        if not meta:
+            errors.append(f"{loop_dir.name}/LOOP.md: missing or invalid frontmatter")
+            continue
+        for field in ("name", "tier", "cadence", "request"):
+            if not meta.get(field):
+                errors.append(f"{loop_dir.name}/LOOP.md: missing required field '{field}'")
+    return errors
+
+
+def _validate_personas(ws: Path) -> list[str]:
+    errors: list[str] = []
+    personas_dir = ws / "personas"
+    if not personas_dir.is_dir():
+        return errors
+    for path in sorted(personas_dir.glob("*.md")):
+        meta = _parse_frontmatter_text(path.read_text(encoding="utf-8"))
+        if not meta:
+            errors.append(f"{path.name}: missing or invalid YAML frontmatter")
+            continue
+        for field in ("allow", "deny"):
+            val = meta.get(field)
+            if val is not None and not isinstance(val, list):
+                errors.append(f"{path.name}: '{field}' must be a list")
+    return errors
+
+
+def _validate_profiles(ws: Path) -> list[str]:
+    errors: list[str] = []
+    profiles_dir = ws / "profiles"
+    if not profiles_dir.is_dir():
+        return errors
+    for path in sorted(profiles_dir.glob("*.yaml")):
+        try:
+            data = _parse_yaml_file(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid YAML ({exc})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path.name}: root must be a mapping")
+            continue
+        if not data.get("name") and not path.stem:
+            errors.append(f"{path.name}: missing required field 'name'")
+        pack_ref = data.get("pack")
+        if pack_ref and _resolve_pack_file(ws, str(pack_ref)) is None:
+            errors.append(f"{path.name}: referenced pack '{pack_ref}' not found")
+        persona = data.get("persona")
+        if persona and not _persona_path(ws, str(persona)).exists():
+            errors.append(f"{path.name}: referenced persona '{persona}' not found")
+    return errors
+
+
+def _validate_knowledge(ws: Path) -> list[str]:
+    errors: list[str] = []
+    knowledge = ws / "knowledge"
+    if not knowledge.is_dir():
+        errors.append("knowledge/: directory not found")
+        return errors
+    for sub in ("learnings", "todos", "processes"):
+        if not (knowledge / sub).is_dir():
+            errors.append(f"knowledge/{sub}/: required directory missing")
+    return errors
+
+
+def _validate_jobs(ws: Path) -> list[str]:
+    errors: list[str] = []
+    jobs_dir = ws / "templates" / "jobs"
+    if not jobs_dir.is_dir():
+        return errors
+    for path in sorted(jobs_dir.glob("*.yaml")):
+        try:
+            data = _parse_yaml_file(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid YAML ({exc})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{path.name}: root must be a mapping")
+            continue
+        for field in ("name", "request"):
+            if not data.get(field):
+                errors.append(f"{path.name}: missing required field '{field}'")
+    return errors
+
+
+_SURFACES = {
+    "packs": _validate_packs,
+    "loops": _validate_loops,
+    "personas": _validate_personas,
+    "profiles": _validate_profiles,
+    "knowledge": _validate_knowledge,
+    "jobs": _validate_jobs,
+}
+
+
+def cmd_validate(args: list[str]) -> int:
+    """Validate workspace schema integrity."""
+    workspace_path: str | None = None
+    surface = "all"
+    i = 0
+    while i < len(args):
+        match args[i]:
+            case "--workspace" if i + 1 < len(args):
+                workspace_path = args[i + 1]
+                i += 2
+            case "--help" | "-h":
+                print("Usage: agent-toolkit workspace validate [surface] [--workspace PATH]")
+                print("Surfaces: all, packs, loops, personas, profiles, knowledge, jobs")
+                return 0
+            case arg if not arg.startswith("-"):
+                surface = arg
+                i += 1
+            case _:
+                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                return 1
+
+    ws = _require_workspace(workspace_path)
+    if ws is None:
+        return 1
+
+    if surface != "all" and surface not in _SURFACES:
+        print(f"Unknown surface: {surface}", file=sys.stderr)
+        print("Valid surfaces: all, packs, loops, personas, profiles, knowledge, jobs", file=sys.stderr)
+        return 1
+
+    print()
+    print("Context Validation")
+    print("------------------")
+
+    surfaces = list(_SURFACES.keys()) if surface == "all" else [surface]
+    all_errors: list[str] = []
+    for name in surfaces:
+        print(_blue(f"Validating {name}/ ..."))
+        errors = _SURFACES[name](ws)
+        if errors:
+            for err in errors:
+                print(f"  {_yellow('✗')}  {err}", file=sys.stderr)
+            all_errors.extend(errors)
+        else:
+            print(f"  {_green('✓')}  {name}/ OK")
+
+    print()
+    if all_errors:
+        print(f"  {_yellow(str(len(all_errors)))} violation(s) found.", file=sys.stderr)
+        return 1
+    print(f"  {_green('All context files valid.')}")
+    print()
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -638,6 +1280,20 @@ def cmd_workspace(args: list[str]) -> int:
             return cmd_context(rest)
         case "sync":
             return cmd_sync(rest)
+        case "use-persona":
+            return cmd_use_persona(rest)
+        case "handoff":
+            return cmd_handoff(rest)
+        case "history":
+            return cmd_history(rest)
+        case "personas":
+            return cmd_personas(rest)
+        case "load":
+            return cmd_load(rest)
+        case "profiles":
+            return cmd_profiles(rest)
+        case "validate":
+            return cmd_validate(rest)
         case _:
             print(f"Unknown workspace subcommand: {sub}", file=sys.stderr)
             print("Run 'agent-toolkit workspace --help' for usage.", file=sys.stderr)

--- a/tests/test_workspace_commands.py
+++ b/tests/test_workspace_commands.py
@@ -1,0 +1,111 @@
+"""Tests for workspace persona, load, and validate commands (#204/#205/#206)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli import workspace as ws
+
+
+def _scaffold_workspace(tmp_path: Path) -> Path:
+    ws.cmd_init(["--dir", str(tmp_path), "--name", "ws"])
+    root = tmp_path / "ws"
+    (root / "packs" / "acme.yaml").write_text(
+        "name: acme\ndescription: Acme client\nnotes: |\n  Key contact: Alice\n",
+        encoding="utf-8",
+    )
+    (root / "profiles").mkdir(exist_ok=True)
+    (root / "profiles" / "oss-contributor.yaml").write_text(
+        "name: oss-contributor\ndescription: OSS mode\npack: acme\npersona: implementer\n",
+        encoding="utf-8",
+    )
+    (root / "templates" / "jobs").mkdir(parents=True, exist_ok=True)
+    (root / "templates" / "jobs" / "code-review.yaml").write_text(
+        "name: code-review\nrequest: Review the code\n",
+        encoding="utf-8",
+    )
+    (root / "knowledge" / "processes").mkdir(exist_ok=True)
+    return root
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = _scaffold_workspace(tmp_path)
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(root))
+    monkeypatch.chdir(root)
+    return root
+
+
+def test_use_persona_and_history(workspace: Path) -> None:
+    assert ws.cmd_use_persona(["implementer"]) == 0
+    assert (workspace / ".active-persona").read_text(encoding="utf-8").strip() == "implementer"
+    assert ws.cmd_use_persona(["reviewer"]) == 0
+    assert ws.cmd_history(["5"]) == 0
+    history = (workspace / ".persona-history").read_text(encoding="utf-8")
+    assert "implementer → reviewer" in history
+
+
+def test_handoff_valid_and_invalid(workspace: Path) -> None:
+    ws.cmd_use_persona(["implementer"])
+    assert ws.cmd_handoff(["reviewer"]) == 0
+    assert (workspace / ".active-persona").read_text(encoding="utf-8").strip() == "reviewer"
+    # researcher is not in reviewer's handoff targets
+    assert ws.cmd_handoff(["researcher"]) == 1
+
+
+def test_personas_list(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert ws.cmd_personas([]) == 0
+    out = capsys.readouterr().out
+    assert "implementer" in out
+    assert "write_files" in out
+
+
+def test_load_pack(workspace: Path) -> None:
+    assert ws.cmd_load(["packs/acme.yaml"]) == 0
+    assert (workspace / ".active-pack").read_text(encoding="utf-8").strip() == "packs/acme.yaml"
+
+
+def test_load_profile(workspace: Path) -> None:
+    assert ws.cmd_load(["--profile", "oss-contributor"]) == 0
+    assert (workspace / ".active-profile").read_text(encoding="utf-8").strip() == "oss-contributor"
+    assert (workspace / ".active-pack").read_text(encoding="utf-8").strip() == "packs/acme.yaml"
+    assert (workspace / ".active-persona").read_text(encoding="utf-8").strip() == "implementer"
+
+
+def test_profiles_list(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert ws.cmd_profiles([]) == 0
+    out = capsys.readouterr().out
+    assert "oss-contributor" in out
+    assert "pack=acme" in out
+
+
+def test_context_includes_persona_constraints(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    ws.cmd_use_persona(["implementer"])
+    ws.cmd_load(["packs/acme.yaml"])
+    assert ws.cmd_context([]) == 0
+    out = capsys.readouterr().out
+    assert "<persona-constraints>" in out
+    assert "persona: implementer" in out
+    assert "Active Pack" in out
+    assert "Key contact: Alice" in out
+
+
+def test_validate_all_passes(workspace: Path) -> None:
+    assert ws.cmd_validate([]) == 0
+
+
+def test_validate_packs_missing_field(workspace: Path) -> None:
+    (workspace / "packs" / "bad.yaml").write_text("name: bad\n", encoding="utf-8")
+    assert ws.cmd_validate(["packs"]) == 1
+
+
+def test_validate_knowledge_missing_dir(workspace: Path) -> None:
+    import shutil
+
+    shutil.rmtree(workspace / "knowledge" / "processes")
+    assert ws.cmd_validate(["knowledge"]) == 1
+
+
+def test_validate_unknown_surface(workspace: Path) -> None:
+    assert ws.cmd_validate(["nope"]) == 1


### PR DESCRIPTION
## Summary

- **#204**: Add persona lifecycle commands (`use-persona`, `handoff`, `history`, `personas`) with `.active-persona` / `.persona-history` state and `<persona-constraints>` output in `workspace context`.
- **#205**: Add `workspace load` for packs and `--profile` for composable profiles, plus `profiles` listing; writes `.active-pack` / `.active-profile`.
- **#206**: Add `workspace validate [surface]` for packs, loops, personas, profiles, knowledge, and jobs with exit code 1 on violations.

Closes #204
Closes #205
Closes #206

## Test plan

- [x] `pytest tests/test_workspace_commands.py` — 11 tests covering persona lifecycle, load/profile, context output, and validate surfaces
- [x] `pytest tests/test_loop_init_workspace.py` — no regressions on workspace root detection