### PR TITLE
fix(cli): propagate doctor --fix install exit codes (#34)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
@@ -14,37 +14,17 @@ Exit codes:
     1 — one or more errors detected
 """
 from __future__ import annotations
-from __future__ import annotations
-
 
 import json
-import json
-import os
 import os
 import platform
-import platform
-import shutil
 import shutil
 import subprocess
-import subprocess
-import sys
 import sys
 import urllib.request
-import urllib.request
 from pathlib import Path
-from pathlib import Path
+
 from agent_toolkit._paths import toolkit_root
-from agent_toolkit._paths import toolkit_root
-
-# Windows: force UTF-8 output so emoji chars (✓ ✗ ⚠) don't crash
-if sys.platform == "win32":
-    try:
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
-        sys.stderr.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
-    except Exception:
-        pass
-
-
 
 # Windows: force UTF-8 output so emoji chars (✓ ✗ ⚠) don't crash
 if sys.platform == "win32":
@@ -466,6 +446,7 @@ def cmd_doctor(args: list[str]) -> int:
         print()
 
     # --fix: call install for warnings/errors related to profiles
+    install_rc = 0
     if fix:
         has_profile_issues = any(
             r.category == "profiles" and r.status != CheckResult.STATUS_OK
@@ -476,13 +457,17 @@ def cmd_doctor(args: list[str]) -> int:
                 print("── Auto-fix: running install ──")
             from agent_toolkit.cli.install import cmd_install
             if json_output:
-                import io
                 import contextlib
+                import io
                 # Keep stdout JSON-pure: swallow install chatter.
                 with contextlib.redirect_stdout(io.StringIO()):
-                    cmd_install([])
+                    install_rc = cmd_install([])
             else:
-                cmd_install([])
+                install_rc = cmd_install([])
 
     errors = [r for r in all_results if r.status == CheckResult.STATUS_ERR]
-    return 1 if errors else 0
+    if errors:
+        return 1
+    if install_rc:
+        return install_rc
+    return 0

--- a/tests/test_doctor_fix_rc.py
+++ b/tests/test_doctor_fix_rc.py
@@ -1,0 +1,58 @@
+"""doctor --fix must propagate install return codes (CLI-005 residual)."""
+from __future__ import annotations
+
+from agent_toolkit.cli import doctor as doctor_mod
+
+
+def _stub_minimal_ok(monkeypatch):
+    """Make doctor checks cheap and mostly green except profiles."""
+    ok = doctor_mod.CheckResult("system", "python", doctor_mod.CheckResult.STATUS_OK, "ok")
+    monkeypatch.setattr(doctor_mod, "_check_python_version", lambda: ok)
+    monkeypatch.setattr(
+        doctor_mod, "_check_command", lambda *a, **k: doctor_mod.CheckResult(a[0], a[1], doctor_mod.CheckResult.STATUS_OK, "ok")
+    )
+    monkeypatch.setattr(
+        doctor_mod, "_check_gh_auth",
+        lambda: doctor_mod.CheckResult("system", "gh auth", doctor_mod.CheckResult.STATUS_OK, "ok"),
+    )
+    monkeypatch.setattr(
+        doctor_mod, "_check_ai_tool",
+        lambda *a, **k: doctor_mod.CheckResult("ai_tools", a[0], doctor_mod.CheckResult.STATUS_OK, "ok"),
+    )
+    monkeypatch.setattr(doctor_mod, "_check_loop_runtime", lambda *_a, **_k: [])
+    monkeypatch.setattr(doctor_mod, "_check_llm_providers", lambda: [])
+    monkeypatch.setattr(doctor_mod, "_check_mcp", lambda: [])
+    monkeypatch.setattr(doctor_mod, "_check_scheduled_loops", lambda: [])
+
+
+def test_doctor_fix_propagates_install_failure(monkeypatch):
+    _stub_minimal_ok(monkeypatch)
+    warn = doctor_mod.CheckResult(
+        "profiles", "cursor", doctor_mod.CheckResult.STATUS_WARN, "missing"
+    )
+    monkeypatch.setattr(doctor_mod, "_check_profiles", lambda: [warn])
+
+    called = {"n": 0}
+
+    def fake_install(args):
+        called["n"] += 1
+        return 3
+
+    monkeypatch.setattr("agent_toolkit.cli.install.cmd_install", fake_install)
+
+    assert doctor_mod.cmd_doctor(["--fix"]) == 3
+    assert called["n"] == 1
+
+    called["n"] = 0
+    assert doctor_mod.cmd_doctor(["--json", "--fix"]) == 3
+    assert called["n"] == 1
+
+
+def test_doctor_fix_ok_when_install_succeeds(monkeypatch):
+    _stub_minimal_ok(monkeypatch)
+    warn = doctor_mod.CheckResult(
+        "profiles", "cursor", doctor_mod.CheckResult.STATUS_WARN, "missing"
+    )
+    monkeypatch.setattr(doctor_mod, "_check_profiles", lambda: [warn])
+    monkeypatch.setattr("agent_toolkit.cli.install.cmd_install", lambda args: 0)
+    assert doctor_mod.cmd_doctor(["--fix"]) == 0


### PR DESCRIPTION
## Summary
- Propagate `cmd_install` return code from `doctor --fix` (human and `--json`)
- Deduplicate accidental double-imports / Windows stdout setup in `doctor.py`
- Add regression tests for install RC propagation

Part of #34. Completes the last HIGH residual (CLI-005) on this epic.

## Test plan
- [x] `pytest tests/test_doctor_fix_rc.py tests/test_json_stdout_purity.py tests/test_cli_parse_exit_codes.py`
- [ ] CI green