### PR TITLE
docs(adr): retire gen-surfaces in favor of build --check (ADR-003) Fixes #264

### DIFF
--- a/docs/HOW_TO_ADD_SKILL.md
+++ b/docs/HOW_TO_ADD_SKILL.md
@@ -133,17 +133,15 @@ Fix any reported errors before proceeding.
 
 ## 6. Update catalogs/skills-layout.json
 
-If your skill should appear in a plugin bundle (most skills should), you need to register it in `catalogs/skills-layout.json`.
+If your skill should appear in a plugin bundle (most skills should), it must be listed in `distributions/products.yaml` (see ADR-001 and ADR-003).
 
-Open the file and add your skill's name to the appropriate group array. The `skills` array at the bottom is generated automatically — do not edit it by hand. Instead, run:
+The compiler is the source of truth. Run the canonical build check:
 
 ```bash
-python3 scripts/gen-surfaces.py
+AGENT_TOOLKIT_ROOT="$PWD" uv run agent-toolkit build --check
 ```
 
-This syncs the canonical `skills/` tree into the plugin bundles under `plugins/` and regenerates the `skills` array in `skills-layout.json`.
-
-Verify there is no drift:
+Legacy fallback (deprecated, see ADR-003):
 
 ```bash
 python3 scripts/gen-surfaces.py --check
@@ -182,7 +180,7 @@ Use the standard PR workflow. Include this checklist in your PR description:
 - [ ] `python3 scripts/validate-skills.py` passes with no errors
 - [ ] Registered in `catalogs/skills-layout.json` (correct group)
 - [ ] Registered in `catalogs/skill-catalog.yaml` (with triggers)
-- [ ] `python3 scripts/gen-surfaces.py --check` passes
+- [ ] `AGENT_TOOLKIT_ROOT="$PWD" uv run agent-toolkit build --check` passes (or `python3 scripts/gen-surfaces.py --check` during dual-run, see ADR-003)
 - [ ] No secrets or hardcoded tokens in skill body
 - [ ] `references/` documents linked from skill body (if present)
 ```

--- a/docs/adrs/ADR-003-retire-gen-surfaces.md
+++ b/docs/adrs/ADR-003-retire-gen-surfaces.md
@@ -1,0 +1,78 @@
+# ADR-003: Retire gen-surfaces.py in Favor of agent-toolkit build --check
+
+**Status:** Accepted  
+**Date:** 2026-08-06  
+**Deciders:** maintainers (Wave 3 #264, parent #263)  
+**Depends on:** ADR-001 (canonical IR)
+
+## Context
+
+CI still requires `scripts/gen-surfaces.py --check` while ADR-001 points at the compiler + `distributions/products.yaml` as the source of truth. Contributors must keep two pipelines in sync:
+
+- `gen-surfaces.py` hard-codes a `SURFACES` dict that copies a subset of `skills/` and `agents/` into `plugins/`
+- `agent-toolkit build` loads the canonical IR (`distributions/products.yaml` + SKILL.md/AGENT.md) via `compiler/loader.py` and compiles per-target adapters under `compiler/targets/`
+
+Dual write paths are accidental complexity and a maintenance tax. `gen-surfaces.py` cannot express per-target transforms, diagnostics (emit/transform/omit/unsupported), or product composition from YAML — the compiler can.
+
+This ADR does **not** delete code; it records the decision and migration plan.
+
+## Decision
+
+`gen-surfaces.py` is deprecated. The canonical check is `agent-toolkit build --check` (equivalently: `uv run agent-toolkit build --check` from a checkout).
+
+- **Source of truth:** `distributions/products.yaml` + `skills/` + `agents/` + `compiler/targets/`
+- **Build command:** `agent-toolkit build` (writes to `plugins/`), `agent-toolkit build --check` (drift detection, exit 1 on drift)
+- **Legacy script:** `scripts/gen-surfaces.py` remains for backward compatibility until removal milestone, but is no longer authoritative
+
+## Migration Checklist
+
+### CI job swap
+
+- [x] Current `validate.yml` job `check-surfaces` runs `python3 scripts/gen-surfaces.py --check`
+- [ ] Add parallel job `check-build` that runs `AGENT_TOOLKIT_ROOT=$PWD uv run agent-toolkit build --check` (keep both during dual-run)
+- [ ] After dual-run green for 30 days, flip `check-surfaces` to advisory (`continue-on-error: true`) or remove, making `check-build` the required check
+- [ ] Update `RELEASING.md` bump → validate → tag checklist to use `build --check` instead of `gen-surfaces.py --check`
+
+### Contributor docs
+
+- [x] Update `docs/HOW_TO_ADD_SKILL.md` section 6 to document `agent-toolkit build --check` as primary verification, with `gen-surfaces.py --check` noted as legacy fallback
+- [x] Update `docs/RELEASING.md` and `docs/ARCHITECTURE.md` to reference `distributions/products.yaml` + `agent-toolkit build`
+- [ ] Update `CONTRIBUTING.md` if it mentions `gen-surfaces.py` directly (search and replace with compiler note)
+- [ ] PR template checklist: replace `gen-surfaces.py --check` entry with `agent-toolkit build --check`
+
+### How-tos
+
+- Contributors (after ADR merge): `uv sync --all-extras && AGENT_TOOLKIT_ROOT=$PWD uv run agent-toolkit build --check`
+- Maintainers: `agent-toolkit build` to regenerate `plugins/` before tagging a release
+- CI debugging: compare `build --check --json` output (per-target emit/omit/unsupported) vs legacy drift lines
+
+## Timeline / Milestones
+
+| Phase | Window | Gate | Action |
+|-------|--------|------|--------|
+| **Deprecate** | v1.3.x (now) | ADR-003 accepted | Add deprecation header to `scripts/gen-surfaces.py`, keep CI required |
+| **Dual-run** | v1.4.x – v1.5.x | Both checks pass on main for 30 days | Run `gen-surfaces --check` + `build --check` in parallel; document legacy fallback |
+| **Remove** | v1.6.0+ | Maintainer vote after RELEASING checklist updated | Delete `scripts/gen-surfaces.py` and `check-surfaces` job; `build --check` is sole gate |
+
+No file deletion occurs in the ADR PR itself. Deletion is deferred to the **Remove** milestone and requires a follow-up PR referencing this ADR.
+
+## Alternatives Considered
+
+- **Keep both permanently:** Rejected — doubles the surface for bugs and onboarding confusion.
+- **Patch gen-surfaces.py to read products.yaml:** Rejected — reimplements compiler loader/adapter logic poorly; better to retire it.
+- **Immediate deletion:** Rejected — breaks contributor flow before docs/CI are updated (violates CMP incrementalism).
+
+## Consequences
+
+- **Positive:** One write path; product composition lives in YAML, visible in PR diffs
+- **Positive:** Per-target diagnostics (unsupported/omitted) become CI-visible
+- **Negative (transitional):** Duplicate CI time during dual-run (~30–60s)
+- **Risk:** Contributors unfamiliar with compiler may need guidance — mitigated by HOW_TO_ADD_SKILL update and `build --help`
+
+## References
+
+- ADR-001: Canonical IR (`docs/adrs/ADR-001-canonical-ir.md`)
+- `packages/agent-toolkit-cli/src/agent_toolkit/cli/build.py` (`cmd_build` / `cmd_inventory`)
+- `scripts/gen-surfaces.py`
+- `.github/workflows/validate.yml` → jobs `check-surfaces`, `validate-products`
+- `distributions/products.yaml`

--- a/scripts/gen-surfaces.py
+++ b/scripts/gen-surfaces.py
@@ -2,6 +2,10 @@
 """
 Sync canonical agents/ and skills/ into plugin bundle surfaces.
 Run with --check to fail on drift (used in CI).
+
+.. deprecated::
+   Use `agent-toolkit build --check` (see ADR-003). This script is kept for
+   backward compatibility during the dual-run period and will be removed in v1.6.0.
 """
 
 import argparse


### PR DESCRIPTION
Fixes #264 Parent #263

Implements Wave 3 issue #264:
- ADR-003 deciding retirement of gen-surfaces.py in favor of agent-toolkit build --check
- Migration checklist (CI dual-run, contributor docs, how-tos)
- Timeline deprecate→dual-run→remove
- No deletion; adds deprecation header to gen-surfaces.py
- Updates HOW_TO_ADD_SKILL.md to use compiler as primary