### PR TITLE
feat(loops): enforce budgets, --pack overrides, gate devcompanion (#42)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/completion.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/completion.py
@@ -35,7 +35,7 @@ INSTALL_FLAGS = ("--tools", "--dry-run", "--force", "--offline", "--help")
 
 UPDATE_FLAGS = ("--tools", "--check", "--pin", "--help")
 
-LOOP_RUN_FLAGS = ("--force", "--quiet", "--help")
+LOOP_RUN_FLAGS = ("--force", "--quiet", "--pack", "--help")
 
 
 def _loop_names() -> list[str]:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py
@@ -140,6 +140,79 @@ def _list_projects() -> list[tuple[str, Path | None]]:
     return result
 
 
+# ── gh gate (reuse loop runner shim) ─────────────────────────────────────────
+
+_MUTATING_DC_TEMPLATES = frozenset({
+    "create-pr",
+    "fix-ci",
+    "refactor",
+    "implement",
+    "investigate",
+})
+
+
+def _gate_script_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "loop" / "loop-gh-gate"
+
+
+def _job_is_mutating(job: dict) -> bool:
+    template = str(job.get("template") or "")
+    if template in _MUTATING_DC_TEMPLATES:
+        return True
+    actions = job.get("actions_allowed") or []
+    return bool(actions) and actions != ["plan_only"]
+
+
+def _install_dc_gate(job: dict, out_dir: Path) -> dict[str, str]:
+    """Install loop-gh-gate PATH shim for devcompanion LLM runners."""
+    from agent_toolkit.loop.gh_gate import install_gh_shim
+
+    gate_script = _gate_script_path()
+    if not gate_script.is_file():
+        raise RuntimeError(f"loop-gh-gate missing at {gate_script} — refusing ungated run")
+
+    gate = job.get("loop_gate") or {}
+    tier = str(gate.get("tier", "L1"))
+    allow = list(gate.get("allowlist") or [])
+    deny = list(gate.get("deny") or [])
+    verifier = str(gate.get("verifier") or "")
+    run_dir = gate.get("run_dir")
+    gate_run_dir = Path(run_dir) if run_dir else out_dir
+
+    env = install_gh_shim(
+        gate_run_dir,
+        tier=tier,
+        allowlist=allow,
+        deny=deny,
+        verifier=verifier,
+        gate_script=gate_script,
+    )
+    _log(
+        f"Hard gate active: gh shim → tier={tier} "
+        f"allow=[{', '.join(allow) or '∅'}]"
+    )
+    return env
+
+
+def _runner_env_for_job(job: dict, out_dir: Path) -> dict[str, str]:
+    """Return subprocess env with gh gate installed; fail closed for mutating jobs."""
+    base = os.environ.copy()
+    try:
+        gate_env = _install_dc_gate(job, out_dir)
+    except RuntimeError as exc:
+        if _job_is_mutating(job):
+            raise RuntimeError(
+                f"mutating devcompanion job requires gh gate: {exc}"
+            ) from exc
+        _warn(f"gh gate not installed ({exc}); proceeding without gate")
+        return base
+    merged = base.copy()
+    for key, value in gate_env.items():
+        if key.startswith("LOOP_GATE_") or key == "PATH":
+            merged[key] = value
+    return merged
+
+
 # ── template loading ──────────────────────────────────────────────────────────
 
 class TemplateNotFoundError(FileNotFoundError):
@@ -321,16 +394,26 @@ def _try_claude_runner(job: dict, out_dir: Path) -> bool:
     )
 
     try:
+        env = _runner_env_for_job(job, out_dir)
+    except RuntimeError as exc:
+        _err(str(exc))
+        return False
+
+    limits = job.get("limits") or {}
+    timeout = int(limits.get("timeout_sec", 1800))
+
+    try:
         result = subprocess.run(
             [claude_bin, "--print", "--allowedTools", "Bash,Read,Write,Edit,Glob,Grep"],
             input=prompt,
             capture_output=True,
             text=True,
             cwd=str(_workspace()),
-            timeout=1800,
+            timeout=timeout,
+            env=env,
         )
     except subprocess.TimeoutExpired:
-        _warn("claude runner timed out (1800s)")
+        _warn(f"claude runner timed out ({timeout}s)")
         return False
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -359,6 +442,16 @@ def _try_opencode_runner(job: dict, out_dir: Path) -> bool:
         f"Write your final report to {out_dir}/report.md and your plan to "
         f"{out_dir}/plan.md. Work from the workspace root shown above."
     )
