### PR TITLE
docs: add ecosystem section, CLI reference, and uv install instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,3 +284,92 @@ bash scripts/build-catalog.sh      # Regenerates and checks catalogs
 ```
 
 All three must exit 0.
+
+---
+
+## Ecosystem — Where This Fits
+
+`agent-toolkit` is the **capability distribution layer (L1.5)** in a three-tier personal DX stack:
+
+```
+L1  │ agentic-workstation  │ Machine provisioning (chezmoi, shell, packages, LLM policy)
+    │                      │ https://github.com/ulises-jeremias/agentic-workstation
+────┼──────────────────────┼─────────────────────────────────────────────────────────────
+L1.5│ agent-toolkit        │ THIS REPO — Capability distribution (skills, loops, profiles)
+    │ (this repo)          │ uv tool install agent-toolkit-cli / uvx agent-toolkit-cli
+────┼──────────────────────┼─────────────────────────────────────────────────────────────
+L3  │ agentic-harness      │ AI workspace scaffold for multi-repo orchestration
+    │                      │ https://github.com/ulises-jeremias/agentic-harness
+```
+
+**Integration flow:**
+1. `agentic-workstation` installs `agent-toolkit-cli` automatically during `chezmoi apply`
+2. `agent-toolkit install` deploys profiles to detected AI tools (Claude Code, Cursor, etc.)
+3. `agentic-harness` workspaces call `agent-toolkit loop`, `agent-toolkit memory`, etc.
+
+---
+
+## CLI Reference for Agents
+
+When working in a workspace that has `agent-toolkit` installed, use these commands:
+
+```bash
+# Installation
+uvx agent-toolkit-cli                          # run without installing
+uv tool install agent-toolkit-cli                  # permanent install
+agent-toolkit install [--force]                # deploy profiles to detected AI tools
+agent-toolkit doctor                           # verify installation health
+
+# Skills and inventory
+agent-toolkit inventory                        # list all 52+ skills
+agent-toolkit skills list                      # list with domain breakdown
+agent-toolkit skills validate                  # check SKILL.md compliance
+
+# Knowledge base (from any workspace with knowledge/)
+agent-toolkit memory search "topic"            # find existing knowledge
+agent-toolkit memory add --type learning "..." # save a pattern or discovery
+agent-toolkit memory add --type todo "..."     # track a follow-up
+agent-toolkit memory inject                    # output knowledge for context
+agent-toolkit memory todo                      # review pending items
+
+# Loop engineering (from workspace with loops/ or templates/loops/)
+agent-toolkit loop init <pattern>              # scaffold from template
+agent-toolkit loop run <name>                  # execute one iteration
+agent-toolkit loop status                      # show all loop instances
+agent-toolkit loop audit <name>                # review past runs
+agent-toolkit loop schedule <name>             # install systemd/launchd timer
+agent-toolkit loop templates                   # list available templates
+
+# Workspace management
+agent-toolkit workspace context                # session state snapshot
+agent-toolkit workspace use-persona <name>     # activate a work mode
+agent-toolkit workspace load packs/<n>.yaml    # load client context bundle
+agent-toolkit workspace validate               # validate workspace schemas
+
+# Project / repo management
+agent-toolkit project init                     # create repos/ + projects/ dirs
+agent-toolkit project clone owner/repo [--ssh] # clone + symlink
+agent-toolkit project list                     # list indexed projects
+
+# Background jobs
+agent-toolkit devcompanion queue <project> --request "..." # queue async job
+agent-toolkit devcompanion run-once            # process next job
+agent-toolkit devcompanion status              # show queue state
+
+# MCP providers
+agent-toolkit mcp list                         # available providers
+agent-toolkit mcp setup <provider>             # interactive MCP setup
+agent-toolkit mcp doctor                       # check provider health
+
+# Build and deploy
+agent-toolkit build --check                    # dry-run compilation
+agent-toolkit build --target claude-code       # compile one target
+agent-toolkit diff                             # show changes vs installed bundles
+```
+
+---
+
+## Cross-Repo Links
+
+- **agentic-workstation** → [`AGENTS.md`](https://github.com/ulises-jeremias/agentic-workstation/blob/main/AGENTS.md) | [`docs/AGENT_TOOLKIT.md`](https://github.com/ulises-jeremias/agentic-workstation/blob/main/docs/AGENT_TOOLKIT.md)
+- **agentic-harness** → [`AGENTS.md`](https://github.com/ulises-jeremias/agentic-harness/blob/main/AGENTS.md) | [`docs/ARCHITECTURE.md`](https://github.com/ulises-jeremias/agentic-harness/blob/main/docs/ARCHITECTURE.md)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ uvx --from agent-toolkit-cli agent-toolkit install
 
 # Or install the CLI persistently
 uv tool install agent-toolkit-cli          # preferred over pip when using uv
-# pip install agent-toolkit-cli            # alternative
+# uv tool install agent-toolkit-cli            # alternative
 
 agent-toolkit install    # auto-detects Claude, Cursor, OpenCode, Windsurf, Pi, Copilot
 agent-toolkit doctor     # verify everything is set up
@@ -348,6 +348,22 @@ Browse packs: [`packs/`](packs/)
 | [🔄 How to create a loop](docs/HOW_TO_CREATE_LOOP.md) | Build a recurring agentic workflow |
 | [🌐 OSS Maintenance example](examples/oss-maintenance/) | Full walkthrough of the oss-maintenance pack |
 | [🚀 Project onboarding example](examples/project-onboarding/) | Bootstrap a new project with agent-toolkit |
+
+---
+
+## 🌐 Ecosystem
+
+`agent-toolkit` is the **capability distribution layer (L1.5)** in a three-tier personal DX stack. It's designed to be consumed by two companion repos:
+
+| Layer | Repo | Role |
+|-------|------|------|
+| **L1** | [agentic-workstation](https://github.com/ulises-jeremias/agentic-workstation) | Machine provisioning — chezmoi, shell, packages, LLM policy |
+| **L1.5** | **agent-toolkit** (this repo) | Capability distribution — skills, loops, profiles, MCP |
+| **L3** | [agentic-harness](https://github.com/ulises-jeremias/agentic-harness) | AI workspace scaffold for multi-repo orchestration |
+
+**agentic-workstation** installs `agent-toolkit-cli` automatically during `chezmoi apply` (via AUR on Arch Linux or pip elsewhere). Running `agent-toolkit install` deploys skills and profiles to all detected AI tools.
+
+**agentic-harness** is an opinionated workspace scaffold that uses `agent-toolkit loop`, `agent-toolkit memory`, `agent-toolkit devcompanion`, and `agent-toolkit project` as its primary CLI interface.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -43,7 +43,7 @@ uvx --from agent-toolkit-cli agent-toolkit doctor
 
 ```bash
 uv tool install agent-toolkit-cli    # preferred when using uv
