### PR TITLE
fix(workspace): replace stale context --pack with workspace load in packs README

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -313,7 +313,9 @@ notes: |
   Key contacts: ...
 ```
 
-Load with: `agent-toolkit workspace context --pack packs/my-client.yaml`
+Load with: `agent-toolkit workspace load packs/my-client.yaml`
+
+Snapshot with: `agent-toolkit workspace context`
 """
 
 _PERSONA_IMPLEMENTER = """\


### PR DESCRIPTION
## What

Replaces the stale `context --pack` command in the generated `packs/README.md` scaffold with the correct `workspace load` command, and adds a note about `workspace context` for snapshots.

## Changes

- `packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py`: Updated `_PACKS_README` string at line 316

## Verification

- Repo-wide grep confirms zero remaining `context --pack` occurrences
- All 19 workspace tests pass

Closes #337