### PR TITLE
docs: polish Agent Plugins 1.0 coverage in COMPATIBILITY and TARGETS

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,14 +4,20 @@
 
 | Target | Minimum version | Notes |
 |--------|----------------|-------|
-| Claude Code | Any current version | Plugin marketplace supported |
-| Cursor | 2.5+ | Plugin system added in 2.5 |
+| Claude Code | Any current version | Plugin marketplace supported — legacy `.claude-plugin/` only (does not yet support Agent Plugins 1.0) |
+| Cursor | 2.5+ | Plugin system added in 2.5 — supports Agent Plugins 1.0 (`plugin.json` + `mcp.json` + `skills/`) |
+| VS Code + GitHub Copilot | Any current | Agent Plugins 1.0 via `plugin.json` (extension `com.github.copilot`) — see `docs/AGENT_PLUGINS.md` |
+| Kiro | Any current | Agent Plugins 1.0 supported |
 | GitHub Copilot CLI | Any current | Open Plugin Spec optional |
 | Gemini CLI | 0.1.0+ | Extension system available |
 | OpenCode | 0.3+ | JS/TS module plugins |
 | Pi Coding Agent | Any current | npm package system |
 | Windsurf/Devin | Any current | No marketplace — bundle only — see `docs/certification/windsurf.md` |
-| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) |
+| OpenAI Codex | Recent | Marketplace launched March 2026 (experimental) — also supports Agent Plugins 1.0 |
+
+### Agent Plugins 1.0
+
+[Agent Plugins 1.0](https://agent-plugins.org) (`plugin.json` `$schema: https://agent-plugins.org/schemas/1.0.0/plugin.schema.json` + `skills/` + `mcp.json` + `com.*` extensions) is the portable standard for Cursor, VS Code, GitHub Copilot, ChatGPT/Codex, and Kiro. Every `plugins/<name>/` bundle in this repo is dual-emit: portable `plugin.json`/`mcp.json` for those clients and legacy `.claude-plugin/plugin.json` for Claude Code. The compiler target is `agent-plugins` (`capabilities/targets/registry.yaml` → `AgentPluginsAdapter`); validation is `scripts/validate-agent-plugins.py --check` and CI job `Validate Agent Plugins 1.0`. Until Claude Code implements the spec, keep `.claude-plugin/` and the `com.anthropic.claude-code` extension. See `docs/AGENT_PLUGINS.md` and `plugins/README.md`.
 
 ## Python version
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -19,6 +19,7 @@ Each target receives the strongest integration it actually supports.
 |--------|-------------|--------|--------|-------|-----|----------|
 | Claude Code | plugin (.claude-plugin/) | native | native | unsupported* | unsupported* | stable |
 | Cursor IDE/CLI | plugin (.cursor-plugin/) | native | native | unsupported* | manual | stable |
+| **Agent Plugins 1.0** | plugin (`plugin.json` + `mcp.json` + `skills/`) | native (portable) | native (via `com.anthropic.claude-code` extension) | unsupported* | native (stdio `mcp.json`) | stable |
 | OpenCode | companion-assets | native | native | unsupported† | unsupported† | stable |
 | Copilot CLI | plugin (plugin.json) | native | native | unsupported* | unknown-blocked | stable |
 | Copilot Repository | repository-customization | native | native | unsupported | unsupported | stable |
@@ -29,6 +30,8 @@ Each target receives the strongest integration it actually supports.
 
 *hooks: no stable cross-tool canonical model yet — see target certification docs
 †requires TypeScript runtime plugin
+
+> **Agent Plugins 1.0** is the portable `plugin.json` target for Cursor, VS Code, Copilot, Kiro, and Codex. It emits `plugin.json` (`$schema: https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`) + `skills/` + `mcp.json` (+ `com.anthropic.claude-code` extension for Claude compatibility). Validate with `python3 scripts/validate-agent-plugins.py --check`; CI job is `Validate Agent Plugins 1.0`. See `docs/AGENT_PLUGINS.md`.
 
 ## Install commands
 


### PR DESCRIPTION
## Summary
Polish docs after Agent Plugins 1.0 migration (#362).

- `docs/COMPATIBILITY.md`: clarify Claude legacy-only, add VS Code + Kiro rows, add dedicated `### Agent Plugins 1.0` subsection (portable `plugin.json` dual-emit, `agent-plugins` target, validator `validate-agent-plugins.py --check` and CI job)
- `docs/TARGETS.md`: add **Agent Plugins 1.0** row to capability matrix and callout with validation command

## Validation
- `python3 scripts/validate-manifests.py` — pass
- `python3 scripts/validate-agent-plugins.py --check` — pass (4 plugins)
- `uv run ruff check` / `format --check` — pass
- `uv run pytest tests/test_target_registry.py` — pass

Follows `assistant` discovery + `dev-companion` gates. No code changes, docs-only.

## Follow-up
After merge, `main` remains 100% green (Validate + CodeQL already success on `fdfefd0`) and ready for `1.9.0` release bump per `docs/RELEASING.md`.