### PR TITLE
ci: harden release, PyPI verify, and notify dispatches

### DIFF
--- a/.github/workflows/notify-aur.yml
+++ b/.github/workflows/notify-aur.yml
@@ -11,6 +11,10 @@ on:
         description: Version to release (e.g. 1.0.0)
         required: true
 
+concurrency:
+  group: notify-aur-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -24,19 +28,55 @@ jobs:
           else
             VERSION="${GITHUB_REF_NAME#v}"
           fi
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.-]+)?$'; then
-            echo "::error::Invalid version: $VERSION"; exit 1
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.+-]+)?$'; then
+            echo "::error::Invalid version: $VERSION"
+            exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Notifying AUR packages for v$VERSION"
 
-      - name: Dispatch to aur-packages
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          gh api /repos/ulises-jeremias/aur-packages/dispatches \
-            -f event_type="new-release" \
-            -f "client_payload[package_name]=agent-toolkit" \
-            -f "client_payload[version]=$VERSION"
-          echo "✓ Dispatched new-release event to aur-packages for v$VERSION"
+      - name: Wait for GitHub Release + source tarball
         env:
           GH_TOKEN: ${{ secrets.AUR_REPO_TOKEN }}
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          TAG="v${VERSION}"
+          URL="https://github.com/ulises-jeremias/agent-toolkit/archive/refs/tags/${TAG}.tar.gz"
+          for attempt in $(seq 1 36); do
+            REL_OK=0
+            TAR_OK=0
+            if gh release view "$TAG" --repo ulises-jeremias/agent-toolkit >/dev/null 2>&1; then
+              REL_OK=1
+            fi
+            CODE=$(curl -fsSL -o /dev/null -w '%{http_code}' --head "$URL" 2>/dev/null || echo 000)
+            if [ "$CODE" = "200" ] || [ "$CODE" = "302" ]; then
+              TAR_OK=1
+            fi
+            if [ "$REL_OK" = "1" ] && [ "$TAR_OK" = "1" ]; then
+              echo "✓ Release $TAG and tarball are available"
+              exit 0
+            fi
+            echo "Attempt $attempt/36: release=$REL_OK tarball_http=$CODE — waiting 15s..."
+            sleep 15
+          done
+          echo "::error::Release/tarball not available after retries"
+          exit 1
+
+      - name: Dispatch to aur-packages (retry)
+        env:
+          GH_TOKEN: ${{ secrets.AUR_REPO_TOKEN }}
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          for attempt in $(seq 1 8); do
+            if gh api /repos/ulises-jeremias/aur-packages/dispatches \
+              -f event_type="new-release" \
+              -f "client_payload[package_name]=agent-toolkit" \
+              -f "client_payload[version]=$VERSION"; then
+              echo "✓ Dispatched new-release to aur-packages for v$VERSION"
+              exit 0
+            fi
+            echo "Attempt $attempt/8: dispatch failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Failed to dispatch aur-packages update"
+          exit 1

--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -11,6 +11,10 @@ on:
         description: Version to release (e.g. 1.0.0)
         required: true
 
+concurrency:
+  group: notify-homebrew-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -22,38 +26,57 @@ jobs:
           if [ -n "${{ github.event.inputs.version }}" ]; then
             VERSION="${{ github.event.inputs.version }}"
           else
-            # Strip leading 'v' from tag
             VERSION="${GITHUB_REF_NAME#v}"
           fi
-          # Validate semver
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.-]+)?$'; then
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.+-]+)?$'; then
             echo "::error::Invalid version: $VERSION"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Notifying Homebrew tap for v$VERSION"
 
-      - name: Wait for GitHub release tarball
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          URL="https://github.com/ulises-jeremias/agent-toolkit/archive/refs/tags/v${VERSION}.tar.gz"
-          for attempt in $(seq 1 24); do
-            if curl -fsSL --head "$URL" 2>/dev/null | grep -q "200\|302"; then
-              echo "✓ Tarball available: $URL"
-              break
-            fi
-            if [ "$attempt" = "24" ]; then echo "::error::Tarball not available after 24 attempts"; exit 1; fi
-            echo "Attempt $attempt/24: not yet available, retrying in 15s..."
-            sleep 15
-          done
-
-      - name: Dispatch to homebrew-tap
-        run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          gh api /repos/ulises-jeremias/homebrew-tap/dispatches \
-            -f event_type="new-release" \
-            -f "client_payload[formula_name]=agent-toolkit" \
-            -f "client_payload[version]=$VERSION"
-          echo "✓ Dispatched new-release event to homebrew-tap for v$VERSION"
+      - name: Wait for GitHub Release + source tarball
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          TAG="v${VERSION}"
+          URL="https://github.com/ulises-jeremias/agent-toolkit/archive/refs/tags/${TAG}.tar.gz"
+          for attempt in $(seq 1 36); do
+            REL_OK=0
+            TAR_OK=0
+            if gh release view "$TAG" --repo ulises-jeremias/agent-toolkit >/dev/null 2>&1; then
+              REL_OK=1
+            fi
+            CODE=$(curl -fsSL -o /dev/null -w '%{http_code}' --head "$URL" 2>/dev/null || echo 000)
+            if [ "$CODE" = "200" ] || [ "$CODE" = "302" ]; then
+              TAR_OK=1
+            fi
+            if [ "$REL_OK" = "1" ] && [ "$TAR_OK" = "1" ]; then
+              echo "✓ Release $TAG and tarball are available"
+              exit 0
+            fi
+            echo "Attempt $attempt/36: release=$REL_OK tarball_http=$CODE — waiting 15s..."
+            sleep 15
+          done
+          echo "::error::Release/tarball not available after retries"
+          exit 1
+
+      - name: Dispatch to homebrew-tap (retry)
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          for attempt in $(seq 1 8); do
+            if gh api /repos/ulises-jeremias/homebrew-tap/dispatches \
+              -f event_type="new-release" \
+              -f "client_payload[formula_name]=agent-toolkit" \
+              -f "client_payload[version]=$VERSION"; then
+              echo "✓ Dispatched new-release to homebrew-tap for v$VERSION"
+              exit 0
+            fi
+            echo "Attempt $attempt/8: dispatch failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Failed to dispatch homebrew-tap update"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 # Sole automated PyPI publish path for version tags (v*).
 # Manual TestPyPI/PyPI republish: workflow "Publish (manual)" only.