-# pip install agent-toolkit-cli      # alternative
+# uv tool install agent-toolkit-cli      # alternative
 
 agent-toolkit install                # auto-detect all tools
 agent-toolkit doctor                 # verify setup

--- a/profiles/cursor/README.md
+++ b/profiles/cursor/README.md
@@ -27,7 +27,7 @@ skills from agent-toolkit, which wrap `gh copilot` functionality.
 ## Install via agent-toolkit CLI
 
 ```bash
-pip install agent-toolkit-cli      # or: uvx agent-toolkit-cli
+uv tool install agent-toolkit-cli      # or: uvx agent-toolkit-cli
 agent-toolkit install --tools copilot
 # Prompts for your project path and copies copilot-instructions.md
 ```


### PR DESCRIPTION
## Summary

Places `agent-toolkit` clearly within the three-tier personal DX stack and gives AI agents a complete CLI reference.

### Changes

**`AGENTS.md`** — New sections:
- **Ecosystem**: L1 (agentic-workstation) → L1.5 (agent-toolkit) → L3 (agentic-harness) table
- **CLI Reference for Agents**: complete command surface — install, doctor, inventory, memory, loop, workspace, project, devcompanion, mcp, build, diff
- **Cross-Repo Links**: direct links to companion repos' AGENTS.md

**`README.md`** — New section:
- **🌐 Ecosystem**: explains the three-tier model and links to agentic-workstation and agentic-harness

**All docs**: Replace `pip install agent-toolkit-cli` → `uv tool install agent-toolkit-cli`

### Why

AI agents reading this repo's AGENTS.md now understand:
1. What agent-toolkit *is* in the broader ecosystem
2. Which CLI commands they can use when working in any workspace that has the toolkit installed
3. How to reach the companion repos' documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the toolkit’s role within the broader development ecosystem and how related tools integrate.
  * Added a CLI reference covering installation, diagnostics, skills, memory, workspace management, background jobs, integrations, and deployment.
  * Added links to related project documentation.
  * Updated installation instructions to recommend `uv tool install agent-toolkit-cli` as the persistent installation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->