### PR TITLE
docs: align SVG assets with catalog and install paths

### DIFF
--- a/static/architecture.svg
+++ b/static/architecture.svg
@@ -176,7 +176,7 @@
   <text x="465" y="215" font-family="'Courier New', monospace" font-size="9" fill="#00ff88" text-anchor="middle" font-weight="bold" filter="url(#glow-green)">◈  THIS REPO  ◈</text>
 
   <text x="42" y="241" font-family="'Courier New', monospace" font-size="20" font-weight="bold" fill="#00ff88" filter="url(#glow-green)">agent-toolkit</text>
-  <text x="42" y="261" font-family="'Courier New', monospace" font-size="11" fill="#00aa66">pip install agent-toolkit  ·  brew install agent-toolkit  ·  docker pull</text>
+  <text x="42" y="261" font-family="'Courier New', monospace" font-size="11" fill="#00aa66">uvx --from agent-toolkit-cli  ·  uv tool install  ·  brew / AUR</text>
 
   <!-- Component chips -->
   <rect x="42" y="272" width="68" height="22" rx="3" fill="#003a20" stroke="#00ff88" stroke-width="1"/>
@@ -206,7 +206,7 @@
   <polygon points="334,340 340,352 346,340" fill="#4a4a8a" opacity="0.6"/>
 
   <rect x="350" y="320" width="80" height="14" rx="2" fill="#080818" stroke="#0a0a2a" stroke-width="1"/>
-  <text x="390" y="330" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a" text-anchor="middle">deploys to ↓</text>
+  <text x="390" y="330" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a" text-anchor="middle">consumed by ↓</text>
 
   <!-- ══════════════════════════════════════ -->
   <!-- ── L3 Layer ── -->
@@ -223,11 +223,11 @@
   <rect x="28" y="363" width="32" height="14" rx="2" fill="#0a0820" stroke="#1a1040" stroke-width="1"/>
   <text x="44" y="374" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a" text-anchor="middle" font-weight="bold">L3</text>
 
-  <text x="68" y="374" font-family="'Courier New', monospace" font-size="10" fill="#2a2a5a" letter-spacing="3">:: PROJECT OVERLAY LAYER</text>
+  <text x="68" y="374" font-family="'Courier New', monospace" font-size="10" fill="#2a2a5a" letter-spacing="3">:: AI WORKSPACE RUNTIME</text>
 
-  <text x="42" y="400" font-family="'Courier New', monospace" font-size="16" font-weight="bold" fill="#2a2a5a">per-project overlay</text>
-  <text x="42" y="420" font-family="'Courier New', monospace" font-size="11" fill="#1a1a4a">project-specific customization · client packs · team conventions</text>
-  <text x="42" y="436" font-family="'Courier New', monospace" font-size="9" fill="#1a1a3a" letter-spacing="2">EXTENDS DISTRIBUTION LAYER</text>
+  <text x="42" y="400" font-family="'Courier New', monospace" font-size="16" font-weight="bold" fill="#2a2a5a">agentic-harness</text>
+  <text x="42" y="420" font-family="'Courier New', monospace" font-size="11" fill="#1a1a4a">memory · loops · personas · packs · multi-repo orchestration</text>
+  <text x="42" y="436" font-family="'Courier New', monospace" font-size="9" fill="#1a1a3a" letter-spacing="2">CONSUMES DISTRIBUTION LAYER</text>
 
   <!-- ══════════════════════════════════════ -->
   <!-- ── Right Column: AI Tools ── -->

--- a/static/banner.svg
+++ b/static/banner.svg
@@ -141,7 +141,7 @@
 
   <!-- Version tag -->
   <rect x="98" y="218" width="80" height="16" rx="2" fill="#0a1428" stroke="#0a2a4a" stroke-width="1"/>
-  <text x="138" y="229" font-family="'Courier New', monospace" font-size="9" fill="#00d4ff" text-anchor="middle" opacity="0.7">v0.1.0-alpha</text>
+  <text x="138" y="229" font-family="'Courier New', monospace" font-size="9" fill="#00d4ff" text-anchor="middle" opacity="0.7">v1.2.1</text>
 
   <!-- ── Center: Main Title ── -->
   <!-- Title glow background -->

