### PR TITLE
docs(adr): deprecate scripts/install.sh behind Python CLI (ADR-007) Fixes #270

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ agent-toolkit is organized around three layers that compose to form a complete A
 The outermost layer is the installer or workstation harness that provisions agent-toolkit onto a machine. This layer is responsible for:
 
 - Cloning or updating the toolkit repository
-- Running `scripts/install.sh` to copy profiles to the right tool-specific locations
+- Running `agent-toolkit install` (Python CLI; `scripts/install.sh` is a deprecated legacy fallback — see ADR-007) to copy profiles/plugins to the right tool-specific locations
 - Managing credentials and environment variables (but never storing secrets in this repo)
 - Scheduling recurring loops via a cron or loop-runner daemon
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -154,16 +154,20 @@ brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
 yay -S agent-toolkit   # Arch Linux (AUR)
 ```
 
-### Git clone + install script
+### Git clone + legacy script fallback (deprecated — see ADR-007)
+
+> **Deprecated:** `scripts/install.sh` prints a warning and is kept only for offline `git clone` installs. Prefer `uvx --from agent-toolkit-cli agent-toolkit install` above. The bash script may delegate to `agent-toolkit install` when available.
 
 For offline installs or pinning a specific commit:
 
 ```bash
 git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
-bash ~/.agent-toolkit/scripts/install.sh
+AGENT_TOOLKIT_NO_DEPRECATION_WARNING=1 bash ~/.agent-toolkit/scripts/install.sh  # legacy fallback
+# Preferred (same clone, via CLI):
+uvx --from agent-toolkit-cli --from ~/.agent-toolkit agent-toolkit install
 ```
 
-Script options:
+Legacy script options (still accepted):
 
 ```bash
 bash ~/.agent-toolkit/scripts/install.sh --tools claude-code,cursor

