### PR TITLE
feat(loop): add Cursor Agent CLI runner for loop run (#223)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
@@ -806,6 +806,76 @@ def _try_opencode_runner(
     return False
 
 
+def _resolve_cursor_cli_bin() -> str | None:
+    """Locate Cursor Agent CLI (`cursor-agent`, then `agent`, then `cursor`)."""
+    for name in ("cursor-agent", "agent", "cursor"):
+        found = shutil.which(name)
+        if found:
+            return found
+    return None
+
+
+def _try_cursor_runner(
+    prompt: str,
+    run_dir: Path,
+    meta: dict[str, Any] | None = None,
+    *,
+    trace_file: Path | None = None,
+    wall_timeout: int | None = None,
+    max_tokens: int | None = None,
+) -> bool:
+    """Invoke Cursor Agent CLI headless (`--print`) as a loop runner (#223).
+
+    Official headless form: ``agent -p --force --trust`` (also shipped as
+    ``cursor-agent``). See https://cursor.com/docs/cli/headless
+    """
+    cursor_bin = _resolve_cursor_cli_bin()
+    if not cursor_bin:
+        return False
+
+    from agent_toolkit.loop.budget import DEFAULT_WALL_SECONDS
+
+    timeout = wall_timeout if wall_timeout is not None else DEFAULT_WALL_SECONDS
+    env = _install_gate_into_environ(run_dir, meta or {})
+    # Prompt as CLI arg (print mode); --force applies edits; --trust skips
+    # workspace trust prompts in headless environments.
+    cmd = [
+        cursor_bin,
+        "--print",
+        "--force",
+        "--trust",
+        "--output-format",
+        "text",
+        prompt,
+    ]
+    try:
+        result = _run_with_live_output(
+            cmd,
+            input_text="",
+            cwd=str(workspace_root()),
+            env=env,
+            trace_file=trace_file or (run_dir / "trace.jsonl"),
+            timeout=timeout,
+            max_tokens=max_tokens,
+        )
+    except subprocess.TimeoutExpired:
+        warn(f"cursor runner hit budget limit (wall={timeout}s or max_tokens)")
+        return False
+
+    if result.returncode == 0:
+        report_md = run_dir / "report.md"
+        if not report_md.exists() and result.stdout.strip():
+            report_md.write_text(result.stdout, encoding="utf-8")
+        ok("cursor runner completed")
+        return True
+
+    error_output = (result.stderr + result.stdout).strip()[:400]
+    warn(f"cursor runner exited {result.returncode}: {error_output or '(no output)'}")
+    if result.returncode != 0 and not error_output:
+        warn("  Hint: Cursor Agent CLI may not be authenticated — run: agent login")
+    return False
+
+
 def _queue_via_devcompanion(
     request: str,
     run_dir: Path,
@@ -1253,6 +1323,15 @@ def cmd_run(args: list[str]) -> int:
             max_tokens=token_limit,
         ):
             pass  # opencode runner handled it
+        elif _try_cursor_runner(
+            prompt,
+            run_dir,
+            meta,
+            trace_file=trace_file,
+            wall_timeout=wall_timeout,
+            max_tokens=token_limit,
+        ):
+            pass  # cursor agent CLI handled it
         elif _queue_via_devcompanion(
             prompt, run_dir, loop_name, rid, meta, wall_timeout=wall_timeout
         ):

--- a/tests/test_cursor_runner.py
+++ b/tests/test_cursor_runner.py
@@ -1,0 +1,82 @@
+"""Tests for Cursor Agent CLI loop runner (#223)."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent_toolkit.loop import runner
+
+
+def test_resolve_cursor_cli_prefers_cursor_agent(monkeypatch):
+    def which(name: str):
+        return {
+            "cursor-agent": "/usr/bin/cursor-agent",
+            "agent": "/usr/bin/agent",
+            "cursor": "/usr/bin/cursor",
+        }.get(name)
+
+    monkeypatch.setattr(runner.shutil, "which", which)
+    assert runner._resolve_cursor_cli_bin() == "/usr/bin/cursor-agent"
+
+
+def test_resolve_cursor_cli_falls_back_to_agent(monkeypatch):
+    def which(name: str):
+        return {"agent": "/opt/agent"}.get(name)
+
+    monkeypatch.setattr(runner.shutil, "which", which)
+    assert runner._resolve_cursor_cli_bin() == "/opt/agent"
+
+
+def test_try_cursor_runner_missing_binary_returns_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner.shutil, "which", lambda _n: None)
+    assert runner._try_cursor_runner("prompt", tmp_path) is False
+
+
+def test_try_cursor_runner_writes_report_on_success(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner, "_resolve_cursor_cli_bin", lambda: "/bin/cursor-agent")
+    monkeypatch.setattr(runner, "_install_gate_into_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr(runner, "workspace_root", lambda: tmp_path)
+
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return SimpleNamespace(returncode=0, stdout="# Report\n\nok\n", stderr="")
+
+    monkeypatch.setattr(runner, "_run_with_live_output", fake_run)
+
+    assert runner._try_cursor_runner("do the thing", tmp_path, wall_timeout=900) is True
+    assert (tmp_path / "report.md").read_text(encoding="utf-8").startswith("# Report")
+    assert captured["cmd"][0] == "/bin/cursor-agent"
+    assert "--print" in captured["cmd"]
+    assert "--force" in captured["cmd"]
+    assert "--trust" in captured["cmd"]
+    assert "do the thing" in captured["cmd"]
+    assert captured["timeout"] == 900
+
+
+def test_try_cursor_runner_timeout_returns_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner, "_resolve_cursor_cli_bin", lambda: "/bin/cursor-agent")
+    monkeypatch.setattr(runner, "_install_gate_into_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr(runner, "workspace_root", lambda: tmp_path)
+
+    def boom(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd=["cursor-agent"], timeout=900)
+
+    monkeypatch.setattr(runner, "_run_with_live_output", boom)
+    assert runner._try_cursor_runner("prompt", tmp_path) is False
+    assert not (tmp_path / "report.md").exists()
+
+
+def test_try_cursor_runner_nonzero_exit_returns_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner, "_resolve_cursor_cli_bin", lambda: "/bin/cursor-agent")
+    monkeypatch.setattr(runner, "_install_gate_into_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr(runner, "workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        runner,
+        "_run_with_live_output",
+        lambda *_a, **_k: SimpleNamespace(returncode=2, stdout="", stderr="auth failed"),
+    )
+    assert runner._try_cursor_runner("prompt", tmp_path) is False


### PR DESCRIPTION
## Summary
- Add `_try_cursor_runner()` following the Claude/OpenCode runner pattern
- Resolve CLI as `cursor-agent` → `agent` → `cursor`
- Headless invoke: `--print --force --trust --output-format text` with the loop prompt
- Enforce wall-clock timeout (default 900s via loop budget) and write `report.md`
- Graceful skip when no Cursor CLI is on `PATH`

Closes #223.

## Test plan
- [x] `pytest tests/test_cursor_runner.py` (+ related loop tests)
- [ ] CI Validate green