+
+    try:
+        env = _runner_env_for_job(job, out_dir)
+    except RuntimeError as exc:
+        _err(str(exc))
+        return False
+
+    limits = job.get("limits") or {}
+    timeout = int(limits.get("timeout_sec", 900))
+
     try:
         result = subprocess.run(
             [opencode_bin, "run", "--print-logs"],
@@ -366,10 +459,11 @@ def _try_opencode_runner(job: dict, out_dir: Path) -> bool:
             capture_output=True,
             text=True,
             cwd=str(_workspace()),
-            timeout=900,
+            timeout=timeout,
+            env=env,
         )
     except subprocess.TimeoutExpired:
-        _warn("opencode runner timed out (900s)")
+        _warn(f"opencode runner timed out ({timeout}s)")
         return False
 
     if result.returncode == 0:
@@ -429,6 +523,13 @@ def _dispatch_run(cfg: DCConfig, job_file: Path, job: dict, out_dir: Path, no_ll
     if no_llm:
         _log("--no-llm flag set, using skeleton runner.")
         return _skeleton_run(job, out_dir)
+
+    if _job_is_mutating(job) and not shutil.which("gh"):
+        _err(
+            "Mutating devcompanion job requires `gh` on PATH for loop-gh-gate "
+            f"(template={job.get('template') or 'custom'})"
+        )
+        return 2
 
     if cfg.harness_mode:
         runner, reason = _import_harness_runner()

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/budget.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/budget.py
@@ -1,0 +1,108 @@
+"""Loop budget helpers: wall-clock timeout and token accounting."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_WALL_SECONDS = 900
+
+
+def wall_timeout_seconds(budget: dict[str, Any]) -> int:
+    """Per-run wall-clock limit from loop budget (never bypassed by --force)."""
+    raw = budget.get("max_wall_seconds")
+    if raw is None:
+        return DEFAULT_WALL_SECONDS
+    try:
+        return max(30, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_WALL_SECONDS
+
+
+def max_tokens_limit(budget: dict[str, Any]) -> int | None:
+    """Per-run token ceiling, or None when unset."""
+    raw = budget.get("max_tokens")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def tokens_from_trace(trace_path: Path) -> int:
+    """Sum token_usage / prompt+completion events from a trace.jsonl file."""
+    if not trace_path.is_file():
+        return 0
+    total = 0
+    for line in trace_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        kind = event.get("kind", "")
+        if kind == "token_usage":
+            total += int(event.get("total_tokens") or event.get("total") or 0)
+        elif kind in ("prompt", "completion"):
+            total += int(event.get("prompt_tokens", 0) or 0)
+            total += int(event.get("completion_tokens", 0) or 0)
+    return total
+
+
+def tokens_today(loop_dir: Path) -> int:
+    """Sum tokens recorded in today's run traces under loop_dir/runs/."""
+    runs_dir = loop_dir / "runs"
+    if not runs_dir.is_dir():
+        return 0
+    today = datetime.now(timezone.utc).date()
+    total = 0
+    for run in runs_dir.iterdir():
+        if not run.is_dir():
+            continue
+        trace = run / "trace.jsonl"
+        if not trace.is_file():
+            continue
+        try:
+            first_line = trace.read_text(encoding="utf-8").splitlines()[0]
+            event = json.loads(first_line)
+            ts = event.get("ts", "")
+            if ts:
+                run_day = datetime.fromisoformat(str(ts).replace("Z", "+00:00")).date()
+                if run_day != today:
+                    continue
+        except (IndexError, json.JSONDecodeError, ValueError):
+            pass
+        total += tokens_from_trace(trace)
+    return total
+
+
+def token_budget_exceeded(tokens_used: int, budget: dict[str, Any]) -> bool:
+    limit = max_tokens_limit(budget)
+    if limit is None:
+        return False
+    return tokens_used >= limit
+
+
+def soft_token_precheck(state: dict[str, Any], budget: dict[str, Any]) -> str | None:
+    """Warn when last run tokens suggest the next run may hit max_tokens immediately."""
+    limit = max_tokens_limit(budget)
+    if limit is None:
+        return None
+    last_tokens = state.get("last_run_tokens")
+    if last_tokens is None:
+        return None
+    try:
+        last = int(last_tokens)
+    except (TypeError, ValueError):
+        return None
+    if last >= limit:
+        return (
+            f"Last run used {last:,} tokens (limit {limit:,}). "
+            "Run may exit with budget_exhausted."
+        )
+    return None

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/pack.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/pack.py
@@ -1,0 +1,62 @@
+"""Pack YAML loading and loop override application for `loop run --pack`."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def resolve_pack_path(pack_arg: str | Path, workspace: Path) -> Path | None:
+    """Resolve a pack file path relative to workspace or as absolute."""
+    candidate = Path(pack_arg).expanduser()
+    if candidate.is_absolute():
+        return candidate if candidate.is_file() else None
+    for rel in (str(pack_arg), f"packs/{pack_arg}", f"packs/{pack_arg}.yaml"):
+        path = workspace / rel
+        if path.is_file():
+            return path
+    return None
+
+
+def load_pack(pack_path: Path) -> dict[str, Any]:
+    """Load pack YAML (PyYAML when available, else minimal parser)."""
+    from agent_toolkit.loop.runner import _parse_simple_yaml
+
+    text = pack_path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+
+        loaded = yaml.safe_load(text)
+        return loaded if isinstance(loaded, dict) else {}
+    except ImportError:
+        return _parse_simple_yaml(text)
+
+
+def loop_pack_entry(pack_data: dict[str, Any], loop_name: str) -> dict[str, Any]:
+    """Return the pack config block for a loop name, or empty dict."""
+    loops = pack_data.get("loops")
+    if not isinstance(loops, dict):
+        return {}
+    entry = loops.get(loop_name)
+    return entry if isinstance(entry, dict) else {}
+
+
+def apply_loop_pack_overrides(meta: dict[str, Any], pack_data: dict[str, Any], loop_name: str) -> dict[str, Any]:
+    """Merge pack loop settings (enabled, cadence, budget, tier, …) into loop meta."""
+    entry = loop_pack_entry(pack_data, loop_name)
+    if not entry:
+        return dict(meta)
+
+    merged = dict(meta)
+    for key in ("enabled", "cadence", "tier", "verifier", "goal"):
+        if key in entry and entry[key] is not None:
+            merged[key] = entry[key]
+
+    if "budget" in entry and isinstance(entry["budget"], dict):
+        base_budget = dict(merged.get("budget") or {})
+        base_budget.update(entry["budget"])
+        merged["budget"] = base_budget
+
+    if entry.get("enabled") is False:
+        merged["enabled"] = False
+
+    return merged

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
@@ -12,7 +12,9 @@ Boris Cherny, Peter Steinberger, Addy Osmani — 2026).
 
 Usage:
     loop init <pattern>           Scaffold a loop from a starter template
-    loop run <loop> [--force] [--quiet]  Execute a loop run (--force bypasses budget; --quiet suppresses live output)
+    loop run <loop> [--force] [--quiet] [--pack PATH]
+      Execute a loop run (--force bypasses max_runs_per_day only; --quiet suppresses live output;
+      --pack loads loop overrides from a pack YAML)
     loop status [loop]            Show loop status (all, or one)
     loop audit [loop]             Summarize past runs (success rate, cost)
     loop cost <loop>              Estimate cost for one run
@@ -55,10 +57,13 @@ _PROGRESS_QUIET = False
 class _TraceTailer:
     """Print trace.jsonl events as they are appended during a run."""
 
-    def __init__(self, trace_file: Path) -> None:
+    def __init__(self, trace_file: Path, *, max_tokens: int | None = None) -> None:
         self._trace_file = trace_file
         self._offset = 0
         self._stop = False
+        self._max_tokens = max_tokens
+        self.tokens_used = 0
+        self.budget_exhausted = False
 
     def poll(self) -> None:
         if not self._trace_file.exists():
@@ -86,11 +91,26 @@ class _TraceTailer:
             log(f"repo: {event.get('name', event.get('path', '?'))}")
         elif kind == "token_usage":
             total = event.get("total_tokens") or event.get("total")
+            if total is not None:
+                self.tokens_used = max(self.tokens_used, int(total))
             cost = event.get("cost_usd")
             if cost is not None:
                 log(f"tokens: {total} (~${cost})")
             elif total is not None:
                 log(f"tokens: {total}")
+            if (
+                self._max_tokens is not None
+                and self.tokens_used >= self._max_tokens
+            ):
+                self.budget_exhausted = True
+        elif kind in ("prompt", "completion"):
+            self.tokens_used += int(event.get("prompt_tokens", 0) or 0)
+            self.tokens_used += int(event.get("completion_tokens", 0) or 0)
+            if (
+                self._max_tokens is not None
+                and self.tokens_used >= self._max_tokens
+            ):
+                self.budget_exhausted = True
         elif kind == "progress":
             current = event.get("current")
             total = event.get("total")
@@ -112,6 +132,7 @@ def _run_with_live_output(
     env: dict[str, str],
     trace_file: Path | None = None,
     timeout: int = 900,
+    max_tokens: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run a subprocess, streaming stdout/stderr unless --quiet."""
     if _PROGRESS_QUIET:
@@ -128,7 +149,9 @@ def _run_with_live_output(
     import threading
     import time
 
-    tailer = _TraceTailer(trace_file) if trace_file else None
+    tailer = (
+        _TraceTailer(trace_file, max_tokens=max_tokens) if trace_file else None
+    )
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
@@ -153,6 +176,13 @@ def _run_with_live_output(
         while proc.poll() is None and not _CANCELLED:
             if tailer:
                 tailer.poll()
+                if tailer.budget_exhausted:
+                    warn(
+                        f"Token budget exhausted ({tailer.tokens_used:,} tokens); "
+                        "terminating runner"
+                    )
+                    proc.kill()
+                    break
             time.sleep(0.25)
         if tailer:
             tailer.poll()
@@ -166,6 +196,8 @@ def _run_with_live_output(
     except subprocess.TimeoutExpired:
         proc.kill()
         raise
+    if tailer and tailer.budget_exhausted:
+        raise subprocess.TimeoutExpired(cmd, timeout)
     pump_thread.join(timeout=1)
     tail_thread.join(timeout=1)
     stdout = "".join(lines)
@@ -688,12 +720,17 @@ def _try_claude_runner(
     meta: dict[str, Any] | None = None,
     *,
     trace_file: Path | None = None,
+    wall_timeout: int | None = None,
+    max_tokens: int | None = None,
 ) -> bool:
     """Invoke `claude --print` as a built-in runner for Claude Code users."""
     claude_bin = shutil.which("claude")
     if not claude_bin:
         return False
 
+    from agent_toolkit.loop.budget import DEFAULT_WALL_SECONDS
+
+    timeout = wall_timeout if wall_timeout is not None else DEFAULT_WALL_SECONDS
     env = _install_gate_into_environ(run_dir, meta or {})
     try:
         result = _run_with_live_output(
@@ -703,9 +740,11 @@ def _try_claude_runner(
             cwd=str(workspace_root()),
             env=env,
             trace_file=trace_file or (run_dir / "trace.jsonl"),
+            timeout=timeout,
+            max_tokens=max_tokens,
         )
     except subprocess.TimeoutExpired:
-        warn("claude runner timed out (900s)")
+        warn(f"claude runner hit budget limit (wall={timeout}s or max_tokens)")
         return False
 
     if result.returncode == 0:
@@ -729,12 +768,17 @@ def _try_opencode_runner(
     meta: dict[str, Any] | None = None,
     *,
     trace_file: Path | None = None,
+    wall_timeout: int | None = None,
+    max_tokens: int | None = None,
 ) -> bool:
     """Invoke `opencode run` as a headless runner."""
     opencode_bin = shutil.which("opencode")
     if not opencode_bin:
         return False
 
+    from agent_toolkit.loop.budget import DEFAULT_WALL_SECONDS
+
+    timeout = wall_timeout if wall_timeout is not None else DEFAULT_WALL_SECONDS
     env = _install_gate_into_environ(run_dir, meta or {})
     try:
         result = _run_with_live_output(
@@ -743,9 +787,11 @@ def _try_opencode_runner(
             cwd=str(workspace_root()),
             env=env,
             trace_file=trace_file or (run_dir / "trace.jsonl"),
+            timeout=timeout,
+            max_tokens=max_tokens,
         )
     except subprocess.TimeoutExpired:
-        warn("opencode runner timed out (900s)")
+        warn(f"opencode runner hit budget limit (wall={timeout}s or max_tokens)")
         return False
 
     if result.returncode == 0:
@@ -766,6 +812,8 @@ def _queue_via_devcompanion(
     loop_name: str,
     rid: str,
     meta: dict[str, Any] | None = None,
+    *,
+    wall_timeout: int | None = None,
 ) -> bool:
     """Queue the loop run as a devcompanion job for async processing.
 
@@ -797,7 +845,7 @@ def _queue_via_devcompanion(
         "loop_run_dir": str(run_dir),
         "llm": True,
         "limits": {
-            "timeout_sec": 1800,
+            "timeout_sec": wall_timeout or 1800,
             "max_steps": 25,
         },
         "actions_allowed": ["plan_only"],
@@ -909,24 +957,72 @@ def cmd_init(args: list[str]) -> int:
     return 0
 
 
+def _parse_run_args(args: list[str]) -> tuple[str, bool, bool, Path | None]:
+    """Parse loop run argv into (loop_name, force, quiet, pack_path)."""
+    force = "--force" in args
+    quiet = "--quiet" in args
+    pack_path: Path | None = None
+    positional: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--pack" and i + 1 < len(args):
+            pack_path = Path(args[i + 1]).expanduser()
+            i += 2
+            continue
+        if args[i].startswith("-"):
+            i += 1
+            continue
+        positional.append(args[i])
+        i += 1
+    return positional[0] if positional else "", force, quiet, pack_path
+
+
+def _run_harness_runner_with_timeout(
+    runner_mod: Any,
+    job_file: Path,
+    run_dir: Path,
+    wall_timeout: int,
+) -> None:
+    """Invoke harness runner with a wall-clock timeout."""
+    import threading
+
+    exc_holder: list[BaseException] = []
+
+    def _target() -> None:
+        try:
+            runner_mod.main(["--job", str(job_file), "--out", str(run_dir)])
+        except BaseException as exc:  # noqa: BLE001
+            exc_holder.append(exc)
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join(timeout=wall_timeout)
+    if thread.is_alive():
+        raise subprocess.TimeoutExpired(
+            ["harness-runner", str(job_file)], wall_timeout
+        )
+    if exc_holder:
+        raise exc_holder[0]
+
+
 def cmd_run(args: list[str]) -> int:
     """Execute one loop run.
 
-    Usage: loop run <loop-name> [--force] [--quiet]
-      --force  bypass max_runs_per_day budget gate
+    Usage: loop run <loop-name> [--force] [--quiet] [--pack PATH]
+      --force  bypass max_runs_per_day only (does not bypass max_wall_seconds or max_tokens)
       --quiet  suppress live runner output and trace progress lines
+      --pack   apply loop overrides (enabled, cadence, budget) from pack YAML
     """
     global _PROGRESS_QUIET
 
     if not args:
-        err("Usage: loop run <loop-name> [--force] [--quiet]")
+        err("Usage: loop run <loop-name> [--force] [--quiet] [--pack PATH]")
         return 1
 
-    _PROGRESS_QUIET = "--quiet" in args
-    force = "--force" in args
-    loop_name = next((a for a in args if not a.startswith("-")), "")
+    loop_name, force, quiet, pack_path = _parse_run_args(args)
+    _PROGRESS_QUIET = quiet
     if not loop_name:
-        err("Usage: loop run <loop-name> [--force] [--quiet]")
+        err("Usage: loop run <loop-name> [--force] [--quiet] [--pack PATH]")
         return 1
 
     loop_dir = resolve_loop_dir(loop_name)
@@ -935,9 +1031,40 @@ def cmd_run(args: list[str]) -> int:
         return 1
 
     meta = parse_loop_md(loop_dir)
+
+    if pack_path is not None:
+        from agent_toolkit.loop.pack import (
+            apply_loop_pack_overrides,
+            load_pack,
+            resolve_pack_path,
+        )
+
+        resolved = resolve_pack_path(pack_path, workspace_root())
+        if resolved is None:
+            err(f"Pack not found: {pack_path}")
+            return 1
+        pack_data = load_pack(resolved)
+        meta = apply_loop_pack_overrides(meta, pack_data, loop_name)
+        if meta.get("enabled") is False:
+            warn(f"Loop '{loop_name}' disabled in pack {resolved.name}. Skipping.")
+            return 0
+        log(f"Pack overrides loaded from {resolved}")
+
+    from agent_toolkit.loop.budget import (
+        max_tokens_limit,
+        soft_token_precheck,
+        token_budget_exceeded,
+        tokens_from_trace,
+        wall_timeout_seconds,
+    )
+
     tier = meta.get("tier", "L1")
     budget = meta.get("budget", {})
+    if not isinstance(budget, dict):
+        budget = {}
     max_runs = int(budget.get("max_runs_per_day", 10))
+    wall_timeout = wall_timeout_seconds(budget)
+    token_limit = max_tokens_limit(budget)
 
     # Load current state
     state_md = loop_dir / "STATE.md"
@@ -976,6 +1103,15 @@ def cmd_run(args: list[str]) -> int:
     if force and runs_today >= max_runs:
         warn(f"Budget gate bypassed via --force (runs_today={runs_today}, max={max_runs})")
 
+    precheck_msg = soft_token_precheck(state, budget)
+    if precheck_msg:
+        warn(f"Budget: {precheck_msg}")
+
+    log(
+        f"Budget: max_wall_seconds={wall_timeout}, "
+        f"max_tokens={token_limit if token_limit is not None else 'unset'}"
+    )
+
     # Create run directory
     rid = run_id()
     run_dir = loop_dir / "runs" / rid
@@ -1007,6 +1143,8 @@ def cmd_run(args: list[str]) -> int:
             "verifier": meta.get("verifier"),
             "agents_md_hash": agents_md_hash,
             "force": force,
+            "max_wall_seconds": wall_timeout,
+            "max_tokens": token_limit,
         }) + "\n",
         encoding="utf-8",
     )
@@ -1067,6 +1205,7 @@ def cmd_run(args: list[str]) -> int:
     # Dispatch: agent-toolkit → claude CLI → opencode → devcompanion queue → skeleton
     # Install the hard gate before any runner that can invoke `gh`.
     queued = False
+    budget_exhausted = False
     try:
         if runner_mod is not None:
             _install_gate_into_environ(run_dir, meta)
@@ -1084,17 +1223,39 @@ def cmd_run(args: list[str]) -> int:
                             "verifier": str(meta.get("verifier") or ""),
                             "run_dir": str(run_dir),
                         },
+                        "limits": {"timeout_sec": wall_timeout},
                     }),
                     encoding="utf-8",
                 )
-                runner_mod.main(["--job", str(job_file), "--out", str(run_dir)])
+                _run_harness_runner_with_timeout(
+                    runner_mod, job_file, run_dir, wall_timeout
+                )
+            except subprocess.TimeoutExpired:
+                budget_exhausted = True
+                warn(f"Run exceeded max_wall_seconds ({wall_timeout}s)")
             except Exception as e:
                 err(f"Runner error: {e}")
-        elif _try_claude_runner(prompt, run_dir, meta, trace_file=trace_file):
+        elif _try_claude_runner(
+            prompt,
+            run_dir,
+            meta,
+            trace_file=trace_file,
+            wall_timeout=wall_timeout,
+            max_tokens=token_limit,
+        ):
             pass  # claude runner handled it
-        elif _try_opencode_runner(prompt, run_dir, meta, trace_file=trace_file):
+        elif _try_opencode_runner(
+            prompt,
+            run_dir,
+            meta,
+            trace_file=trace_file,
+            wall_timeout=wall_timeout,
+            max_tokens=token_limit,
+        ):
             pass  # opencode runner handled it
-        elif _queue_via_devcompanion(prompt, run_dir, loop_name, rid, meta):
+        elif _queue_via_devcompanion(
+            prompt, run_dir, loop_name, rid, meta, wall_timeout=wall_timeout
+        ):
             queued = True  # queued for async devcompanion processing
             log("Loop dispatched to devcompanion queue — worker will process asynchronously.")
         else:
@@ -1129,14 +1290,39 @@ def cmd_run(args: list[str]) -> int:
         finalize_run(loop_dir, run_dir, rid, worktree_path, trace_file, "gate_failed")
         return 2
 
+    tokens_used = tokens_from_trace(trace_file)
+    if token_budget_exceeded(tokens_used, budget):
+        budget_exhausted = True
+        warn(
+            f"Run exceeded max_tokens ({token_limit:,}); "
+            f"recorded {tokens_used:,} in trace"
+        )
+
+    if budget_exhausted:
+        trace_file.write_text(
+            trace_file.read_text(encoding="utf-8")
+            + json.dumps({
+                "ts": utc_now(),
+                "kind": "budget_exhausted",
+                "tokens_used": tokens_used,
+                "max_wall_seconds": wall_timeout,
+                "max_tokens": token_limit,
+            }) + "\n",
+            encoding="utf-8",
+        )
+
     # Update state — preserve pending/escalations/notes the agent wrote (or prior)
-    run_status = "queued" if queued else "completed"
+    if budget_exhausted:
+        run_status = "partial (budget_exhausted)"
+    else:
+        run_status = "queued" if queued else "completed"
     post = parse_state_md(loop_dir) if state_md.exists() else {}
     new_state: dict[str, Any] = {
         "last_run": utc_now(),
         "last_run_status": run_status,
         "last_run_id": rid,
         "runs_today": runs_today + 1,
+        "last_run_tokens": tokens_used,
     }
     # Prefer agent-updated lists when present; otherwise keep prior
     for key in ("pending", "escalations", "notes"):
@@ -1179,8 +1365,15 @@ def cmd_run(args: list[str]) -> int:
             capture_output=True,
         )
 
-    finalize_run(loop_dir, run_dir, rid, worktree_path, trace_file, "completed")
-    return 0
+    finalize_run(
+        loop_dir,
+        run_dir,
+        rid,
+        worktree_path,
+        trace_file,
+        "budget_exhausted" if budget_exhausted else "completed",
+    )
+    return 1 if budget_exhausted else 0
 
 
 def finalize_run(

--- a/tests/test_loop_budget_pack.py
+++ b/tests/test_loop_budget_pack.py
@@ -1,0 +1,253 @@
+"""Tests for loop budget enforcement, --pack overrides, and devcompanion gh-gate (#42)."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.loop import budget, pack, runner
+from agent_toolkit.loop.pack import apply_loop_pack_overrides, load_pack
+
+
+def test_parse_run_args_with_pack() -> None:
+    name, force, quiet, pack_path = runner._parse_run_args(
+        ["oss-daily-briefing", "--pack", "/tmp/pack.yaml", "--force", "--quiet"]
+    )
+    assert name == "oss-daily-briefing"
+    assert force is True
+    assert quiet is True
+    assert pack_path == Path("/tmp/pack.yaml")
+
+
+def test_apply_pack_overrides_budget_and_cadence() -> None:
+    meta = {"tier": "L1", "cadence": "1d", "budget": {"max_tokens": 80000, "max_wall_seconds": 900}}
+    pack_data = {
+        "loops": {
+            "oss-daily-briefing": {
+                "enabled": True,
+                "cadence": "12h",
+                "budget": {"max_tokens": 120000, "max_wall_seconds": 600},
+            }
+        }
+    }
+    merged = apply_loop_pack_overrides(meta, pack_data, "oss-daily-briefing")
+    assert merged["cadence"] == "12h"
+    assert merged["budget"]["max_tokens"] == 120000
+    assert merged["budget"]["max_wall_seconds"] == 600
+    assert merged["tier"] == "L1"
+
+
+def test_pack_disabled_loop_skips(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    loop_dir = tmp_path / "loops" / "demo-loop"
+    loop_dir.mkdir(parents=True)
+    (loop_dir / "LOOP.md").write_text(
+        "---\nname: demo-loop\ntier: L1\ncadence: 1d\nbudget:\n  max_runs_per_day: 10\n---\n",
+        encoding="utf-8",
+    )
+    (loop_dir / "STATE.md").write_text(
+        "---\nlast_run: never\nruns_today: 0\n---\n",
+        encoding="utf-8",
+    )
+
+    pack_file = tmp_path / "packs" / "demo.yaml"
+    pack_file.parent.mkdir(parents=True)
+    pack_file.write_text(
+        "pack: demo\nloops:\n  demo-loop:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+
+    rc = runner.cmd_run(["demo-loop", "--pack", str(pack_file)])
+    assert rc == 0
+    assert not any((loop_dir / "runs").iterdir()) if (loop_dir / "runs").exists() else True
+
+
+def test_wall_timeout_enforced_on_subprocess(tmp_path: Path) -> None:
+    trace = tmp_path / "trace.jsonl"
+    trace.write_text("", encoding="utf-8")
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner._run_with_live_output(
+            ["sleep", "5"],
+            input_text="",
+            cwd=str(tmp_path),
+            env={"PATH": "/usr/bin:/bin", **dict(__import__("os").environ)},
+            trace_file=trace,
+            timeout=1,
+        )
+
+
+def test_token_trace_tailer_triggers_budget_exhausted() -> None:
+    trace = Path("/tmp/loop-budget-trace-test.jsonl")
+    trace.write_text(
+        json.dumps({"kind": "token_usage", "total_tokens": 50000}) + "\n",
+        encoding="utf-8",
+    )
+    tailer = runner._TraceTailer(trace, max_tokens=40000)
+    tailer.poll()
+    assert tailer.budget_exhausted is True
+    assert tailer.tokens_used >= 40000
+
+
+def test_tokens_from_trace_and_budget_check() -> None:
+    trace = Path("/tmp/loop-budget-sum-test.jsonl")
+    trace.write_text(
+        json.dumps({"kind": "prompt", "prompt_tokens": 1000, "completion_tokens": 0}) + "\n"
+        + json.dumps({"kind": "completion", "prompt_tokens": 0, "completion_tokens": 500}) + "\n",
+        encoding="utf-8",
+    )
+    assert budget.tokens_from_trace(trace) == 1500
+    assert budget.token_budget_exceeded(1500, {"max_tokens": 1500})
+    assert not budget.token_budget_exceeded(1499, {"max_tokens": 1500})
+
+
+def test_cmd_run_records_pack_budget_in_trace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(runner, "_try_claude_runner", lambda *a, **k: False)
+    monkeypatch.setattr(runner, "_try_opencode_runner", lambda *a, **k: False)
+    monkeypatch.setattr(runner, "_queue_via_devcompanion", lambda *a, **k: False)
+
+    loop_dir = tmp_path / "loops" / "budget-loop"
+    loop_dir.mkdir(parents=True)
+    (loop_dir / "LOOP.md").write_text(
+        "---\nname: budget-loop\ntier: L1\ncadence: 1d\n"
+        "budget:\n  max_runs_per_day: 5\n  max_wall_seconds: 120\n  max_tokens: 25000\n---\n",
+        encoding="utf-8",
+    )
+    (loop_dir / "STATE.md").write_text("---\nlast_run: never\nruns_today: 0\n---\n", encoding="utf-8")
+
+    pack_file = tmp_path / "packs" / "override.yaml"
+    pack_file.parent.mkdir(parents=True)
+    pack_file.write_text(
+        "pack: override\nloops:\n  budget-loop:\n    budget:\n      max_wall_seconds: 45\n      max_tokens: 10000\n",
+        encoding="utf-8",
+    )
+
+    rc = runner.cmd_run(["budget-loop", "--pack", str(pack_file)])
+    assert rc == 0
+
+    runs = list((loop_dir / "runs").iterdir())
+    assert len(runs) == 1
+    trace_lines = (runs[0] / "trace.jsonl").read_text(encoding="utf-8").splitlines()
+    start = json.loads(trace_lines[0])
+    assert start["max_wall_seconds"] == 45
+    assert start["max_tokens"] == 10000
+
+
+def test_load_pack_from_yaml_file(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("pack: test\nloops:\n  foo:\n    enabled: true\n", encoding="utf-8")
+    data = load_pack(path)
+    assert data["pack"] == "test"
+    assert pack.loop_pack_entry(data, "foo")["enabled"] is True
+
+
+def test_devcompanion_claude_runner_installs_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent_toolkit.cli import devcompanion
+
+    out_dir = tmp_path / "artifacts" / "job-1"
+    job = {"id": "job-1", "request": "review code", "repo_path": str(tmp_path)}
+
+    installed: list[dict] = []
+
+    def fake_install(run_dir: Path, **kwargs: object) -> dict[str, str]:
+        installed.append({"run_dir": str(run_dir), **kwargs})
+        return {
+            "PATH": f"{run_dir}/.gate/bin:/usr/bin",
+            "LOOP_GATE_TIER": str(kwargs.get("tier", "L1")),
+        }
+
+    monkeypatch.setattr("agent_toolkit.loop.gh_gate.install_gh_shim", fake_install)
+
+    def fake_which(name: str) -> str | None:
+        if name == "claude":
+            return "/usr/bin/claude"
+        if name == "gh":
+            return "/usr/bin/gh"
+        return None
+
+    monkeypatch.setattr("shutil.which", fake_which)
+
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        env = kwargs.get("env")
+        if isinstance(env, dict):
+            captured.update(env)
+        return subprocess.CompletedProcess(cmd, 0, "# plan", "")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert devcompanion._try_claude_runner(job, out_dir) is True
+    assert installed
+    assert captured.get("LOOP_GATE_TIER") == "L1"
+    assert ".gate/bin" in captured.get("PATH", "")
+
+
+def test_devcompanion_mutating_job_refuses_without_gh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent_toolkit.cli import devcompanion
+    from agent_toolkit.cli.devcompanion_queue import get_dc_config
+
+    dc_home = tmp_path / "dc"
+    monkeypatch.setenv("HARNESS_DC_HOME", str(dc_home))
+    monkeypatch.setenv("AGENT_TOOLKIT_WORKSPACE", str(tmp_path))
+
+    cfg = get_dc_config(tmp_path)
+    job = {
+        "id": "mut-1",
+        "template": "create-pr",
+        "request": "open a draft PR",
+        "repo_path": str(tmp_path),
+        "actions_allowed": ["plan_only"],
+    }
+    out_dir = cfg.runs_dir / "mut-1"
+
+    def fake_which(name: str) -> str | None:
+        if name == "claude":
+            return "/usr/bin/claude"
+        return None
+
+    monkeypatch.setattr("shutil.which", fake_which)
+
+    rc = devcompanion._dispatch_run(cfg, Path("mut-1.job"), job, out_dir, no_llm=False)
+    assert rc == 2
+
+
+def test_devcompanion_mutating_job_requires_gate_when_gh_missing_on_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from agent_toolkit.cli import devcompanion
+
+    out_dir = tmp_path / "out"
+    job = {
+        "id": "mut-2",
+        "template": "fix-ci",
+        "request": "fix CI",
+        "actions_allowed": ["write", "push"],
+    }
+
+    def fake_which(name: str) -> str | None:
+        if name == "claude":
+            return "/usr/bin/claude"
+        if name == "gh":
+            return "/usr/bin/gh"
+        return None
+
+    monkeypatch.setattr("shutil.which", fake_which)
+
+    def fail_install(*_a: object, **_k: object) -> dict[str, str]:
+        raise RuntimeError("real `gh` binary not found on PATH")
+
+    monkeypatch.setattr("agent_toolkit.loop.gh_gate.install_gh_shim", fail_install)
+
+    assert devcompanion._try_claude_runner(job, out_dir) is False


### PR DESCRIPTION
## Summary

- **LOOP-001 budgets**: Enforce `max_wall_seconds` via subprocess/harness timeouts and `max_tokens` via trace polling plus post-run accounting; `--force` bypasses `max_runs_per_day` only (documented).
- **LOOP-006 `--pack`**: `loop run <name> --pack <yaml>` loads pack loop overrides (enabled, cadence, budget) mirroring `packs/oss-maintenance/config.yaml`.
- **LOOP-008 devcompanion gate**: Claude/opencode runners install `loop-gh-gate`; mutating templates refuse when `gh` or gate install is unavailable.
- **Tests**: Pack overrides, wall/token budget helpers, trace budget fields, and devcompanion gate install/refusal paths.

Part of #42.

## Test plan

- [x] `pytest tests/test_loop_budget_pack.py -v`
- [x] `pytest tests/test_loop_progress.py tests/test_loop_tier_gate.py tests/test_devcompanion_queue.py -v`
- [ ] Manual: `agent-toolkit loop run <loop> --pack packs/oss-maintenance/config.yaml`
- [ ] Manual: devcompanion mutating job with/without `gh` on PATH