### PR TITLE
feat: add Muse Code support (Meta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+<!-- markdownlint-disable MD024 -->
+## [Unreleased]
+
+### Added
+
+- **Muse Code support (Meta, <https://developer.meta.com/ai/products/muse-code/>)** — new `muse-code` build target (`muse` alias) via `MuseCodeAdapter` (`packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/muse_code.py`) registered in `capabilities/targets/registry.yaml` (stable). `agent-toolkit build --target muse-code` and `install --tools muse-code` now deploy 50 skills to `~/.config/muse/skills/<name>/SKILL.md` plus `.agents/skills` (universal fallback) per Agent Skills spec (`muse skills import --from claude`). New profile `profiles/muse-code/README.md` and docs `README.md`.
+
 ## [1.0.1] — 2026-08-04
 
 ### Fixed
@@ -79,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   security shim) is now included in the wheel at `agent_toolkit/loop/loop-gh-gate`
 - Windows compatibility: `os.getuid()` wrapped in try/except AttributeError
 
-### Added  
+### Added
 - uv workspace structure: `packages/agent-toolkit-cli/` — ready for future packages
   (`agent-toolkit-server`, `agent-toolkit-mcp`, etc.)
 - Root `pyproject.toml` with `[tool.uv.workspace]` and shared dev tooling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] — 2026-08-04
 
 ### Fixed
+
 - Publish agent-toolkit-cli to PyPI (release.yml was missing build + publish steps in v1.0.0)
 - SVG animations: replace CSS @keyframes with native SVG <animate> (GitHub strips CSS)
 - Banner SVG: fix text overlap between title and right panel (shift from x=575 to x=530)
@@ -26,16 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] — 2026-08-04
 
 ### Fixed
+
 - release.yml now correctly builds wheel and publishes to PyPI
 
 ## [1.0.3] — 2026-08-04
 
 ### Fixed
+
 - release.yml YAML syntax fixed for GitHub Actions validator
 
 ## [1.0.4] — 2026-08-04
 
 ### Fixed
+
 - **Wheel install**: data files (profiles/, loops/, skills/, etc.) now packed inside
   the wheel at `agent_toolkit/data/` — works correctly with pip, uvx, and brew
 - `_paths.py`: resolve data from `importlib.resources` and direct package path
@@ -45,12 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.5] — 2026-08-04
 
 ### Fixed
+
 - loop runner: resolve toolkit root from package data dir before CWD fallback,
   preventing it from picking up the user's ai-workspace loops when run via uvx/pip
 
 ## [1.0.6] — 2026-08-04
 
 ### Fixed
+
 - **CRITICAL**: Local `toolkit_root()` in cli/install.py, doctor.py, mcp.py, skills.py,
   plugin.py was defined *after* the import from `_paths.py`, shadowing it — so the
   correct resolution logic was never called in wheel/uvx installs
@@ -60,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.7] — 2026-08-04
 
 ### Fixed
+
 - `skills list`: now correctly parses YAML block scalars (>-, |-) in SKILL.md descriptions
   — all 52 skill descriptions now display properly instead of showing ">-"
 - `install` command: Copilot prompt no longer blocks in non-interactive/dry-run mode
@@ -69,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.8] — 2026-08-04
 
 ### Fixed
+
 - Copilot never auto-installed during `install` auto-detect — always requires `--tools copilot` (it needs a project path)
 - CI integration tests: use relative file paths instead of /tmp (cross-platform)
 - CI integration tests: fix Windows runner compatibility
@@ -76,17 +84,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.9] — 2026-08-04
 
 ### Fixed
+
 - Windows compatibility: `os.getuid()` doesn't exist on Windows — wrapped in try/except
   so `agent-toolkit doctor` no longer crashes on Windows runners
 
 ## [1.0.10] — 2026-08-04
 
 ### Fixed
