### PR TITLE
docs(adr): decide packs are docs-only (ADR-006) (#269)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ Loops follow a three-tier model (L1/L2/L3) based on the risk level of their acti
 
 ### Packs
 
-A pack bundles skills, agents, and loops into an outcome-oriented workflow. A pack is a `pack.yaml` file (or directory with a `README.md` and `config.yaml`) that declares which skills to activate, which loops to enable, and any configuration overrides.
+A pack bundles skills, agents, and loops into an outcome-oriented workflow. A pack is a `pack.yaml` file (or directory with a `README.md` and `config.yaml`) that declares which skills to activate, which loops to enable, and any configuration overrides. **Packs are docs-only** (ADR-006): they are not loaded by `agent-toolkit build`; product composition lives in `distributions/products.yaml`.
 
 Packs are the recommended entry point for teams. Instead of picking individual skills, you load a pack and get a coherent setup for your context (OSS maintainer, startup delivery team, data platform, etc.).
 

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -10,7 +10,7 @@ One mental model for how agent-toolkit pieces fit together.
 | **Products** | `distributions/products.yaml` | Named bundles of skills/agents/hooks/MCP for plugins | Shipping a marketplace plugin |
 | **Compiler output** | `plugins/` | Target-native manifests + copied SKILL.md/AGENT.md | **Generated** — do not hand-edit; validated by `build --check` (ADR-003/004) |
 | **Profiles** | `profiles/` | Legacy hand-copied install layouts per tool | **Deprecated** — fallback only; prefer `plugins/` via `installer/sources.py` (ADR-004) |
-| **Packs** | `packs/` | Solution-oriented README + config | Team workflow templates, not plugin composition |
+| **Packs** | `packs/` | Solution-oriented README + config | **Docs-only** workflow templates; not loaded by compiler (ADR-006) |
 | **Presets** | *(planned)* | Named capability sets for `agent-toolkit.yaml` projects | Future — not implemented yet |
 
 ## Key rules
@@ -18,7 +18,7 @@ One mental model for how agent-toolkit pieces fit together.
 1. **Products compose capabilities** — edit `distributions/products.yaml`, then `build`.
 2. **Plugins are compiler output** — Claude `.claude-plugin/`, Cursor `.cursor-plugin/`, etc.
 3. **Profiles are install shortcuts** — being replaced by build + copy for parity with plugins.
-4. **Packs are documentation bundles** — they reference loops/skills but are not loaded by the compiler today.
+4. **Packs are **docs-only** bundles (ADR-006)** — they reference loops/skills but are not loaded by the compiler today.
 
 ## README / docs alignment
 

--- a/docs/adrs/ADR-006-packs-docs-only.md
+++ b/docs/adrs/ADR-006-packs-docs-only.md
@@ -1,0 +1,54 @@
+# ADR-006: Packs are Docs-Only Solution Bundles (Not Compiler-Wired)
+
+**Status:** Accepted  
+**Date:** 2026-08-06  
+**Deciders:** maintainers (Wave 3 #269, parent #263)
+
+## Context
+
+`packs/` are documented as solution bundles that combine skills, agents, and loops for an outcome (e.g. `oss-maintenance`). They are not loaded by `agent-toolkit build` — `distributions/products.yaml` is the compiler input for marketplace plugins. Consumers cannot tell if packs are real product surface or docs-only, and the name overloads with “products”.
+
+## Decision
+
+**Packs are docs-only.** They are **not** compiler-wired.
+
+- `packs/<name>/` contains a human-oriented bundle: `README.md` + `config.yaml` (+ optional AGENTS snippet / loop refs). It is a **workflow template** that documents which skills/loops to use together and how to configure them.
+- `distributions/products.yaml` remains the **sole compiler input** for `plugins/` (ADR-001). Packs do not appear in `products.yaml` and are not compiled to marketplace manifests.
+- If a pack's loop/skill set should become a shipped product, create or extend a product entry in `products.yaml` referencing those same canonical IDs — do not teach the compiler to ingest `packs/`.
+
+This is explicitly the **“mark docs-only”** option from #269, not “wire packs into compiler”.
+
+## Rationale
+
+- Keeps the compiler surface small (products → targets) and packs as low-ceremony team docs.
+- Avoids a second composition layer before the product/pack noun is clarified with the community.
+- A follow-up implementation issue can propose “wire-in” later with a clear scope (schema for `pack.yaml`, pack→product mapping, target wiring) if the community wants it.
+
+## Follow-up (if wiring is ever desired)
+
+Open a separate issue with:
+
+- Proposed `packs/<name>/pack.yaml` schema (extends `distributions/products.yaml` or references it)
+- How packs map to products/targets
+- Compiler change scope (`loader.py` + `build.py` + one adapter)
+- Migration for existing packs
+
+No such implementation occurs in this decision issue.
+
+## Docs updates
+
+- `packs/README.md` header now states “Docs-only — not loaded by `agent-toolkit build`”
+- `docs/CONCEPTS.md` and `docs/ARCHITECTURE.md` explicitly call packs docs-only (not plugin composition)
+- This ADR is the decision log; `README.md` and `packs/README.md` cross-link here
+
+## Consequences
+
+- **Positive:** Noun is no longer ambiguous; contributors stop hunting for “pack compiler” code
+- **Positive:** Packs can evolve as workflow docs without blocking compiler work
+- **Negative:** Teams wanting one-command “install a pack” still copy config manually — acceptable for now; Wave 5 may add `agent-toolkit pack install` as a docs-only helper
+
+## References
+
+- `packs/README.md`, `packs/{oss-maintenance,engineering-workflow,delivery-discipline}/`
+- `distributions/products.yaml` (compiler SoT), `docs/CONCEPTS.md`, `docs/ARCHITECTURE.md`
+- #269 (decision), #263 (CMP Wave 3)

--- a/packs/README.md
+++ b/packs/README.md
@@ -1,5 +1,7 @@
 # Solution Packs
 
+> **Docs-only** — packs are not loaded by the compiler (`agent-toolkit build`). They are workflow templates that reference skills/loops. For plugin composition, edit `distributions/products.yaml` (see `docs/adrs/ADR-006-packs-docs-only.md`).
+
 Solution packs bundle related skills, agent personas, loop templates, and MCP configurations
 into outcome-oriented workflows for common team setups.
 


### PR DESCRIPTION
## Summary

Fixes #269
Parent #263

Records maintainer decision: packs are docs-only solution bundles, not compiler-wired. Updates packs/README, CONCEPTS.md, ARCHITECTURE.md to mark docs-only and cross-links ADR-006. Follow-up wiring remains a separate issue with clear scope.

## Changes

- docs/adrs/ADR-006-packs-docs-only.md: new decision
- packs/README.md: header docs-only note
- docs/CONCEPTS.md, docs/ARCHITECTURE.md: explicit docs-only marking (ADR-006) with correct deprecation wording

## Testing

- Resolved rebase conflict on docs/CONCEPTS.md (kept HEAD's Generated/Deprecated wording, applied ADR-006 packs line)
- Fixed duplicated suffix in ARCHITECTURE.md

## Checklist

- [x] No secrets
- [x] Docs updated
