### PR TITLE
docs(skills): retire skill.json from contributor guide (#40)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,26 +76,7 @@ If any script exits non-zero, read the output carefully — it will tell you whi
    ...usage guide...
    ```
 
-5. **Write `skill.json`** with the compatibility matrix:
-
-   ```json
-   {
-     "name": "my-skill-name",
-     "version": "1.0.0",
-     "description": "One-sentence description matching SKILL.md.",
-     "source": "skills/delivery/my-skill-name",
-     "author": "your-github-username",
-     "tags": ["tag1", "tag2"],
-     "compatibility": {
-       "claude-code": true,
-       "cursor": true,
-       "opencode": true,
-       "copilot": false,
-       "windsurf": true,
-       "pi": false
-     }
-   }
-   ```
+5. **Declare tool compatibility** in `SKILL.md` frontmatter (optional `tools:` map). Do **not** add `skill.json` — removed in v1.0.4; see `docs/MIGRATION.md`.
 
 6. **Run validation**:
 
@@ -215,7 +196,8 @@ Before submitting a PR, confirm the following:
 - [ ] `bash scripts/validate-loops.sh` passes with exit 0 (if you added/modified loops)
 - [ ] `bash scripts/build-catalog.sh` was run and catalog changes are included in the commit
 - [ ] `SKILL.md` frontmatter is complete (name, description, author, version, tags, domain)
-- [ ] `skill.json` compatibility matrix is accurate — only mark `true` for tools you have verified
+- [ ] Optional `tools:` frontmatter in `SKILL.md` is accurate — only mark tools you have verified
+- [ ] No deprecated `skill.json` files under `skills/`
 - [ ] No secrets, API keys, or credentials in any file
 - [ ] PR description explains what the skill/loop/profile does and which tools it targets
 - [ ] If this is a new domain, an issue was opened and discussed before work started


### PR DESCRIPTION
## Summary
- Remove the obsolete `skill.json` authoring step from `CONTRIBUTING.md` (DOC-002)
- Point contributors at `SKILL.md` frontmatter + `docs/MIGRATION.md`
- Update the PR checklist accordingly

Part of #40.

## Test plan
- [x] CONTRIBUTING no longer requires writing `skill.json`
- [ ] CI green