### PR TITLE
test: expand provider, pack, inventory, and audit policy coverage

### DIFF
--- a/tests/test_audit_policy.py
+++ b/tests/test_audit_policy.py
@@ -1,0 +1,479 @@
+"""Contract tests for the audit policy surface in agent_toolkit.runner.policy."""
+
+# Author: RawNuke
+# Copyright (c) 2026 RawNuke. All rights reserved.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit.runner.policy import (
+    KNOWN_PROVIDERS,
+    LLMPolicy,
+    PolicyError,
+    _normalize_name,
+    _split_list,
+    _truthy,
+    merge_policies,
+)
+
+
+class DummyProvider:
+    """Minimal provider stub with name, priority, and model attributes."""
+
+    def __init__(self, name: str, priority: int = 100, model: str | None = None) -> None:
+        self.name = name
+        self._priority = priority
+        self.model = model
+
+    def get_priority(self) -> int:
+        return self._priority
+
+
+# ── from_env ────────────────────────────────────────────────────────────────
+
+
+def test_from_env_splits_allowlist_and_denylist() -> None:
+    env = {
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode, anthropic",
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_DENYLIST": "ollama, openai",
+    }
+    policy = LLMPolicy.from_env(env)
+    assert policy.allowlist == ("opencode", "anthropic")
+    assert policy.denylist == ("ollama", "openai")
+    assert policy.sources == ("env",)
+
+
+def test_from_env_normalizes_pinned_provider_and_model() -> None:
+    env = {
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_PINNED_PROVIDER": "  OpenCode  ",
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_PINNED_MODEL": "  claude-3-5-haiku  ",
+    }
+    policy = LLMPolicy.from_env(env)
+    assert policy.pinned_provider == "opencode"
+    assert policy.pinned_model == "claude-3-5-haiku"
+    assert policy.sources == ("env",)
+
+
+def test_from_env_blank_pinned_model_is_none() -> None:
+    env = {"DOTS_WORKSTATION_DEVCOMPANION_LLM_PINNED_MODEL": "   "}
+    policy = LLMPolicy.from_env(env)
+    assert policy.pinned_model is None
+    assert policy.sources == ()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        (" Yes ", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("2", False),
+    ],
+)
+def test_from_env_strict_truthiness(raw: str, expected: bool) -> None:
+    policy = LLMPolicy.from_env({"DOTS_WORKSTATION_DEVCOMPANION_LLM_STRICT": raw})
+    assert policy.strict is expected
+    assert ("env" in policy.sources) is expected
+
+
+def test_from_env_empty_env_has_no_sources() -> None:
+    policy = LLMPolicy.from_env({})
+    assert policy.allowlist is None
+    assert policy.denylist == ()
+    assert policy.sources == ()
+    assert policy.warnings == ()
+
+
+def test_from_env_warns_on_unknown_providers() -> None:
+    env = {
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode, mystery-provider",
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_DENYLIST": "ghost",
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_PINNED_PROVIDER": "phantom",
+    }
+    policy = LLMPolicy.from_env(env)
+    assert any(
+        "allowlist contains unknown provider 'mystery-provider'" in w for w in policy.warnings
+    )
+    assert any("denylist contains unknown provider 'ghost'" in w for w in policy.warnings)
+    assert any("pinned provider 'phantom' is unknown" in w for w in policy.warnings)
+    assert len(policy.warnings) == 3
+
+
+# ── from_file ───────────────────────────────────────────────────────────────
+
+
+def test_from_file_reads_json_config(tmp_path: Path) -> None:
+    cfg = tmp_path / "policy.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "allowlist": ["opencode", "ollama"],
+                "denylist": ["openai"],
+                "pinned_provider": "Anthropic",
+                "pinned_model": " claude-3-5-haiku ",
+                "strict": True,
+            }
+        )
+    )
+    policy = LLMPolicy.from_file(cfg)
+    assert policy.allowlist == ("opencode", "ollama")
+    assert policy.denylist == ("openai",)
+    assert policy.pinned_provider == "anthropic"
+    assert policy.pinned_model == "claude-3-5-haiku"
+    assert policy.strict is True
+    assert policy.sources == (f"file:{cfg}",)
+
+
+def test_from_file_legacy_provider_and_model_keys(tmp_path: Path) -> None:
+    cfg = tmp_path / "legacy.json"
+    cfg.write_text(json.dumps({"provider": "  OpenAI ", "model": "gpt-4o"}))
+    policy = LLMPolicy.from_file(cfg)
+    assert policy.pinned_provider == "openai"
+    assert policy.pinned_model == "gpt-4o"
+    assert policy.sources == (f"file:{cfg}",)
+
+
+def test_from_file_missing_path_returns_empty(tmp_path: Path) -> None:
+    policy = LLMPolicy.from_file(tmp_path / "does-not-exist.json")
+    assert policy.allowlist is None
+    assert policy.denylist == ()
+    assert policy.sources == ()
+    assert policy.warnings == ()
+
+
+def test_from_file_invalid_json_returns_warning(tmp_path: Path) -> None:
+    cfg = tmp_path / "broken.json"
+    cfg.write_text("{not json", encoding="utf-8")
+    policy = LLMPolicy.from_file(cfg)
+    assert policy.allowlist is None
+    assert len(policy.warnings) == 1
+    assert policy.warnings[0].startswith("failed to parse policy file")
+
+
+def test_from_file_non_object_json_returns_warning(tmp_path: Path) -> None:
+    cfg = tmp_path / "array.json"
+    cfg.write_text("[1, 2, 3]", encoding="utf-8")
+    policy = LLMPolicy.from_file(cfg)
+    assert policy.allowlist is None
+    assert len(policy.warnings) == 1
+    assert "must contain a JSON object" in policy.warnings[0]
+
+
+def test_from_file_respects_config_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = tmp_path / "custom.json"
+    cfg.write_text(json.dumps({"allowlist": ["opencode"]}))
+    monkeypatch.setenv("DOTS_WORKSTATION_DEVCOMPANION_LLM_CONFIG", str(cfg))
+    policy = LLMPolicy.from_file()
+    assert policy.allowlist == ("opencode",)
+    assert policy.sources == (f"file:{cfg}",)
+
+
+# ── from_job ────────────────────────────────────────────────────────────────
+
+
+def test_from_job_none_and_bool_are_empty() -> None:
+    assert LLMPolicy.from_job(None).allowlist is None
+    assert LLMPolicy.from_job(True).sources == ()
+    assert LLMPolicy.from_job(False).sources == ()
+
+
+def test_from_job_non_mapping_is_empty() -> None:
+    for value in ("opencode", 42, ["opencode"], 3.14):
+        policy = LLMPolicy.from_job(value)
+        assert policy.allowlist is None
+        assert policy.sources == ()
+
+
+def test_from_job_mapping_parses_like_file() -> None:
+    job = {
+        "allowlist": ["opencode"],
+        "denylist": ["openai"],
+        "provider": " Ollama ",
+        "model": " llama3.2 ",
+        "strict": "yes",
+    }
+    policy = LLMPolicy.from_job(job)
+    assert policy.allowlist == ("opencode",)
+    assert policy.denylist == ("openai",)
+    assert policy.pinned_provider == "ollama"
+    assert policy.pinned_model == "llama3.2"
+    assert policy.strict is True
+    assert policy.sources == ("job",)
+
+
+# ── load ────────────────────────────────────────────────────────────────────
+
+
+def test_load_layers_env_file_job(tmp_path: Path) -> None:
+    cfg = tmp_path / "policy.json"
+    cfg.write_text(json.dumps({"denylist": ["openai"]}))
+    env = {"DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode, ollama"}
+    policy = LLMPolicy.load(env=env, config_path=cfg, job_llm={"pinned_provider": "opencode"})
+    assert policy.allowlist == ("opencode", "ollama")
+    assert policy.denylist == ("openai",)
+    assert policy.pinned_provider == "opencode"
+    assert policy.sources == ("env", f"file:{cfg}", "job")
+
+
+def test_load_without_job_merges_env_and_file(tmp_path: Path) -> None:
+    cfg = tmp_path / "policy.json"
+    cfg.write_text(json.dumps({"allowlist": ["opencode"]}))
+    policy = LLMPolicy.load(
+        env={"DOTS_WORKSTATION_DEVCOMPANION_LLM_DENYLIST": "openai"},
+        config_path=cfg,
+    )
+    assert policy.allowlist == ("opencode",)
+    assert policy.denylist == ("openai",)
+    assert policy.sources == ("env", f"file:{cfg}")
+
+
+def test_load_job_cannot_widen_allowlist(tmp_path: Path) -> None:
+    env = {"DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode"}
+    with pytest.raises(PolicyError, match="not allowed globally"):
+        LLMPolicy.load(
+            env=env,
+            config_path=tmp_path / "missing.json",
+            job_llm={"allowlist": ["opencode", "openai"]},
+        )
+
+
+def test_load_job_pin_outside_allowlist_raises(tmp_path: Path) -> None:
+    env = {"DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode"}
+    with pytest.raises(PolicyError, match="not in the global allowlist"):
+        LLMPolicy.load(
+            env=env,
+            config_path=tmp_path / "missing.json",
+            job_llm={"provider": "ollama"},
+        )
+
+
+def test_load_job_pin_denied_provider_raises(tmp_path: Path) -> None:
+    cfg = tmp_path / "policy.json"
+    cfg.write_text(json.dumps({"denylist": ["ollama"]}))
+    env = {"DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode, ollama"}
+    with pytest.raises(PolicyError, match="denied by policy"):
+        LLMPolicy.load(env=env, config_path=cfg, job_llm={"provider": "ollama"})
+
+
+def test_load_strict_can_only_escalate(tmp_path: Path) -> None:
+    env = {
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode",
+        "DOTS_WORKSTATION_DEVCOMPANION_LLM_STRICT": "true",
+    }
+    policy = LLMPolicy.load(
+        env=env,
+        config_path=tmp_path / "missing.json",
+        job_llm={"strict": False, "denylist": ["openai"]},
+    )
+    assert policy.strict is True
+    assert any("tried to set strict=false" in w for w in policy.warnings)
+
+
+def test_load_job_can_escalate_strict(tmp_path: Path) -> None:
+    env = {"DOTS_WORKSTATION_DEVCOMPANION_LLM_ALLOWLIST": "opencode"}
+    policy = LLMPolicy.load(
+        env=env,
+        config_path=tmp_path / "missing.json",
+        job_llm={"strict": "on", "denylist": ["openai"]},
+    )
+    assert policy.strict is True
+
+
+# ── merge_policies ──────────────────────────────────────────────────────────
+
+
+def test_merge_denylist_union_sorted() -> None:
+    base = LLMPolicy(denylist=("ollama", "openai"))
+    overlay = LLMPolicy(denylist=("anthropic", "ollama"))
+    merged = merge_policies(base, overlay)
+    assert merged.denylist == ("anthropic", "ollama", "openai")
+
+
+def test_merge_allowlist_intersection_keeps_overlay_order() -> None:
+    base = LLMPolicy(allowlist=("anthropic", "opencode", "ollama"))
+    overlay = LLMPolicy(allowlist=("ollama", "anthropic"))
+    merged = merge_policies(base, overlay)
+    assert merged.allowlist == ("ollama", "anthropic")
+
+
+def test_merge_empty_allowlist_intersection_raises() -> None:
+    base = LLMPolicy(allowlist=("opencode",))
+    overlay = LLMPolicy(allowlist=("ollama",))
+    with pytest.raises(PolicyError, match="empty after intersecting"):
+        merge_policies(base, overlay)
+
+
+def test_merge_warnings_concatenated() -> None:
+    base = LLMPolicy(warnings=("w1", "w2"))
+    overlay = LLMPolicy(warnings=("w3",))
+    merged = merge_policies(base, overlay)
+    assert merged.warnings == ("w1", "w2", "w3")
+
+
+def test_merge_sources_dedup_preserves_order() -> None:
+    base = LLMPolicy(sources=("env", "file:a"))
+    overlay = LLMPolicy(sources=("file:a", "job"))
+    merged = merge_policies(base, overlay)
+    assert merged.sources == ("env", "file:a", "job")
+
+
+# ── filter ──────────────────────────────────────────────────────────────────
+
+
+def test_filter_allowlist_ordering_preserved() -> None:
+    providers = [
+        DummyProvider("opencode"),
+        DummyProvider("anthropic"),
+        DummyProvider("ollama"),
+    ]
+    policy = LLMPolicy(allowlist=("anthropic", "ollama", "opencode"))
+    assert [p.name for p in policy.filter(providers)] == ["anthropic", "ollama", "opencode"]
+
+
+def test_filter_denylist_excluded() -> None:
+    providers = [DummyProvider("opencode"), DummyProvider("ollama")]
+    policy = LLMPolicy(allowlist=("opencode", "ollama"), denylist=("ollama",))
+    assert [p.name for p in policy.filter(providers)] == ["opencode"]
+
+
+def test_filter_pinned_provider_sets_pinned_model() -> None:
+    provider = DummyProvider("opencode", model="default")
+    policy = LLMPolicy(pinned_provider="opencode", pinned_model="deepseek-v4-flash")
+    result = policy.filter([provider])
+    assert result == [provider]
+    assert provider.model == "deepseek-v4-flash"
+
+
+def test_filter_pinned_provider_denied_returns_empty() -> None:
+    policy = LLMPolicy(pinned_provider="opencode", denylist=("opencode",))
+    assert policy.filter([DummyProvider("opencode")]) == []
+
+
+def test_filter_unknown_pinned_provider_returns_empty() -> None:
+    policy = LLMPolicy(pinned_provider="nonexistent")
+    assert policy.filter([DummyProvider("opencode")]) == []
+
+
+def test_filter_default_priority_sort() -> None:
+    providers = [
+        DummyProvider("opencode", priority=10),
+        DummyProvider("ollama", priority=2),
+        DummyProvider("anthropic", priority=1),
+    ]
+    policy = LLMPolicy(denylist=("openai",))
+    assert [p.name for p in policy.filter(providers)] == ["anthropic", "ollama", "opencode"]
+
+
+# ── to_audit ────────────────────────────────────────────────────────────────
+
+
+def test_to_audit_exact_shape() -> None:
+    policy = LLMPolicy(
+        allowlist=("opencode", "ollama"),
+        denylist=("openai",),
+        pinned_provider="opencode",
+        pinned_model="m1",
+        strict=True,
+        sources=("env", "file:x", "job"),
+        warnings=("w1",),
+    )
+    assert policy.to_audit() == {
+        "allowlist": ["opencode", "ollama"],
+        "denylist": ["openai"],
+        "pinned_provider": "opencode",
+        "pinned_model": "m1",
+        "strict": True,
+        "sources": ["env", "file:x", "job"],
+        "warnings": ["w1"],
+    }
+
+
+def test_to_audit_empty_policy_shape() -> None:
+    assert LLMPolicy.empty().to_audit() == {
+        "allowlist": None,
+        "denylist": [],
+        "pinned_provider": None,
+        "pinned_model": None,
+        "strict": False,
+        "sources": [],
+        "warnings": [],
+    }
+
+
+# ── helper functions ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        (None, False),
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        (" Yes ", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("2", False),
+        ("maybe", False),
+        (1, True),
+        (0, False),
+    ],
+)
+def test_truthy_edge_cases(value: object, expected: bool) -> None:
+    assert _truthy(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, ()),
+        ("", ()),
+        ("opencode, ollama", ("opencode", "ollama")),
+        (" OpenCode ,ANTHROPIC ", ("opencode", "anthropic")),
+        (["OpenCode", " anthropic "], ("opencode", "anthropic")),
+        (("ollama", "openai"), ("ollama", "openai")),
+        (42, ()),
+        (b"opencode", ()),
+    ],
+)
+def test_split_list_cases(value: object, expected: tuple[str, ...]) -> None:
+    assert _split_list(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        (" OpenCode ", "opencode"),
+        ("ANTHROPIC", "anthropic"),
+    ],
+)
+def test_normalize_name_cases(value: object, expected: str | None) -> None:
+    assert _normalize_name(value) == expected
+
+
+def test_known_providers_constant() -> None:
+    assert KNOWN_PROVIDERS == ("opencode", "ollama", "anthropic", "openai")