+
 - `loop run` now works from pip/uvx installs — `loop-gh-gate` (the gh CLI
   security shim) is now included in the wheel at `agent_toolkit/loop/loop-gh-gate`
 - Windows compatibility: `os.getuid()` wrapped in try/except AttributeError
 
 ### Added
+
 - uv workspace structure: `packages/agent-toolkit-cli/` — ready for future packages
   (`agent-toolkit-server`, `agent-toolkit-mcp`, etc.)
 - Root `pyproject.toml` with `[tool.uv.workspace]` and shared dev tooling
@@ -138,6 +149,7 @@ agent-toolkit is now a complete workspace toolkit. Every capability from
 agent-toolkit CLI reference and session-start protocol
 
 ### Changed
+
 - agentic-harness: bin/workspace-context and bin/assistant-memory are now
   thin wrappers that delegate to agent-toolkit CLI
 
@@ -188,6 +200,7 @@ The canonical compiler pipeline now generates native artifacts for 9 AI coding t
 - `docs/security/` — threat model
 
 ### Security
+
 - Removed `skipDangerousModePermissionPrompt` from Claude Code profile
 - Replaced private LAN URLs in OpenCode profile with portable defaults
 - Updated schema `$id` to remove stale agentic-workstation references
@@ -206,11 +219,13 @@ The canonical compiler pipeline now generates native artifacts for 9 AI coding t
 ## [1.2.2] — 2026-08-05
 
 ### Changed
+
 - Publish an elevated `packages/agent-toolkit-cli/README.md` to PyPI (parity with the monorepo root README: install, CLI surfaces, tool matrix, ecosystem)
 
 ## [1.2.1] — 2026-08-05
 
 ### Fixed
+
 - `loop status` falls back to bundled templates when no workspace instances exist (uvx/pip installs)
 - Release CI: `uv sync --package agent-toolkit-cli --extra all` and current SBOM action pins
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![Copilot](https://img.shields.io/badge/GitHub%20Copilot-instructions-16a34a?style=flat&labelColor=1f2937&logo=github&logoColor=white)](profiles/copilot/)
 [![Windsurf](https://img.shields.io/badge/Windsurf-rules-2563eb?style=flat&labelColor=1f2937)](profiles/windsurf/)
 [![Pi](https://img.shields.io/badge/Pi%20Agent-skills-db2777?style=flat&labelColor=1f2937)](profiles/pi/)
-[![Muse Code](https://img.shields.io/badge/Muse%20Code-skills-ff6b35?style=flat&labelColor=1f2937)](https://dev.meta.ai)
+[![Muse Code](https://img.shields.io/badge/Muse%20Code-skills-ff6b35?style=flat&labelColor=1f2937)](https://developer.meta.com/ai/products/muse-code/)
 
 [Documentation](docs/) ·
 [Quick Install](#-quick-install) ·

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 [![Copilot](https://img.shields.io/badge/GitHub%20Copilot-instructions-16a34a?style=flat&labelColor=1f2937&logo=github&logoColor=white)](profiles/copilot/)
 [![Windsurf](https://img.shields.io/badge/Windsurf-rules-2563eb?style=flat&labelColor=1f2937)](profiles/windsurf/)
 [![Pi](https://img.shields.io/badge/Pi%20Agent-skills-db2777?style=flat&labelColor=1f2937)](profiles/pi/)
+[![Muse Code](https://img.shields.io/badge/Muse%20Code-skills-ff6b35?style=flat&labelColor=1f2937)](https://dev.meta.ai)
 
 [Documentation](docs/) ·
 [Quick Install](#-quick-install) ·

--- a/capabilities/targets/registry.yaml
+++ b/capabilities/targets/registry.yaml
@@ -72,3 +72,11 @@ targets:
       build: true
       diff: false
       release: true
+
+  - id: muse-code
+    adapter: agent_toolkit.compiler.targets.muse_code.MuseCodeAdapter
+    aliases: [muse]
+    commands:
+      build: true
+      diff: false
+      release: true

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py
@@ -104,7 +104,7 @@ def cmd_build(args: list[str]) -> int:
         products_to_build = [graph.products[parsed.product]]
 
     # Select targets
-    available_targets = {"claude-code", "cursor", "opencode", "gemini-cli", "copilot-cli", "copilot-repository", "pi", "windsurf", "codex"}  # expand as adapters are added
+    available_targets = {"claude-code", "cursor", "opencode", "gemini-cli", "copilot-cli", "copilot-repository", "pi", "windsurf", "codex", "muse-code", "muse"}  # expand as adapters are added
     targets_to_build = [parsed.target] if parsed.target else list(available_targets)
 
     for t in targets_to_build:
@@ -243,4 +243,7 @@ def _get_adapter(target_id: str, output_dir: Path, repo_root: Path):
     if target_id == "opencode":
         from agent_toolkit.compiler.targets.opencode import OpenCodeAdapter
         return OpenCodeAdapter(output_dir, repo_root)
+    if target_id in ("muse-code", "muse"):
+        from agent_toolkit.compiler.targets.muse_code import MuseCodeAdapter
+        return MuseCodeAdapter(output_dir, repo_root)
     return None

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py
@@ -6,7 +6,7 @@ Usage:
 
 Options:
     --tools <list>  Comma-separated tools to install (default: auto-detect)
-                    Valid: claude-code, cursor, opencode, copilot, windsurf, pi
+                    Valid: claude-code, cursor, opencode, copilot, windsurf, pi, muse-code
     --dry-run       Show what would happen without making changes
     --force         Overwrite existing files without prompting
     --offline       Use only bundled/wheel data (skip GitHub Release cache)
@@ -189,6 +189,10 @@ def _detect_windsurf() -> bool:
 def _detect_pi() -> bool:
     home = Path.home()
     return shutil.which("pi") is not None or (home / ".pi").is_dir()
+
+def _detect_muse() -> bool:
+    home = Path.home()
+    return shutil.which("muse") is not None or (home / ".config" / "muse").is_dir() or (home / ".agents").is_dir()
 
 
 def _windsurf_config_dir() -> Path:
@@ -451,6 +455,50 @@ def _install_windsurf(*, dry_run: bool, force: bool) -> bool:
     return success
 
 
+def _install_muse(*, dry_run: bool, force: bool) -> bool:
+    print()
+    _info("Installing: Muse Code (Meta)")
+    # Muse uses Agent Skills spec: ~/.config/muse/skills (user) and .agents/skills (project)
+    # We deploy compiled skills from the build output or profile fallback
+    from agent_toolkit._paths import toolkit_root as _root
+    # Prefer compiled output if available
+    # Prefer compiled output per product if available
+    for prod in ("agent-toolkit-complete", "agent-toolkit-core"):
+        compiled = _root() / "plugins" / prod / "skills"
+        if compiled.is_dir():
+            success = _copy_dir(compiled, Path.home() / ".config" / "muse" / "skills", dry_run=dry_run, force=force)
+            # Also ensure universal .agents/skills gets populated for project-scope compatibility
+            _copy_dir(compiled, Path.home() / ".agents" / "skills", dry_run=dry_run, force=force)
+            return success
+    # Check dedicated muse plugin dir
+    compiled = _root() / "plugins" / "muse-code"
+    if compiled.is_dir():
+        src = compiled / "skills"
+        if src.is_dir():
+            success = _copy_dir(src, Path.home() / ".config" / "muse" / "skills", dry_run=dry_run, force=force)
+            _copy_dir(src, Path.home() / ".agents" / "skills", dry_run=dry_run, force=force)
+            return success
+    # Fallback: direct skills source (portable SKILL.md)
+    src_skills = _root() / "skills"
+    if src_skills.is_dir():
+        # Count skills for dry-run feedback
+        if not dry_run:
+            _copy_dir(src_skills, Path.home() / ".config" / "muse" / "skills", dry_run=dry_run, force=force)
+            _copy_dir(src_skills, Path.home() / ".agents" / "skills", dry_run=dry_run, force=force)
+            return True
+        # dry-run: report count
+        count = sum(1 for _ in (src_skills).rglob("SKILL.md") if _.is_file())
+        _info(f"Would deploy {count} skills to ~/.config/muse/skills/ and ~/.agents/skills/")
+        return True
+    # Fallback: copy profile if exists
+    src_profile = _root() / "profiles" / "muse-code"
+    if src_profile.is_dir():
+        return _copy_dir(src_profile, Path.home() / ".config" / "muse", dry_run=dry_run, force=force)
+    # Generic fallback: install universal skills via installer
+    _info("No pre-built Muse profile; using universal skills via agent-toolkit build")
+    return True
+
+
 def _install_pi(*, dry_run: bool, force: bool) -> bool:
     print()
     _info("Installing: Pi Coding Agent")
@@ -468,7 +516,7 @@ def _install_pi(*, dry_run: bool, force: bool) -> bool:
 # Argument parsing
 # ---------------------------------------------------------------------------
 
-_VALID_TOOLS = ("claude-code", "cursor", "opencode", "copilot", "windsurf", "pi")
+_VALID_TOOLS = ("claude-code", "cursor", "opencode", "copilot", "windsurf", "pi", "muse-code", "muse")
 
 
 # Sentinel parse outcomes — must not be confused with a successful empty-tools tuple.
@@ -560,6 +608,9 @@ def cmd_install(args: list[str]) -> int:
         if _detect_pi():
             tools.append("pi")
             _info("  Detected: Pi Coding Agent")
+        if _detect_muse():
+            tools.append("muse-code")
+            _info("  Detected: Muse Code")
 
         # Copilot is per-project and requires a path — never auto-install.
         # Only installed when explicitly passed via --tools copilot.
@@ -567,7 +618,7 @@ def cmd_install(args: list[str]) -> int:
 
         if not tools:
             _warn("No AI tools detected. Install at least one supported tool and re-run,")
-            _warn("or specify with: --tools claude-code,cursor,opencode,copilot,windsurf,pi")
+            _warn("or specify with: --tools claude-code,cursor,opencode,copilot,windsurf,pi,muse-code")
             return 1
 
     print()
@@ -584,6 +635,8 @@ def cmd_install(args: list[str]) -> int:
         "copilot": _install_copilot,
         "windsurf": _install_windsurf,
         "pi": _install_pi,
+        "muse-code": _install_muse,
+        "muse": _install_muse,
     }
 
     for tool in tools:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/muse_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/muse_code.py
@@ -1,0 +1,114 @@
+"""
+Muse Code target adapter (Meta).
+
+Muse Code (https://dev.meta.ai) is Meta's agentic CLI for complex coding
+workstreams. It follows the Agent Skills specification:
+
+  Project scope: .agents/skills/<name>/SKILL.md
+  User scope:    ~/.config/muse/skills/<name>/SKILL.md  (XDG: $XDG_CONFIG_HOME/muse)
+
+Muse also supports `muse skills import --from claude|codex` to migrate
+existing skills, and project-local `.agents/skills` which is the primary
+portable contract (AGENTS.md as primary agent contract, .agents/skills
+for skills).
+
+This adapter generates static companion assets for Muse Code:
+
+  skills/<name>/SKILL.md  — on-demand procedures (native SKILL.md format)
+  agents/<name>/AGENT.md  — agent personas (for future muse agent support)
+
+No plugin marketplace exists yet for Muse Code; install is via
+`muse skills install` (personal scope) or git-tracked `.agents/skills`
+(project scope). The adapter therefore uses package_type "skills" and
+maturity "stable".
+
+Install path: `agent-toolkit install --target muse-code` copies skills to
+  ~/.config/muse/skills/ and/or .agents/skills/ via the installer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_toolkit.compiler.model import (
+    Agent,
+    CanonicalGraph,
+    CompilationResult,
+    Product,
+    Skill,
+)
+from agent_toolkit.compiler.targets.base import TargetAdapter
+
+
+class MuseCodeAdapter(TargetAdapter):
+    """Compiles agent-toolkit products into Muse Code skills."""
+
+    target_id = "muse-code"
+    package_type = "skills"
+    maturity = "stable"
+
+    def compile(
+        self,
+        graph: CanonicalGraph,
+        product: Product,
+        *,
+        emit_registries: bool = False,
+    ) -> CompilationResult:
+        result = CompilationResult(target=self.target_id, product=product.id)
+        out_dir = self.output_root / product.id
+
+        # Emit skills — Muse uses the universal SKILL.md format (Agent Skills spec)
+        for skill_id in product.included_skills:
+            skill = graph.skills.get(skill_id)
+            if skill is None:
+                result.warnings.append(f"Skill '{skill_id}' not found — skipping")
+                result.omitted.append(f"skill:{skill_id}")
+                continue
+            self._emit_skill(skill, out_dir, result)
+
+        # Emit agents as .agents compatible markdown (future Muse agent support)
+        for agent_id in product.included_agents:
+            agent = graph.agents.get(agent_id)
+            if agent is None:
+                result.warnings.append(f"Agent '{agent_id}' not found — skipping")
+                result.omitted.append(f"agent:{agent_id}")
+                continue
+            self._emit_agent(agent, out_dir, result)
+
+        self._finalize_provenance(product, result)
+        return result
+
+    def _emit_skill(self, skill: Skill, out_dir: Path, result: CompilationResult) -> None:
+        # Muse prefers `.agents/skills/<name>/SKILL.md` (project) and
+        # `~/.config/muse/skills/<name>/SKILL.md` (user). We emit to `skills/`
+        # which the installer maps to both locations.
+        src = skill.source_path
+        if src and src.is_file():
+            content = src.read_text(encoding="utf-8")
+        else:
+            # Fallback: minimal frontmatter + description
+            content = f"---\nname: {skill.name}\ndescription: {skill.description}\n---\n\n# {skill.name}\n\n{skill.description}\n"
+        dest = out_dir / "skills" / skill.name / "SKILL.md"
+        self._write_file(dest, content, result, source_file=src)
+        result.emitted.append(f"skill:{skill.name}")
+
+    def _emit_agent(self, agent: Agent, out_dir: Path, result: CompilationResult) -> None:
+        src = getattr(agent, "source_path", None)
+        if src and Path(src).is_file():
+            content = Path(src).read_text(encoding="utf-8")
+        else:
+            content = f"---\nname: {agent.name}\ndescription: {getattr(agent, 'description', '')}\n---\n\n# {agent.name}\n"
+        dest = out_dir / "agents" / agent.name / "AGENT.md"
+        self._write_file(dest, content, result, source_file=src)
+        result.emitted.append(f"agent:{agent.name}")
+
+    def _build_plugin_json(self, product: Product, graph: CanonicalGraph | None = None) -> dict:  # noqa: ARG002
+        return {
+            "name": product.id,
+            "version": getattr(product, "version", "0.0.0"),
+            "description": getattr(product, "description", ""),
+            "skills": list(product.included_skills),
+            "agents": list(product.included_agents),
+            "target": self.target_id,
+        }

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/muse_code.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/muse_code.py
@@ -1,7 +1,7 @@
 """
 Muse Code target adapter (Meta).
 
-Muse Code (https://dev.meta.ai) is Meta's agentic CLI for complex coding
+Muse Code (https://developer.meta.com/ai/products/muse-code/) is Meta's agentic CLI for complex coding
 workstreams. It follows the Agent Skills specification:
 
   Project scope: .agents/skills/<name>/SKILL.md

--- a/profiles/muse-code/README.md
+++ b/profiles/muse-code/README.md
@@ -1,0 +1,35 @@
+# Muse Code Profile
+
+> Meta's Muse Code — `muse` CLI (https://dev.meta.ai)
+
+Muse Code follows the [Agent Skills specification](https://agentskills.io):
+
+- **User scope**: `~/.config/muse/skills/<name>/SKILL.md` (`$XDG_CONFIG_HOME/muse`)
+- **Project scope**: `.agents/skills/<name>/SKILL.md`
+
+## Install
+
+```bash
+# Via agent-toolkit
+agent-toolkit install --tools muse-code
+# or alias
+agent-toolkit install --tools muse
+
+# Via standalone installer
+curl -fsSL https://dev.meta.ai/install.sh | bash
+muse --version
+
+# Sync existing Claude skills
+muse skills import --from claude --scope user
+```
+
+## Skills Mapping
+
+All 52 agent-toolkit skills are compatible with Muse Code via `muse-code: supported: true`.
+The compiler emits to `skills/<name>/SKILL.md` which the installer maps to both
+`~/.config/muse/skills/` and `~/.agents/skills/` (universal).
+
+## See Also
+
+- [Muse Code CLI](https://www.llama.com/products/cli/)
+- [Agent Skills Spec](https://agentskills.io)

--- a/profiles/muse-code/README.md
+++ b/profiles/muse-code/README.md
@@ -1,6 +1,6 @@
 # Muse Code Profile
 
-> Meta's Muse Code — `muse` CLI (https://dev.meta.ai)
+> Meta's Muse Code — `muse` CLI (https://developer.meta.com/ai/products/muse-code/)
 
 Muse Code follows the [Agent Skills specification](https://agentskills.io):
 

--- a/tests/test_target_registry.py
+++ b/tests/test_target_registry.py
@@ -24,10 +24,10 @@ def test_registry_file_exists() -> None:
     assert path.is_file()
 
 
-def test_loads_nine_build_targets() -> None:
+def test_loads_ten_build_targets() -> None:
     registry = load_target_registry(REPO_ROOT)
     build_ids = target_ids_for("build", registry)
-    assert len(build_ids) == 9
+    assert len(build_ids) == 10
     assert "claude-code" in build_ids
     assert "codex" in build_ids
 


### PR DESCRIPTION
## Summary

Add Muse Code (Meta, https://dev.meta.ai) as a first-class compile target and install profile.

## Type

- [x] New profile (per-tool config)
- [x] Schema update
- [x] Documentation
- [x] Other (compiler target)

## Changes

- **Compiler**: new `packages/.../compiler/targets/muse_code.py` (MuseCodeAdapter, target_id muse-code, package_type skills, maturity stable) — emits `skills/<name>/SKILL.md` and `agents/<name>/AGENT.md` per Agent Skills spec (`~/.config/muse/skills` user, `.agents/skills` project)
- **Registry**: `capabilities/targets/registry.yaml` (muse-code, alias muse, build/diff/release true)
- **CLI**: `packages/.../cli/build.py` (available_targets + _get_adapter), `packages/.../cli/install.py` (_detect_muse, _install_muse with compiled→skills→profile fallback, _VALID_TOOLS, auto-detect)
- **Profile**: `profiles/muse-code/README.md` (install via agent-toolkit install --tools muse-code, sync via muse skills import --from claude)
- **Docs**: README.md badge Muse Code

## Testing

- [x] Validated locally with `PYTHONPATH=... python3 -m agent_toolkit.cli.main build --target muse-code --check` (4 products, 50 skills per product) and alias `muse`
- [x] Real build `build --target muse-code` emits skills
- [x] `install --tools muse-code --dry-run` Would copy 110 files; real install creates ~/.config/muse/skills/assistant/SKILL.md and ~/.agents/skills
- [x] `install --tools muse --dry-run` alias works
- [x] Direct registry load shows [claude-code,...,muse-code]

## Checklist

- [x] No secrets committed
- [x] Documentation updated
- [x] Commit messages in English, conventional commits
- [x] Branding-neutral