--- a/docs/adrs/ADR-007-install-sh-deprecation.md
+++ b/docs/adrs/ADR-007-install-sh-deprecation.md
@@ -1,0 +1,64 @@
+# ADR-007: Deprecate scripts/install.sh Behind Python CLI (Thin Wrapper)
+
+**Status:** Accepted  
+**Date:** 2026-08-06  
+**Deciders:** maintainers (Wave 3 #270, parent #263)
+
+## Context
+
+Two installers exist: `scripts/install.sh` (bash, profile-copy) and `packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py` (Python, `agent-toolkit install`). Dual paths drift — examples still teach `bash install.sh`, `INSTALLATION.md` lists both, and bash lacks the CLI's detection, receipts, and target-aware logic (`installer/sources.py`).
+
+The goal is one consumer install path to reduce support load.
+
+## Decision
+
+**Deprecate `scripts/install.sh` with a warning; do not remove it in this ADR.** Offer a thin-wrapper option for contributors who prefer the bash entrypoint.
+
+- `scripts/install.sh` remains but prints a deprecation notice on every invocation:
+  ```
+  [warn] scripts/install.sh is deprecated — use `uvx --from agent-toolkit-cli agent-toolkit install` (or `agent-toolkit install` after `uv tool install`). See docs/INSTALLATION.md and docs/adrs/ADR-007-install-sh-deprecation.md
+  ```
+- **Primary install** is the Python CLI (`uvx` one-liner or `uv tool install`):
+  ```bash
+  uvx --from agent-toolkit-cli agent-toolkit install
+  uvx --from agent-toolkit-cli agent-toolkit install --dry-run
+  agent-toolkit install --tools claude-code,cursor --force
+  ```
+- **Examples and INSTALLATION.md** now point at the Python CLI first; `bash install.sh` is documented under “Legacy / offline fallback” with the deprecation note.
+- **Bash as thin caller (optional):** if `agent-toolkit` is on PATH, `install.sh` may delegate to it (preserving flags `--tools`, `--dry-run`, `--force`) while still printing the deprecation warning. Implementation is a small `if command -v agent-toolkit >/dev/null; then exec agent-toolkit install "$@"; fi` guard — out of scope for this ADR's docs-only PR but recorded as the intended wrapper direction.
+- No removal in this ADR's PR. Removal requires the migration notes in INSTALLATION.md and a deprecation period (see timeline).
+
+## Migration checklist
+
+- [x] Add deprecation `warn` echo at top of `scripts/install.sh` (before `parse_args`)
+- [x] Update `docs/INSTALLATION.md` — primary flow is `uvx`/CLI; bash script moved to “Git clone + legacy fallback” with deprecation callout
+- [x] Update `examples/project-onboarding/README.md` — replace `bash install.sh` tutorial with `uvx ... install` primary, keep bash as fallback with warning
+- [x] Update `docs/ARCHITECTURE.md` L1 layer note (installer is `agent-toolkit install`, not only `scripts/install.sh`)
+- [ ] CI: no job change needed (`install.sh` still works); follow-up may add a lint that fails on `bash install.sh` in new docs
+- [ ] Removal milestone: v2.0 or next major, after deprecation notice has shipped for one minor
+
+## Timeline
+
+| Phase | Window | Action |
+|-------|--------|--------|
+| **Deprecate (now)** | v1.3.x | ADR-007 accepted; `install.sh` prints warning; docs point to CLI |
+| **Wrapper (optional, next minor)** | v1.4.x | Teach `install.sh` to `exec agent-toolkit install` when available (thin caller), still warning |
+| **Remove** | v2.0 | Maintainer vote to delete `scripts/install.sh` if CLI covers all needs; keep fallback copy in release notes if offline users need it |
+
+## Alternatives Considered
+
+- **Keep both permanently:** Rejected — doubles support and example maintenance.
+- **Immediate removal:** Rejected — breaks offline/git-clone users before migration docs land (violates CMP incrementalism, out of scope per #270).
+- **Rewrite bash as full compiler-aware installer:** Rejected — Python CLI already has receipts, detection, and `installer/sources.py` logic; bash wrapper should stay thin.
+
+## Consequences
+
+- **Positive:** One documented consumer path; fewer divergent example code blocks
+- **Negative (transitional):** Two paths still work, but the warning makes the preferred path visible
+- **Risk:** Users without `uv`/`pip` still rely on bash + `git clone` — fallback remains functional with warning
+
+## References
+
+- `scripts/install.sh`, `packages/agent-toolkit-cli/src/agent_toolkit/cli/install.py`
+- `docs/INSTALLATION.md`, `examples/project-onboarding/README.md`, `docs/ARCHITECTURE.md`
+- #270 (parent #263)

--- a/examples/project-onboarding/README.md
+++ b/examples/project-onboarding/README.md
@@ -8,11 +8,13 @@ This covers four AI tools: Claude Code, Cursor, GitHub Copilot, and OpenCode. Do
 
 ## Prerequisites
 
-- **agent-toolkit installed** on your machine:
+- **agent-toolkit installed** on your machine (preferred: Python CLI):
   ```bash
-  git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
-  bash ~/.agent-toolkit/scripts/install.sh --dry-run    # Preview what will be installed
-  bash ~/.agent-toolkit/scripts/install.sh              # Install
+  uvx --from agent-toolkit-cli agent-toolkit install --dry-run    # Preview (auto-detects tools)
+  uvx --from agent-toolkit-cli agent-toolkit install              # Install
+  # Legacy/offline fallback (deprecated, see docs/adrs/ADR-007-install-sh-deprecation.md):
+  # git clone https://github.com/ulises-jeremias/agent-toolkit ~/.agent-toolkit
+  # bash ~/.agent-toolkit/scripts/install.sh --dry-run
   ```
 
 - **Your project cloned** and the working directory set to its root:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,14 @@
 #   bash scripts/install.sh --force
 set -euo pipefail
 
+# --- Deprecation notice (ADR-007) ---
+# Primary install is now the Python CLI: `uvx --from agent-toolkit-cli agent-toolkit install`
+# This script is kept as a legacy/offline fallback and will be removed in v2.0.
+# It may delegate to `agent-toolkit install` when available (thin wrapper).
+if [[ -z "${AGENT_TOOLKIT_NO_DEPRECATION_WARNING:-}" ]]; then
+  printf '  [warn]  scripts/install.sh is deprecated — use `uvx --from agent-toolkit-cli agent-toolkit install` (see docs/INSTALLATION.md and docs/adrs/ADR-007-install-sh-deprecation.md)\n' >&2
+fi
+
 # ---------------------------------------------------------------------------
 # Globals
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #270 Parent #263

- Decision: wrap bash as thin caller OR deprecate with warning + migration (chooses deprecation with optional thin wrapper)
- Adds deprecation warning to scripts/install.sh
- Updates INSTALLATION.md to point at Python CLI/uvx as primary, bash as legacy fallback
- Updates examples/project-onboarding/README.md and ARCHITECTURE.md

Out of scope: removing bash in same PR (deferred to v2.0)