--- a/static/loop-tiers.svg
+++ b/static/loop-tiers.svg
@@ -189,7 +189,7 @@
   <text x="30" y="165" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
   <text x="42" y="165" font-family="'Courier New', monospace" font-size="9" fill="#00aa66">oss-daily-briefing</text>
   <text x="30" y="180" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
-  <text x="42" y="180" font-family="'Courier New', monospace" font-size="9" fill="#00aa66">pr-health-monitor</text>
+  <text x="42" y="180" font-family="'Courier New', monospace" font-size="9" fill="#00aa66">daily-triage</text>
   <text x="30" y="195" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
   <text x="42" y="195" font-family="'Courier New', monospace" font-size="9" fill="#00aa66">oss-triage</text>
 
@@ -208,11 +208,11 @@
   <line x1="292" y1="150" x2="508" y2="150" stroke="#ff6b35" stroke-width="0.5" opacity="0.3"/>
 
   <text x="298" y="165" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
-  <text x="310" y="165" font-family="'Courier New', monospace" font-size="9" fill="#cc5520">dep-update-pr</text>
+  <text x="310" y="165" font-family="'Courier New', monospace" font-size="9" fill="#cc5520">ci-sweeper</text>
   <text x="298" y="180" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
-  <text x="310" y="180" font-family="'Courier New', monospace" font-size="9" fill="#cc5520">oss-pr-monitor</text>
+  <text x="310" y="180" font-family="'Courier New', monospace" font-size="9" fill="#cc5520">dep-sweeper</text>
   <text x="298" y="195" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
-  <text x="310" y="195" font-family="'Courier New', monospace" font-size="9" fill="#cc5520">issue-labeler</text>
+  <text x="310" y="195" font-family="'Courier New', monospace" font-size="9" fill="#cc5520">pr-babysitter</text>
 
   <!-- Caution badge -->
   <rect x="298" y="216" width="204" height="14" rx="2" fill="#3a1a00" stroke="#ff6b35" stroke-width="1"/>
@@ -229,11 +229,11 @@
   <line x1="560" y1="150" x2="776" y2="150" stroke="#ff2244" stroke-width="0.5" opacity="0.3"/>
 
   <text x="566" y="165" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
-  <text x="578" y="165" font-family="'Courier New', monospace" font-size="9" fill="#cc1133">auto-merge-green</text>
+  <text x="578" y="165" font-family="'Courier New', monospace" font-size="9" fill="#cc1133">oss-pr-monitor</text>
   <text x="566" y="180" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
-  <text x="578" y="180" font-family="'Courier New', monospace" font-size="9" fill="#cc1133">repo-house-keeper</text>
+  <text x="578" y="180" font-family="'Courier New', monospace" font-size="9" fill="#cc1133">(+ custom L3 loops)</text>
   <text x="566" y="195" font-family="'Courier New', monospace" font-size="8" fill="#4a4a8a">►</text>
-  <text x="578" y="195" font-family="'Courier New', monospace" font-size="9" fill="#cc1133">release-publisher</text>
+  <text x="578" y="195" font-family="'Courier New', monospace" font-size="9" fill="#cc1133">merge/close allowlist</text>
 
   <!-- Danger badge -->
   <rect x="566" y="216" width="204" height="14" rx="2" fill="#3a0210" stroke="#ff2244" stroke-width="1"/>

--- a/static/tools-grid.svg
+++ b/static/tools-grid.svg
@@ -121,7 +121,7 @@
   <line x1="160" y1="30" x2="296" y2="30" stroke="#00d4ff" stroke-width="0.5" opacity="0.3"/>
 
   <text x="228" y="50" font-family="'Courier New', monospace" font-size="15" font-weight="bold" fill="#00d4ff" text-anchor="middle" filter="url(#text-glow)">CURSOR</text>
-  <text x="228" y="63" font-family="'Courier New', monospace" font-size="8" fill="#003a4a" text-anchor="middle" letter-spacing="2">IDE + AGENT MODE</text>
+  <text x="228" y="63" font-family="'Courier New', monospace" font-size="8" fill="#003a4a" text-anchor="middle" letter-spacing="2">PLUGIN + IDE + CLI</text>
 
   <line x1="168" y1="74" x2="290" y2="74" stroke="#00d4ff" stroke-width="0.5" opacity="0.2"/>
   <text x="172" y="88" font-family="'Courier New', monospace" font-size="9" fill="#00d4ff" filter="url(#text-glow)">● SUPPORTED
@@ -156,8 +156,8 @@
   <rect x="312" y="96" width="132" height="60" rx="2" fill="#140603" stroke="#3a1a08" stroke-width="1"/>
   <text x="316" y="108" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">$ install</text>
   <text x="316" y="122" font-family="'Courier New', monospace" font-size="7.5" fill="#ff6b35">copy agents/*.md</text>
-  <text x="316" y="136" font-family="'Courier New', monospace" font-size="7.5" fill="#ff9966">→ .opencode/</text>
-  <text x="316" y="150" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">agents/</text>
+  <text x="316" y="136" font-family="'Courier New', monospace" font-size="7.5" fill="#ff9966">→ ~/.config/</text>
+  <text x="316" y="150" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">opencode/</text>
 
   <line x1="318" y1="164" x2="440" y2="164" stroke="#ff6b35" stroke-width="0.5" opacity="0.2"/>
   <text x="322" y="176" font-family="'Courier New', monospace" font-size="8" fill="#4a2a1a">AGENTS SKILLS MCP</text>
@@ -205,9 +205,9 @@
 
   <rect x="612" y="96" width="132" height="60" rx="2" fill="#020814" stroke="#001a38" stroke-width="1"/>
   <text x="616" y="108" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">$ install</text>
-  <text x="616" y="122" font-family="'Courier New', monospace" font-size="7.5" fill="#0080ff">copy rules/*.mdc</text>
-  <text x="616" y="136" font-family="'Courier New', monospace" font-size="7.5" fill="#4499ff">→ .windsurf/</text>
-  <text x="616" y="150" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">rules/</text>
+  <text x="616" y="122" font-family="'Courier New', monospace" font-size="7.5" fill="#0080ff">copy rules + memory</text>
+  <text x="616" y="136" font-family="'Courier New', monospace" font-size="7.5" fill="#4499ff">→ ~/.codeium/</text>
+  <text x="616" y="150" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">windsurf/</text>
 
   <line x1="618" y1="164" x2="740" y2="164" stroke="#0080ff" stroke-width="0.5" opacity="0.2"/>
   <text x="622" y="176" font-family="'Courier New', monospace" font-size="8" fill="#001a3a">RULES  CASCADE MCP</text>
@@ -231,8 +231,8 @@
   <rect x="762" y="96" width="126" height="60" rx="2" fill="#130210" stroke="#3a0038" stroke-width="1"/>
   <text x="766" y="108" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">$ install</text>
   <text x="766" y="122" font-family="'Courier New', monospace" font-size="7.5" fill="#ff00aa">copy skills/*.md</text>
-  <text x="766" y="136" font-family="'Courier New', monospace" font-size="7.5" fill="#ff66cc">→ ~/.pi/skills/</text>
-  <text x="766" y="150" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">+ loops/</text>
+  <text x="766" y="136" font-family="'Courier New', monospace" font-size="7.5" fill="#ff66cc">→ ~/.pi/agent/</text>
+  <text x="766" y="150" font-family="'Courier New', monospace" font-size="7" fill="#4a4a8a">skills/ + loops</text>
 
   <line x1="768" y1="164" x2="888" y2="164" stroke="#ff00aa" stroke-width="0.5" opacity="0.2"/>
   <text x="772" y="176" font-family="'Courier New', monospace" font-size="8" fill="#4a003a">SKILLS LOOPS  MCP</text>


### PR DESCRIPTION
## Summary
- Update `static/banner.svg` version tag to **v1.2.1**
- Fix `architecture.svg`: L3 = **agentic-harness**, install line uses `uvx` / `uv tool` / brew·AUR
- Rewrite `loop-tiers.svg` examples to real templates (`daily-triage`, `ci-sweeper`, `oss-pr-monitor`, …)
- Fix `tools-grid.svg` paths for Windsurf (`~/.codeium/windsurf`), Pi (`~/.pi/agent/`), OpenCode (`~/.config/opencode/`), Cursor subtitle

## Test plan
- [ ] Preview SVGs on the PR Files changed tab / raw GitHub render
- [ ] Confirm README embeds still resolve for all four assets