+#
+# Job graph:
+#   create-release ─┬─► publish-pypi
+#                   ├─► build-binaries ─► upload-assets
+#                   └─► sbom (attach after release exists)
 
 on:
   push:
@@ -12,10 +17,16 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -26,6 +37,22 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
+      - name: Wait until release API is readable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          for attempt in $(seq 1 30); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "✓ Release $TAG is visible via API"
+              exit 0
+            fi
+            echo "Attempt $attempt/30: release not visible yet..."
+            sleep 5
+          done
+          echo "::error::Release $TAG never became visible"
+          exit 1
 
   publish-pypi:
     name: Publish to PyPI
@@ -46,6 +73,25 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+      - name: Verify PyPI shows this version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for attempt in $(seq 1 24); do
+            LATEST=$(curl -fsSL "https://pypi.org/pypi/agent-toolkit-cli/json" \
+              | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])" 2>/dev/null || echo "")
+            if [ "$LATEST" = "$VERSION" ]; then
+              echo "✓ PyPI latest is $LATEST"
+              exit 0
+            fi
+            # Also accept if this version exists even when not "latest" (yanked older etc.)
+            if curl -fsSL "https://pypi.org/pypi/agent-toolkit-cli/${VERSION}/json" >/dev/null 2>&1; then
+              echo "✓ PyPI has agent-toolkit-cli==$VERSION (latest reported: ${LATEST:-unknown})"
+              exit 0
+            fi
+            echo "Attempt $attempt/24: waiting for PyPI (saw '${LATEST:-none}')..."
+            sleep 15
+          done
+          echo "::warning::PyPI verification timed out — publish step succeeded; CDN may lag"
 
   build-binaries:
     name: Build ${{ matrix.artifact }}
@@ -96,13 +142,26 @@ jobs:
         with:
           path: binaries/
           merge-multiple: true
-      - run: gh release upload "${GITHUB_REF_NAME}" binaries/agent-toolkit* --clobber
+      - name: Upload binaries (retry)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 10); do
+            if gh release upload "${GITHUB_REF_NAME}" binaries/agent-toolkit* --clobber; then
+              echo "✓ Binaries attached"
+              exit 0
+            fi
+            echo "Attempt $attempt/10 failed; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Failed to attach binaries"
+          exit 1
 
   sbom:
     name: Generate SBOM
+    needs: create-release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -120,12 +179,21 @@ jobs:
         with:
           name: sbom
           path: sbom.cyclonedx.json
-      - name: Attach SBOM to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Attach SBOM to GitHub Release (retry)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          if [ -f sbom.cyclonedx.json ]; then
-            gh release upload "${GITHUB_REF_NAME}" sbom.cyclonedx.json --clobber
-          fi
+          set -euo pipefail
+          test -f sbom.cyclonedx.json
+          for attempt in $(seq 1 15); do
+            if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
+              && gh release upload "${GITHUB_REF_NAME}" sbom.cyclonedx.json --clobber; then
+              echo "✓ SBOM attached to ${GITHUB_REF_NAME}"
+              exit 0
+            fi
+            echo "Attempt $attempt/15: release not ready or upload failed; retrying in 8s..."
+            sleep 8
+          done
+          echo "::error::Failed to attach SBOM after retries"
+          exit 1


### PR DESCRIPTION
## Summary
Makes the tag → PyPI / Homebrew / AUR pipeline resilient to races we hit on v1.2.x:

- **SBOM** now `needs: create-release` + retry attach (fixes race that failed the Release workflow)
- **Binaries** upload retries
- **PyPI** soft-verifies the published version
- **Notify Homebrew/AUR** wait for GitHub Release + source tarball, retry `repository_dispatch`

## Test plan
- [ ] Merge
- [ ] Optional: workflow_dispatch notify for 1.2.2 once AUR is healthy