### PR TITLE
docs(troubleshooting): add doctor error recipes for top 5 failure modes (#277)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -62,3 +62,5 @@ You should see the assistant skill instructions load. Browse the full catalog: `
 * `agent-toolkit doctor` reports missing tool → install that tool first
 * `inventory` empty → re-run `agent-toolkit install` with `--force`
 * Broken install channel → prefer `uv tool install agent-toolkit-cli` (AUR pending)
+
+See also: [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for doctor error recipes.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -336,3 +336,5 @@ Restart OpenCode after adding agent files.
 | [TARGETS.md](TARGETS.md) | Supported compile targets and capability matrix |
 | [MIGRATION.md](MIGRATION.md) | Move from profile-copy to native plugins |
 | [MCP.md](MCP.md) | MCP provider setup |
+
+See also: [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for doctor error recipes.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,77 @@
+# Troubleshooting — Doctor & CLI error recipes
+
+Actionable fixes for the top failure modes reported by `agent-toolkit doctor` and `install`.
+
+## 1. Missing toolkit data
+
+**Symptom:** `doctor` reports `data missing` or `skills: 0`.
+
+**Cause:** installed from source tarball without bundled data.
+
+**Fix:**
+
+```bash
+uv tool install --force agent-toolkit-cli   # wheel with data
+# or, from source checkout:
+scripts/prepare-package-data.sh
+agent-toolkit install
+```
+
+See `docs/INSTALLATION.md` and `docs/GETTING_STARTED.md`.
+
+## 2. Wrong tool path
+
+**Symptom:** `install --target <tool>` copies to unexpected directory.
+
+**Fix:**
+
+```bash
+agent-toolkit doctor          # shows detected paths per tool
+agent-toolkit install --target muse-code --dry-run   # preview
+```
+
+Per-tool paths are tabled in `docs/INSTALLATION.md`.
+
+## 3. Partial install (skills without agents/loops)
+
+**Symptom:** `doctor` shows `skills: 52, agents: 0` or similar.
+
+**Fix:**
+
+```bash
+agent-toolkit build
+agent-toolkit install --force
+```
+
+See `docs/CONCEPTS.md` layer hierarchy.
+
+## 4. Stale catalog
+
+**Symptom:** CI `generate-catalogs` check fails.
+
+**Fix:**
+
+```bash
+python3 scripts/generate-catalogs.py
+git add catalogs/
+```
+
+See `CONTRIBUTING.md` Validation Commands.
+
+## 5. Surface drift
+
+**Symptom:** `python3 scripts/gen-surfaces.py --check` fails.
+
+**Fix:**
+
+```bash
+python3 scripts/gen-surfaces.py
+# or
+agent-toolkit build --check
+```
+
+See `docs/CONCEPTS.md` and `docs/ARCHITECTURE.md` ADR-003/004.
+
+---
+
+If none of these match, run `agent-toolkit doctor --verbose` and open an issue with the output (redact paths if needed).


### PR DESCRIPTION
## Summary

Fixes #277
Parent #263

Add actionable error recipes for top 5 doctor/install failure modes.

## Changes

- docs/TROUBLESHOOTING.md: 5 recipes (missing data, wrong path, partial install, stale catalog, surface drift) with symptom/cause/fix + doc links
- docs/INSTALLATION.md, docs/GETTING_STARTED.md: link to troubleshooting

## Testing

- Markdown lint via CI
- No code change

## Checklist

- [x] No secrets
- [x] Docs updated
