### PR TITLE
fix(packs): document skills/agents as advisory in pack config.yaml

### DIFF
--- a/docs/adrs/ADR-006-packs-docs-only.md
+++ b/docs/adrs/ADR-006-packs-docs-only.md
@@ -37,7 +37,11 @@ No such implementation occurs in this decision issue.
 
 ## Docs updates
 
-- `packs/README.md` header now states “Docs-only — not loaded by `agent-toolkit build`”
+- `packs/README.md` header now states "Docs-only — not loaded by `agent-toolkit build`"
+- `packs/README.md` now documents that `skills:` and `agents:` keys in pack config.yaml
+  are advisory only and are not applied by `loop run --pack` (see `loop/pack.py`).
+- `packs/engineering-workflow/config.yaml` and `packs/delivery-discipline/config.yaml`
+  now carry advisory-only comments above their `skills:` and `agents:` sections.
 - `docs/CONCEPTS.md` and `docs/ARCHITECTURE.md` explicitly call packs docs-only (not plugin composition)
 - This ADR is the decision log; `README.md` and `packs/README.md` cross-link here
 

--- a/packs/README.md
+++ b/packs/README.md
@@ -24,6 +24,23 @@ cp packs/oss-maintenance/config.yaml ~/.ai-workspace/packs/
 # Then use loops/oss-pr-monitor, loops/oss-triage, loops/oss-daily-briefing
 ```
 
+## Pack config.yaml fields
+
+The `config.yaml` declares three top-level sections:
+
+- `loops` — Loop overrides (`enabled`, `cadence`, `tier`, `verifier`, `goal`, `budget`).
+  These are applied by `loop run --pack`. See `loop/pack.py`.
+- `skills` — Advisory only. Lists which skills the pack recommends. The `loop run --pack`
+  command does **not** read or apply `skills:` entries. Authors may list them as
+  documentation.
+- `agents` — Advisory only. Lists which agent personas the pack recommends. The `loop run --pack`
+  command does **not** read or apply `agents:` entries. Authors may list them as
+  documentation.
+
+The `skills:` and `agents:` keys are human-readable labels, not machine-applied actions.
+The pack format may grow a loader in the future (see ADR-006 follow-up note), but today
+only `loops:` is handled by the code.
+
 ## Creating a Pack
 
 A pack is a directory containing:

--- a/packs/delivery-discipline/config.yaml
+++ b/packs/delivery-discipline/config.yaml
@@ -12,7 +12,9 @@ version: "1.0"
 # ---------------------------------------------------------------------------
 # Skills
 # ---------------------------------------------------------------------------
+# Advisory only — not applied by `loop run --pack`.
 # Domain/path IDs matching catalogs/skill-catalog.yaml.
+# See packs/README.md and ADR-006.
 
 skills:
   delivery/task:
@@ -31,6 +33,7 @@ skills:
 # ---------------------------------------------------------------------------
 # Agents
 # ---------------------------------------------------------------------------
+# Advisory only — not applied by `loop run --pack`.
 
 agents:
   tech-assistant:

--- a/packs/engineering-workflow/config.yaml
+++ b/packs/engineering-workflow/config.yaml
@@ -12,7 +12,11 @@ version: "1.0"
 # ---------------------------------------------------------------------------
 # Skills
 # ---------------------------------------------------------------------------
+# Advisory only — not applied by `loop run --pack`.
 # Domain/path IDs matching catalogs/skill-catalog.yaml.
+# These entries document which skills the pack recommends. The loader in
+# loop/pack.py does not read or apply skills: or agents: keys. See
+# packs/README.md and ADR-006 for the design decision.
 
 skills:
   forge/workflow-generic-project:
@@ -25,6 +29,7 @@ skills:
 # ---------------------------------------------------------------------------
 # Agents
 # ---------------------------------------------------------------------------
+# Advisory only — not applied by `loop run --pack`.
 
 agents:
   architect:

--- a/scripts/smoke-test-skills.py
+++ b/scripts/smoke-test-skills.py
@@ -80,9 +80,7 @@ def path_relative(path: Path) -> str:
 def check_file_exists(ref_path: Path, source: Path) -> bool:
     if ref_path.exists():
         return True
-    error(
-        f"{path_relative(source)}: references '{ref_path}' which does not exist"
-    )
+    error(f"{path_relative(source)}: references '{ref_path}' which does not exist")
     return False
 
 
@@ -132,9 +130,7 @@ def resolve_links(content: str, source_path: Path) -> None:
         except ValueError:
             continue
         if not candidate.exists():
-            error(
-                f"{path_relative(source_path)}: link target '{file_part}' does not resolve"
-            )
+            error(f"{path_relative(source_path)}: link target '{file_part}' does not resolve")
 
 
 def validate_skill(skill_dir: Path) -> bool:
@@ -158,16 +154,12 @@ def validate_skill(skill_dir: Path) -> bool:
 
     name = fm.get("name", "")
     if name and name != skill_dir.name:
-        error(
-            f"{rel}/SKILL.md: name '{name}' does not match directory '{skill_dir.name}'"
-        )
+        error(f"{rel}/SKILL.md: name '{name}' does not match directory '{skill_dir.name}'")
         ok_flag = False
 
     desc = fm.get("description", "")
     if isinstance(desc, str) and desc.strip() in PLACEHOLDER_DESCRIPTIONS:
-        error(
-            f"{rel}/SKILL.md: description is a placeholder ('{desc.strip()}')"
-        )
+        error(f"{rel}/SKILL.md: description is a placeholder ('{desc.strip()}')")
         ok_flag = False
 
     content = skill_md.read_text(errors="replace")
@@ -199,16 +191,12 @@ def validate_agent(agent_dir: Path) -> bool:
 
     name = fm.get("name", "")
     if name and name != agent_dir.name:
-        error(
-            f"{rel}/AGENT.md: name '{name}' does not match directory '{agent_dir.name}'"
-        )
+        error(f"{rel}/AGENT.md: name '{name}' does not match directory '{agent_dir.name}'")
         ok_flag = False
 
     desc = fm.get("description", "")
     if isinstance(desc, str) and desc.strip() in PLACEHOLDER_DESCRIPTIONS:
-        error(
-            f"{rel}/AGENT.md: description is a placeholder ('{desc.strip()}')"
-        )
+        error(f"{rel}/AGENT.md: description is a placeholder ('{desc.strip()}')")
         ok_flag = False
 
     content = agent_md.read_text(errors="replace")

--- a/tests/test_pack_skills_agents_advisory.py
+++ b/tests/test_pack_skills_agents_advisory.py
@@ -96,9 +96,7 @@ def test_pack_skills_and_agents_are_advisory_in_all_pack_configs() -> None:
         has_agents = "agents" in data
 
         if has_skills or has_agents:
-            assert (
-                "advisory" in text.lower() or "not applied" in text.lower()
-            ), (
+            assert "advisory" in text.lower() or "not applied" in text.lower(), (
                 f"{config_path.relative_to(repo_root)} has skills: or agents: "
                 "but does not state they are advisory"
             )
@@ -108,9 +106,7 @@ def test_load_pack_preserves_skills_and_agents_keys() -> None:
     """load_pack returns the raw YAML dict including skills and agents keys."""
     import tempfile
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as f:
         f.write(
             "pack: test\n"
             "skills:\n  forge/test:\n    enabled: true\n"

--- a/tests/test_pack_skills_agents_advisory.py
+++ b/tests/test_pack_skills_agents_advisory.py
@@ -1,0 +1,129 @@
+"""
+Author: RawNuke
+Copyright (c) 2026 RawNuke. All rights reserved.
+
+Contract tests for packs skills/agents advisory status.
+Skills/agents in pack config.yaml are docs-only; loop/pack.py does not apply them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from agent_toolkit.loop.pack import apply_loop_pack_overrides, load_pack
+
+
+def test_apply_loop_pack_overrides_does_not_merge_skills() -> None:
+    """Skills key in pack data must not appear in merged loop meta."""
+    meta: dict[str, object] = {"tier": "L1", "cadence": "1d"}
+    pack_data: dict[str, object] = {
+        "skills": {"forge/workflow-generic-project": {"enabled": True}},
+        "loops": {"demo": {"enabled": True, "cadence": "15m"}},
+    }
+    merged = apply_loop_pack_overrides(meta, pack_data, "demo")
+    assert "skills" not in merged
+    assert merged["cadence"] == "15m"
+
+
+def test_apply_loop_pack_overrides_does_not_merge_agents() -> None:
+    """Agents key in pack data must not appear in merged loop meta."""
+    meta: dict[str, object] = {"tier": "L2", "cadence": "1d"}
+    pack_data: dict[str, object] = {
+        "agents": {"architect": {"enabled": True}},
+        "loops": {"demo": {"enabled": True, "cadence": "6h"}},
+    }
+    merged = apply_loop_pack_overrides(meta, pack_data, "demo")
+    assert "agents" not in merged
+    assert merged["cadence"] == "6h"
+
+
+def test_top_level_skills_agents_never_leak_into_merged_meta() -> None:
+    """Even when pack has skills, agents, and loops at top level, only loop keys merge."""
+    meta: dict[str, object] = {
+        "tier": "L1",
+        "cadence": "1d",
+        "goal": "do work",
+        "budget": {"max_tokens": 80000},
+    }
+    pack_data: dict[str, object] = {
+        "pack": "test",
+        "skills": {"delivery/task": {"enabled": True}},
+        "agents": {"planner": {"enabled": True}},
+        "loops": {
+            "test-loop": {
+                "enabled": True,
+                "cadence": "30m",
+                "budget": {"max_wall_seconds": 300},
+            }
+        },
+    }
+    merged = apply_loop_pack_overrides(meta, pack_data, "test-loop")
+    assert "skills" not in merged
+    assert "agents" not in merged
+    assert merged["cadence"] == "30m"
+    assert merged["budget"]["max_wall_seconds"] == 300
+    assert merged["goal"] == "do work"
+
+
+def test_missing_loop_entry_returns_original_meta_unchanged() -> None:
+    """When a loop name is not in pack data, meta returns unchanged with no skills/agents."""
+    meta: dict[str, object] = {"tier": "L3", "cadence": "2d"}
+    pack_data: dict[str, object] = {
+        "skills": {"core/memory": {"enabled": True}},
+        "agents": {"code-reviewer": {"enabled": True}},
+    }
+    merged = apply_loop_pack_overrides(meta, pack_data, "nonexistent")
+    assert merged == meta
+    assert "skills" not in merged
+    assert "agents" not in merged
+
+
+def test_pack_skills_and_agents_are_advisory_in_all_pack_configs() -> None:
+    """Every pack config.yaml with skills: or agents: must state they are advisory."""
+    repo_root = Path(__file__).resolve().parent.parent
+    packs_dir = repo_root / "packs"
+    configs = sorted(packs_dir.glob("*/config.yaml"))
+
+    assert len(configs) >= 1, "Expected at least one pack config.yaml"
+
+    for config_path in configs:
+        text = config_path.read_text(encoding="utf-8")
+        data = yaml.safe_load(text)
+
+        has_skills = "skills" in data
+        has_agents = "agents" in data
+
+        if has_skills or has_agents:
+            assert (
+                "advisory" in text.lower() or "not applied" in text.lower()
+            ), (
+                f"{config_path.relative_to(repo_root)} has skills: or agents: "
+                "but does not state they are advisory"
+            )
+
+
+def test_load_pack_preserves_skills_and_agents_keys() -> None:
+    """load_pack returns the raw YAML dict including skills and agents keys."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(
+            "pack: test\n"
+            "skills:\n  forge/test:\n    enabled: true\n"
+            "agents:\n  reviewer:\n    enabled: true\n"
+            "loops:\n  loop-a:\n    enabled: true\n"
+        )
+        tmp_path = Path(f.name)
+
+    try:
+        data = load_pack(tmp_path)
+        assert data["pack"] == "test"
+        assert "skills" in data
+        assert "agents" in data
+        assert "loops" in data
+    finally:
+        tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
Closes #345

## What

Option A from issue #345: Mark skills/agents fields in pack config.yaml as advisory-only. These keys are not applied by `loop run --pack`; only `loops:` entries are read by `loop/pack.py`.

## Changes

- **packs/README.md** — new section documenting that `skills:` and `agents:` are advisory
- **packs/engineering-workflow/config.yaml** — advisory comments above `skills:` and `agents:` sections
- **packs/delivery-discipline/config.yaml** — advisory comments above `skills:` and `agents:` sections
- **docs/adrs/ADR-006-packs-docs-only.md** — Docs updates section references the advisory status
- **tests/test_pack_skills_agents_advisory.py** — 6 contract tests verifying non-application behavior

## Test results

```
65 passed (6 new + 59 existing loop/pack tests). No regressions.
```

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke