### PR TITLE
docs: add three kinds of packs section and sync AGENTS.md structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,10 @@ agent-toolkit/
 │       ├── loop.yaml   # Required: loop definition (tier, cadence, goal, request, budget, allow/deny)
 │       ├── STATE.md    # Runtime: checkpoint state (written by runner, not committed)
 │       └── report.md   # Runtime: output report (written by agent, not committed)
-├── packs/              # Solution packs (YAML bundles)
+├── packs/              # Docs-only solution packs (ADR-006) — workflow templates, not loaded by compiler
+├── plugins/            # Compiler-generated target manifests (do not hand-edit; ADR-003/004)
+├── distributions/      # Product specification for compiler input (products.yaml)
+├── integrations/       # Swarm UI integrations (e.g., Herdr plugin; ADR-008)
 ├── catalogs/
 │   ├── skill-catalog.yaml
 │   └── agent-catalog.yaml
@@ -51,6 +54,8 @@ agent-toolkit/
 │   ├── skill.schema.json
 │   └── loop.schema.json
 ├── docs/               # Human-facing documentation
+│   ├── CONCEPTS.md     # Public concept model — see "Three kinds of packs"
+│   └── adrs/           # Architecture Decision Records
 └── scripts/            # validate-skills.py, validate-agents.py, generate-catalogs.py, gen-surfaces.py
 ```
 

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -13,6 +13,51 @@ One mental model for how agent-toolkit pieces fit together.
 | **Packs** | `packs/` | Solution-oriented README + config | **Docs-only** workflow templates; not loaded by compiler (ADR-006) |
 | **Presets** | *(planned)* | Named capability sets for `agent-toolkit.yaml` projects | Future — not implemented yet |
 
+## Three kinds of packs
+
+The word "pack" has three distinct meanings in this project. The noun is not ambiguous, but the context selects the meaning.
+
+### 1. Solution packs (`packs/` in the toolkit repo)
+
+Solution packs are **docs-only workflow templates** under the repository `packs/` directory. Each pack bundles related skills, agent personas, loop templates, and MCP configurations into an outcome-oriented workflow for a common team setup. Examples: `oss-maintenance`, `engineering-workflow`, `delivery-discipline`.
+
+A solution pack is a directory with `README.md`, `config.yaml`, and optional references to loops and skills. The compiler does **not** load solution packs. `distributions/products.yaml` is the sole compiler input for marketplace plugins. See `docs/adrs/ADR-006-packs-docs-only.md`.
+
+### 2. Workspace packs (`packs/*.yaml` in a harness workspace)
+
+Workspace packs are **YAML context files** inside a harness workspace `packs/` directory. They carry per-client or per-project context: project names, notes, and configuration. A user loads a workspace pack with:
+
+```bash
+agent-toolkit workspace load packs/my-client.yaml
+```
+
+The pack content is surfaced by `agent-toolkit workspace context`. These packs are local to one workspace. They have no connection to the toolkit repository solution packs.
+
+### 3. Loop `--pack` overrides (loaded by `loop run --pack`)
+
+Loop packs are **YAML files that override loop settings at runtime**. A user passes `--pack <path>` to `agent-toolkit loop run`. The pack resolves relative to the workspace `packs/` directory. The loader (`loop/pack.py`) merges enabled, cadence, budget, tier, and other fields from the pack into the loop meta before the loop runs.
+
+A loop pack file has a `loops` key mapping loop names to their override blocks:
+
+```yaml
+loops:
+  oss-triage:
+    enabled: false
+    cadence: 12h
+    budget:
+      max_tokens: 30000
+```
+
+### Summary
+
+| Noun | Location | Loaded by | Purpose |
+|------|----------|-----------|---------|
+| Solution pack | `packs/<name>/` (repo) | Not loaded — docs-only reference | Workflow template for a team setup |
+| Workspace pack | `packs/*.yaml` (workspace) | `agent-toolkit workspace load` | Per-client context bundle |
+| Loop pack | `packs/*.yaml` (workspace) | `agent-toolkit loop run --pack` | Runtime loop setting overrides |
+
+See also: `packs/README.md` (solution packs), `workspace load` CLI help, `loop/pack.py` (override logic), `docs/adrs/ADR-006-packs-docs-only.md`.
+
 ## Key rules
 
 1. **Products compose capabilities** — edit `distributions/products.yaml`, then `build`.

--- a/packs/README.md
+++ b/packs/README.md
@@ -1,6 +1,8 @@
 # Solution Packs
 
 > **Docs-only** — packs are not loaded by the compiler (`agent-toolkit build`). They are workflow templates that reference skills/loops. For plugin composition, edit `distributions/products.yaml` (see `docs/adrs/ADR-006-packs-docs-only.md`).
+>
+> **Not the only pack noun.** The word "pack" has three meanings in this project. This file documents solution packs. See `docs/CONCEPTS.md#three-kinds-of-packs` for workspace packs (`workspace load`) and loop `--pack` overrides (`loop run --pack`).
 
 Solution packs bundle related skills, agent personas, loop templates, and MCP configurations
 into outcome-oriented workflows for common team setups.


### PR DESCRIPTION
## What

- Adds a 'Three kinds of packs' section to `docs/CONCEPTS.md` that distinguishes solution packs, workspace packs, and loop `--pack` overrides with examples and a summary table.
- Syncs `AGENTS.md` repository structure section with on-disk reality: adds `plugins/`, `distributions/`, `integrations/` directories; updates `packs/` description to note docs-only per ADR-006; adds `docs/CONCEPTS.md` and `docs/adrs/` entries.
- Adds cross-link from `packs/README.md` to the new CONCEPTS section.

## Acceptance criteria

- [x] CONCEPTS explicitly distinguishes the three pack nouns with examples
- [x] AGENTS.md structure section matches on-disk reality at HEAD
- [x] No contradictory "packs are the primary install path" language vs ADR-006

Closes #343