### PR TITLE
docs: publish skill→product→target membership matrix Fixes #268

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,6 +92,16 @@ jobs:
       - name: Assert plugin surfaces are in sync with canonical sources
         run: python3 scripts/gen-surfaces.py --check
 
+  check-skill-matrix:
+    name: Check Skill→Product Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install PyYAML
+        run: pip install pyyaml==6.0.2
+      - name: Check skill→product→target matrix is up to date
+        run: python3 scripts/generate-skill-matrix.py --check
+
   # ── Job 5: Validate loop.yaml files against loop.schema.json ──────────────
   validate-loops:
     name: Validate Loop Templates

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ All skills use `SKILL.md` frontmatter only — no `skill.json` required. Fully c
 | 🛡️ `ops` | 3 | triage, docs-generator, llm-cost-advisor |
 | 🔄 `loops` | 1 | loop-runner (see [Loop Engineering](#-loop-engineering) for 10 templates) |
 
-Browse the full catalog: [`catalogs/skill-catalog.yaml`](catalogs/skill-catalog.yaml) · regenerate with `bash scripts/validate-skills.sh` (CI) and inspect live inventory via `agent-toolkit inventory`
+Browse the full catalog: [`catalogs/skill-catalog.yaml`](catalogs/skill-catalog.yaml) · **membership matrix** [`docs/SKILL_PRODUCT_MATRIX.md`](docs/SKILL_PRODUCT_MATRIX.md) (`scripts/generate-skill-matrix.py --check` in CI) · regenerate with `bash scripts/validate-skills.sh` (CI) and inspect live inventory via `agent-toolkit inventory`
 
 ### Loading skills in Claude Code
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -4,6 +4,13 @@ Skills are the core unit of capability in agent-toolkit. Each skill is a portabl
 
 ---
 
+## Product membership
+
+Discoverability: only a minority of skills appear in stable marketplace products. Check membership via:
+
+- **Matrix (checked in):** [`docs/SKILL_PRODUCT_MATRIX.md`](SKILL_PRODUCT_MATRIX.md) — generated from `distributions/products.yaml` (`python3 scripts/generate-skill-matrix.py --check` in CI)
+- **Live CLI:** `agent-toolkit inventory` (lists skills by domain + products)
+
 ## What Is a Skill?
 
 A skill is a directory containing exactly two files:

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -1,0 +1,105 @@
+# Skill → Product → Target Membership Matrix
+
+> Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
+
+_Generated from 4 products × 52 skills × 16 agents._
+
+## Products and targets
+
+| Product | Stability | Targets | Skills | Agents |
+|---------|-----------|---------|--------|--------|
+| `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
+| `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
+| `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
+| `agent-toolkit-complete` | experimental | — | 52 | 0 |
+
+## Skills → Products
+
+| Skill | Products | Targets (via products) |
+|-------|----------|------------------------|
+| `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
+| `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
+| `core/onboarding` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
+| `core/output-handshake` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
+| `core/pr-fallback` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
+| `core/workspace-knowledge-sync` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
+| `data/dbt-validation` | `agent-toolkit-complete` | — |
+| `data/snowflake-validation` | `agent-toolkit-complete` | — |
+| `delivery/adr` | `agent-toolkit-complete` | — |
+| `delivery/agreement` | `agent-toolkit-complete` | — |
+| `delivery/bug` | `agent-toolkit-complete` | — |
+| `delivery/decision-log` | `agent-toolkit-complete` | — |
+| `delivery/development-workflow` | `agent-toolkit-complete` | — |
+| `delivery/epic` | `agent-toolkit-complete` | — |
+| `delivery/incident` | `agent-toolkit-complete` | — |
+| `delivery/management-unit-assessment` | `agent-toolkit-complete` | — |
+| `delivery/meeting-minutes` | `agent-toolkit-complete` | — |
+| `delivery/planning` | `agent-toolkit-complete` | — |
+| `delivery/prd` | `agent-toolkit-complete` | — |
+| `delivery/project-assessment` | `agent-toolkit-complete` | — |
+| `delivery/project-assessment-evidence` | `agent-toolkit-complete` | — |
+| `delivery/spike` | `agent-toolkit-complete` | — |
+| `delivery/task` | `agent-toolkit-complete` | — |
+| `delivery/technical-unit-assessment` | `agent-toolkit-complete` | — |
+| `delivery/trd` | `agent-toolkit-complete` | — |
+| `delivery/user-story` | `agent-toolkit-complete` | — |
+| `delivery/work-item` | `agent-toolkit-complete` | — |
+| `delivery/workflow-client-bootstrap` | `agent-toolkit-complete` | — |
+| `delivery/workflow-generic-project` | `agent-toolkit-complete` | — |
+| `design/figma` | `agent-toolkit-complete` | — |
+| `design/figma-code-connect-components` | `agent-toolkit-complete` | — |
+| `design/figma-create-design-system-rules` | `agent-toolkit-complete` | — |
+| `design/figma-create-new-file` | `agent-toolkit-complete` | — |
+| `design/figma-implement-design` | `agent-toolkit-complete` | — |
+| `design/ui-ux-pro-max` | `agent-toolkit-complete` | — |
+| `forge/gh-address-comments` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
+| `forge/gh-contribution-planner` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
+| `forge/gh-fix-ci` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
+| `forge/github-cli-workflow` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
+| `forge/gitlab-cli-workflow` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
+| `forge/workflow-client-bootstrap` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
+| `forge/workflow-generic-project` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
+| `integrations/clickup-cli` | `agent-toolkit-complete` | — |
+| `integrations/linear` | `agent-toolkit-complete` | — |
+| `integrations/slack-assistant` | `agent-toolkit-complete` | — |
+| `integrations/slack-cli` | `agent-toolkit-complete` | — |
+| `loops/loop-runner` | `agent-toolkit-complete` | — |
+| `ops/docs-generator` | `agent-toolkit-complete` | — |
+| `ops/llm-cost-advisor` | `agent-toolkit-complete` | — |
+| `ops/triage` | `agent-toolkit-complete` | — |
+| `tooling/jupyter-notebook` | `agent-toolkit-complete` | — |
+| `tooling/playwright-cli` | `agent-toolkit-complete` | — |
+
+## Agents → Products
+
+| Agent | Products | Targets (via products) |
+|-------|----------|------------------------|
+| `architect` | `agent-toolkit-agents` | claude-code, cursor |
+| `assistant` | `agent-toolkit-agents` | claude-code, cursor |
+| `build-error-resolver` | `agent-toolkit-agents` | claude-code, cursor |
+| `client-workflow-bootstrap` | `agent-toolkit-agents` | claude-code, cursor |
+| `code-reviewer` | `agent-toolkit-agents`, `agent-toolkit-core` | claude-code, cursor |
+| `database-reviewer` | `agent-toolkit-agents` | claude-code, cursor |
+| `docs-lookup` | `agent-toolkit-agents` | claude-code, cursor |
+| `e2e-runner` | `agent-toolkit-agents` | claude-code, cursor |
+| `performance-optimizer` | `agent-toolkit-agents` | claude-code, cursor |
+| `planner` | `agent-toolkit-agents` | claude-code, cursor |
+| `refactor-cleaner` | `agent-toolkit-agents` | claude-code, cursor |
+| `reference-lookup` | `agent-toolkit-agents` | claude-code, cursor |
+| `security-reviewer` | `agent-toolkit-agents` | claude-code, cursor |
+| `tdd-guide` | `agent-toolkit-agents` | claude-code, cursor |
+| `tech-assistant` | `agent-toolkit-agents` | claude-code, cursor |
+| `typescript-reviewer` | `agent-toolkit-agents` | claude-code, cursor |
+
+## How to read
+
+- A skill appears in a marketplace plugin when its product is built for that target (`agent-toolkit build --product <id> --target <target>`).
+- `_uncovered_` means the skill/agent is not in any stable product yet — it exists canonically but is not shipped. See Wave 5 curation for promotion decisions.
+- Verify membership locally via `agent-toolkit inventory` (canonical counts) or `python3 scripts/generate-skill-matrix.py --check`.
+
+## See also
+
+- `distributions/products.yaml` — source of truth
+- `agent-toolkit inventory` — CLI inventory
+- `agent-toolkit build --check` — drift check
+

--- a/scripts/generate-skill-matrix.py
+++ b/scripts/generate-skill-matrix.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Generate docs/SKILL_PRODUCT_MATRIX.md from distributions/products.yaml.
+
+Source of truth is distributions/products.yaml (products define included
+skills/agents). The matrix is checked in but validated in CI via --check.
+"""
+from __future__ import annotations
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRODUCTS_YAML = REPO_ROOT / "distributions" / "products.yaml"
+OUTPUT_MD = REPO_ROOT / "docs" / "SKILL_PRODUCT_MATRIX.md"
+
+def load_products():
+    text = PRODUCTS_YAML.read_text(encoding="utf-8")
+    try:
+        import yaml
+        return yaml.safe_load(text)
+    except ImportError:
+        # minimal: parse product ids and includes naively is not enough; require yaml
+        print("PyYAML required to generate matrix", file=sys.stderr)
+        sys.exit(1)
+
+def build_matrix():
+    data = load_products()
+    products = data.get("products", [])
+    # collect all skills/agents
+    sku_to_products: dict[str, list[str]] = {}
+    agent_to_products: dict[str, list[str]] = {}
+    product_targets: dict[str, list[str]] = {}
+    product_stability: dict[str, str] = {}
+    for p in products:
+        pid = p["id"]
+        product_stability[pid] = p.get("stability", "")
+        targets = sorted(p.get("targets", {}).keys())
+        product_targets[pid] = targets
+        for s in p.get("includes", {}).get("skills", []) or []:
+            sku_to_products.setdefault(s, []).append(pid)
+        for a in p.get("includes", {}).get("agents", []) or []:
+            agent_to_products.setdefault(a, []).append(pid)
+    # also enumerate canonical skills/agents from filesystem for uncovered detection
+    skills_dir = REPO_ROOT / "skills"
+    all_skills = sorted(
+        str(p.parent.relative_to(skills_dir)) + "/" + p.parent.name
+        if False else ""
+        for _ in []
+    )
+    # simpler: walk
+    all_skills = []
+    for domain in sorted((REPO_ROOT / "skills").iterdir()):
+        if not domain.is_dir():
+            continue
+        for skill in sorted(domain.iterdir()):
+            if (skill / "SKILL.md").is_file():
+                all_skills.append(f"{domain.name}/{skill.name}")
+    all_agents = sorted(
+        d.name for d in (REPO_ROOT / "agents").iterdir() if d.is_dir()
+    )
+    return products, sku_to_products, agent_to_products, product_targets, product_stability, all_skills, all_agents
+
+def render_md():
+    products, sku_to_products, agent_to_products, product_targets, product_stability, all_skills, all_agents = build_matrix()
+    product_ids = [p["id"] for p in products]
+    # header
+    lines = []
+    lines.append("# Skill → Product → Target Membership Matrix")
+    lines.append("")
+    lines.append(f"> Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.")
+    lines.append("")
+    lines.append(f"_Generated from {len(products)} products × {len(all_skills)} skills × {len(all_agents)} agents._")
+    lines.append("")
+    lines.append("## Products and targets")
+    lines.append("")
+    lines.append("| Product | Stability | Targets | Skills | Agents |")
+    lines.append("|---------|-----------|---------|--------|--------|")
+    for p in products:
+        pid = p["id"]
+        stab = product_stability.get(pid, "")
+        tgs = ", ".join(product_targets.get(pid, [])) or "—"
+        sc = len(p.get("includes", {}).get("skills", []) or [])
+        ag = len(p.get("includes", {}).get("agents", []) or [])
+        lines.append(f"| `{pid}` | {stab} | {tgs} | {sc} | {ag} |")
+    lines.append("")
+    lines.append("## Skills → Products")
+    lines.append("")
+    lines.append("| Skill | Products | Targets (via products) |")
+    lines.append("|-------|----------|------------------------|")
+    for skill in all_skills:
+        prods = sku_to_products.get(skill, [])
+        if prods:
+            prod_str = ", ".join(f"`{p}`" for p in sorted(prods))
+            tset = sorted({t for pr in prods for t in product_targets.get(pr, [])})
+            target_str = ", ".join(tset) if tset else "—"
+        else:
+            prod_str = "_uncovered_"
+            target_str = "—"
+        lines.append(f"| `{skill}` | {prod_str} | {target_str} |")
+    lines.append("")
+    lines.append("## Agents → Products")
+    lines.append("")
+    lines.append("| Agent | Products | Targets (via products) |")
+    lines.append("|-------|----------|------------------------|")
+    for agent in all_agents:
+        prods = agent_to_products.get(agent, [])
+        if prods:
+            prod_str = ", ".join(f"`{p}`" for p in sorted(prods))
+            tset = sorted({t for pr in prods for t in product_targets.get(pr, [])})
+            target_str = ", ".join(tset) if tset else "—"
+        else:
+            prod_str = "_uncovered_"
+            target_str = "—"
+        lines.append(f"| `{agent}` | {prod_str} | {target_str} |")
+    lines.append("")
+    lines.append("## How to read")
+    lines.append("")
+    lines.append("- A skill appears in a marketplace plugin when its product is built for that target (`agent-toolkit build --product <id> --target <target>`).")
+    lines.append("- `_uncovered_` means the skill/agent is not in any stable product yet — it exists canonically but is not shipped. See Wave 5 curation for promotion decisions.")
+    lines.append("- Verify membership locally via `agent-toolkit inventory` (canonical counts) or `python3 scripts/generate-skill-matrix.py --check`.")
+    lines.append("")
+    lines.append("## See also")
+    lines.append("")
+    lines.append("- `distributions/products.yaml` — source of truth")
+    lines.append("- `agent-toolkit inventory` — CLI inventory")
+    lines.append("- `agent-toolkit build --check` — drift check")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate skill→product→target matrix")
+    parser.add_argument("--check", action="store_true", help="Fail if matrix is out of date")
+    parser.add_argument("--output", default=str(OUTPUT_MD), help="Output path")
+    args = parser.parse_args()
+    content = render_md()
+    out = Path(args.output)
+    if args.check:
+        if not out.is_file():
+            print(f"Missing matrix file: {out.relative_to(REPO_ROOT)}", file=sys.stderr)
+            return 1
+        existing = out.read_text(encoding="utf-8")
+        if existing != content:
+            print(f"Matrix out of date: {out.relative_to(REPO_ROOT)} differs from distributions/products.yaml", file=sys.stderr)
+            print(f"Run: python3 scripts/generate-skill-matrix.py", file=sys.stderr)
+            return 1
+        print(f"Matrix up to date: {out.relative_to(REPO_ROOT)}")
+        return 0
+    # also handle --check fallback if yaml missing to just write
+    out.write_text(content, encoding="utf-8")
+    print(f"Wrote matrix to {out.relative_to(REPO_ROOT)} ({len(content.splitlines())} lines)")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #268 Parent #263

- Doc matrix (generated) mapping skills/agents to products→targets (docs/SKILL_PRODUCT_MATRIX.md via scripts/generate-skill-matrix.py)
- agent-toolkit inventory already surfaces membership (live CLI); matrix cross-links it
- CI check preventing silent drift (validate.yml check-skill-matrix --check)
- README/docs/SKILLS.md link to matrix

Out of scope: deciding which skills to promote (Wave 5)