### PR TITLE
docs(trust): align TRUST.md with actual CI scanners (#250)

### DIFF
--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -81,7 +81,7 @@ agent-toolkit follows these principles (see also
 - No private hostnames in distributed configs
 - No permission-bypass flags (e.g. skip dangerous-mode prompts) in shipped artifacts
 - MCP credentials via environment variables only
-- Secret scanning (Gitleaks) and dependency scanning (Trivy) in CI
+- Secret scanning (Gitleaks) in CI — Trivy **Planned** (see #262 Wave 2); CodeQL **Planned** (see #262)
 
 ---
 


### PR DESCRIPTION
Fixes #250
Parent #240

- TRUST.md now lists only scanners present today (Gitleaks in validate.yml)
- Trivy and CodeQL marked **Planned** with link to Wave 2 #262 (Dependabot/CodeQL), not claimed as current
- Cross-checked TRUST_BOUNDARIES.md — no Trivy drift

Testing: grep validate.yml confirms gitleaks/gitleaks-action@v2 present, no Trivy/CodeQL jobs.