### PR TITLE
feat(project): project init and --ssh clone (#208)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
@@ -5,7 +5,8 @@ Usage:
     agent-toolkit project <subcommand> [args]
 
 Subcommands:
-    clone owner/repo [--workspace PATH]   Clone a GitHub repo and create a symlink
+    init [--workspace PATH]               Create repos/ and projects/ scaffolding
+    clone owner/repo [--ssh] [--workspace PATH]   Clone a GitHub repo and create a symlink
     list [--workspace PATH]               List all symlinked projects
     add <path> [--workspace PATH]         Symlink an already-cloned repo
     remove <name> [--workspace PATH]      Remove symlink (keeps the actual repo)
@@ -133,13 +134,46 @@ def _upsert_project(ws: Path, name: str, path: str, source: str = "") -> None:
 # Subcommands
 # ---------------------------------------------------------------------------
 
+def _gitignore_append(ws: Path, entries: list[str]) -> None:
+    gi = ws / ".gitignore"
+    existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
+    lines = existing.splitlines()
+    changed = False
+    for entry in entries:
+        if entry not in lines:
+            lines.append(entry)
+            changed = True
+    if changed or not gi.exists():
+        text = "\n".join(lines)
+        if text and not text.endswith("\n"):
+            text += "\n"
+        gi.write_text(text, encoding="utf-8")
+
+
+def cmd_init(args: list[str], ws: Path) -> int:
+    """Create repos/ and projects/ scaffolding (#208)."""
+    if args and args[0] in ("--help", "-h"):
+        print("Usage: agent-toolkit project init [--workspace PATH]")
+        print("Creates repos/github.com/ and projects/, updates .gitignore.")
+        return 0
+
+    (ws / "repos" / "github.com").mkdir(parents=True, exist_ok=True)
+    (ws / "projects").mkdir(parents=True, exist_ok=True)
+    _gitignore_append(ws, ["repos/", "projects/"])
+    print(_green("Initialized project directories"))
+    print(f"  {ws / 'repos' / 'github.com'}")
+    print(f"  {ws / 'projects'}")
+    return 0
+
+
 def cmd_clone(args: list[str], ws: Path) -> int:
     """Clone a GitHub repo and create a symlink in projects/."""
     if not args or args[0] in ("--help", "-h"):
-        print("Usage: agent-toolkit project clone owner/repo [--workspace PATH]")
+        print("Usage: agent-toolkit project clone owner/repo [--ssh] [--workspace PATH]")
         return 0
 
     repo_slug = args[0]
+    use_ssh = "--ssh" in args
     if "/" not in repo_slug:
         print(f"Error: expected owner/repo, got: {repo_slug}", file=sys.stderr)
         return 1
@@ -155,8 +189,11 @@ def cmd_clone(args: list[str], ws: Path) -> int:
         print(f"{_yellow('Already cloned:')} {target_dir}")
     else:
         repos_dir.mkdir(parents=True, exist_ok=True)
-        # Prefer `gh repo clone` if available, fall back to git clone HTTPS
-        if shutil.which("gh"):
+        if use_ssh:
+            url = f"git@github.com:{owner}/{repo_name}.git"
+            cmd = ["git", "clone", url, str(target_dir)]
+            verb = "git clone (ssh)"
+        elif shutil.which("gh"):
             cmd = ["gh", "repo", "clone", f"{owner}/{repo_name}", str(target_dir)]
             verb = "gh repo clone"
         else:
@@ -166,7 +203,7 @@ def cmd_clone(args: list[str], ws: Path) -> int:
 
         print(f"Cloning {owner}/{repo_name} via {verb} ...")
         try:
-            result = subprocess.run(cmd, check=True)
+            subprocess.run(cmd, check=True)
         except subprocess.CalledProcessError as exc:
             print(f"Error: clone failed (exit {exc.returncode})", file=sys.stderr)
             return 1
@@ -375,6 +412,8 @@ def cmd_project(args: list[str]) -> int:
         return 1
 
     match sub:
+        case "init":
+            return cmd_init(rest, ws)
         case "clone":
             return cmd_clone(rest, ws)
         case "list":

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/project.py
@@ -156,6 +156,10 @@ def cmd_init(args: list[str], ws: Path) -> int:
         print("Usage: agent-toolkit project init [--workspace PATH]")
         print("Creates repos/github.com/ and projects/, updates .gitignore.")
         return 0
+    if args:
+        print(f"Error: unexpected arguments for project init: {' '.join(args)}", file=sys.stderr)
+        print("Usage: agent-toolkit project init [--workspace PATH]", file=sys.stderr)
+        return 1
 
     (ws / "repos" / "github.com").mkdir(parents=True, exist_ok=True)
     (ws / "projects").mkdir(parents=True, exist_ok=True)

--- a/tests/test_project_init.py
+++ b/tests/test_project_init.py
@@ -73,3 +73,8 @@ def test_project_init_via_router(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 def test_project_init_unknown_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
     assert cmd_project(["nope"]) == 1
+
+
+def test_project_init_rejects_unexpected_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    assert cmd_init(["--workspace"], tmp_path) == 1

--- a/tests/test_project_init.py
+++ b/tests/test_project_init.py
@@ -1,0 +1,75 @@
+"""Tests for agent-toolkit project init (#208)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli.project import cmd_init, cmd_project
+
+
+def test_project_init_creates_dirs_and_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    assert cmd_init([], tmp_path) == 0
+    out = capsys.readouterr().out
+    assert "Initialized project directories" in out
+
+    assert (tmp_path / "repos" / "github.com").is_dir()
+    assert (tmp_path / "projects").is_dir()
+
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert "repos/" in gitignore
+    assert "projects/" in gitignore
+
+
+def test_project_init_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    assert cmd_init([], tmp_path) == 0
+    assert cmd_init([], tmp_path) == 0
+    out = capsys.readouterr().out
+    assert out.count("Initialized project directories") == 2
+
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert gitignore.count("repos/") == 1
+    assert gitignore.count("projects/") == 1
+
+
+def test_project_init_preserves_existing_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    (tmp_path / ".gitignore").write_text("node_modules/\n", encoding="utf-8")
+
+    assert cmd_init([], tmp_path) == 0
+
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "node_modules/"
+    assert "repos/" in lines
+    assert "projects/" in lines
+
+
+def test_project_init_help_exits_0(capsys: pytest.CaptureFixture[str]) -> None:
+    assert cmd_init(["--help"], Path("/tmp")) == 0
+    assert "project init" in capsys.readouterr().out
+
+
+def test_project_init_via_router(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    assert cmd_project(["init", "--workspace", str(tmp_path)]) == 0
+    assert (tmp_path / "repos" / "github.com").is_dir()
+    assert (tmp_path / "projects").is_dir()
+
+
+def test_project_init_unknown_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    assert cmd_project(["nope"]) == 1


### PR DESCRIPTION
## Summary
- `agent-toolkit project init` creates `repos/github.com/` + `projects/` and appends them to `.gitignore` (idempotent)
- `project clone … --ssh` uses `git@github.com:` URLs

Based on #211 (`feat/200-loop-init`) for shared workspace detection.

## Test plan
- [x] `pytest tests/test_project_init.py`

Closes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `project init` to set up the project workspace structure and update `.gitignore`.
  * Added an optional SSH mode for project cloning.
  * Improved loop setup to support custom names, workspace templates, and bundled fallbacks.

* **Bug Fixes**
  * Made workspace detection more reliable across CLI commands by centralizing how the workspace root is found.
  * Improved handling when no valid workspace is available, reducing confusing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->