--- a/tests/test_inventory_matrix.py
+++ b/tests/test_inventory_matrix.py
@@ -1,0 +1,81 @@
+"""CLI contract tests for cmd_inventory and cmd_matrix in agent_toolkit.cli.build."""
+
+# Author: RawNuke
+# Copyright (c) 2026 RawNuke. All rights reserved.
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import agent_toolkit._paths as paths_mod
+from agent_toolkit.cli import build as build_mod
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def clone_root(monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Resolve the toolkit root inside the repository clone."""
+    monkeypatch.setenv("AGENT_TOOLKIT_ROOT", str(REPO_ROOT))
+    monkeypatch.setenv("AGENT_TOOLKIT_OFFLINE", "1")
+    paths_mod.reset_toolkit_root()
+    yield REPO_ROOT
+    paths_mod.reset_toolkit_root()
+
+
+def test_cmd_inventory_prints_header_and_counts(
+    clone_root: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """cmd_inventory prints the header and counts, then returns 0."""
+    rc = build_mod.cmd_inventory([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "agent-toolkit Inventory" in out
+    assert re.search(r"Skills: \d+ across \d+ domains", out)
+    assert re.search(r"Agents: \d+", out)
+    assert re.search(r"Products: \d+", out)
+
+
+def test_cmd_inventory_lists_agents_and_products(
+    clone_root: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """cmd_inventory lists agents and products with their counts."""
+    rc = build_mod.cmd_inventory([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Agents: " in out
+    assert "Products: " in out
+    assert "agent-toolkit-core" in out
+    assert re.search(r"skills: \d+  agents: \d+", out)
+    assert "✓" in out
+
+
+def test_cmd_matrix_prints_matrix_content_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """cmd_matrix prints the matrix file content when the file exists."""
+    matrix = tmp_path / "docs" / "research" / "platform-capability-matrix.md"
+    matrix.parent.mkdir(parents=True)
+    matrix.write_text("UNIQUE MATRIX CONTENT\nsecond line\n", encoding="utf-8")
+    monkeypatch.setattr(build_mod, "_find_repo_root", lambda: tmp_path)
+    rc = build_mod.cmd_matrix([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "UNIQUE MATRIX CONTENT" in out
+    assert "second line" in out
+
+
+def test_cmd_matrix_fallback_when_matrix_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """cmd_matrix prints the fallback message when the matrix file is missing."""
+    monkeypatch.setattr(build_mod, "_find_repo_root", lambda: tmp_path)
+    rc = build_mod.cmd_matrix([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Matrix not found." in out
+    expected_path = tmp_path / "docs" / "research" / "platform-capability-matrix.md"
+    assert str(expected_path) in out

--- a/tests/test_pack_composition.py
+++ b/tests/test_pack_composition.py
@@ -1,0 +1,180 @@
+"""Contract tests for pack composition in agent_toolkit.loop.pack.
+
+Author: RawNuke
+Copyright (c) 2026 RawNuke. All rights reserved.
+
+Covers pack path resolution, YAML loading (with the simple-parser fallback),
+loop entry lookup and the loop override merge matrix. Focus is the
+resolution and merge behaviour; skills/agents advisory keys are covered by
+test_pack_skills_agents_advisory.py and are not duplicated here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from agent_toolkit.loop.pack import (
+    apply_loop_pack_overrides,
+    load_pack,
+    loop_pack_entry,
+    resolve_pack_path,
+)
+
+
+class TestResolvePackPath:
+    def test_absolute_existing_file_returns_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "pack.yaml"
+        target.write_text("name: demo\n", encoding="utf-8")
+        assert resolve_pack_path(target, tmp_path) == target
+
+    def test_absolute_missing_file_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "missing.yaml"
+        assert resolve_pack_path(target, tmp_path) is None
+
+    def test_relative_bare_name_resolves_under_workspace(self, tmp_path: Path) -> None:
+        (tmp_path / "demo.yaml").write_text("name: demo\n", encoding="utf-8")
+        assert resolve_pack_path("demo.yaml", tmp_path) == tmp_path / "demo.yaml"
+
+    def test_packs_prefix_resolution(self, tmp_path: Path) -> None:
+        packs = tmp_path / "packs"
+        packs.mkdir()
+        (packs / "demo.yaml").write_text("name: demo\n", encoding="utf-8")
+        assert resolve_pack_path("packs/demo.yaml", tmp_path) == packs / "demo.yaml"
+
+    def test_packs_name_resolves_under_packs_dir(self, tmp_path: Path) -> None:
+        packs = tmp_path / "packs"
+        packs.mkdir()
+        (packs / "demo.yaml").write_text("name: demo\n", encoding="utf-8")
+        assert resolve_pack_path("demo", tmp_path) == packs / "demo.yaml"
+
+    def test_packs_name_with_extension_resolves(self, tmp_path: Path) -> None:
+        packs = tmp_path / "packs"
+        packs.mkdir()
+        (packs / "demo.yaml").write_text("name: demo\n", encoding="utf-8")
+        assert resolve_pack_path("demo.yaml", tmp_path) == packs / "demo.yaml"
+
+    def test_no_match_returns_none(self, tmp_path: Path) -> None:
+        assert resolve_pack_path("nope", tmp_path) is None
+
+
+class TestLoadPack:
+    def test_yaml_dict_loads(self, tmp_path: Path) -> None:
+        pack_path = tmp_path / "pack.yaml"
+        pack_path.write_text("name: demo\nloops:\n  a:\n    enabled: true\n", encoding="utf-8")
+        data = load_pack(pack_path)
+        assert data["name"] == "demo"
+        assert data["loops"]["a"]["enabled"] is True
+
+    def test_non_dict_yaml_returns_empty(self, tmp_path: Path) -> None:
+        pack_path = tmp_path / "list.yaml"
+        pack_path.write_text("- a\n- b\n", encoding="utf-8")
+        assert load_pack(pack_path) == {}
+
+    def test_scalar_yaml_returns_empty(self, tmp_path: Path) -> None:
+        pack_path = tmp_path / "scalar.yaml"
+        pack_path.write_text("just a string\n", encoding="utf-8")
+        assert load_pack(pack_path) == {}
+
+    def test_simple_parser_fallback(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """Without PyYAML, flat keys, budget sub-keys and lists still parse."""
+        pack_path = tmp_path / "pack.yaml"
+        pack_path.write_text(
+            "name: demo\ntier: L1\ncadence: 1d\nbudget:\n  max_tokens: 50000\ndeny:\n  - merge\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        data = load_pack(pack_path)
+        assert data["name"] == "demo"
+        assert data["tier"] == "L1"
+        assert data["cadence"] == "1d"
+        assert data["budget"] == {"max_tokens": 50000}
+        assert data["deny"] == ["merge"]
+
+
+class TestLoopPackEntry:
+    def test_missing_loops_key_returns_empty(self) -> None:
+        assert loop_pack_entry({"pack": "demo"}, "a") == {}
+
+    def test_loop_name_not_present_returns_empty(self) -> None:
+        assert loop_pack_entry({"loops": {"a": {"enabled": True}}}, "b") == {}
+
+    def test_non_dict_loops_returns_empty(self) -> None:
+        assert loop_pack_entry({"loops": ["a", "b"]}, "a") == {}
+        assert loop_pack_entry({"loops": "demo"}, "a") == {}
+
+    def test_valid_entry_returned(self) -> None:
+        entry = {"enabled": True, "cadence": "15m"}
+        assert loop_pack_entry({"loops": {"a": entry}}, "a") == entry
+
+
+class TestApplyLoopPackOverrides:
+    def _meta(self) -> dict[str, Any]:
+        return {
+            "enabled": True,
+            "cadence": "1d",
+            "tier": "L1",
+            "verifier": None,
+            "goal": "old goal",
+            "budget": {"max_tokens": 50000},
+            "request": "keep me",
+        }
+
+    def test_merges_only_allowed_keys(self) -> None:
+        pack_data: dict[str, Any] = {
+            "loops": {
+                "a": {
+                    "enabled": True,
+                    "cadence": "15m",
+                    "tier": "L2",
+                    "verifier": "reviewer",
+                    "goal": "new goal",
+                }
+            }
+        }
+        merged = apply_loop_pack_overrides(self._meta(), pack_data, "a")
+        assert merged["enabled"] is True
+        assert merged["cadence"] == "15m"
+        assert merged["tier"] == "L2"
+        assert merged["verifier"] == "reviewer"
+        assert merged["goal"] == "new goal"
+        assert merged["request"] == "keep me"
+
+    def test_budget_merges_on_top_of_meta_budget(self) -> None:
+        pack_data: dict[str, Any] = {
+            "loops": {"a": {"budget": {"max_wall_seconds": 600, "max_runs_per_day": 2}}}
+        }
+        merged = apply_loop_pack_overrides(self._meta(), pack_data, "a")
+        assert merged["budget"] == {
+            "max_tokens": 50000,
+            "max_wall_seconds": 600,
+            "max_runs_per_day": 2,
+        }
+
+    def test_budget_added_when_meta_has_no_budget(self) -> None:
+        meta = self._meta()
+        meta["budget"] = {}
+        pack_data: dict[str, Any] = {"loops": {"a": {"budget": {"max_tokens": 100}}}}
+        merged = apply_loop_pack_overrides(meta, pack_data, "a")
+        assert merged["budget"] == {"max_tokens": 100}
+
+    def test_entry_enabled_false_forces_false(self) -> None:
+        pack_data: dict[str, Any] = {"loops": {"a": {"enabled": False, "cadence": "2d"}}}
+        merged = apply_loop_pack_overrides(self._meta(), pack_data, "a")
+        assert merged["enabled"] is False
+        assert merged["cadence"] == "2d"
+
+    def test_unknown_keys_are_ignored(self) -> None:
+        pack_data: dict[str, Any] = {"loops": {"a": {"skills": {"x": 1}, "agents": {"y": 2}}}}
+        merged = apply_loop_pack_overrides(self._meta(), pack_data, "a")
+        assert "skills" not in merged
+        assert "agents" not in merged
+
+    def test_no_entry_returns_copy_without_mutating_input(self) -> None:
+        meta = self._meta()
+        pack_data: dict[str, Any] = {"loops": {"a": {"enabled": False}}}
+        merged = apply_loop_pack_overrides(meta, pack_data, "missing")
+        assert merged == meta
+        assert merged is not meta
+        assert meta["enabled"] is True

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,292 @@
+"""Contract tests for the LLM provider abstraction and the LLM dispatcher.
+
+Author: RawNuke
+Copyright (c) 2026 RawNuke. All rights reserved.
+
+Covers LLMResponse fields, the LLMProvider ABC defaults, the concrete
+providers (anthropic, ollama, openai, opencode) and the policy-based
+candidate selection in LLMDispatcher. No live endpoint is ever called;
+availability checks run on monkeypatched subprocess and environ.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent_toolkit.runner.dispatcher import LLMDispatcher
+from agent_toolkit.runner.policy import LLMPolicy
+from agent_toolkit.runner.providers import (
+    AnthropicProvider,
+    LLMProvider,
+    LLMResponse,
+    OllamaProvider,
+    OpenAIProvider,
+    OpenCodeProvider,
+)
+
+
+class _StubProvider(LLMProvider):
+    """Minimal concrete provider for ABC behaviour checks."""
+
+    name = "stub"
+
+    def is_available(self) -> bool:
+        return True
+
+    def generate(self, prompt: str, **kwargs: Any) -> LLMResponse:
+        return LLMResponse(content="ok", model="stub", provider="stub")
+
+
+def _stub_run(returncode: int, stdout: str = "") -> Any:
+    return SimpleNamespace(returncode=returncode, stdout=stdout)
+
+
+def _stub_available(monkeypatch: pytest.MonkeyPatch, run: Any) -> Any:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: run)
+    return run
+
+
+class TestLLMResponse:
+    def test_defaults(self) -> None:
+        resp = LLMResponse(content="hi", model="m", provider="p")
+        assert resp.content == "hi"
+        assert resp.model == "m"
+        assert resp.provider == "p"
+        assert resp.tokens_used is None
+        assert resp.duration_sec is None
+
+    def test_optional_fields_set(self) -> None:
+        resp = LLMResponse(content="hi", model="m", provider="p", tokens_used=12, duration_sec=1.5)
+        assert resp.tokens_used == 12
+        assert resp.duration_sec == 1.5
+
+
+class TestLLMProviderABC:
+    def test_abstract_methods(self) -> None:
+        assert LLMProvider.__abstractmethods__ == frozenset({"is_available", "generate"})
+
+    def test_default_behaviour(self) -> None:
+        stub = _StubProvider()
+        assert stub.get_priority() == 100
+        assert stub.supports_directory_context() is False
+        assert stub.get_model_name() == "unknown"
+
+    def test_default_class_attributes(self) -> None:
+        assert LLMProvider.is_local is False
+        assert LLMProvider.is_free is False
+
+
+class TestAnthropicProvider:
+    def test_metadata(self) -> None:
+        p = AnthropicProvider()
+        assert p.name == "anthropic"
+        assert p.is_local is False
+        assert p.is_free is False
+        assert p.get_priority() == 10
+        assert p.supports_directory_context() is False
+        assert p.get_model_name() == "claude-3-5-haiku-20241022"
+
+    def test_is_available_with_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        assert AnthropicProvider().is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert AnthropicProvider().is_available() is False
+
+
+class TestOllamaProvider:
+    def test_metadata(self) -> None:
+        p = OllamaProvider()
+        assert p.name == "ollama"
+        assert p.is_local is True
+        assert p.is_free is True
+        assert p.get_priority() == 2
+        assert p.supports_directory_context() is False
+        assert p.get_model_name() == "llama3.2"
+
+    def test_is_available_model_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(0, stdout="llama3.2  other-model\n"))
+        assert OllamaProvider().is_available() is True
+
+    def test_is_available_model_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(0, stdout="mistral\n"))
+        assert OllamaProvider().is_available() is False
+
+    def test_is_available_nonzero_returncode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(1, stdout="llama3.2\n"))
+        assert OllamaProvider().is_available() is False
+
+    def test_is_available_missing_binary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_fnf(*args: Any, **kwargs: Any) -> Any:
+            raise FileNotFoundError
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+        assert OllamaProvider().is_available() is False
+
+    def test_is_available_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_timeout(*args: Any, **kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd=["ollama", "list"], timeout=5)
+
+        monkeypatch.setattr(subprocess, "run", raise_timeout)
+        assert OllamaProvider().is_available() is False
+
+
+class TestOpenAIProvider:
+    def test_metadata(self) -> None:
+        p = OpenAIProvider()
+        assert p.name == "openai"
+        assert p.is_local is False
+        assert p.is_free is False
+        assert p.get_priority() == 20
+        assert p.supports_directory_context() is False
+        assert p.get_model_name() == "gpt-4o-mini"
+
+    def test_is_available_with_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        assert OpenAIProvider().is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert OpenAIProvider().is_available() is False
+
+
+class TestOpenCodeProvider:
+    def test_metadata(self) -> None:
+        p = OpenCodeProvider()
+        assert p.name == "opencode"
+        assert p.is_local is True
+        assert p.is_free is True
+        assert p.get_priority() == 1
+        assert p.supports_directory_context() is True
+        assert p.get_model_name() == "opencode/big-pickle"
+
+    def test_is_available_returncode_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(0))
+        assert OpenCodeProvider().is_available() is True
+
+    def test_is_available_returncode_nonzero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(1))
+        assert OpenCodeProvider().is_available() is False
+
+    def test_is_available_missing_binary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_fnf(*args: Any, **kwargs: Any) -> Any:
+            raise FileNotFoundError
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+        assert OpenCodeProvider().is_available() is False
+
+    def test_is_available_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_timeout(*args: Any, **kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd=["opencode", "--version"], timeout=5)
+
+        monkeypatch.setattr(subprocess, "run", raise_timeout)
+        assert OpenCodeProvider().is_available() is False
+
+
+class TestLLMDispatcher:
+    def test_policy_violation_constant(self) -> None:
+        assert LLMDispatcher.POLICY_VIOLATION == "policy_no_provider_available"
+
+    def test_policy_attribute_defaults_to_empty(self) -> None:
+        """Dispatcher's policy class is distinct; compare the audit shape."""
+        dispatcher = LLMDispatcher()
+        assert dispatcher.policy.to_audit() == LLMPolicy.empty().to_audit()
+
+    def test_allowlist_order_wins_over_priority(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(0))
+        policy = LLMPolicy(allowlist=("openai", "opencode"))
+        dispatcher = LLMDispatcher(policy=policy)
+        names = [c.name for c in dispatcher._candidates]
+        assert names == ["openai", "opencode"]
+
+    def test_pinned_provider_returns_single_candidate(self) -> None:
+        policy = LLMPolicy(pinned_provider="ollama")
+        dispatcher = LLMDispatcher(policy=policy)
+        assert [c.name for c in dispatcher._candidates] == ["ollama"]
+
+    def test_denylist_excludes_provider(self) -> None:
+        policy = LLMPolicy(denylist=("openai",))
+        dispatcher = LLMDispatcher(policy=policy)
+        assert all(c.name != "openai" for c in dispatcher._candidates)
+
+    def test_get_available_provider_no_candidates_returns_none(self) -> None:
+        policy = LLMPolicy(denylist=("opencode", "ollama", "anthropic", "openai"))
+        dispatcher = LLMDispatcher(policy=policy)
+        assert dispatcher._candidates == []
+        assert dispatcher.get_available_provider() is None
+
+    def test_get_available_provider_none_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(1))
+        policy = LLMPolicy(denylist=("openai", "anthropic"))
+        dispatcher = LLMDispatcher(policy=policy)
+        assert dispatcher.get_available_provider() is None
+
+    def test_get_available_provider_selects_first_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_available(monkeypatch, _stub_run(0))
+        dispatcher = LLMDispatcher()
+        provider = dispatcher.get_available_provider()
+        assert provider is not None
+        assert provider.name == "opencode"
+        assert dispatcher.get_selected() is provider
+
+    def test_list_candidates_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(0, stdout="llama3.2\n"))
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        dispatcher = LLMDispatcher()
+        candidates = dispatcher.list_candidates()
+        assert [c["name"] for c in candidates] == ["opencode", "ollama", "anthropic", "openai"]
+        assert [c["available"] for c in candidates] == [True, True, False, False]
+        for c in candidates:
+            assert set(c.keys()) == {
+                "name",
+                "model",
+                "available",
+                "is_local",
+                "is_free",
+                "priority",
+            }
+            assert c["is_local"] is (c["name"] in ("opencode", "ollama"))
+
+    def test_list_all_providers_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_available(monkeypatch, _stub_run(0, stdout="llama3.2\n"))
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        dispatcher = LLMDispatcher()
+        providers = dispatcher.list_all_providers()
+        assert [p["name"] for p in providers] == ["opencode", "ollama", "anthropic", "openai"]
+        assert [p["available"] for p in providers] == [True, True, False, False]
+        for p in providers:
+            assert set(p.keys()) == {
+                "name",
+                "model",
+                "available",
+                "is_local",
+                "is_free",
+                "priority",
+                "in_policy",
+            }
+        assert all(p["in_policy"] is True for p in providers)
+
+
+def test_never_touches_real_subprocess_or_live_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard: provider availability must not escape to a real CLI."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *args: Any, **kwargs: Any) -> Any:
+        calls.append(cmd)
+        return _stub_run(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    for provider in (OllamaProvider(), OpenCodeProvider()):
+        provider.is_available()
+    assert calls == [["ollama", "list"], ["opencode", "--version"]]

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,7 @@ requires-dist = [{ name = "agent-toolkit-cli", editable = "packages/agent-toolki
 [package.metadata.requires-dev]
 dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "mypy", specifier = ">=1.10.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -236,7 +236,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Adds four hermetic pytest files covering the surfaces issue #389 names: the provider abstraction (`runner/providers`, `runner/dispatcher`), pack composition (`loop/pack`), the CLI inventory/matrix commands (`cli/build`), and the LLM execution policy audit surface (`runner/policy`).
- Aligns `uv.lock` with the manifest: `mypy >= 2.3.0` was already pinned in `pyproject.toml` (PR #359); the lock still carried `>= 1.10.0`.
- No source code changes. Provenance tests (`tests/test_provenance.py`) and isolated-HOME install tests (`tests/test_install_lifecycle.py`) already exist from prior work, so this PR covers the missing layers without duplicating them.

## Type

- [ ] New skill
- [ ] New loop template
- [ ] New agent persona
- [ ] New profile (per-tool config)
- [ ] New pack
- [ ] Catalog update (skill-catalog, agent-catalog, loop-catalog)
- [ ] Schema update
- [ ] Documentation
- [ ] Bug fix
- [x] Other

## Changes

- `tests/test_provider.py` — LLMResponse fields, LLMProvider ABC defaults, concrete provider metadata and monkeypatched availability (Anthropic, Ollama, OpenAI, OpenCode), LLMDispatcher selection under LLMPolicy (allowlist order, pinned provider, denylist), candidate/listing shapes.
- `tests/test_pack_composition.py` — `resolve_pack_path` resolution matrix, `load_pack` YAML and fallback-parser paths, `loop_pack_entry` edge cases, `apply_loop_pack_overrides` merge matrix (budget dict merge, `enabled: false` override, no-entry copy).
- `tests/test_inventory_matrix.py` — `cmd_inventory` output contract (headers, counts, domain grouping) and `cmd_matrix` present/fallback behavior.
- `tests/test_audit_policy.py` — `LLMPolicy` env/file/job loaders, precedence and restriction validation (`PolicyError` on widening), `merge_policies` semantics, `filter` ordering and pinning, `to_audit` shape, helper edge cases.
- `uv.lock` — regenerate the stale lock so it matches the manifest.

## Testing

- [ ] Validated locally with `python3 scripts/validate-skills.py` (if skill changes)
- [ ] Validated loops with `python3` + `schemas/loop.schema.json` (if loop changes) — see `.github/workflows/validate.yml` `validate-loops` job
- [ ] Ran `python3 scripts/validate-agents.py` (if agent changes)
- [ ] Regenerated catalogs with `python3 scripts/generate-catalogs.py` (if skill/agent/loop added)
- [ ] Checked `python3 scripts/gen-surfaces.py --check` (if skill/agent/loop or surface changed)
- [x] Confirmed `validate` CI workflow passes (or ran checks locally via `uv sync --all-extras && AGENT_TOOLKIT_ROOT=$PWD uv run pytest tests/ -v`)
- [ ] Tested with at least one supported AI tool (Claude Code, Cursor, Copilot, etc.)

Local results on commit 5a6e12f + these files:

- `AGENT_TOOLKIT_ROOT=$PWD uv run pytest tests/ -v` — 708 passed, 2 skipped
- `uv run pytest tests/compiler/ -v` — 208 passed
- `uv run ruff check tests` — all checks passed
- Narrow coverage measured for the new surfaces: `runner/policy.py` 99%, `loop/pack.py` 100%

## Checklist

- [x] `SKILL.md` frontmatter present (`name`, `description`) — no `skill.json` (removed in v1.0.4)
- [x] Loop `loops/<name>/loop.yaml` includes required fields: `name`, `goal`, `request`
- [x] Loop `tier` set (`L1`/`L2`/`L3`) with `budget` (`max_tokens`, `max_runs_per_day`, `max_wall_seconds`) and `exit_conditions`
- [x] Loop `allowlist`/`deny` scoped correctly for tier
- [x] Loop `loop.yaml` validates against `schemas/loop.schema.json`
- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes
- [x] Branding-neutral: no organization-specific references in public-facing files
- [x] Catalog entries regenerated (`python3 scripts/generate-catalogs.py`) if a skill, agent, or loop was added
- [x] Commit messages are in English and follow conventional commits format

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke
