### PR TITLE
feat(loop): add OpenAI Codex CLI runner for loop run (#225)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
@@ -944,6 +944,68 @@ def _try_copilot_runner(
     return False
 
 
+def _try_codex_runner(
+    prompt: str,
+    run_dir: Path,
+    meta: dict[str, Any] | None = None,
+    *,
+    trace_file: Path | None = None,
+    wall_timeout: int | None = None,
+    max_tokens: int | None = None,
+) -> bool:
+    """Invoke OpenAI Codex CLI headless (``codex exec``) as a loop runner (#225).
+
+    See https://developers.openai.com/codex/noninteractive
+    """
+    codex_bin = shutil.which("codex")
+    if not codex_bin:
+        return False
+
+    from agent_toolkit.loop.budget import DEFAULT_WALL_SECONDS
+
+    timeout = wall_timeout if wall_timeout is not None else DEFAULT_WALL_SECONDS
+    env = _install_gate_into_environ(run_dir, meta or {})
+    report_md = run_dir / "report.md"
+    # ``codex exec -`` reads the full prompt from stdin; workspace-write + never
+    # ask keeps loops unattended; ``-o`` captures the final agent message.
+    cmd = [
+        codex_bin,
+        "exec",
+        "--ask-for-approval",
+        "never",
+        "--sandbox",
+        "workspace-write",
+        "--output-last-message",
+        str(report_md),
+        "-",
+    ]
+    try:
+        result = _run_with_live_output(
+            cmd,
+            input_text=prompt,
+            cwd=str(workspace_root()),
+            env=env,
+            trace_file=trace_file or (run_dir / "trace.jsonl"),
+            timeout=timeout,
+            max_tokens=max_tokens,
+        )
+    except subprocess.TimeoutExpired:
+        warn(f"codex runner hit budget limit (wall={timeout}s or max_tokens)")
+        return False
+
+    if result.returncode == 0:
+        if not report_md.exists() and result.stdout.strip():
+            report_md.write_text(result.stdout, encoding="utf-8")
+        ok("codex runner completed")
+        return True
+
+    error_output = (result.stderr + result.stdout).strip()[:400]
+    warn(f"codex runner exited {result.returncode}: {error_output or '(no output)'}")
+    if result.returncode != 0 and not error_output:
+        warn("  Hint: Codex CLI may not be authenticated — set OPENAI_API_KEY / CODEX_API_KEY")
+    return False
+
+
 def _queue_via_devcompanion(
     request: str,
     run_dir: Path,
@@ -1409,6 +1471,15 @@ def cmd_run(args: list[str]) -> int:
             max_tokens=token_limit,
         ):
             pass  # GitHub Copilot CLI handled it
+        elif _try_codex_runner(
+            prompt,
+            run_dir,
+            meta,
+            trace_file=trace_file,
+            wall_timeout=wall_timeout,
+            max_tokens=token_limit,
+        ):
+            pass  # OpenAI Codex CLI handled it
         elif _queue_via_devcompanion(
             prompt, run_dir, loop_name, rid, meta, wall_timeout=wall_timeout
         ):

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -1,0 +1,81 @@
+"""Tests for OpenAI Codex CLI loop runner (#225)."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent_toolkit.loop import runner
+
+
+def test_try_codex_runner_missing_binary_returns_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner.shutil, "which", lambda _n: None)
+    assert runner._try_codex_runner("prompt", tmp_path) is False
+
+
+def test_try_codex_runner_writes_report_on_success(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner.shutil, "which", lambda n: "/bin/codex" if n == "codex" else None)
+    monkeypatch.setattr(runner, "_install_gate_into_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr(runner, "workspace_root", lambda: tmp_path)
+
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input_text")
+        captured["timeout"] = kwargs.get("timeout")
+        # Simulate --output-last-message writing the report.
+        Path(cmd[cmd.index("--output-last-message") + 1]).write_text(
+            "# Codex report\n", encoding="utf-8"
+        )
+        return SimpleNamespace(returncode=0, stdout="", stderr="progress")
+
+    monkeypatch.setattr(runner, "_run_with_live_output", fake_run)
+
+    assert runner._try_codex_runner("fix tests", tmp_path, wall_timeout=900) is True
+    assert (tmp_path / "report.md").read_text(encoding="utf-8").startswith("# Codex")
+    assert captured["cmd"][0:2] == ["/bin/codex", "exec"]
+    assert "--ask-for-approval" in captured["cmd"]
+    assert "never" in captured["cmd"]
+    assert "--sandbox" in captured["cmd"]
+    assert "workspace-write" in captured["cmd"]
+    assert captured["cmd"][-1] == "-"
+    assert captured["input"] == "fix tests"
+    assert captured["timeout"] == 900
+
+
+def test_try_codex_runner_falls_back_to_stdout(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner.shutil, "which", lambda n: "/bin/codex" if n == "codex" else None)
+    monkeypatch.setattr(runner, "_install_gate_into_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr(runner, "workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        runner,
+        "_run_with_live_output",
+        lambda *_a, **_k: SimpleNamespace(returncode=0, stdout="from stdout\n", stderr=""),
+    )
+    assert runner._try_codex_runner("p", tmp_path) is True
+    assert (tmp_path / "report.md").read_text(encoding="utf-8") == "from stdout\n"
+
+
+def test_try_codex_runner_timeout_returns_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner.shutil, "which", lambda n: "/bin/codex" if n == "codex" else None)
+    monkeypatch.setattr(runner, "_install_gate_into_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr(runner, "workspace_root", lambda: tmp_path)
+
+    def boom(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd=["codex"], timeout=900)
+
+    monkeypatch.setattr(runner, "_run_with_live_output", boom)
+    assert runner._try_codex_runner("prompt", tmp_path) is False
+
+
+def test_try_codex_runner_nonzero_exit_returns_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(runner.shutil, "which", lambda n: "/bin/codex" if n == "codex" else None)
+    monkeypatch.setattr(runner, "_install_gate_into_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr(runner, "workspace_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        runner,
+        "_run_with_live_output",
+        lambda *_a, **_k: SimpleNamespace(returncode=1, stdout="", stderr="no auth"),
+    )
+    assert runner._try_codex_runner("prompt", tmp_path) is False


### PR DESCRIPTION
## Summary
- Add `_try_codex_runner()` using OpenAI Codex non-interactive mode (`codex exec`)
- Prompt via stdin (`codex exec -`); `--ask-for-approval never`; `--sandbox workspace-write`
- Write final message with `--output-last-message report.md` (stdout fallback)
- Default 900s wall timeout; skip gracefully when `codex` is not on `PATH`

Closes #225.

## Test plan
- [x] `pytest tests/test_codex_runner.py`
- [ ] CI green