### PR TITLE
ci(security): add CodeQL workflow for Python on PRs and main (#262)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,24 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v3

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -81,7 +81,7 @@ agent-toolkit follows these principles (see also
 - No private hostnames in distributed configs
 - No permission-bypass flags (e.g. skip dangerous-mode prompts) in shipped artifacts
 - MCP credentials via environment variables only
-- Secret scanning (Gitleaks) in CI — Trivy **Planned** (see #262 Wave 2); CodeQL **Planned** (see #262)
+- Secret scanning (Gitleaks) and CodeQL Python analysis in CI (`.github/workflows/codeql.yml` — PRs and `main`); Trivy **Planned** (see #260)
 
 ---
 


### PR DESCRIPTION
Fixes #262
Parent #240

- .github/workflows/codeql.yml: Python analysis on push/PR/schedule
- docs/TRUST.md: Gitleaks + CodeQL present, Trivy planned (was both planned)

Testing: workflow validates via GitHub CodeQL