### PR TITLE
fix(compiler): contain references/ copies and provenance-aware plugin check (#37)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/plugin.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/plugin.py
@@ -18,6 +18,7 @@ import shutil
 import sys
 from pathlib import Path
 from agent_toolkit._paths import toolkit_root
+from agent_toolkit.compiler.provenance import verify_generated_digests
 
 import sys as _sys_win
 if _sys_win.platform == "win32":
@@ -156,6 +157,14 @@ def _run_gen_surfaces(toolkit_dir: Path, *, check: bool) -> int:
             ok = _sync_surface(src, dst, toolkit_dir, check=check)
             if not ok:
                 drift = True
+
+        if check:
+            provenance_path = plugin_dir / ".provenance.json"
+            if provenance_path.exists():
+                for msg in verify_generated_digests(plugins_dir, provenance_path):
+                    print(f"  ✗  {msg}")
+                    drift = True
+
         print()
 
     if drift:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/provenance.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/provenance.py
@@ -83,3 +83,54 @@ def write_provenance(
     provenance_path = out_dir / ".provenance.json"
     provenance_path.write_text(manifest.to_json(), encoding="utf-8")
     return provenance_path
+
+
+def load_provenance(path: Path) -> ProvenanceManifest | None:
+    """Load a .provenance.json manifest. Returns None if missing or invalid."""
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    artifacts = [
+        ArtifactRecord(
+            path=item["path"],
+            source_file=item["sourceFile"],
+            source_digest=item["sourceDigest"],
+            generated_digest=item["generatedDigest"],
+        )
+        for item in data.get("artifacts", [])
+    ]
+    return ProvenanceManifest(
+        generator_version=data.get("generatorVersion", "unknown"),
+        product=data.get("product", ""),
+        target=data.get("target", ""),
+        artifacts=artifacts,
+    )
+
+
+def verify_generated_digests(
+    plugins_dir: Path,
+    provenance_path: Path,
+) -> list[str]:
+    """Compare recorded generatedDigest values to current artifact content.
+
+    Artifact paths in the manifest are relative to *plugins_dir* (compiler
+    output root). Returns human-readable drift messages (empty when in sync).
+    """
+    manifest = load_provenance(provenance_path)
+    if manifest is None:
+        return []
+
+    errors: list[str] = []
+    for record in manifest.artifacts:
+        artifact_path = plugins_dir / record.path
+        current = file_digest(artifact_path)
+        if current != record.generated_digest:
+            errors.append(
+                f"provenance digest drift: {record.path} "
+                f"(expected {record.generated_digest}, got {current})"
+            )
+    return errors

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
@@ -5,8 +5,12 @@ import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from agent_toolkit.compiler.model import CanonicalGraph, CompilationResult, Product
+from agent_toolkit.compiler.model import CanonicalGraph, CompilationResult, Product, Skill
 from agent_toolkit.compiler.provenance import ArtifactRecord, file_digest, write_provenance
+
+
+class PathEscapeError(ValueError):
+    """Raised when a path resolves outside its containment root."""
 
 
 class TargetAdapter(ABC):
@@ -107,3 +111,85 @@ class TargetAdapter(ABC):
                     pass
         if removed:
             result.emitted.append(f"stale-cleaned:{removed}")
+
+    def _safe_relpath(self, file: Path, root: Path) -> Path:
+        """Return *file* relative to *root* after resolving symlinks.
+
+        Raises PathEscapeError when the resolved path is not under *root*.
+        """
+        root_resolved = root.resolve()
+        file_resolved = file.resolve()
+        try:
+            return file_resolved.relative_to(root_resolved)
+        except ValueError as exc:
+            raise PathEscapeError(
+                f"Path escapes containment root {root}: {file} -> {file_resolved}"
+            ) from exc
+
+    def _iter_contained_files(
+        self,
+        root: Path,
+        result: CompilationResult,
+        *,
+        label: str = "",
+    ) -> list[Path]:
+        """List files under *root*, skipping entries that escape after symlink resolution."""
+        if not root.is_dir():
+            return []
+
+        root_resolved = root.resolve()
+        prefix = f"{label}: " if label else ""
+        safe: list[Path] = []
+
+        for path in sorted(root.rglob("*")):
+            if path.is_dir():
+                continue
+            try:
+                resolved = path.resolve()
+            except OSError as exc:
+                result.errors.append(f"{prefix}cannot resolve {path}: {exc}")
+                continue
+            if not resolved.is_file():
+                continue
+            try:
+                resolved.relative_to(root_resolved)
+            except ValueError:
+                result.errors.append(
+                    f"{prefix}reference escapes containment root {root}: {path}"
+                )
+                continue
+            safe.append(path)
+
+        return safe
+
+    def _copy_skill_references(
+        self,
+        skill: Skill,
+        dst: Path,
+        result: CompilationResult,
+        *,
+        text_mode: bool = False,
+    ) -> None:
+        """Copy skill ``references/`` into *dst* with path containment checks."""
+        refs_src = skill.source_path.parent / "references"
+        if not refs_src.is_dir():
+            return
+
+        skill_root = skill.source_path.parent
+        label = f"skill:{skill.id}"
+
+        for ref_file in self._iter_contained_files(refs_src, result, label=label):
+            try:
+                rel = self._safe_relpath(ref_file, skill_root)
+            except PathEscapeError as exc:
+                result.errors.append(f"{label}: {exc}")
+                continue
+
+            ref_dst = dst / rel
+            if text_mode:
+                ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
+                self._write_file(ref_dst, ref_content, result, source_file=ref_file)
+            else:
+                ref_dst.parent.mkdir(parents=True, exist_ok=True)
+                ref_dst.write_bytes(ref_file.read_bytes())
+                result.artifacts.append(ref_dst)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
@@ -153,15 +153,7 @@ class ClaudeCodeAdapter(TargetAdapter):
         self._write_file(dst / "SKILL.md", content, result)
 
         # Copy references/ directory if present
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_dst = dst / rel
-                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
-                    ref_dst.write_bytes(ref_file.read_bytes())
-                    result.artifacts.append(ref_dst)
+        self._copy_skill_references(skill, dst, result)
 
         result.emitted.append(f"skill:{skill.id}")
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/codex.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/codex.py
@@ -221,15 +221,7 @@ class CodexAdapter(TargetAdapter):
         self._write_file(dst / "SKILL.md", content, result)
 
         # Progressive disclosure: copy references/
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_dst = dst / rel
-                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
-                    ref_dst.write_bytes(ref_file.read_bytes())
-                    result.artifacts.append(ref_dst)
+        self._copy_skill_references(skill, dst, result)
 
         result.emitted.append(f"skill:{skill.id}")
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/copilot.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/copilot.py
@@ -131,15 +131,7 @@ class CopilotCLIAdapter(TargetAdapter):
         content = skill.source_path.read_text(encoding="utf-8", errors="replace")
         self._write_file(dst / "SKILL.md", content, result)
 
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_dst = dst / rel
-                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
-                    ref_dst.write_bytes(ref_file.read_bytes())
-                    result.artifacts.append(ref_dst)
+        self._copy_skill_references(skill, dst, result)
 
         result.emitted.append(f"skill:{skill.id}")
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/cursor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/cursor.py
@@ -159,15 +159,7 @@ class CursorAdapter(TargetAdapter):
         self._write_file(dst / "SKILL.md", content, result)
 
         # Copy references/ (progressive disclosure)
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_dst = dst / rel
-                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
-                    ref_dst.write_bytes(ref_file.read_bytes())
-                    result.artifacts.append(ref_dst)
+        self._copy_skill_references(skill, dst, result)
 
         result.emitted.append(f"skill:{skill.id}")
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/gemini_cli.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/gemini_cli.py
@@ -163,13 +163,7 @@ class GeminiCLIAdapter(TargetAdapter):
         content = skill.source_path.read_text(encoding="utf-8", errors="replace")
         self._write_file(dst / "SKILL.md", content, result)
 
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
-                    self._write_file(dst / rel, ref_content, result)
+        self._copy_skill_references(skill, dst, result, text_mode=True)
 
         return f"skills/{skill.name}/SKILL.md"
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/opencode.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/opencode.py
@@ -158,15 +158,7 @@ class OpenCodeAdapter(TargetAdapter):
         self._write_file(dst / "SKILL.md", content, result)
 
         # Progressive disclosure: copy references/
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_dst = dst / rel
-                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
-                    ref_dst.write_bytes(ref_file.read_bytes())
-                    result.artifacts.append(ref_dst)
+        self._copy_skill_references(skill, dst, result)
 
         result.emitted.append(f"skill:{skill.id}")
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py
@@ -224,15 +224,7 @@ class PiAdapter(TargetAdapter):
         self._write_file(dst / "SKILL.md", content, result)
 
         # Progressive disclosure: copy references/
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_dst = dst / rel
-                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
-                    ref_dst.write_bytes(ref_file.read_bytes())
-                    result.artifacts.append(ref_dst)
+        self._copy_skill_references(skill, dst, result)
 
         result.emitted.append(f"skill:{skill.id}")
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/windsurf.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/windsurf.py
@@ -196,15 +196,7 @@ class WindsurfAdapter(TargetAdapter):
         self._write_file(dst / "SKILL.md", content, result)
 
         # Progressive disclosure: copy references/
-        refs_src = skill.source_path.parent / "references"
-        if refs_src.is_dir():
-            for ref_file in sorted(refs_src.rglob("*")):
-                if ref_file.is_file():
-                    rel = ref_file.relative_to(skill.source_path.parent)
-                    ref_dst = dst / rel
-                    ref_dst.parent.mkdir(parents=True, exist_ok=True)
-                    ref_dst.write_bytes(ref_file.read_bytes())
-                    result.artifacts.append(ref_dst)
+        self._copy_skill_references(skill, dst, result)
 
         result.emitted.append(f"skill:{skill.id}")
 

--- a/tests/security/test_path_traversal.py
+++ b/tests/security/test_path_traversal.py
@@ -1,11 +1,11 @@
 """Security tests: path traversal prevention in compiler."""
 from pathlib import Path
-import tempfile
 import pytest
 
 pytest.importorskip("yaml")
 
 from agent_toolkit.compiler.loader import load_graph
+from agent_toolkit.compiler.model import CompilationResult, Skill
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
 
 REPO_ROOT = Path(__file__).parent.parent.parent
@@ -40,3 +40,40 @@ def test_no_symlink_escape(graph, tmp_path):
                 target.relative_to(tmp_path)
             except ValueError:
                 pytest.fail(f"Symlink escape: {f} -> {target}")
+
+
+def test_references_symlink_outside_root_fails_compile(tmp_path):
+    """A references/ symlink pointing outside the skill tree must fail closed."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("outside secret", encoding="utf-8")
+
+    skill_dir = tmp_path / "skills" / "evil"
+    skill_dir.mkdir(parents=True)
+    refs = skill_dir / "references"
+    refs.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: evil\ndescription: test\n---\n",
+        encoding="utf-8",
+    )
+    (refs / "escape.md").symlink_to(secret)
+
+    skill = Skill(
+        id="test/evil",
+        name="evil",
+        domain="test",
+        description="test",
+        source_path=skill_dir / "SKILL.md",
+    )
+
+    adapter = ClaudeCodeAdapter(tmp_path / "plugins", tmp_path)
+    out_dir = tmp_path / "plugins" / "test-product"
+    result = CompilationResult(target=adapter.target_id, product="test-product")
+    adapter._emit_skill(skill, out_dir, result)
+
+    assert not result.is_valid
+    assert any("escapes containment" in err for err in result.errors)
+
+    leaked = out_dir / "references" / "escape.md"
+    assert not leaked.exists() or leaked.read_text(encoding="utf-8") != "outside secret"

--- a/tests/test_plugin_provenance_check.py
+++ b/tests/test_plugin_provenance_check.py
@@ -1,0 +1,106 @@
+"""Plugin check verifies .provenance.json digest drift when present."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.cli.plugin import _run_gen_surfaces
+from agent_toolkit.compiler.provenance import (
+    ArtifactRecord,
+    ProvenanceManifest,
+    file_digest,
+)
+
+
+def _write_minimal_toolkit(tmp_path: Path) -> Path:
+    """Minimal toolkit layout with all agent-toolkit-core surfaces in sync."""
+    core_surfaces = [
+        ("agents/code-reviewer", "agents/code-reviewer"),
+        ("skills/core/assistant", "skills/assistant"),
+        ("skills/core/dev-companion", "skills/dev-companion"),
+        ("skills/core/output-handshake", "skills/output-handshake"),
+        ("skills/core/pr-fallback", "skills/pr-fallback"),
+        ("skills/core/workspace-knowledge-sync", "skills/workspace-knowledge-sync"),
+        ("skills/core/onboarding", "skills/onboarding"),
+    ]
+
+    for src_rel, dst_rel in core_surfaces:
+        src = tmp_path / src_rel
+        src.mkdir(parents=True, exist_ok=True)
+        filename = "AGENT.md" if src_rel.startswith("agents/") else "SKILL.md"
+        body = f"# {src_rel}\n"
+        (src / filename).write_text(body, encoding="utf-8")
+
+        dst = tmp_path / "plugins" / "agent-toolkit-core" / dst_rel
+        dst.mkdir(parents=True, exist_ok=True)
+        (dst / filename).write_text(body, encoding="utf-8")
+
+    return tmp_path
+
+
+def test_plugin_check_fails_on_provenance_digest_drift(tmp_path, capsys):
+    """Digest drift on compiler-only artifacts is detected after surface sync passes."""
+    toolkit = _write_minimal_toolkit(tmp_path)
+    plugins_dir = toolkit / "plugins"
+    plugin_dir = plugins_dir / "agent-toolkit-core"
+
+    manifest_path = plugin_dir / ".claude-plugin" / "plugin.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text('{"name": "agent-toolkit-core"}\n', encoding="utf-8")
+    digest = file_digest(manifest_path)
+
+    provenance = ProvenanceManifest(
+        generator_version="1.0.0",
+        product="agent-toolkit-core",
+        target="claude-code",
+        artifacts=[
+            ArtifactRecord(
+                path="agent-toolkit-core/.claude-plugin/plugin.json",
+                source_file="generated",
+                source_digest="n/a",
+                generated_digest=digest,
+            )
+        ],
+    )
+    (plugin_dir / ".provenance.json").write_text(provenance.to_json(), encoding="utf-8")
+
+    manifest_path.write_text('{"name": "agent-toolkit-core", "tampered": true}\n', encoding="utf-8")
+
+    rc = _run_gen_surfaces(toolkit, check=True)
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert "digest drift" in out
+
+
+def test_plugin_check_passes_when_provenance_matches(tmp_path, capsys):
+    toolkit = _write_minimal_toolkit(tmp_path)
+    plugins_dir = toolkit / "plugins"
+    plugin_dir = plugins_dir / "agent-toolkit-core"
+
+    manifest_path = plugin_dir / ".claude-plugin" / "plugin.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text('{"name": "agent-toolkit-core"}\n', encoding="utf-8")
+    digest = file_digest(manifest_path)
+
+    provenance = ProvenanceManifest(
+        generator_version="1.0.0",
+        product="agent-toolkit-core",
+        target="claude-code",
+        artifacts=[
+            ArtifactRecord(
+                path="agent-toolkit-core/.claude-plugin/plugin.json",
+                source_file="generated",
+                source_digest="n/a",
+                generated_digest=digest,
+            )
+        ],
+    )
+    (plugin_dir / ".provenance.json").write_text(provenance.to_json(), encoding="utf-8")
+
+    rc = _run_gen_surfaces(toolkit, check=True)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "digest drift" not in out

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -8,7 +8,8 @@ import tempfile
 import pytest
 
 from agent_toolkit.compiler.provenance import (
-    ArtifactRecord, ProvenanceManifest, file_digest, write_provenance
+    ArtifactRecord, ProvenanceManifest, file_digest, load_provenance,
+    verify_generated_digests, write_provenance,
 )
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -75,3 +76,55 @@ def test_provenance_json_no_timestamps():
     content = manifest.to_json()
     assert "timestamp" not in content.lower()
     assert "date" not in content.lower()
+
+
+def test_load_provenance_round_trip(tmp_path):
+    records = [
+        ArtifactRecord(
+            path="agent-toolkit-core/skills/foo/SKILL.md",
+            source_file="skills/core/foo/SKILL.md",
+            source_digest="abc123",
+            generated_digest="def456",
+        )
+    ]
+    path = write_provenance(tmp_path, "agent-toolkit-core", "cursor", records)
+    loaded = load_provenance(path)
+    assert loaded is not None
+    assert loaded.product == "agent-toolkit-core"
+    assert len(loaded.artifacts) == 1
+    assert loaded.artifacts[0].generated_digest == "def456"
+
+
+def test_verify_generated_digests_detects_drift(tmp_path):
+    plugins_dir = tmp_path / "plugins"
+    bundle = plugins_dir / "agent-toolkit-core" / "skills" / "foo"
+    bundle.mkdir(parents=True)
+    skill_md = bundle / "SKILL.md"
+    skill_md.write_text("original", encoding="utf-8")
+    digest = file_digest(skill_md)
+
+    provenance_path = plugins_dir / "agent-toolkit-core" / ".provenance.json"
+    provenance_path.parent.mkdir(parents=True, exist_ok=True)
+    provenance_path.write_text(
+        ProvenanceManifest(
+            generator_version="1.0.0",
+            product="agent-toolkit-core",
+            target="cursor",
+            artifacts=[
+                ArtifactRecord(
+                    path="agent-toolkit-core/skills/foo/SKILL.md",
+                    source_file="generated",
+                    source_digest="n/a",
+                    generated_digest=digest,
+                )
+            ],
+        ).to_json(),
+        encoding="utf-8",
+    )
+
+    assert verify_generated_digests(plugins_dir, provenance_path) == []
+
+    skill_md.write_text("tampered", encoding="utf-8")
+    drift = verify_generated_digests(plugins_dir, provenance_path)
+    assert len(drift) == 1
+    assert "digest drift" in drift[0]


### PR DESCRIPTION
## Summary

- **COMP-014**: Add shared `_iter_contained_files`, `_safe_relpath`, and `_copy_skill_references` helpers on `TargetAdapter` so all eight target adapters resolve symlinks and fail closed when `references/` entries escape the skill root.
- **COMP-008**: Extend `plugin check` to verify `.provenance.json` `generatedDigest` values (via new `load_provenance` / `verify_generated_digests` helpers) in addition to the existing surface `dircmp` sync check.
- Add security test for symlink escape under `references/` and plugin-check digest drift tests.

Closes #37.

## Test plan

- [x] `pytest tests/security/test_path_traversal.py tests/test_provenance.py tests/test_plugin_provenance_check.py`
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plugin checks now verify provenance digests and report when generated files have changed unexpectedly.
  - Skill reference files are copied safely, preventing links from accessing files outside the skill directory.

- **Bug Fixes**
  - Prevented external files from being unintentionally included in compiled plugin bundles.

- **Tests**
  - Added coverage for provenance validation, digest drift detection, and path-containment protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->