### PR TITLE
docs(readme): fix skill paths and community CTAs (#248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Formulas live in dedicated repos ([homebrew-tap](https://github.com/ulises-jerem
 
 ```bash
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
-yay -S agent-toolkit   # Arch Linux (AUR)
+yay -S agent-toolkit   # Arch Linux (AUR) — pending publish, use `uv tool install agent-toolkit-cli` until AUR RPC shows package
 ```
 
 </details>
@@ -275,9 +275,9 @@ Browse the full catalog: [`catalogs/skill-catalog.yaml`](catalogs/skill-catalog.
 // .claude/settings.json
 {
   "skills": [
-    "ulises-jeremias/agent-toolkit/skills/delivery/code-review",
-    "ulises-jeremias/agent-toolkit/skills/delivery/github-cli-workflow",
-    "ulises-jeremias/agent-toolkit/skills/delivery/gh-fix-ci"
+    "ulises-jeremias/agent-toolkit/skills/core/assistant",
+    "ulises-jeremias/agent-toolkit/skills/delivery/workflow-generic-project",
+    "ulises-jeremias/agent-toolkit/skills/delivery/bug"
   ]
 }
 ```


### PR DESCRIPTION
Fixes #248
Parent #240

- Replace non-existent skill examples (delivery/code-review) with on-disk real paths (core/assistant, delivery/workflow-generic-project, delivery/bug) verified via `find skills -name SKILL.md`
- AUR section adds pending-publish honesty note and points to `uv tool install agent-toolkit-cli` as interim (coord with #244)
- Inventory counts 52/16/10 verified against catalogs/*.yaml

Testing: `find skills -name SKILL.md` confirms paths exist; `python3 scripts/generate-catalogs.py` still 52 entries.