### PR TITLE
feat(workspace): apply profile skills/loops fields in loader, context, and validate

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -466,6 +466,8 @@ projects/
 .active-persona
 .active-pack
 .active-profile
+.active-skills
+.active-loops
 .persona-history
 """
 
@@ -691,6 +693,30 @@ def cmd_context(args: list[str]) -> int:
         if meta:
             print(_format_persona_constraints(persona, meta))
         print()
+
+    # Active skills (from profile load)
+    active_skills_file = ws / ".active-skills"
+    if active_skills_file.exists():
+        skills_text = active_skills_file.read_text(encoding="utf-8").strip()
+        if skills_text:
+            skills_list = [s.strip() for s in skills_text.splitlines() if s.strip()]
+            if skills_list:
+                print(_blue("── Active Skills ─────────────────────────────────────────"))
+                for s in skills_list:
+                    print(f"  - {s}")
+                print()
+
+    # Active loops (from profile load)
+    active_loops_file = ws / ".active-loops"
+    if active_loops_file.exists():
+        loops_text = active_loops_file.read_text(encoding="utf-8").strip()
+        if loops_text:
+            loops_list = [ln.strip() for ln in loops_text.splitlines() if ln.strip()]
+            if loops_list:
+                print(_blue("── Active Loops ──────────────────────────────────────────"))
+                for ln in loops_list:
+                    print(f"  - {ln}")
+                print()
 
     # AGENTS.md hash
     agents_md = ws / "AGENTS.md"
@@ -1072,6 +1098,16 @@ def _load_profile(ws: Path, profile_name: str) -> int:
             _write(active_file, str(persona) + "\n")
             print(_green(f"  Persona: {persona}"))
 
+    skills = data.get("skills")
+    if isinstance(skills, list) and skills:
+        _write(ws / ".active-skills", "\n".join(str(s) for s in skills) + "\n")
+        print(_green(f"  Skills: {', '.join(str(s) for s in skills)}"))
+
+    loops = data.get("loops")
+    if isinstance(loops, list) and loops:
+        _write(ws / ".active-loops", "\n".join(str(ln) for ln in loops) + "\n")
+        print(_green(f"  Loops: {', '.join(str(ln) for ln in loops)}"))
+
     return 0
 
 
@@ -1110,7 +1146,13 @@ def cmd_profiles(args: list[str]) -> int:
         pack = data.get("pack") or "-"
         persona = data.get("persona") or "-"
         desc = data.get("description") or ""
+        skills = data.get("skills")
+        loops = data.get("loops")
         print(f"  {name:25s} pack={pack} persona={persona}")
+        if isinstance(skills, list) and skills:
+            print(_dim(f"    skills: {', '.join(str(s) for s in skills)}"))
+        if isinstance(loops, list) and loops:
+            print(_dim(f"    loops: {', '.join(str(ln) for ln in loops)}"))
         if desc:
             print(_dim(f"    {desc}"))
 
@@ -1201,6 +1243,26 @@ def _validate_profiles(ws: Path) -> list[str]:
         persona = data.get("persona")
         if persona and not _persona_path(ws, str(persona)).exists():
             errors.append(f"{path.name}: referenced persona '{persona}' not found")
+        skills = data.get("skills")
+        if skills is not None:
+            if not isinstance(skills, list):
+                errors.append(f"{path.name}: 'skills' must be a list of strings")
+            else:
+                for idx, s in enumerate(skills):
+                    if not isinstance(s, str) or not s.strip():
+                        errors.append(
+                            f"{path.name}: skills[{idx}] must be a non-empty string"
+                        )
+        loops = data.get("loops")
+        if loops is not None:
+            if not isinstance(loops, list):
+                errors.append(f"{path.name}: 'loops' must be a list of strings")
+            else:
+                for idx, ln in enumerate(loops):
+                    if not isinstance(ln, str) or not ln.strip():
+                        errors.append(
+                            f"{path.name}: loops[{idx}] must be a non-empty string"
+                        )
     return errors
 
 

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -1252,9 +1252,7 @@ def _validate_profiles(ws: Path) -> list[str]:
             else:
                 for idx, s in enumerate(skills):
                     if not isinstance(s, str) or not s.strip():
-                        errors.append(
-                            f"{path.name}: skills[{idx}] must be a non-empty string"
-                        )
+                        errors.append(f"{path.name}: skills[{idx}] must be a non-empty string")
         loops = data.get("loops")
         if loops is not None:
             if not isinstance(loops, list):
@@ -1262,9 +1260,7 @@ def _validate_profiles(ws: Path) -> list[str]:
             else:
                 for idx, ln in enumerate(loops):
                     if not isinstance(ln, str) or not ln.strip():
-                        errors.append(
-                            f"{path.name}: loops[{idx}] must be a non-empty string"
-                        )
+                        errors.append(f"{path.name}: loops[{idx}] must be a non-empty string")
     return errors
 
 

--- a/tests/test_workspace_commands.py
+++ b/tests/test_workspace_commands.py
@@ -158,8 +158,7 @@ def test_profiles_list_shows_skills_and_loops(
 
 def test_validate_profile_bad_skills(workspace: Path) -> None:
     (workspace / "profiles" / "bad-skills.yaml").write_text(
-        "name: bad-skills\ndescription: Bad skills field\n"
-        "skills:\n  - ''\n  - 42\n",
+        "name: bad-skills\ndescription: Bad skills field\nskills:\n  - ''\n  - 42\n",
         encoding="utf-8",
     )
     assert ws.cmd_validate(["profiles"]) == 1
@@ -167,8 +166,7 @@ def test_validate_profile_bad_skills(workspace: Path) -> None:
 
 def test_validate_profile_bad_loops(workspace: Path) -> None:
     (workspace / "profiles" / "bad-loops.yaml").write_text(
-        "name: bad-loops\ndescription: Bad loops field\n"
-        "loops: not-a-list\n",
+        "name: bad-loops\ndescription: Bad loops field\nloops: not-a-list\n",
         encoding="utf-8",
     )
     assert ws.cmd_validate(["profiles"]) == 1

--- a/tests/test_workspace_commands.py
+++ b/tests/test_workspace_commands.py
@@ -21,6 +21,13 @@ def _scaffold_workspace(tmp_path: Path) -> Path:
         "name: oss-contributor\ndescription: OSS mode\npack: acme\npersona: implementer\n",
         encoding="utf-8",
     )
+    (root / "profiles" / "full-stack.yaml").write_text(
+        "name: full-stack\ndescription: Full stack profile with skills and loops\n"
+        "pack: acme\npersona: reviewer\n"
+        "skills:\n  - delivery/gh-address-comments\n  - core/memory\n"
+        "loops:\n  - daily-triage\n  - weekly-report\n",
+        encoding="utf-8",
+    )
     (root / "templates" / "jobs").mkdir(parents=True, exist_ok=True)
     (root / "templates" / "jobs" / "code-review.yaml").write_text(
         "name: code-review\nrequest: Review the code\n",
@@ -112,3 +119,56 @@ def test_validate_knowledge_missing_dir(workspace: Path) -> None:
 
 def test_validate_unknown_surface(workspace: Path) -> None:
     assert ws.cmd_validate(["nope"]) == 1
+
+
+def test_load_profile_stores_skills_and_loops(workspace: Path) -> None:
+    assert ws.cmd_load(["--profile", "full-stack"]) == 0
+    assert (workspace / ".active-profile").read_text(encoding="utf-8").strip() == "full-stack"
+    skills = (workspace / ".active-skills").read_text(encoding="utf-8").strip()
+    assert "delivery/gh-address-comments" in skills
+    assert "core/memory" in skills
+    loops = (workspace / ".active-loops").read_text(encoding="utf-8").strip()
+    assert "daily-triage" in loops
+    assert "weekly-report" in loops
+
+
+def test_context_shows_skills_and_loops(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ws.cmd_load(["--profile", "full-stack"])
+    assert ws.cmd_context([]) == 0
+    out = capsys.readouterr().out
+    assert "Active Skills" in out
+    assert "delivery/gh-address-comments" in out
+    assert "core/memory" in out
+    assert "Active Loops" in out
+    assert "daily-triage" in out
+    assert "weekly-report" in out
+
+
+def test_profiles_list_shows_skills_and_loops(
+    workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert ws.cmd_profiles([]) == 0
+    out = capsys.readouterr().out
+    assert "full-stack" in out
+    assert "delivery/gh-address-comments" in out
+    assert "daily-triage" in out
+
+
+def test_validate_profile_bad_skills(workspace: Path) -> None:
+    (workspace / "profiles" / "bad-skills.yaml").write_text(
+        "name: bad-skills\ndescription: Bad skills field\n"
+        "skills:\n  - ''\n  - 42\n",
+        encoding="utf-8",
+    )
+    assert ws.cmd_validate(["profiles"]) == 1
+
+
+def test_validate_profile_bad_loops(workspace: Path) -> None:
+    (workspace / "profiles" / "bad-loops.yaml").write_text(
+        "name: bad-loops\ndescription: Bad loops field\n"
+        "loops: not-a-list\n",
+        encoding="utf-8",
+    )
+    assert ws.cmd_validate(["profiles"]) == 1


### PR DESCRIPTION
## Summary

Closes #346

This PR implements option 1 from the issue: apply profile `skills` and `loops` fields in the loader as session notes (v1 minimal).

## What changed

- **`_load_profile`**: reads `skills` and `loops` from profile YAML and writes them to `.active-skills` and `.active-loops` dotfiles
- **`cmd_context`**: displays active skills and loops when they are set
- **`cmd_profiles`**: shows skills/loops summary when listing profiles
- **`_validate_profiles`**: validates that `skills` and `loops` entries are non-empty strings; reports errors for non-list values or empty entries
- **`.gitignore` template**: includes `.active-skills` and `.active-loops`

## Verification

- All 16 workspace tests pass (`uv run pytest tests/test_workspace_commands.py -v`)
- ruff lint passes with zero errors
- New tests cover: profile load stores skills/loops, context shows them, profiles list shows them, validate rejects bad skills (empty strings, non-strings) and bad loops (non-list)

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke