### PR TITLE
test(swarm): cover budget_exhausted resume and report paths

### DIFF
--- a/tests/test_swarm_cli.py
+++ b/tests/test_swarm_cli.py
@@ -213,3 +213,61 @@ def test_swarm_status_json_and_artifacts():
         assert res2.returncode == 0
         arts = json.loads(res2.stdout)
         assert any(a["name"] == "task-contract.md" for a in arts)
+
+
+# budget_exhausted resume / report path — see docs/SWARM_ARCHITECTURE.md
+
+
+def test_swarm_status_surfaces_budget_exhausted():
+    with tempfile.TemporaryDirectory() as td:
+        repo = init_repo(Path(td))
+        run_swarm(
+            ["start", "--recipe", "pair", "--ui", "tmux", "--runner", "skeleton", "Task"], repo
+        )
+        run_id = next((repo / ".agent-toolkit" / "swarm" / "runs").iterdir()).name
+        run_dir = repo / ".agent-toolkit" / "swarm" / "runs" / run_id
+        state = json.loads((run_dir / "state.json").read_text())
+        state["run_state"] = "budget_exhausted"
+        (run_dir / "state.json").write_text(json.dumps(state))
+        res = run_swarm(["status", run_id, "--json"], repo)
+        assert res.returncode == 0, res.stderr
+        data = json.loads(res.stdout)
+        assert data["state"]["run_state"] == "budget_exhausted"
+
+
+def test_swarm_resume_from_budget_exhausted():
+    with tempfile.TemporaryDirectory() as td:
+        repo = init_repo(Path(td))
+        run_swarm(
+            ["start", "--recipe", "pair", "--ui", "tmux", "--runner", "skeleton", "Task"], repo
+        )
+        run_id = next((repo / ".agent-toolkit" / "swarm" / "runs").iterdir()).name
+        run_dir = repo / ".agent-toolkit" / "swarm" / "runs" / run_id
+        state = json.loads((run_dir / "state.json").read_text())
+        state["run_state"] = "budget_exhausted"
+        (run_dir / "state.json").write_text(json.dumps(state))
+        res = run_swarm(["resume", run_id], repo)
+        assert res.returncode == 0, res.stderr
+        assert "running" in res.stdout
+        state2 = json.loads((run_dir / "state.json").read_text())
+        assert state2["run_state"] == "running"
+
+
+def test_swarm_report_on_budget_exhausted():
+    with tempfile.TemporaryDirectory() as td:
+        repo = init_repo(Path(td))
+        run_swarm(
+            ["start", "--recipe", "pair", "--ui", "tmux", "--runner", "skeleton", "Task"], repo
+        )
+        run_id = next((repo / ".agent-toolkit" / "swarm" / "runs").iterdir()).name
+        run_dir = repo / ".agent-toolkit" / "swarm" / "runs" / run_id
+        state = json.loads((run_dir / "state.json").read_text())
+        state["run_state"] = "budget_exhausted"
+        (run_dir / "state.json").write_text(json.dumps(state))
+        res = run_swarm(["report", run_id], repo)
+        output = res.stdout + res.stderr
+        assert (
+            "No final-report.md yet" in output
+            or "budget_exhausted" in output
+            or "partial" in output.lower()
+        )

--- a/tests/test_swarm_units.py
+++ b/tests/test_swarm_units.py
@@ -192,3 +192,34 @@ def test_atomic_write_json():
         assert json.loads(p.read_text())["a"] == 1
         atomic_write_json(p, {"b": 2})
         assert json.loads(p.read_text())["b"] == 2
+
+
+def test_budget_exhausted_state_transitions():
+    assert can_transition_run("running", "budget_exhausted")
+    assert can_transition_run("budget_exhausted", "running")
+    assert can_transition_run("budget_exhausted", "cancelled")
+    assert can_transition_run("budget_exhausted", "cleanup_pending")
+    assert not can_transition_run("budget_exhausted", "completed")
+    assert not can_transition_run("completed", "budget_exhausted")
+
+
+def test_budget_tight_limits_detection():
+    b = resolve_budget({"max_total_tokens": 10, "max_cost_usd": 0.01, "max_wall_seconds": 5})
+    violated = check_limits(b, {"total_tokens": 11, "cost_usd": 0.02, "wall_seconds": 6})
+    assert "max_total_tokens" in violated
+    assert "max_cost_usd" in violated
+    assert "max_wall_seconds" in violated
+
+
+def test_budget_limits_exact_boundary():
+    b = resolve_budget({"max_total_tokens": 100, "max_cost_usd": 1.0, "max_wall_seconds": 60})
+    violated_at_limit = check_limits(b, {"total_tokens": 100, "cost_usd": 1.0, "wall_seconds": 60})
+    assert "max_total_tokens" in violated_at_limit
+    assert "max_cost_usd" in violated_at_limit
+    assert "max_wall_seconds" in violated_at_limit
+    under = check_limits(b, {"total_tokens": 99, "cost_usd": 0.99, "wall_seconds": 59})
+    assert under == []
+
+
+def test_budget_exhausted_to_running_resume_path():
+    assert can_transition_run("budget_exhausted", "running")


### PR DESCRIPTION
## Summary

Add 7 tests covering the **budget_exhausted → resumable state / partial report** path described in `docs/SWARM_ARCHITECTURE.md`. The existing `check_limits` test only covers limit violation detection, not the end-to-end state lifecycle.

### Unit tests (`tests/test_swarm_units.py`)

- `test_budget_exhausted_state_transitions` — verifies `running→budget_exhausted`, `budget_exhausted→running`, and blocked transitions (e.g. `budget_exhausted→completed` is invalid)
- `test_budget_tight_limits_detection` — all three limit types (tokens, cost, wall) detected simultaneously with tight bounds
- `test_budget_limits_exact_boundary` — at-limit values trigger violation; under-limit values return clean
- `test_budget_exhausted_to_running_resume_path` — confirms resume from budget_exhausted to running is permitted

### CLI integration tests (`tests/test_swarm_cli.py`)

- `test_swarm_status_surfaces_budget_exhausted` — forces `budget_exhausted` state and asserts `status --json` exposes it
- `test_swarm_resume_from_budget_exhausted` — forces `budget_exhausted`, runs `resume`, asserts state transitions to `running`
- `test_swarm_report_on_budget_exhausted` — verifies report command handles a budget-exhausted (partial) run without silent failure

All tests use `--runner skeleton` and `--ui tmux` — no real LLM or Herdr dependency.

## Checklist

- [x] Branch name follows the naming convention
- [x] No secrets, API keys, or credentials in any file
- [x] No real LLM or Herdr dependency in CI
- [x] Tests reference `docs/SWARM_ARCHITECTURE.md`

Closes #342

---

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke