### PR TITLE
fix(hooks): package capabilities, real validate hook, bundle-relative emit (#38)

### DIFF
--- a/capabilities/hooks/scripts/pre-commit-validate.sh
+++ b/capabilities/hooks/scripts/pre-commit-validate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Minimal pre-write validation hook for agent-toolkit.
+# Pre-write validation hook for agent-toolkit.
 # Reads the candidate path from AGENT_TOOLKIT_HOOK_PATH when set.
 set -euo pipefail
 path="${AGENT_TOOLKIT_HOOK_PATH:-${1:-}}"
@@ -11,9 +11,31 @@ if [[ ! -f "$path" ]]; then
   echo "pre-commit-validate: skip missing file $path" >&2
   exit 0
 fi
+
+# Reject unresolved merge conflict markers.
+if grep -qE '^(<<<<<<<|=======|>>>>>>>)' "$path"; then
+  echo "pre-commit-validate: merge conflict markers in $path" >&2
+  exit 1
+fi
+
 # Reject obvious secret material in staged content (best-effort).
 if grep -Eiq 'ghp_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|BEGIN (RSA |OPENSSH )?PRIVATE KEY' "$path"; then
   echo "pre-commit-validate: refusing write — secret-like material detected in $path" >&2
   exit 1
 fi
+
+# Basic skill frontmatter when writing SKILL.md files.
+case "$path" in
+  */SKILL.md|SKILL.md)
+    if ! head -n 30 "$path" | grep -q '^---$'; then
+      echo "pre-commit-validate: SKILL.md missing YAML frontmatter delimiters in $path" >&2
+      exit 1
+    fi
+    if ! head -n 30 "$path" | grep -qE '^name:'; then
+      echo "pre-commit-validate: SKILL.md frontmatter missing name in $path" >&2
+      exit 1
+    fi
+    ;;
+esac
+
 exit 0

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/registry_emit.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/registry_emit.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from agent_toolkit.compiler.hook_registry import HookDefinition, load_hooks
 from agent_toolkit.compiler.mcp_registry import McpProvider, load_registry
 
+_BUNDLE_SCRIPTS_PREFIX = "hooks/scripts"
+
 # Canonical event → Claude Code hook event name
 _CLAUDE_HOOK_EVENTS: dict[str, str] = {
     "session.start": "SessionStart",
@@ -67,10 +69,50 @@ def resolve_mcp_ids(
     ]
 
 
+def hook_script_basename(command: list[str]) -> str | None:
+    """Return the script filename from a command handler, if present."""
+    if len(command) < 2:
+        return None
+    script = command[-1]
+    if script.endswith((".sh", ".py", ".bash")):
+        return Path(script).name
+    return None
+
+
+def hook_script_source(command: list[str], repo_root: Path) -> Path | None:
+    """Resolve the repo-relative script path referenced by a hook command."""
+    if len(command) < 2:
+        return None
+    script = Path(command[-1])
+    if script.is_absolute():
+        return script if script.is_file() else None
+    candidate = repo_root / script
+    return candidate if candidate.is_file() else None
+
+
+def rewrite_hook_command_for_bundle(
+    command: list[str],
+    *,
+    bundle_scripts_prefix: str = _BUNDLE_SCRIPTS_PREFIX,
+) -> list[str]:
+    """Rewrite repo-relative script paths to plugin-bundle-relative paths."""
+    if len(command) < 2:
+        return command
+    script = command[-1]
+    if script.startswith("/") or "://" in script:
+        return command
+    if "/" not in script and not script.endswith((".sh", ".py", ".bash")):
+        return command
+    name = Path(script).name
+    return [*command[:-1], f"{bundle_scripts_prefix}/{name}"]
+
+
 def emit_claude_hooks_json(
     hook_ids: list[str],
     hooks_dir: Path,
     target_id: str = "claude-code",
+    *,
+    bundle_relative: bool = False,
 ) -> dict | None:
     """Build Claude Code hooks/hooks.json content from canonical hook IDs."""
     registry = _hooks_dict(hooks_dir)
@@ -83,9 +125,14 @@ def emit_claude_hooks_json(
         event_name = _CLAUDE_HOOK_EVENTS.get(hook.event, hook.event)
         if hook.handler_type != "command" or not hook.command:
             continue
+        command = (
+            rewrite_hook_command_for_bundle(hook.command)
+            if bundle_relative
+            else hook.command
+        )
         entry = {
             "type": "command",
-            "command": " ".join(hook.command),
+            "command": " ".join(command),
             "timeout": hook.timeout_ms,
         }
         hooks_block.setdefault(event_name, []).append(entry)
@@ -126,8 +173,19 @@ def emit_claude_mcp_json(
     return {"mcpServers": servers}
 
 
-def hooks_json_text(hook_ids: list[str], hooks_dir: Path, target_id: str = "claude-code") -> str | None:
-    payload = emit_claude_hooks_json(hook_ids, hooks_dir, target_id)
+def hooks_json_text(
+    hook_ids: list[str],
+    hooks_dir: Path,
+    target_id: str = "claude-code",
+    *,
+    bundle_relative: bool = False,
+) -> str | None:
+    payload = emit_claude_hooks_json(
+        hook_ids,
+        hooks_dir,
+        target_id,
+        bundle_relative=bundle_relative,
+    )
     if payload is None:
         return None
     return json.dumps(payload, indent=2) + "\n"

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/claude_code.py
@@ -87,7 +87,13 @@ class ClaudeCodeAdapter(TargetAdapter):
             hooks_dir=hooks_dir,
             emit_registries=emit_registries,
         )
-        hooks_text = hooks_json_text(hook_ids, hooks_dir, self.target_id)
+        self._emit_hook_scripts(hook_ids, hooks_dir, out_dir, result)
+        hooks_text = hooks_json_text(
+            hook_ids,
+            hooks_dir,
+            self.target_id,
+            bundle_relative=True,
+        )
         if hooks_text:
             self._write_file(out_dir / "hooks" / "hooks.json", hooks_text, result)
             result.emitted.append("hooks")
@@ -178,6 +184,45 @@ class ClaudeCodeAdapter(TargetAdapter):
         content = agent.source_path.read_text(encoding="utf-8", errors="replace")
         self._write_file(dst / "AGENT.md", content, result)
         result.emitted.append(f"agent:{agent.id}")
+
+    def _emit_hook_scripts(
+        self,
+        hook_ids: list[str],
+        hooks_dir: Path,
+        out_dir: Path,
+        result: CompilationResult,
+    ) -> None:
+        """Copy hook handler scripts into the plugin bundle for bundle-relative commands."""
+        from agent_toolkit.compiler.hook_registry import load_hooks
+        from agent_toolkit.compiler.registry_emit import (
+            hook_script_basename,
+            hook_script_source,
+        )
+
+        registry, _errors = load_hooks(hooks_dir)
+        scripts_dir = out_dir / "hooks" / "scripts"
+        copied: set[str] = set()
+
+        for hook_id in hook_ids:
+            hook = registry.get(hook_id)
+            if hook is None or hook.handler_type != "command" or not hook.command:
+                continue
+            script_name = hook_script_basename(hook.command)
+            if script_name is None or script_name in copied:
+                continue
+            src = hook_script_source(hook.command, self.repo_root)
+            if src is None:
+                result.warnings.append(
+                    f"Hook '{hook_id}' script not found: {hook.command[-1]}"
+                )
+                continue
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            dst = scripts_dir / script_name
+            dst.write_bytes(src.read_bytes())
+            dst.chmod(dst.stat().st_mode | 0o111)
+            result.artifacts.append(dst)
+            copied.add(script_name)
+            result.emitted.append(f"hook-script:{script_name}")
 
     @staticmethod
     def validate_settings(settings: dict) -> list[str]:

--- a/scripts/prepare-package-data.sh
+++ b/scripts/prepare-package-data.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/packages/agent-toolkit-cli/src/agent_toolkit/data"
 mkdir -p "$DEST"
-for name in skills agents loops profiles mcp catalogs distributions packs; do
+for name in skills agents loops profiles mcp catalogs distributions packs capabilities; do
   rm -rf "$DEST/$name"
   cp -a "$ROOT/$name" "$DEST/$name"
 done

--- a/tests/compiler/test_registry_emission.py
+++ b/tests/compiler/test_registry_emission.py
@@ -14,6 +14,7 @@ from agent_toolkit.compiler.registry_emit import (
     emit_claude_mcp_json,
     resolve_hook_ids,
     resolve_mcp_ids,
+    rewrite_hook_command_for_bundle,
 )
 from agent_toolkit.compiler.targets.claude_code import ClaudeCodeAdapter
 
@@ -58,6 +59,24 @@ def test_emit_claude_hooks_json():
     assert "session-start-context" in payload["hooks"]["SessionStart"][0]["command"]
 
 
+def test_emit_claude_hooks_json_bundle_relative():
+    payload = emit_claude_hooks_json(
+        ["session-start-context"],
+        HOOKS_DIR,
+        bundle_relative=True,
+    )
+    assert payload is not None
+    command = payload["hooks"]["SessionStart"][0]["command"]
+    assert command.startswith("bash hooks/scripts/")
+    assert "capabilities/" not in command
+
+
+def test_rewrite_hook_command_for_bundle():
+    canonical = ["bash", "capabilities/hooks/scripts/session-start-context.sh"]
+    rewritten = rewrite_hook_command_for_bundle(canonical)
+    assert rewritten == ["bash", "hooks/scripts/session-start-context.sh"]
+
+
 def test_emit_claude_mcp_json():
     payload = emit_claude_mcp_json(["github"], MCP_DIR)
     assert payload is not None
@@ -79,6 +98,13 @@ def test_adapter_emits_hooks_and_mcp(adapter, graph):
     mcp = json.loads((out / ".mcp.json").read_text())
     assert "SessionStart" in hooks["hooks"]
     assert "github" in mcp["mcpServers"]
+
+    command = hooks["hooks"]["SessionStart"][0]["command"]
+    assert command.startswith("bash hooks/scripts/")
+    assert "capabilities/" not in command
+    script = out / "hooks" / "scripts" / "session-start-context.sh"
+    assert script.is_file()
+    assert script.stat().st_mode & 0o111
 
 
 def test_agents_product_without_hooks_mcp(adapter, graph):

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -160,6 +160,26 @@ def test_no_echo_stub_handlers():
             )
 
 
+def test_hook_handler_scripts_are_not_placeholders():
+    """Hook script files must not contain stub/placeholder handlers."""
+    hooks, _errs = load_hooks(HOOKS_DIR)
+    for hook in hooks.values():
+        if hook.handler_type != "command" or len(hook.command) < 2:
+            continue
+        script = Path(hook.command[-1])
+        if not script.is_absolute():
+            script = REPO_ROOT / script
+        if not script.is_file():
+            continue
+        content = script.read_text(encoding="utf-8").lower()
+        assert "validation hook placeholder" not in content, (
+            f"Hook script for '{hook.id}' is still a placeholder: {script}"
+        )
+        assert 'echo "placeholder' not in content, (
+            f"Hook script for '{hook.id}' uses echo placeholder: {script}"
+        )
+
+
 def test_no_placeholder_handlers_in_default_enabled_hooks():
     """Production hooks (default_enabled) must not use stub/placeholder commands."""
     hooks, _errs = load_hooks(HOOKS_DIR)

--- a/tests/test_prepare_package_data.py
+++ b/tests/test_prepare_package_data.py
@@ -1,0 +1,31 @@
+"""Tests for scripts/prepare-package-data.sh — pip wheel must ship hook registry."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "prepare-package-data.sh"
+DATA_DEST = (
+    REPO_ROOT
+    / "packages"
+    / "agent-toolkit-cli"
+    / "src"
+    / "agent_toolkit"
+    / "data"
+)
+
+
+def test_prepare_package_data_script_lists_capabilities():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "capabilities" in text
+
+
+def test_prepare_package_data_copies_capabilities(tmp_path, monkeypatch):
+    """Running the script must copy capabilities/hooks for pip-installed CLI."""
+    dest = tmp_path / "data"
+    monkeypatch.setenv("DEST_OVERRIDE", str(dest))
+    # Run with a patched DEST via subshell — script uses fixed DEST; invoke inline copy check instead.
+    subprocess.run(["bash", str(SCRIPT)], check=True, cwd=REPO_ROOT)
+    assert (DATA_DEST / "capabilities" / "hooks").is_dir()
+    assert list((DATA_DEST / "capabilities" / "hooks").glob("*.yaml"))


### PR DESCRIPTION
## Summary

Closes gaps from epic #38 (hooks packaging):

- **HOOK-005**: `prepare-package-data.sh` now copies `capabilities/` into the pip wheel data tree so installed CLI can load the hook registry.
- **HOOK-001**: `pre-commit-validate.sh` performs real checks (merge conflict markers, secret patterns, SKILL.md frontmatter) instead of a blocking placeholder.
- **HOOK-003**: Claude Code adapter copies hook scripts into plugin bundles and emits `hooks.json` commands with bundle-relative paths (`hooks/scripts/...`).

## Test plan

- [x] `pytest tests/test_prepare_package_data.py` — capabilities copied into package data
- [x] `pytest tests/compiler/test_registry_emission.py` — bundle-relative hook emit + script copy
- [x] `pytest tests/test_hook_registry.py` — no placeholder handlers in commands or scripts
- [x] `pytest tests/compiler/test_claude_code_adapter.py`