### PR TITLE
docs(releasing): add RELEASING runbook and bump-version script (#255)

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,77 @@
+# Releasing agent-toolkit
+
+Runbook for cutting a versioned release.
+
+## Bump → validate → tag → watch → verify
+
+```bash
+# 1. Bump all version sources atomically
+python3 scripts/bump-version.py 1.3.0
+git diff --stat  # VERSION, packages/agent-toolkit-cli/src/agent_toolkit/__init__.py, package.json, .claude-plugin/marketplace.json, .cursor-plugin/marketplace.json
+
+# 2. Validate (CI parity)
+uv sync --all-extras
+AGENT_TOOLKIT_ROOT="$PWD" uv run pytest tests/ -v
+python3 scripts/validate-skills.py
+python3 scripts/validate-agents.py
+python3 scripts/generate-catalogs.py
+python3 scripts/gen-surfaces.py --check
+
+# 3. Commit + tag
+git add -A && git commit -m "chore(release): bump to v1.3.0"
+git tag -a v1.3.0 -m "v1.3.0"
+git push origin main --follow-tags
+
+# 4. Watch Release + downstream
+gh run list --repo ulises-jeremias/agent-toolkit --limit 5  # Release v1.3.0 should be completed success
+gh release view v1.3.0 --repo ulises-jeremias/agent-toolkit
+# Homebrew/AUR notifies run after Release create-release; check their repos
+gh run list --repo ulises-jeremias/homebrew-tap --limit 3
+gh run list --repo ulises-jeremias/aur-packages --limit 3
+
+# 5. Verify PyPI / AUR / formula
+curl -sS https://pypi.org/pypi/agent-toolkit-cli/json | python3 -c "import json,urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/agent-toolkit-cli/json'))['info']['version'])"
+curl -sS 'https://aur.archlinux.org/rpc/v5/info?arg[]=agent-toolkit' | python3 -m json.tool  # resultcount 0 until published
+# Homebrew formula version matches tag
+```
+
+## Bump script
+
+`scripts/bump-version.py` updates atomically:
+
+* `VERSION`
+* `packages/agent-toolkit-cli/src/agent_toolkit/__init__.py` (`__version__`)
+* `package.json` (`version`)
+* `.claude-plugin/marketplace.json` (`metadata.version` + `plugins[].version`)
+* `.cursor-plugin/marketplace.json` (same)
+* Plugin manifests `plugins/*/plugin.json` if present
+
+Usage:
+
+```bash
+python3 scripts/bump-version.py --check 1.3.0  # dry-run, exits 1 if would change
+python3 scripts/bump-version.py 1.3.0         # writes files
+```
+
+## Rollback / republish
+
+* **PyPI:** Trusted Publishing only via `release.yml` on tag `v*`. Manual republish: workflow `Publish (manual)` (`.github/workflows/publish.yml`) with `TestPyPI`/`PyPI` env.
+* **GitHub Release:** delete tag locally + remote + release, fix, re-tag. Prefer `gh release delete v1.3.0 --yes && git tag -d v1.3.0 && git push origin :v1.3.0`.
+* **Homebrew/AUR:** downstream repos are notified via `repository_dispatch` from `release.yml` `create-release`. If they missed, replay per `docs/AUR_PLAYBOOK.md`:
+  ```bash
+  gh api repos/ulises-jeremias/aur-packages/dispatches -f event_type=new-release -f 'client_payload[package_name]=agent-toolkit' -f 'client_payload[version]=v1.3.0'
+  ```
+
+## Asset naming
+
+Release binaries are platform-suffixed to avoid upload collisions (see #256):
+
+* `agent-toolkit-linux-x86_64`
+* `agent-toolkit-macos-arm64`
+* `agent-toolkit-windows-x86_64.exe`
+
+Darwin x86_64 is intentionally deferred (documented skip). Release notes / this doc mention naming.
+
+## AUR retry playbook
+
+See `docs/AUR_PLAYBOOK.md` for re-dispatch when AUR leaves maintenance.

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Bump all version sources atomically. Usage: bump-version.py [--check] X.Y.Z"""
+import pathlib, json, re, sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+def bump_file(path, pattern, repl, version):
+    p = ROOT / path
+    if not p.exists():
+        return False
+    t = p.read_text()
+    new, n = re.subn(pattern, repl.format(version=version), t)
+    if n == 0:
+        return False
+    if "--check" in sys.argv:
+        print(f"would bump {path}")
+        return True
+    p.write_text(new)
+    print(f"bumped {path}")
+    return True
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    check = "--check" in sys.argv
+    if not args:
+        print("Usage: bump-version.py [--check] X.Y.Z", file=sys.stderr)
+        sys.exit(2)
+    version = args[0]
+    if not re.match(r"^\d+\.\d+\.\d+", version):
+        print(f"invalid version {version}", file=sys.stderr)
+        sys.exit(2)
+    changed = 0
+    # VERSION
+    p = ROOT / "VERSION"
+    if p.exists():
+        old = p.read_text().strip()
+        if old != version:
+            print(f"VERSION {old} -> {version}")
+            if not check:
+                p.write_text(version + "\n")
+            changed += 1
+    # __init__.py
+    changed += bump_file("packages/agent-toolkit-cli/src/agent_toolkit/__init__.py", r'__version__ = ".*"', '__version__ = "{version}"', version)
+    # package.json
+    pkg = ROOT / "package.json"
+    if pkg.exists():
+        data = json.loads(pkg.read_text())
+        if data.get("version") != version:
+            print(f"package.json {data.get('version')} -> {version}")
+            if not check:
+                data["version"] = version
+                pkg.write_text(json.dumps(data, indent=2) + "\n")
+            changed += 1
+    # marketplace jsons
+    for mp in [".claude-plugin/marketplace.json", ".cursor-plugin/marketplace.json"]:
+        mp_path = ROOT / mp
+        if mp_path.exists():
+            data = json.loads(mp_path.read_text())
+            orig = json.dumps(data, sort_keys=True)
+            if "metadata" in data and "version" in data["metadata"]:
+                data["metadata"]["version"] = version
+            for pl in data.get("plugins", []):
+                if "version" in pl:
+                    pl["version"] = version
+            if json.dumps(data, sort_keys=True) != orig:
+                print(f"bumped {mp}")
+                if not check:
+                    mp_path.write_text(json.dumps(data, indent=2) + "\n")
+                changed += 1
+    # plugins/*/plugin.json
+    for pl in (ROOT / "plugins").glob("*/plugin.json"):
+        data = json.loads(pl.read_text())
+        if data.get("version") != version:
+            print(f"bumped {pl.relative_to(ROOT)}")
+            if not check:
+                data["version"] = version
+                pl.write_text(json.dumps(data, indent=2) + "\n")
+            changed += 1
+    if check and changed:
+        print(f"{changed} files would change", file=sys.stderr)
+        sys.exit(1)
+    if not check:
+        print(f"bumped {changed} files to {version}")
+        # also sync marketplace via same
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #255
Parent #240

- docs/RELEASING.md covering bump → validate → tag vX.Y.Z → watch Release + notify Homebrew/AUR → verify PyPI/RPC/formula, includes bump script doc, rollback via publish.yml, AUR playbook pointer, asset naming per #256
- scripts/bump-version.py updates VERSION, packages/agent-toolkit-cli/src/agent_toolkit/__init__.py, package.json, .claude-plugin/.cursor-plugin marketplace.json, plugins/*/plugin.json atomically; --check dry-run

Testing: python3 scripts/bump-version.py --check 1.3.0 and 1.3.1 dry-run verified