### PR TITLE
feat(memory): implement review with duplicates, stale, contradictions (#226)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/memory.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/memory.py
@@ -9,7 +9,8 @@ Subcommands:
                        Add a learning, process, or todo entry
     search "query"     Case-insensitive search across all knowledge files
     inject             Output full knowledge base for AI session injection
-    review             Show stale or old entries
+    review [--fix] [--stale-after N]
+                       Detect duplicates, stale/orphan refs, and contradictions
     todo               List unchecked todos
 
 Types for add:
@@ -26,7 +27,9 @@ from __future__ import annotations
 import os
 import re
 import sys
-from datetime import date, timedelta
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from difflib import SequenceMatcher
 from pathlib import Path
 
 import sys as _sys
@@ -293,75 +296,326 @@ def cmd_inject(args: list[str], knowledge: Path) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class KnowledgeEntry:
+    """A reviewable knowledge snippet with location metadata."""
+
+    path: Path
+    line_no: int
+    text: str
+    dated: date | None = None
+
+
+_PATH_REF_RE = re.compile(
+    r"(?<![\w])("
+    r"(?:~/|\.{1,2}/|/)?"
+    r"(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+"
+    r")"
+)
+_CONTRACTION_PAIR_RE = re.compile(
+    r"\b(?:do\s+not|don't|dont|never|avoid)\s+(?:use|call|run|install)\s+([A-Za-z0-9_./-]+)",
+    re.I,
+)
+_USE_RE = re.compile(
+    r"\b(?:use|prefer|always\s+use|should\s+use)\s+([A-Za-z0-9_./-]+)",
+    re.I,
+)
+
+
+def _similarity(a: str, b: str) -> float:
+    """Return normalized similarity in [0, 1] (SequenceMatcher ≈ Levenshtein ratio)."""
+    a_n = re.sub(r"\s+", " ", a.strip().lower())
+    b_n = re.sub(r"\s+", " ", b.strip().lower())
+    if not a_n or not b_n:
+        return 0.0
+    return SequenceMatcher(None, a_n, b_n).ratio()
+
+
+def _parse_entry_date(text: str) -> date | None:
+    m = re.search(r"\b(\d{4}-\d{2}-\d{2})\b", text)
+    if not m:
+        return None
+    try:
+        return date.fromisoformat(m.group(1))
+    except ValueError:
+        return None
+
+
+def _collect_entries(knowledge: Path) -> list[KnowledgeEntry]:
+    """Extract reviewable lines/sections from knowledge markdown files."""
+    entries: list[KnowledgeEntry] = []
+    if not knowledge.is_dir():
+        return entries
+
+    for md_file in sorted(knowledge.rglob("*.md")):
+        lines = _read(md_file).splitlines()
+        for i, line in enumerate(lines, start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or stripped.startswith("<!--"):
+                continue
+            # Table separator / header
+            if re.match(r"^\|[-:| ]+\|$", stripped):
+                continue
+            if stripped.startswith("| Date |") or stripped.startswith("|------"):
+                continue
+            # Prefer meaningful content rows / bullets / process body lines
+            if stripped.startswith("|") or stripped.startswith("- ") or len(stripped) >= 24:
+                text = stripped
+                if stripped.startswith("|"):
+                    cells = [c.strip() for c in stripped.strip("|").split("|")]
+                    text = " — ".join(c for c in cells if c)
+                entries.append(
+                    KnowledgeEntry(
+                        path=md_file,
+                        line_no=i,
+                        text=text,
+                        dated=_parse_entry_date(stripped),
+                    )
+                )
+    return entries
+
+
+def _extract_path_refs(text: str) -> list[str]:
+    refs: list[str] = []
+    for m in _PATH_REF_RE.finditer(text):
+        refs.append(m.group(1))
+    for m in re.finditer(r"`([^`]+)`", text):
+        raw = m.group(1).strip()
+        if "://" in raw or raw.startswith("http"):
+            continue
+        if "/" in raw or raw.startswith((".", "~")):
+            refs.append(raw)
+    # Deduplicate preserving order
+    seen: set[str] = set()
+    out: list[str] = []
+    for ref in refs:
+        if ref not in seen:
+            seen.add(ref)
+            out.append(ref)
+    return out
+
+
+def _resolve_ref(ref: str, workspace: Path) -> Path:
+    if ref.startswith("~/"):
+        return Path.home() / ref[2:]
+    p = Path(ref)
+    if p.is_absolute():
+        return p
+    return (workspace / ref).resolve()
+
+
+def _find_duplicates(entries: list[KnowledgeEntry], *, threshold: float = 0.8) -> list[tuple[KnowledgeEntry, KnowledgeEntry, float]]:
+    dupes: list[tuple[KnowledgeEntry, KnowledgeEntry, float]] = []
+    for i, left in enumerate(entries):
+        for right in entries[i + 1 :]:
+            if left.path == right.path and left.line_no == right.line_no:
+                continue
+            ratio = _similarity(left.text, right.text)
+            if ratio >= threshold:
+                dupes.append((left, right, ratio))
+    return dupes
+
+
+def _find_contradictions(entries: list[KnowledgeEntry]) -> list[tuple[KnowledgeEntry, KnowledgeEntry, str]]:
+    """Detect 'use X' vs 'don't use X' pairs across the knowledge base."""
+    use_map: dict[str, list[KnowledgeEntry]] = {}
+    avoid_map: dict[str, list[KnowledgeEntry]] = {}
+    for entry in entries:
+        for m in _USE_RE.finditer(entry.text):
+            # Skip if the match is actually a negation captured loosely
+            start = max(0, m.start() - 12)
+            window = entry.text[start : m.start()].lower()
+            if any(neg in window for neg in ("don't", "dont", "do not", "never", "avoid")):
+                continue
+            use_map.setdefault(m.group(1).lower(), []).append(entry)
+        for m in _CONTRACTION_PAIR_RE.finditer(entry.text):
+            avoid_map.setdefault(m.group(1).lower(), []).append(entry)
+
+    hits: list[tuple[KnowledgeEntry, KnowledgeEntry, str]] = []
+    for key, avoiders in avoid_map.items():
+        for user in use_map.get(key, []):
+            for avoider in avoiders:
+                if user is avoider:
+                    continue
+                hits.append((user, avoider, key))
+    return hits
+
+
+def _find_stale_and_orphans(
+    entries: list[KnowledgeEntry],
+    knowledge: Path,
+    *,
+    stale_after: int,
+) -> tuple[list[tuple[KnowledgeEntry, str]], list[tuple[KnowledgeEntry, str]]]:
+    """Return (stale, orphaned) findings.
+
+    Stale: entry older than threshold AND a referenced path/tool is missing.
+    Orphaned: any referenced path that no longer exists (regardless of age).
+    """
+    workspace = knowledge.parent
+    cutoff = date.today() - timedelta(days=stale_after)
+    stale: list[tuple[KnowledgeEntry, str]] = []
+    orphans: list[tuple[KnowledgeEntry, str]] = []
+
+    for entry in entries:
+        refs = _extract_path_refs(entry.text)
+        missing: list[str] = []
+        for ref in refs:
+            target = _resolve_ref(ref, workspace)
+            if not target.exists():
+                missing.append(ref)
+
+        mtime_date: date | None = entry.dated
+        if mtime_date is None:
+            try:
+                mtime_date = datetime.fromtimestamp(
+                    entry.path.stat().st_mtime, tz=timezone.utc
+                ).date()
+            except OSError:
+                mtime_date = None
+
+        for ref in missing:
+            orphans.append((entry, f"missing path `{ref}`"))
+
+        if missing and mtime_date is not None and mtime_date < cutoff:
+            stale.append(
+                (
+                    entry,
+                    f"last seen {mtime_date.isoformat()} (>{stale_after}d) and refs missing: "
+                    + ", ".join(f"`{r}`" for r in missing),
+                )
+            )
+
+    return stale, orphans
+
+
 def cmd_review(args: list[str], knowledge: Path) -> int:
-    """Show stale entries (>30 days) and old todos (>14 days)."""
-    stale_days = 30
-    todo_days = 14
+    """Detect duplicates, stale/orphan refs, and contradictions (#226).
+
+    Exit codes: 0 if clean, 1 if any issues found.
+    """
+    stale_after = 90
+    fix = False
     i = 0
     while i < len(args):
         match args[i]:
-            case "--stale-days" if i + 1 < len(args):
+            case "--stale-after" | "--stale-days" if i + 1 < len(args):
                 try:
-                    stale_days = int(args[i + 1])
-                    todo_days = stale_days // 2
+                    stale_after = int(args[i + 1])
                 except ValueError:
-                    pass
+                    print(f"Invalid --stale-after value: {args[i + 1]}", file=sys.stderr)
+                    return 1
                 i += 2
+            case "--fix":
+                fix = True
+                i += 1
             case "--help" | "-h":
-                print("Usage: agent-toolkit memory review [--stale-days N]")
+                print(
+                    "Usage: agent-toolkit memory review [--fix] [--stale-after N]\n"
+                    "\n"
+                    "Detects duplicates (similarity ≥ 80%), stale entries, contradictions,\n"
+                    "and orphaned path references. Exit 1 when issues are found.\n"
+                    "\n"
+                    "  --stale-after N   Age threshold in days (default: 90)\n"
+                    "  --fix            Print merge/fix suggestions (does not mutate files)\n"
+                )
                 return 0
             case _:
-                i += 1
+                print(f"Unknown review option: {args[i]}", file=sys.stderr)
+                return 1
 
-    today = date.today()
-    stale_cutoff = (today - timedelta(days=stale_days)).isoformat()
-    todo_cutoff = (today - timedelta(days=todo_days)).isoformat()
+    entries = _collect_entries(knowledge)
+    duplicates = _find_duplicates(entries)
+    contradictions = _find_contradictions(entries)
+    stale, orphans = _find_stale_and_orphans(entries, knowledge, stale_after=stale_after)
 
     print(f"\n{_blue('=== Memory Review ===')}\n")
-    found_any = False
-
-    # Scan markdown files for dated entries
-    print(f"{_cyan('Learnings older than')} {stale_days} {_cyan('days:')}")
-    learnings_path = knowledge / "learnings" / "general.md"
-    if learnings_path.exists():
-        content = learnings_path.read_text(encoding="utf-8")
-        stale_rows = []
-        for line in content.splitlines():
-            m = re.match(r"^\| (\d{4}-\d{2}-\d{2}) \|", line)
-            if m and m.group(1) < stale_cutoff:
-                stale_rows.append(line)
-        if stale_rows:
-            for row in stale_rows[:10]:
-                print(f"  {row}")
-            found_any = True
-        else:
-            print(_dim(f"  (none older than {stale_days} days)"))
-    else:
-        print(_dim("  (no learnings file)"))
+    print(_dim(f"Scanned {len(entries)} entries under {knowledge} (stale-after={stale_after}d)"))
     print()
 
-    print(f"{_cyan('Todos older than')} {todo_days} {_cyan('days:')}")
-    todos_path = knowledge / "todos" / "pending.md"
-    if todos_path.exists():
-        content = todos_path.read_text(encoding="utf-8")
-        old_todos = []
-        for line in content.splitlines():
-            m = re.match(r"^- \[ \] (\d{4}-\d{2}-\d{2}) ", line)
-            if m and m.group(1) < todo_cutoff:
-                old_todos.append(line)
-        if old_todos:
-            for item in old_todos[:10]:
-                print(f"  {item}")
-            found_any = True
-        else:
-            print(_dim(f"  (none older than {todo_days} days)"))
+    issue_count = 0
+
+    print(f"{_cyan('Duplicates')} (similarity ≥ 80%):")
+    if duplicates:
+        for left, right, ratio in duplicates[:20]:
+            issue_count += 1
+            rel_l = left.path.name
+            rel_r = right.path.name
+            print(
+                f"  • {ratio:.0%}  {rel_l}:{left.line_no} ↔ {rel_r}:{right.line_no}"
+            )
+            print(_dim(f"      A: {left.text[:100]}"))
+            print(_dim(f"      B: {right.text[:100]}"))
+            if fix:
+                print(
+                    _yellow(
+                        f"      suggestion: merge into one entry and delete the weaker duplicate "
+                        f"({rel_r}:{right.line_no})"
+                    )
+                )
     else:
-        print(_dim("  (no todos file)"))
+        print(_dim("  (none)"))
     print()
 
-    if not found_any:
-        print(_dim("Knowledge base is up to date — no stale entries."))
-    return 0
+    print(f"{_cyan('Contradictions')} (use X vs don't use X):")
+    if contradictions:
+        seen: set[tuple[int, int, str]] = set()
+        for user, avoider, key in contradictions:
+            sig = (user.line_no, avoider.line_no, key)
+            if sig in seen:
+                continue
+            seen.add(sig)
+            issue_count += 1
+            print(f"  • subject `{key}`")
+            print(_dim(f"      use:     {user.path.name}:{user.line_no} — {user.text[:100]}"))
+            print(_dim(f"      avoid:   {avoider.path.name}:{avoider.line_no} — {avoider.text[:100]}"))
+            if fix:
+                print(
+                    _yellow(
+                        "      suggestion: reconcile guidance; keep a single current recommendation"
+                    )
+                )
+    else:
+        print(_dim("  (none)"))
+    print()
+
+    print(f"{_cyan('Stale')} (older than {stale_after}d AND missing refs):")
+    if stale:
+        for entry, detail in stale[:20]:
+            issue_count += 1
+            print(f"  • {entry.path.name}:{entry.line_no} — {detail}")
+            print(_dim(f"      {entry.text[:100]}"))
+            if fix:
+                print(_yellow("      suggestion: update the entry or remove obsolete guidance"))
+    else:
+        print(_dim("  (none)"))
+    print()
+
+    print(f"{_cyan('Orphaned references')} (path no longer exists):")
+    if orphans:
+        # Deduplicate by path+ref for display
+        seen_o: set[tuple[str, int, str]] = set()
+        for entry, detail in orphans[:30]:
+            sig = (str(entry.path), entry.line_no, detail)
+            if sig in seen_o:
+                continue
+            seen_o.add(sig)
+            issue_count += 1
+            print(f"  • {entry.path.name}:{entry.line_no} — {detail}")
+            if fix:
+                print(_yellow("      suggestion: fix the path or delete the orphaned note"))
+    else:
+        print(_dim("  (none)"))
+    print()
+
+    if issue_count == 0:
+        print(_green("Knowledge base looks clean — no issues found."))
+        return 0
+
+    print(_yellow(f"Found {issue_count} issue(s)."))
+    if not fix:
+        print(_dim("Re-run with --fix for merge/update suggestions."))
+    return 1
 
 
 def cmd_todo(args: list[str], knowledge: Path) -> int:

--- a/tests/test_memory_review.py
+++ b/tests/test_memory_review.py
@@ -1,0 +1,91 @@
+"""Tests for agent-toolkit memory review (#226)."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+from agent_toolkit.cli import memory as memory_mod
+
+
+def _seed_knowledge(root: Path) -> Path:
+    knowledge = root / "knowledge"
+    (knowledge / "learnings").mkdir(parents=True)
+    (knowledge / "processes").mkdir(parents=True)
+    (knowledge / "todos").mkdir(parents=True)
+    return knowledge
+
+
+def test_review_clean_returns_0(tmp_path: Path, capsys):
+    knowledge = _seed_knowledge(tmp_path)
+    (knowledge / "learnings" / "general.md").write_text(
+        "# Learnings\n\n| Date | Learning | Context |\n|------|----------|---------|\n"
+        f"| {date.today().isoformat()} | Prefer uv for Python tooling | Session |\n",
+        encoding="utf-8",
+    )
+    assert memory_mod.cmd_review([], knowledge) == 0
+    out = capsys.readouterr().out
+    assert "no issues found" in out.lower() or "clean" in out.lower()
+
+
+def test_review_detects_duplicates(tmp_path: Path, capsys):
+    knowledge = _seed_knowledge(tmp_path)
+    today = date.today().isoformat()
+    (knowledge / "learnings" / "general.md").write_text(
+        "# Learnings\n\n| Date | Learning | Context |\n|------|----------|---------|\n"
+        f"| {today} | Always run pytest before pushing changes to main | Session |\n"
+        f"| {today} | Always run pytest before pushing changes onto main | Session |\n",
+        encoding="utf-8",
+    )
+    assert memory_mod.cmd_review([], knowledge) == 1
+    out = capsys.readouterr().out
+    assert "Duplicates" in out
+    assert "%" in out
+
+
+def test_review_detects_contradictions(tmp_path: Path, capsys):
+    knowledge = _seed_knowledge(tmp_path)
+    (knowledge / "learnings" / "general.md").write_text(
+        "# Learnings\n\n"
+        "- Use npm for package installs in this monorepo\n"
+        "- Don't use npm; prefer pnpm instead\n",
+        encoding="utf-8",
+    )
+    assert memory_mod.cmd_review([], knowledge) == 1
+    out = capsys.readouterr().out
+    assert "Contradictions" in out
+    assert "npm" in out.lower()
+
+
+def test_review_detects_orphaned_and_stale(tmp_path: Path, capsys):
+    knowledge = _seed_knowledge(tmp_path)
+    old = (date.today() - timedelta(days=120)).isoformat()
+    (knowledge / "learnings" / "general.md").write_text(
+        "# Learnings\n\n| Date | Learning | Context |\n|------|----------|---------|\n"
+        f"| {old} | See docs/missing-runbook.md for the deploy steps | Session |\n",
+        encoding="utf-8",
+    )
+    rc = memory_mod.cmd_review(["--stale-after", "90"], knowledge)
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Orphaned" in out or "missing path" in out
+    assert "Stale" in out
+
+
+def test_review_fix_prints_suggestions(tmp_path: Path, capsys):
+    knowledge = _seed_knowledge(tmp_path)
+    today = date.today().isoformat()
+    (knowledge / "learnings" / "general.md").write_text(
+        "# Learnings\n\n| Date | Learning | Context |\n|------|----------|---------|\n"
+        f"| {today} | Prefer ruff check before commit in this repo | Session |\n"
+        f"| {today} | Prefer ruff check before committing in this repo | Session |\n",
+        encoding="utf-8",
+    )
+    assert memory_mod.cmd_review(["--fix"], knowledge) == 1
+    out = capsys.readouterr().out
+    assert "suggestion" in out.lower()
+
+
+def test_similarity_threshold():
+    assert memory_mod._similarity("hello world", "hello world") == 1.0
+    assert memory_mod._similarity("run pytest before push", "run pytest before pushing") >= 0.8
+    assert memory_mod._similarity("alpha", "zzzzz completely different") < 0.5


### PR DESCRIPTION
## Summary
- Expand `agent-toolkit memory review` beyond age-only scans
- Detect **duplicates** (similarity ≥ 80%), **contradictions** (use X vs don't use X), **orphaned path refs**, and **stale** entries (age + missing refs)
- Add `--stale-after N` (default 90; `--stale-days` alias) and `--fix` for non-mutating suggestions
- Exit **1** when issues are found, **0** when clean

Closes #226.

## Test plan
- [x] `pytest tests/test_memory_review.py`
- [ ] CI green