### PR TITLE
ci(security): add CodeQL workflow for Python on PRs and main (#262)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -81,7 +81,7 @@ agent-toolkit follows these principles (see also
 - No private hostnames in distributed configs
 - No permission-bypass flags (e.g. skip dangerous-mode prompts) in shipped artifacts
 - MCP credentials via environment variables only
-- Secret scanning (Gitleaks) and dependency scanning (Trivy) in CI
+- Secret scanning (Gitleaks), dependency scanning (Trivy), and CodeQL Python analysis in CI (`.github/workflows/codeql.yml` — PRs and `main`, results visible as check runs)
 
 ---
 


### PR DESCRIPTION
Fixes #262
Parent #240

- .github/workflows/codeql.yml: analyze Python on PRs, main, weekly schedule; results visible as check runs
- docs/TRUST.md: list CodeQL as current (coordinate with #250)