### PR TITLE
docs(security): semver support policy latest minor only (#249)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,14 +5,9 @@
 
 ## Supported Versions
 
-Only the latest commit on the `main` branch is actively supported. There are no versioned releases with backported security patches at this time.
+This project ships **semver-tagged GitHub Releases** and **PyPI `agent-toolkit-cli`** (see [RELEASING.md](docs/RELEASING.md)). Those are the supported distribution channels.
 
-| Version | Supported |
-|---|---|
-| `main` (latest) | Yes |
-| Any tagged release | Best-effort only |
-
-If you are using a pinned commit or an older tag, we recommend updating to `main` before reporting an issue, in case it has already been fixed.
+**Support policy:** **latest released minor only** (e.g. `1.3.x` when `v1.3.0` is latest). The previous minor receives best-effort guidance to upgrade; we do not backport patches unless the maintainer announces otherwise. `main` is pre-release and may contain fixes ahead of the next tag.
 
 ---
 


### PR DESCRIPTION
Fixes #249
Parent #240

- GitHub Releases + PyPI agent-toolkit-cli are the supported distribution channels (semver tags e.g. v1.2.2)
- Support policy: latest released minor only (e.g. 1.3.x), previous minor best-effort, no backports unless maintainer says otherwise; main is pre-release
- Remove contradiction with tagged releases; disclosure/secret sections untouched

Testing: manual doc review; no code change.