### PR TITLE
chore(deps): add Dependabot for GHA, pip, and Danger npm (#261)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "infrastructure"
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Python — uv workspace (pip)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Python — agent-toolkit-cli package
+  - package-ecosystem: "pip"
+    directory: "/packages/agent-toolkit-cli"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # npm — Danger.js tooling
+  - package-ecosystem: "npm"
+    directory: "/tools/danger"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
Fixes #261
Parent #240

- .github/dependabot.yml covering github-actions, pip (uv/pyproject), and npm for tools/danger with weekly schedule and PR limits