### PR TITLE
docs(pr-template): drop skill.json; align checklist to loop.yaml reality

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,20 +29,23 @@
 
 <!-- Describe how you verified the changes work correctly. -->
 
-- [ ] Validated locally with `bash scripts/validate-skills.sh` (if skill changes)
-- [ ] Ran affected loop templates manually end-to-end (if loop changes)
-- [ ] Confirmed `validate` CI workflow passes (or ran checks locally)
+- [ ] Validated locally with `python3 scripts/validate-skills.py` (if skill changes)
+- [ ] Validated loops with `python3` + `schemas/loop.schema.json` (if loop changes) — see `.github/workflows/validate.yml` `validate-loops` job
+- [ ] Ran `python3 scripts/validate-agents.py` (if agent changes)
+- [ ] Regenerated catalogs with `python3 scripts/generate-catalogs.py` (if skill/agent/loop added)
+- [ ] Checked `python3 scripts/gen-surfaces.py --check` (if skill/agent/loop or surface changed)
+- [ ] Confirmed `validate` CI workflow passes (or ran checks locally via `uv sync --all-extras && AGENT_TOOLKIT_ROOT=$PWD uv run pytest tests/ -v`)
 - [ ] Tested with at least one supported AI tool (Claude Code, Cursor, Copilot, etc.)
 
 ## Checklist
 
-- [ ] Skill directories include both `SKILL.md` and `skill.json`
-- [ ] `skill.json` validates against `schemas/skill.schema.json`
-- [ ] Loop templates include required fields: `name`, `goal`, `request`
-- [ ] Loop templates include `budget`, `deny`, and `exit_conditions` fields
-- [ ] Loop templates validate against `schemas/loop.schema.json`
+- [ ] `SKILL.md` frontmatter present (`name`, `description`) — no `skill.json` (removed in v1.0.4)
+- [ ] Loop `loops/<name>/loop.yaml` includes required fields: `name`, `goal`, `request`
+- [ ] Loop `tier` set (`L1`/`L2`/`L3`) with `budget` (`max_tokens`, `max_runs_per_day`, `max_wall_seconds`) and `exit_conditions`
+- [ ] Loop `allowlist`/`deny` scoped correctly for tier
+- [ ] Loop `loop.yaml` validates against `schemas/loop.schema.json`
 - [ ] No secrets, tokens, API keys, or credentials committed
 - [ ] Documentation updated to reflect any behavior changes
 - [ ] Branding-neutral: no organization-specific references in public-facing files
-- [ ] Catalog entries updated (`catalogs/`) if a skill, agent, or loop was added
+- [ ] Catalog entries regenerated (`python3 scripts/generate-catalogs.py`) if a skill, agent, or loop was added
 - [ ] Commit messages are in English and follow conventional commits format


### PR DESCRIPTION
Fixes #247
Parent #240

## Summary
- Remove `skill.json` checklist items (removed in v1.0.4); require `SKILL.md` frontmatter only.
- Loop checklist now references `loop.yaml` fields used in `schemas/loop.schema.json` and CI (`tier`, `budget.max_tokens`/`max_runs_per_day`/`max_wall_seconds`, `allowlist`/`deny`, `exit_conditions`).
- Replace deprecated `bash scripts/validate-*.sh` / `build-catalog.sh` with real scripts: `python3 scripts/validate-skills.py`, `validate-agents.py`, `generate-catalogs.py`, `gen-surfaces.py --check`, and `uv sync --all-extras` parity.

## Testing
- Verified `loop.schema.json` fields locally; templates validate via `.github/workflows/validate.yml` `validate-loops` job.
- `AGENT_TOOLKIT_ROOT=$PWD uv run pytest tests/ -v` described in Testing section.

## Checklist
- [x] `skill.json` items removed
- [x] Loop checklist uses `loop.yaml` tier/budget fields
- [x] Scripts point to on-disk reality