### PR TITLE
docs(community): add CODE_OF_CONDUCT, SUPPORT, MAINTAINERS (#252)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,81 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [@ulises-jeremias](https://github.com/ulises-jeremias) via GitHub or email listed on the profile. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome.
+
+**Consequence**: A written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved for a specified period. This includes avoiding interactions in community spaces as well as external channels.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating continued patterns of violation, harassment, or aggression toward individuals or groups.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq.
+
+## Contact
+
+Maintainer: [@ulises-jeremias](https://github.com/ulises-jeremias) — use GitHub Discussions or profile email for private reports. See also [SUPPORT.md](SUPPORT.md) and [MAINTAINERS.md](MAINTAINERS.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,18 @@
+# Maintainers
+
+## Current maintainers
+
+* **@ulises-jeremias** ([ulises-jeremias](https://github.com/ulises-jeremias)) — lead maintainer, review and release owner
+
+## Review expectations
+
+* PRs labeled `wave:*` are reviewed in wave order (Wave 0 → 5 per #240/#263)
+* `good first issue` / `help wanted` are community-friendly; `maintainer-only` requires maintainer approval
+* `CODEOWNERS` defines review routing for `skills/`, `loops/`, `distributions/`, and release paths
+* See [CONTRIBUTING.md](CONTRIBUTING.md) for local validation (`uv sync --all-extras`, `AGENT_TOOLKIT_ROOT=$PWD uv run pytest tests/ -v`, `python3 scripts/validate-skills.py` etc.) and PR template checklist
+
+## Governance
+
+* Until multi-maintainer: single-maintainer model; no GOVERNANCE.md voting yet (see #252 out-of-scope)
+* Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+* Support: [SUPPORT.md](SUPPORT.md)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,18 @@
+# Support
+
+## Where to ask
+
+* **Q&A / how-to:** [GitHub Discussions — Q&A](https://github.com/ulises-jeremias/agent-toolkit/discussions) (preferred for open questions)
+* **Chat:** [Discord](https://discord.gg/bR5VyATgka) (same invite as `packages/agent-toolkit-cli/README.md`)
+* **Bug reports / feature requests:** [GitHub Issues](https://github.com/ulises-jeremias/agent-toolkit/issues) — search existing issues first
+* **Security reports:** see [SECURITY.md](SECURITY.md) — use private disclosure, not public issues
+
+## What not to file as issues
+
+* General how-to or “is this possible?” — use Discussions Q&A
+* Private data, tokens, or credentials — never in issues; use private disclosure per SECURITY.md
+* Duplicate requests — search `is:issue` first
+
+## Response expectations
+
+Maintainer: [@ulises-jeremias](https://github.com/ulises-jeremias). Reviews triaged via loops/labels (`wave:*`, `good first issue`). See [MAINTAINERS.md](MAINTAINERS.md) and `.github/CODEOWNERS` for review routing.


### PR DESCRIPTION
Fixes #252
Parent #240

- CODE_OF_CONDUCT.md: Contributor Covenant 2.1 (consistent with CONTRIBUTING link), contact @ulises-jeremias, link to SUPPORT/MAINTAINERS
- SUPPORT.md: Discussions Q&A + Discord (same invite as CLI README) + Issues; what not to file; response expectations
- MAINTAINERS.md: @ulises-jeremias lead, wave-order review, CODEOWNERS link, governance note

Testing: files at repo root per GitHub community health; README/CONTRIBUTING link via new files.