### PR TITLE
chore: epic residuals + README Key Concepts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest,  artifact: agent-toolkit-linux-x86_64 }
-          - { os: macos-latest,   artifact: agent-toolkit-macos-arm64 }
-          - { os: windows-latest, artifact: agent-toolkit-windows-x86_64 }
+          - {os: ubuntu-latest, artifact: agent-toolkit-linux-x86_64}
+          - {os: macos-latest, artifact: agent-toolkit-macos-arm64}
+          - {os: windows-latest, artifact: agent-toolkit-windows-x86_64}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install uv

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -255,6 +255,8 @@ jobs:
         run: npm install -g markdownlint-cli@0.44.0
 
       - name: Run markdownlint
+        # Advisory: large markdown corpus; MegaLinter also soft-fails MARKDOWN.
+        # YAML lint below is blocking for structured config.
         run: |
           markdownlint \
             --config .markdownlint.yaml \
@@ -282,8 +284,7 @@ jobs:
             catalogs/ \
             schemas/ \
             packs/ \
-            .github/workflows/ \
-            || true
+            .github/workflows/
 
   # ── Job 9: Build package — ensures a clean wheel and sdist ────────────────
   build-package:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,55 @@ agent-toolkit doctor
 
 ---
 
+## Key Concepts
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <h3>🛠️ Skills</h3>
+      <sub>Reusable capability units (<code>SKILL.md</code>) that teach an agent how to do a job — delivery workflows, forge CLIs, design, data, ops.</sub>
+      <br><br>
+      <sub>52 skills across 9 domains. Browse <code>skills/</code> or <code>agent-toolkit inventory</code>.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <h3>🤖 Agents</h3>
+      <sub>Personas that constrain <em>how</em> the AI works in a session — review, plan, architect, fix CI — without rewriting your prompts each time.</sub>
+      <br><br>
+      <sub>16 personas under <code>agents/</code>, compiled into each target's native format.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h3>🔄 Loops</h3>
+      <sub>Recurring agentic workflows with mutation-safety tiers (L1 observe → L2 controlled → L3 high autonomy).</sub>
+      <br><br>
+      <sub><code>agent-toolkit loop run daily-triage</code> · 10 templates in <code>loops/</code></sub>
+    </td>
+    <td width="50%" valign="top">
+      <h3>📦 Packs</h3>
+      <sub>Solution bundles that combine skills, agents, and loops for a team context (OSS maintenance, engineering workflow, delivery discipline).</sub>
+      <br><br>
+      <sub>Declared under <code>packs/</code>; load with your workspace tooling.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h3>🧩 Plugins</h3>
+      <sub>Product distributions for Claude Code / Cursor marketplaces — core, agents, forge — compiled from one catalog.</sub>
+      <br><br>
+      <sub>Source of truth: <code>distributions/products.yaml</code></sub>
+    </td>
+    <td width="50%" valign="top">
+      <h3>🔗 MCP</h3>
+      <sub>Provider registry + ready templates (GitHub, Slack, Notion, Linear, Figma, ClickUp) emitted into target-native MCP configs.</sub>
+      <br><br>
+      <sub><code>mcp/registry/</code> · <code>mcp/templates/</code> · <code>agent-toolkit mcp</code></sub>
+    </td>
+  </tr>
+</table>
+
+---
+
 ## 🚀 Quick Install
 
 **Recommended:** use the Python CLI with [uv](https://docs.astral.sh/uv/) — one flow for every supported tool.

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -27,7 +27,7 @@ Each target receives the strongest integration it actually supports.
 | Windsurf | customization-bundle | native | generated (rules) | unsupported | unsupported | stable |
 | OpenAI Codex | plugin (.codex-plugin/) | native | native | unknown-blocked | unknown-blocked | experimental |
 
-*pending canonical hook model (issue #16)
+*hooks: no stable cross-tool canonical model yet — see target certification docs
 †requires TypeScript runtime plugin
 
 ## Install commands
@@ -38,6 +38,11 @@ Each target receives the strongest integration it actually supports.
 uvx --from agent-toolkit-cli agent-toolkit install
 agent-toolkit doctor
 ```
+
+`agent-toolkit install` deploys profiles for: Claude Code, Cursor, OpenCode,
+Copilot, Windsurf, and Pi. **Gemini CLI** and **OpenAI Codex** are compile /
+release targets today (`agent-toolkit build --target …`); profile install for
+those tools is deferred until consumer install paths are certified.
 
 **Advanced** (build, selective tools, release engineering):
 

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -51,9 +51,9 @@ JSON schema for recording what was installed:
 - **Fields:** product, target, version, file paths, content digests
 - **Secrets:** always empty (`secrets: []`)
 
-Receipts help you audit changes and support future uninstall-by-receipt
-workflows. Full install integration is rolling out; tests cover create/save/load
-today.
+Receipts are written by `agent-toolkit install` / `update` and consumed by
+`agent-toolkit uninstall` / rollback. Lifecycle tests cover create, save, load,
+and uninstall-by-receipt.
 
 Example shape (illustrative):
 

--- a/examples/oss-maintenance/README.md
+++ b/examples/oss-maintenance/README.md
@@ -60,10 +60,12 @@ Edit `~/.agent-toolkit/loops/oss-daily-briefing/loop.yaml`. Find the repo list s
 # You can embed it directly in your workspace config or pack.
 ```
 
-For the OSS ecosystem loops, create or edit a pack file at `packs/oss-ecosystem.yaml` in your ai-workspace:
+For the OSS maintenance loops, create or edit a pack file at
+`packs/oss-maintenance/config.yaml` in your workspace (or copy from this
+repo's [`packs/oss-maintenance/`](../../packs/oss-maintenance/)):
 
 ```yaml
-name: oss-ecosystem
+name: oss-maintenance
 repos:
   - owner/repo-one
   - owner/repo-two

--- a/mcp/templates/figma/README.md
+++ b/mcp/templates/figma/README.md
@@ -9,7 +9,7 @@ Connects an AI tool to the remote Figma MCP server
   assets scopes.
 - `FIGMA_REGION` — Figma region header (default `us-east-1`).
 
-Store them in `~/.config/agent-toolkit/env.d/figma.env` (covered by `dots-loadenv`):
+Store them in a local env file (never commit tokens):
 
 ```bash
 mkdir -p ~/.config/agent-toolkit/env.d
@@ -18,10 +18,8 @@ export FIGMA_OAUTH_TOKEN="<paste-token-here>"
 export FIGMA_REGION="us-east-1"
 EOF
 chmod 600 ~/.config/agent-toolkit/env.d/figma.env
+# Then: source ~/.config/agent-toolkit/env.d/figma.env
 ```
-
-`dots-doctor` will pick up `figma.env` under "Integrations" without printing
-the value.
 
 > [!CAUTION]
 > Tokens copied from the Figma UI must not include surrounding quotes. Never

--- a/packs/oss-maintenance/config.yaml
+++ b/packs/oss-maintenance/config.yaml
@@ -23,12 +23,9 @@ version: "1.0"
 #   60 repos → oss-pr-monitor needs ~450k tokens
 #
 # If you have more than 50 repos, split into two config files.
+# Add repositories below in owner/repo format, e.g. - owner/repo1
 
-repos:
-  # Add your repositories here
-  # - owner/repo1
-  # - owner/repo2
-  # - owner/repo3
+repos: []
 
 # ---------------------------------------------------------------------------
 # Loop settings

--- a/profiles/windsurf/rules/assistant.mdc
+++ b/profiles/windsurf/rules/assistant.mdc
@@ -1,0 +1,61 @@
+---
+description: agent-toolkit development conventions and standards. Apply when working in any agent-toolkit or client repository to ensure compliance with internal standards.
+alwaysApply: false
+---
+
+# agent-toolkit Dev Companion
+
+## Repository inspection order
+Before writing any code, read in this order:
+1. README.md → docs/ → AGENTS.md or CLAUDE.md → CONTRIBUTING.md → PR templates → task runners → CI
+
+Always cite which file a convention comes from.
+
+## Standards
+- Shell scripts: `set -euo pipefail`, idempotent, OS-aware
+- chezmoi repos: `Internal chezmoi commands use the `dots-` prefix (agentic-workstation convention)
+- Never commit secrets — use `.env.example`
+- English: all documentation, commits, and ticket descriptions
+- Update documentation when behavior changes
+
+## agent-toolkit CLI
+
+Use these commands for workspace operations:
+
+```bash
+# Workspace
+agent-toolkit workspace context          # session state at start
+agent-toolkit workspace init [--dir .]  # scaffold a new workspace
+
+# Knowledge
+agent-toolkit memory add --type learning "pattern"
+agent-toolkit memory add --type todo "follow-up"
+agent-toolkit memory search "topic"
+agent-toolkit memory inject
+agent-toolkit memory todo
+
+# Loops
+agent-toolkit loop run <name>
+agent-toolkit loop status
+agent-toolkit loop schedule <name>
+
+# Projects
+agent-toolkit project clone owner/repo
+agent-toolkit project list
+
+# Background jobs
+agent-toolkit devcompanion queue <project> --request "..."
+agent-toolkit devcompanion run-once
+agent-toolkit devcompanion status
+
+# Health check
+agent-toolkit doctor
+```
+
+**Session start:** run `agent-toolkit workspace context` then `agent-toolkit memory inject`.
+
+## Client projects
+- Respect existing patterns and conventions
+- Check for project-specific AGENTS.md or CLAUDE.md first
+- Follow the project's branching and PR strategy
+- Surface conflicts between agent-toolkit standards and project conventions

--- a/profiles/windsurf/rules/reference-lookup.mdc
+++ b/profiles/windsurf/rules/reference-lookup.mdc
@@ -1,0 +1,20 @@
+---
+description: agent-toolkit reference examples lookup. Apply when looking for official agent-toolkit examples, starter templates, or established patterns from the agent-toolkit ecosystem.
+alwaysApply: false
+---
+
+# agent-toolkit Reference Lookup
+
+## Sources
+- **public examples**: https://github.com/ulises-jeremias/public examples
+- Examples API: https://raw.githubusercontent.com/agent-toolkit/public examples/refs/heads/main/examples.json
+- Local docs/ directory
+- Existing patterns in the current codebase
+
+## Process
+1. Fetch and scan the public examples examples API
+2. Identify the most relevant matches for the requested pattern
+3. Summarize with key implementation points
+4. Adapt to the current project's context and conventions
+
+Always cite the source URL or repository path.


### PR DESCRIPTION
## Summary
- Sync Windsurf profile rules with Cursor (`assistant`, `reference-lookup`)
- Docs/examples cleanup: TRUST receipts, TARGETS footnotes + gemini/codex install deferral, oss-maintenance pack naming, Figma env without workstation-specific tooling
- Make structured YAML lint blocking in `validate.yml` (markdown stays advisory); fix release matrix yamllint errors
- Add harness-style **Key Concepts** HTML table to README

Closes residual work for #43 #44 #46 (enables closing #32).

## Test plan
- [x] `yamllint` on loops/catalogs/schemas/packs/workflows exits 0
- [x] `pytest tests/test_install_sources.py tests/test_golden.py`
- [ ] CI validate on this PR