### PR TITLE
feat(governance): add upstream provenance schema, trust tiers & validate-upstream (Closes #364)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -90,14 +90,19 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install PyYAML
-        run: pip install pyyaml==6.0.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+
+      - name: Sync workspace
+        run: uv sync --all-extras
 
       - name: Validate SKILL.md frontmatter (Agent Skills spec)
-        run: python3 scripts/validate-skills.py
+        run: uv run python scripts/validate-skills.py
 
       - name: Validate AGENT.md frontmatter
-        run: python3 scripts/validate-agents.py
+        run: uv run python scripts/validate-agents.py
 
   # ── Job 3: Validate marketplace manifests and plugin.json files ────────────
   validate-manifests:
@@ -132,11 +137,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install PyYAML
-        run: pip install pyyaml==6.0.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+
+      - name: Sync workspace (uses locked dependencies)
+        run: uv sync --all-extras
 
       - name: Check upstream provenance (immutable refs, SPDX)
-        run: python3 scripts/validate-upstream.py --check
+        run: uv run python scripts/validate-upstream.py --check
 
   # ── Job 4: Detect plugin surface drift ────────────────────────────────────
   check-surfaces:
@@ -145,21 +155,33 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install PyYAML
-        run: pip install pyyaml==6.0.2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+
+      - name: Sync workspace
+        run: uv sync --all-extras
 
       - name: Assert plugin surfaces are in sync with canonical sources
-        run: python3 scripts/gen-surfaces.py --check
+        run: uv run python scripts/gen-surfaces.py --check
 
   check-skill-matrix:
     name: Check Skill→Product Matrix
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install PyYAML
-        run: pip install pyyaml==6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+
+      - name: Sync workspace
+        run: uv sync --all-extras
+
       - name: Check skill→product→target matrix is up to date
-        run: python3 scripts/generate-skill-matrix.py --check
+        run: uv run python scripts/generate-skill-matrix.py --check
 
   # ── Job 5: Validate loop.yaml files against loop.schema.json ──────────────
   validate-loops:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -125,6 +125,19 @@ jobs:
       - name: Validate Agent Plugins 1.0 manifests (plugin.json + mcp.json)
         run: python3 scripts/validate-agent-plugins.py --check
 
+  # ── Job 3c: Validate upstream provenance (no mutable refs) ──────────────
+  validate-upstream:
+    name: Validate Upstream Provenance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: pip install pyyaml==6.0.2
+
+      - name: Check upstream provenance (immutable refs, SPDX)
+        run: python3 scripts/validate-upstream.py --check
+
   # ── Job 4: Detect plugin surface drift ────────────────────────────────────
   check-surfaces:
     name: Check Plugin Bundle Sync

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -96,79 +96,84 @@ agent-toolkit follows these principles (see also
 
 Prefer tagged releases or marketplace installs over unreviewed forks.
 
-### Provenance & third-party capabilities (per #364)
+### Provenance & third-party capabilities (per #364) — P0 foundation
 
-Every third-party skill/plugin/MCP declares immutable provenance in its `SKILL.md` frontmatter:
+**Implemented now (in #399):** Explicit origin classification + immutable provenance in `SKILL.md` frontmatter, validated in CI via `scripts/validate-upstream.py`. Every distributable `SKILL.md` must declare `origin.type`.
+
+**Planned in #370:** `capabilities/upstream.lock` will become the canonical provenance registry (single source of truth). Until #370 merges, `SKILL.md` frontmatter is authoritative. Do not document `upstream.lock` as already implemented — target architecture is:
+
+```
+canonical registry (capabilities/upstream.lock)  ← planned in #370
+    ↓
+validation (validate-upstream.py)
+    ↓
+SKILL.md frontmatter projection (currently authoritative)
+    ↓
+catalog/inventory
+```
+
+**Planned in #387:** `agent-toolkit inventory` and `doctor` provenance wiring (display upstream/sources, warn on stale pins, missing provenance). Until #387, provenance is visible via `validate-upstream.py --check` and frontmatter inspection only.
+
+Every `SKILL.md` must have an explicit origin — no inference from path or absence (gate 2):
 
 ```yaml
+origin:
+  type: first-party  # or upstream
+```
+
+For `first-party`, no provenance is allowed. For `upstream`, one or more sources are required (gate 9).
+
+#### First-party example
+
+```yaml
+---
+name: assistant
+description: Assistant — scan README→docs→AGENTS before code; cite sources.
+origin:
+  type: first-party
+---
+```
+
+#### Single-source upstream (Anthropic frontend-design — Apache-2.0 verified 2026-08-11)
+
+```yaml
+---
+name: frontend-design
+description: Distinctive, intentional visual design (Anthropic).
+origin:
+  type: upstream
 upstream:
   repository: anthropics/skills
   path: skills/frontend-design
-  ref: f17010c9bb483898c1d9c9f42dde2b3a98889434  # 40-char SHA (verified 2026-08-11: LICENSE.txt Apache-2.0, not MIT)
-  license: Apache-2.0
-  commit: f17010c9bb483898c1d9c9f42dde2b3a98889434  # required for tag, optional for SHA (redundant but explicit)
+  ref: f17010c9bb483898c1d9c9f42dde2b3a98889434  # full 40-char SHA, never short SHA (gate 1)
+  license: Apache-2.0  # SPDX subset (gate 6) — verified 2026-08-11: LICENSE.txt Apache-2.0, not MIT
 trust:
-  tier: verified  # first-party | verified | community | experimental
+  tier: reviewed  # gate 5: 'reviewed' replaces 'verified' (verified is deprecated alias)
+  reviewed_at: "2026-08-11"
+  reviewed_by: ulises-jeremias
+maintenance:
+  status: active  # gate 4: independent of trust tier
+  last_activity: "2026-08-07"
 distribution:
-  mode: vendored  # vendored | external | generated | native-plugin
+  mode: vendored  # gate 8: mutually exclusive delivery channel (see semantics below)
   redistribution_allowed: true
 security:
   scripts: false
   shell: false
   network: false
+  cve_policy: not-applicable  # gate 4: for pure instruction assets, not package CVE
+---
 ```
 
-**Trust tiers — objective criteria (per review §9):**
+#### Multi-source upstream (Vercel web-design-guidelines — gate 9)
 
-| Tier | Criteria (all must hold) | Default install | Auto-update | Permissions gate |
-|------|---------|-----------------|-------------|------------------|
-| `first-party` | Toolkit-authored, no external ref, passes `validate-skills.py` | enabled | via Toolkit release | none |
-| `verified` | Immutable ref (40-char SHA or tag+commit) + SPDX license known + `security.*` declared + `audit-capability.py` no high findings + human review recorded (`trust.reviewed_at/by`) + upstream active <90d + no critical CVE | enabled | PR with diff + license/security surface check → human review (never auto-merge if `shell/network` changes) | declare `security.*` |
-| `community` | Useful but missing ≥1 verified criterion (e.g., no human review, unknown license) | **opt-in** only | manual PR | explicit opt-in + `dangerous_permissions` review |
-| `experimental` | Unstable/research, no provenance or high findings | opt-in | manual | human gate required |
+One capability may derive from multiple artifacts. Use `sources` with `role`:
 
-> `verified` ≠ popular (stars irrelevant). Popularity is metadata only (per §46).
-
-**Note on scope (§10):** Provenance is not skill-only. `upstream.lock` is source of truth for all capability types (skills, agents, MCP, hooks, plugins, scripts). `SKILL.md` frontmatter `upstream:` is a convenience projection; canonical registry is `capabilities/upstream.lock` (generated, not hand-copied). Do not duplicate without sync.
-
-**Decision matrix:**
-
-| Situation | Decision | Distribution |
-|-----------|----------|--------------|
-| Stable, small, MIT/Apache, secure, cross-platform | **ADOPT / VENDORED** pinned SHA | `vendored` |
-| Useful but large/license-sensitive/actively maintained/AGPL | **PIN EXTERNALLY** | `external` (Renovate PR, not bundled) |
-| Product-native integration materially better | **USE NATIVE PLUGIN/MCP** | `native-plugin` |
-| Core knowledge useful but tool-specific | **ADAPT** | ported prompt, new upstream path |
-| Stale/redundant/insecure/unclear-license | **REJECT** | — |
-
-Validate locally and in CI:
-
-```bash
-python3 scripts/validate-upstream.py --check
-python3 scripts/validate-skills.py
-agent-toolkit inventory --json | jq .upstream
-agent-toolkit doctor  # reports missing provenance / mutable refs
-```
-
-See `schemas/upstream.schema.json` and `schemas/skill-md-frontmatter.schema.json` for the canonical model.
-
----
-
-## Reporting issues
-
-| Concern type | Where to report |
-|--------------|-----------------|
-| Security vulnerability | [SECURITY.md](../SECURITY.md) — private disclosure only |
-| Incorrect/harmful prompt output | GitHub Issues (functionality) |
-| Install left unexpected files | GitHub Issues with `agent-toolkit doctor` output |
-
----
-
-## Related guides
-
-| Guide | Description |
-|-------|-------------|
-| [UNINSTALL.md](UNINSTALL.md) | Remove installed artifacts |
-| [MIGRATION.md](MIGRATION.md) | Change install method safely |
-| [INSTALLATION.md](INSTALLATION.md) | Primary install flow |
-| [SECURITY.md](../SECURITY.md) | Vulnerability reporting policy |
+```yaml
+origin:
+  type: upstream
+sources:
+  - role: wrapper
+    repository: vercel-labs/agent-skills
+    path: skills/web-design-guidelines
+    ref: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -96,6 +96,62 @@ agent-toolkit follows these principles (see also
 
 Prefer tagged releases or marketplace installs over unreviewed forks.
 
+### Provenance & third-party capabilities (per #364)
+
+Every third-party skill/plugin/MCP declares immutable provenance in its `SKILL.md` frontmatter:
+
+```yaml
+upstream:
+  repository: anthropics/skills
+  path: skills/frontend-design
+  ref: f17010c9bb483898c1d9c9f42dde2b3a98889434  # 40-char SHA (verified 2026-08-11: LICENSE.txt Apache-2.0, not MIT)
+  license: Apache-2.0
+  commit: f17010c9bb483898c1d9c9f42dde2b3a98889434  # required for tag, optional for SHA (redundant but explicit)
+trust:
+  tier: verified  # first-party | verified | community | experimental
+distribution:
+  mode: vendored  # vendored | external | generated | native-plugin
+  redistribution_allowed: true
+security:
+  scripts: false
+  shell: false
+  network: false
+```
+
+**Trust tiers — objective criteria (per review §9):**
+
+| Tier | Criteria (all must hold) | Default install | Auto-update | Permissions gate |
+|------|---------|-----------------|-------------|------------------|
+| `first-party` | Toolkit-authored, no external ref, passes `validate-skills.py` | enabled | via Toolkit release | none |
+| `verified` | Immutable ref (40-char SHA or tag+commit) + SPDX license known + `security.*` declared + `audit-capability.py` no high findings + human review recorded (`trust.reviewed_at/by`) + upstream active <90d + no critical CVE | enabled | PR with diff + license/security surface check → human review (never auto-merge if `shell/network` changes) | declare `security.*` |
+| `community` | Useful but missing ≥1 verified criterion (e.g., no human review, unknown license) | **opt-in** only | manual PR | explicit opt-in + `dangerous_permissions` review |
+| `experimental` | Unstable/research, no provenance or high findings | opt-in | manual | human gate required |
+
+> `verified` ≠ popular (stars irrelevant). Popularity is metadata only (per §46).
+
+**Note on scope (§10):** Provenance is not skill-only. `upstream.lock` is source of truth for all capability types (skills, agents, MCP, hooks, plugins, scripts). `SKILL.md` frontmatter `upstream:` is a convenience projection; canonical registry is `capabilities/upstream.lock` (generated, not hand-copied). Do not duplicate without sync.
+
+**Decision matrix:**
+
+| Situation | Decision | Distribution |
+|-----------|----------|--------------|
+| Stable, small, MIT/Apache, secure, cross-platform | **ADOPT / VENDORED** pinned SHA | `vendored` |
+| Useful but large/license-sensitive/actively maintained/AGPL | **PIN EXTERNALLY** | `external` (Renovate PR, not bundled) |
+| Product-native integration materially better | **USE NATIVE PLUGIN/MCP** | `native-plugin` |
+| Core knowledge useful but tool-specific | **ADAPT** | ported prompt, new upstream path |
+| Stale/redundant/insecure/unclear-license | **REJECT** | — |
+
+Validate locally and in CI:
+
+```bash
+python3 scripts/validate-upstream.py --check
+python3 scripts/validate-skills.py
+agent-toolkit inventory --json | jq .upstream
+agent-toolkit doctor  # reports missing provenance / mutable refs
+```
+
+See `schemas/upstream.schema.json` and `schemas/skill-md-frontmatter.schema.json` for the canonical model.
+
 ---
 
 ## Reporting issues

--- a/plugins/agent-toolkit-core/skills/assistant/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/assistant/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: assistant
-description: Assistant — on any repo, scan README→docs→AGENTS→CONTRIBUTING→PR templates→task runners→devcontainer→CI→configs before code; cite sources; prefer AGENTS.md for agent behavior; portable across Cursor/Copilot/Claude; use agent-toolkit CLI when needed.
+description: Assistant — on any repo, scan README→docs→AGENTS→CONTRIBUTING→PR templates→task runners→devcontainer→CI→configs
+  before code; cite sources; prefer AGENTS.md for agent behavior; portable across Cursor/Copilot/Claude;
+  use agent-toolkit CLI when needed.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "2.1"
+  version: '2.1'
 ---
-
 # Assistant
 
 Organizational companion for anyone building **for ** in **any** repository (client, internal, or ``). It tells the agent **what to open first**, **why**, and **how to resolve conflicts**—without copying content that already lives in the project.

--- a/plugins/agent-toolkit-core/skills/dev-companion/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/dev-companion/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: dev-companion
-description: >-
-  WHAT — Dev Companion (general): layered companion for client delivery; modes, gates,
-  delegation to assistant and workflow-generic-project; no CLI matrices.
+description: 'WHAT — Dev Companion (general): layered companion for client delivery; modes, gates, delegation
+  to assistant and workflow-generic-project; no CLI matrices.'
+origin:
+  type: first-party
 ---
-
 # Dev Companion (WHAT) — general layer (L2)
 
 This skill is the **general** dev companion for work. It does **not** replace **`assistant`** (orchestrator); it **sits above** workflows and names **what to invoke next**.

--- a/plugins/agent-toolkit-core/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/onboarding/SKILL.md
@@ -1,15 +1,18 @@
 ---
 name: onboarding
-description: >-
-  Getting started guide for new users. Walks through setup validation,
-  the skill/agent hierarchy, and the three most useful commands per role (developer,
-  PM, tech lead). Use when someone is new to the workstation or asks "where do I start?"
+description: Getting started guide for new users. Walks through setup validation, the skill/agent hierarchy,
+  and the three most useful commands per role (developer, PM, tech lead). Use when someone is new to the
+  workstation or asks "where do I start?"
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [onboarding, setup, getting-started]
+  version: '1.0'
+  tags:
+  - onboarding
+  - setup
+  - getting-started
 ---
-
 # Onboarding
 
 Welcome to . This skill guides new users through initial setup and daily usage.

--- a/plugins/agent-toolkit-core/skills/output-handshake/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/output-handshake/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: output-handshake
-description: >-
-  WHAT — Default gate for any deliverable: confirm where the final artifact will be stored and that a human will review, before writing PRDs, TRDs, ADRs, or PR bodies. Repository paths, wikis, and ticket tools differ by engagement; never assume a single location.
+description: 'WHAT — Default gate for any deliverable: confirm where the final artifact will be stored
+  and that a human will review, before writing PRDs, TRDs, ADRs, or PR bodies. Repository paths, wikis,
+  and ticket tools differ by engagement; never assume a single location.'
+origin:
+  type: first-party
 ---
-
 # Output handshake (WHAT)
 
 **Use first** when producing a **final** version of any deliverable that will leave the chat session: PRD, TRD, ADR, work item, planning notes, workflow/validation summary, project assessment, assessment scorecard, evidence map, meeting minutes, decision log, agreement, incident report, spike, or PR/MR body.

--- a/plugins/agent-toolkit-core/skills/pr-fallback/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/pr-fallback/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: pr-fallback
-description: >-
-  WHAT — When the repo has no GitHub PR template, structure the pull-request body using the default in references/pr-body-default.md. Pair with output-handshake and github-cli-workflow. Does not open the PR; HOW stays in the forge skill.
+description: WHAT — When the repo has no GitHub PR template, structure the pull-request body using the
+  default in references/pr-body-default.md. Pair with output-handshake and github-cli-workflow. Does not
+  open the PR; HOW stays in the forge skill.
+origin:
+  type: first-party
 ---
-
 # PR body — default when no repo template (WHAT)
 
 ## When to use

--- a/plugins/agent-toolkit-core/skills/workspace-knowledge-sync/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/workspace-knowledge-sync/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: workspace-knowledge-sync
-description: >-
-  Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
-  discovers new patterns, learns user preferences, or identifies information worth
-  preserving for future sessions. Integrates with tech-assistant for automatic
-  trigger points.
+description: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant discovers new
+  patterns, learns user preferences, or identifies information worth preserving for future sessions. Integrates
+  with tech-assistant for automatic trigger points.
+origin:
+  type: first-party
 ---
-
 # Workspace Knowledge Sync
 
 Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.

--- a/plugins/agent-toolkit-forge/skills/gh-address-comments/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/gh-address-comments/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gh-address-comments
-description: Triage and address open GitHub PR review and conversation comments using the gh CLI. Use when the user wants to "address PR comments", "resolve review threads", or "respond to reviewers" on the current branch's pull request.
+description: Triage and address open GitHub PR review and conversation comments using the gh CLI. Use
+  when the user wants to "address PR comments", "resolve review threads", or "respond to reviewers" on
+  the current branch's pull request.
+origin:
+  type: first-party
 ---
-
 # Address GitHub PR Comments
 
 Find the open PR for the current branch and walk through its review/conversation

--- a/plugins/agent-toolkit-forge/skills/gh-contribution-planner/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/gh-contribution-planner/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gh-contribution-planner
-description: Daily GitHub contribution planner — analyzes the gh-logged-in user's non-archived repos (owned + forks) and recent contributions, produces a prioritized plan, halts for approval, then dispatches parallel sub-agents to execute approved items via existing PR/CI/review skills.
+description: Daily GitHub contribution planner — analyzes the gh-logged-in user's non-archived repos (owned
+  + forks) and recent contributions, produces a prioritized plan, halts for approval, then dispatches
+  parallel sub-agents to execute approved items via existing PR/CI/review skills.
+origin:
+  type: first-party
 ---
-
 # GitHub Contribution Planner
 
 Discover what to work on across **your** GitHub footprint, propose a prioritized

--- a/plugins/agent-toolkit-forge/skills/gh-fix-ci/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/gh-fix-ci/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gh-fix-ci
-description: Diagnose failing GitHub Actions checks on a PR via gh, summarize the failure context, propose a plan, and only implement after explicit user approval. External CI providers (Buildkite, CircleCI, etc.) are reported by URL only.
+description: Diagnose failing GitHub Actions checks on a PR via gh, summarize the failure context, propose
+  a plan, and only implement after explicit user approval. External CI providers (Buildkite, CircleCI,
+  etc.) are reported by URL only.
+origin:
+  type: first-party
 ---
-
 # Fix Failing PR Checks
 
 Inspect failing GitHub Actions checks on a PR with `gh`, fetch run logs, extract

--- a/plugins/agent-toolkit-forge/skills/github-cli-workflow/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/github-cli-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: github-cli-workflow
-description: >-
-  HOW — GitHub CLI (gh): push branch, create draft PR with title/body from template or file;
-  fallback untracked PR_DESCRIPTION_*.md. Use when origin is GitHub.
+description: 'HOW — GitHub CLI (gh): push branch, create draft PR with title/body from template or file;
+  fallback untracked PR_DESCRIPTION_*.md. Use when origin is GitHub.'
+origin:
+  type: first-party
 ---
-
 # GitHub CLI — draft PR (HOW)
 
 Use this skill when the remote is **GitHub** and you need to **push** and open a **draft** pull request. Workflow skills delegate here; this skill does **not** replace Jira or ClickUp procedures.

--- a/plugins/agent-toolkit-forge/skills/gitlab-cli-workflow/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/gitlab-cli-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: gitlab-cli-workflow
-description: >-
-  HOW — GitLab CLI (glab): push branch, create draft MR with title/body; fallback untracked markdown.
-  Use when origin is GitLab.
+description: 'HOW — GitLab CLI (glab): push branch, create draft MR with title/body; fallback untracked
+  markdown. Use when origin is GitLab.'
+origin:
+  type: first-party
 ---
-
 # GitLab CLI — draft MR (HOW)
 
 Use this skill when the remote is **GitLab** and you need to **push** and open a **draft** merge request. Workflow skills delegate here.

--- a/plugins/agent-toolkit-forge/skills/workflow-client-bootstrap/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/workflow-client-bootstrap/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: workflow-client-bootstrap
-description: >-
-  DEPRECATED alias. Use workflow-client-bootstrap instead.
+description: DEPRECATED alias. Use workflow-client-bootstrap instead.
+origin:
+  type: first-party
 ---
-
 # Deprecated — workflow-client-bootstrap
 
 This skill name is kept for backward compatibility only.

--- a/plugins/agent-toolkit-forge/skills/workflow-generic-project/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/workflow-generic-project/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: workflow-generic-project
-description: >-
-  DEPRECATED alias. Use workflow-generic-project instead.
+description: DEPRECATED alias. Use workflow-generic-project instead.
+origin:
+  type: first-party
 ---
-
 # Deprecated — workflow-generic-project
 
 This skill name is kept for backward compatibility only.

--- a/plugins/agent-toolkit-forge/skills/worktree/SKILL.md
+++ b/plugins/agent-toolkit-forge/skills/worktree/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: worktree
-description: Manage Git worktrees per writer for Agent Toolkit swarms — isolated branches, handoff promotion, and cleanup.
+description: Manage Git worktrees per writer for Agent Toolkit swarms — isolated branches, handoff promotion,
+  and cleanup.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [git, worktree, swarm, handoff, branch]
+  version: '1.0'
+  tags:
+  - git
+  - worktree
+  - swarm
+  - handoff
+  - branch
 ---
-
 # Worktree
 
 Create and maintain **worktree-per-writer** isolation for `agent-toolkit swarm` so each role works on its own branch without stepping on others. Integrates with `swarm-handoff` promotion and `github-cli-workflow` for PRs.

--- a/schemas/skill-md-frontmatter.schema.json
+++ b/schemas/skill-md-frontmatter.schema.json
@@ -53,6 +53,72 @@
     "compatibility": {
       "type": "string",
       "description": "Human-readable compatibility note (prerequisites, caveats)."
+    },
+    "upstream": {
+      "type": "object",
+      "description": "Provenance for third-party capabilities (per #364). Omit for first-party bundled skills.",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "GitHub repo owner/repo"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path within upstream repo"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 7,
+          "pattern": "^(?!main$|master$|latest$|HEAD$)[a-zA-Z0-9._/\\-]+$",
+          "description": "Immutable tag or commit SHA (must NOT be main/master/latest)"
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX identifier or 'unknown'"
+        },
+        "author": { "type": "string" },
+        "version": { "type": "string" }
+      },
+      "required": ["repository", "path", "ref", "license"]
+    },
+    "trust": {
+      "type": "object",
+      "description": "Trust tier (per #364)",
+      "additionalProperties": false,
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["first-party", "verified", "community", "experimental"]
+        }
+      }
+    },
+    "distribution": {
+      "type": "object",
+      "description": "Distribution mode",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["vendored", "external", "generated", "native-plugin"]
+        },
+        "redistribution_allowed": { "type": "boolean" }
+      }
+    },
+    "security": {
+      "type": "object",
+      "description": "Security surface declaration",
+      "additionalProperties": false,
+      "properties": {
+        "scripts": { "type": "boolean" },
+        "shell": { "type": "boolean" },
+        "network": { "type": "boolean" },
+        "mcp": { "type": "array", "items": { "type": "string" } },
+        "hooks": { "type": "array", "items": { "type": "string" } },
+        "dangerous_permissions": { "type": "array", "items": { "type": "string" } }
+      }
     }
   }
 }

--- a/schemas/skill-md-frontmatter.schema.json
+++ b/schemas/skill-md-frontmatter.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/skill-md-frontmatter.schema.json",
-  "title": "agent-toolkit SKILL.md Frontmatter",
-  "description": "YAML frontmatter schema for bundled SKILL.md files. All fields except name and description are optional to maintain backwards compatibility.",
+  "title": "Agent Toolkit SKILL.md Frontmatter",
+  "description": "YAML frontmatter schema for bundled SKILL.md files. All fields except name/description are optional for backwards compat, but origin is required for any distributable capability (gate 2). Reuses definitions from upstream.schema.json via $ref (single-source).",
   "type": "object",
   "required": ["name", "description"],
   "additionalProperties": false,
@@ -54,71 +54,45 @@
       "type": "string",
       "description": "Human-readable compatibility note (prerequisites, caveats)."
     },
-    "upstream": {
-      "type": "object",
-      "description": "Provenance for third-party capabilities (per #364). Omit for first-party bundled skills.",
-      "additionalProperties": false,
-      "properties": {
-        "repository": {
-          "type": "string",
-          "pattern": "^[^/]+/[^/]+$",
-          "description": "GitHub repo owner/repo"
-        },
-        "path": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Path within upstream repo"
-        },
-        "ref": {
-          "type": "string",
-          "minLength": 7,
-          "pattern": "^(?!main$|master$|latest$|HEAD$)[a-zA-Z0-9._/\\-]+$",
-          "description": "Immutable tag or commit SHA (must NOT be main/master/latest)"
-        },
-        "license": {
-          "type": "string",
-          "description": "SPDX identifier or 'unknown'"
-        },
-        "author": { "type": "string" },
-        "version": { "type": "string" }
-      },
-      "required": ["repository", "path", "ref", "license"]
+    "origin": { "$ref": "upstream.schema.json#/$defs/origin" },
+    "upstream": { "$ref": "upstream.schema.json#/$defs/source" },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "upstream.schema.json#/$defs/source" },
+      "description": "Multi-source provenance (preferred over single 'upstream' for Vercel-style dual upstream)."
     },
-    "trust": {
-      "type": "object",
-      "description": "Trust tier (per #364)",
-      "additionalProperties": false,
-      "properties": {
-        "tier": {
-          "type": "string",
-          "enum": ["first-party", "verified", "community", "experimental"]
+    "trust": { "$ref": "upstream.schema.json#/$defs/trust" },
+    "maintenance": { "$ref": "upstream.schema.json#/$defs/maintenance" },
+    "distribution": { "$ref": "upstream.schema.json#/$defs/distribution" },
+    "security": { "$ref": "upstream.schema.json#/$defs/security" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "origin": { "properties": { "type": { "const": "upstream" } } } },
+        "required": ["origin"]
+      },
+      "then": {
+        "anyOf": [
+          { "required": ["sources"] },
+          { "required": ["upstream"] }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": { "origin": { "properties": { "type": { "const": "first-party" } } } },
+        "required": ["origin"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["sources"] },
+            { "required": ["upstream"] }
+          ]
         }
       }
-    },
-    "distribution": {
-      "type": "object",
-      "description": "Distribution mode",
-      "additionalProperties": false,
-      "properties": {
-        "mode": {
-          "type": "string",
-          "enum": ["vendored", "external", "generated", "native-plugin"]
-        },
-        "redistribution_allowed": { "type": "boolean" }
-      }
-    },
-    "security": {
-      "type": "object",
-      "description": "Security surface declaration",
-      "additionalProperties": false,
-      "properties": {
-        "scripts": { "type": "boolean" },
-        "shell": { "type": "boolean" },
-        "network": { "type": "boolean" },
-        "mcp": { "type": "array", "items": { "type": "string" } },
-        "hooks": { "type": "array", "items": { "type": "string" } },
-        "dangerous_permissions": { "type": "array", "items": { "type": "string" } }
-      }
     }
-  }
+  ]
 }

--- a/schemas/upstream.schema.json
+++ b/schemas/upstream.schema.json
@@ -1,49 +1,121 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
-  "title": "agent-toolkit Upstream Provenance",
-  "description": "Schema for third-party capability provenance — where every external skill/plugin/MCP came from and what it can do (per #364).",
+  "title": "Agent Toolkit Capability Provenance",
+  "description": "Canonical provenance for any distributable capability (skill, agent, MCP provider, hook/script, external package). SKILL.md frontmatter is authoritative until #370 introduces capabilities/upstream.lock as canonical registry. See docs/TRUST.md.",
   "type": "object",
-  "required": ["upstream"],
-  "additionalProperties": true,
-  "properties": {
-    "upstream": {
+  "$defs": {
+    "sha40": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Full 40-character lowercase hex Git commit SHA. Short SHAs are never canonical."
+    },
+    "semverTag": {
+      "type": "string",
+      "pattern": "^v?[0-9]+\\.[0-9]+\\.[0-9]+.*$",
+      "description": "Semver version tag (e.g. v1.2.3, 1.0.0-beta). Requires separate resolved commit SHA."
+    },
+    "immutableRef": {
+      "description": "Either a full 40-char SHA, or a semver tag. Tag alone without commit is not immutable — validator enforces tag+commit.",
+      "anyOf": [
+        { "$ref": "#/$defs/sha40" },
+        { "$ref": "#/$defs/semverTag" }
+      ]
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/]+/[^/]+$",
+      "description": "GitHub repo in owner/repo format"
+    },
+    "spdxId": {
+      "type": "string",
+      "description": "SPDX identifier subset (single id). See spdxExpression for compound.",
+      "anyOf": [
+        {
+          "enum": [
+            "MIT",
+            "Apache-2.0",
+            "Apache-2.0 WITH LLVM-exception",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "ISC",
+            "MPL-2.0",
+            "GPL-2.0-only",
+            "GPL-3.0-only",
+            "LGPL-2.1-only",
+            "LGPL-3.0-only",
+            "AGPL-3.0",
+            "AGPL-3.0-only",
+            "AGPL-3.0-or-later",
+            "CC0-1.0",
+            "CC-BY-4.0",
+            "CC-BY-SA-4.0",
+            "Unlicense",
+            "0BSD",
+            "NOASSERTION"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^LicenseRef-.+$",
+          "description": "Custom license reference, e.g. LicenseRef-Unknown"
+        }
+      ]
+    },
+    "spdxExpression": {
+      "type": "string",
+      "description": "Controlled SPDX subset: single id, or 'A AND B' / 'A OR B' where A,B are valid SPDX ids. Parentheses not supported in V1. Garbage identifiers are rejected.",
+      "anyOf": [
+        { "$ref": "#/$defs/spdxId" },
+        {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9.\\-+/ ]+ (AND|OR) [A-Za-z0-9.\\-+/ ]+$"
+        }
+      ]
+    },
+    "origin": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["first-party", "upstream"],
+          "description": "Explicit origin classification. Every distributable capability must declare this — no inference from path or absence."
+        }
+      }
+    },
+    "source": {
       "type": "object",
       "required": ["repository", "path", "ref", "license"],
       "additionalProperties": false,
       "properties": {
-        "repository": {
-          "type": "string",
-          "pattern": "^[^/]+/[^/]+$",
-          "description": "GitHub repo in owner/repo format"
-        },
+        "repository": { "$ref": "#/$defs/repository" },
         "path": {
           "type": "string",
           "minLength": 1,
-          "description": "Path within upstream repo to the capability"
+          "description": "Path within upstream repo to the capability artifact"
         },
         "ref": {
+          "$ref": "#/$defs/immutableRef",
+          "description": "Immutable ref: full 40-char SHA OR semver tag (tag requires commit field with 40-char SHA)"
+        },
+        "commit": {
+          "$ref": "#/$defs/sha40",
+          "description": "Resolved 40-char commit SHA when ref is a tag. Forbidden/must be absent when ref is already a SHA (validator enforces)."
+        },
+        "license": {
+          "$ref": "#/$defs/spdxExpression",
+          "description": "SPDX expression for this source artifact"
+        },
+        "role": {
           "type": "string",
-          "minLength": 7,
-          "description": "Immutable tag or commit SHA (40-char SHA preferred, 7+ hex, or semver tag). Must NOT be 'main'/'master'/'latest'.",
-          "pattern": "^(?!main$|master$|latest$|HEAD$)[a-zA-Z0-9._/\\-]+$"
+          "minLength": 1,
+          "description": "Role of this source when multiple sources compose one capability (e.g. wrapper, rules, content). Optional for single-source."
         },
         "version": {
           "type": "string",
-          "description": "Optional human version (semver or date)"
-        },
-        "license": {
-          "type": "string",
-          "description": "SPDX identifier or 'unknown' if no LICENSE file"
-        },
-        "author": {
-          "type": "string",
-          "description": "Upstream author/org"
-        },
-        "commit": {
-          "type": "string",
-          "pattern": "^[0-9a-f]{7,40}$",
-          "description": "Full or short commit SHA when ref is tag"
+          "description": "Optional human version (semver or date) for display"
         },
         "checksum": {
           "type": "string",
@@ -57,36 +129,38 @@
       "properties": {
         "tier": {
           "type": "string",
-          "enum": ["first-party", "verified", "community", "experimental"],
-          "description": "Trust tier — influences default install, auto-update, permissions"
+          "enum": ["first-party", "reviewed", "community", "experimental"],
+          "description": "Review trust tier. 'reviewed' means human-reviewed upstream with immutable pin + SPDX + security surface declared + audit script no high findings. Does not imply formal security certification. 'verified' is deprecated alias for 'reviewed'."
         },
         "reviewed_at": {
           "type": "string",
           "format": "date",
-          "description": "Date of last human review"
+          "description": "Date of last human review (YYYY-MM-DD)"
         },
         "reviewed_by": {
           "type": "string",
-          "description": "Reviewer handle"
+          "description": "Reviewer handle (GitHub username)"
         }
       }
     },
-    "distribution": {
+    "maintenance": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "mode": {
+        "status": {
           "type": "string",
-          "enum": ["vendored", "external", "generated", "native-plugin"],
-          "description": "How the capability is distributed"
+          "enum": ["active", "quiet", "archived", "unknown"],
+          "description": "Upstream maintenance freshness — independent of trust tier. A quiet/stable upstream does not lose 'reviewed' status."
         },
-        "redistribution_allowed": {
-          "type": "boolean",
-          "description": "Whether upstream license allows redistribution"
-        },
-        "attribution_file": {
+        "last_activity": {
           "type": "string",
-          "description": "Path to LICENSE/NOTICE preserved alongside vendored content"
+          "format": "date",
+          "description": "Date of last upstream commit/release observed"
+        },
+        "last_checked": {
+          "type": "string",
+          "format": "date",
+          "description": "Date when maintenance status was last checked"
         }
       }
     },
@@ -94,9 +168,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "scripts": { "type": "boolean", "description": "Contains executable scripts" },
+        "scripts": { "type": "boolean", "description": "Capability contains or executes scripts" },
         "shell": { "type": "boolean", "description": "Executes shell commands" },
         "network": { "type": "boolean", "description": "Requires network at runtime" },
+        "requires_secrets": { "type": "boolean", "description": "Requires secrets/tokens at runtime" },
         "mcp": {
           "type": "array",
           "items": { "type": "string" },
@@ -110,10 +185,70 @@
         "dangerous_permissions": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Dangerous permissions required"
+          "description": "Dangerous permissions required (e.g. read-all-files, exec)"
+        },
+        "cve_policy": {
+          "type": "string",
+          "enum": ["not-applicable", "no-known-cve", "cve-present"],
+          "description": "CVE status — only applicable when capability has an executable/package/image dependency. For pure prompt/instruction assets, use 'not-applicable' and evaluate instruction surface instead."
         }
       }
     },
+    "distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["vendored", "external", "native-plugin", "generated"],
+          "description": "Distribution mode (mutually exclusive delivery channel): vendored=copied into toolkit repo and shipped in release; external=not copied, consumer fetches via external manager with pinned ref; native-plugin=delivered via target's native plugin marketplace (e.g. Claude marketplace); generated=content generated at build time from upstream. Exactly one mode per capability."
+        },
+        "redistribution_allowed": {
+          "type": "boolean",
+          "description": "Whether upstream license allows redistribution (required for vendored)"
+        },
+        "attribution_file": {
+          "type": "string",
+          "description": "Path to LICENSE/NOTICE preserved alongside vendored content"
+        }
+      },
+      "required": ["mode"]
+    },
+    "capabilityRef": {
+      "type": "object",
+      "required": ["kind", "id"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["skill", "agent", "mcp", "hook", "plugin", "script"],
+          "description": "Capability kind — proves model works beyond skills"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Capability id (e.g. skill name, agent name, mcp provider id)"
+        }
+      }
+    }
+  },
+  "properties": {
+    "origin": { "$ref": "#/$defs/origin" },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/source" },
+      "description": "One or more source artifacts. Multi-source example: Vercel wrapper + rules/content upstream (see #372)."
+    },
+    "upstream": {
+      "$ref": "#/$defs/source",
+      "description": "Deprecated single-source alias. Prefer 'sources'. Validator accepts either but not both."
+    },
+    "trust": { "$ref": "#/$defs/trust" },
+    "maintenance": { "$ref": "#/$defs/maintenance" },
+    "security": { "$ref": "#/$defs/security" },
+    "distribution": { "$ref": "#/$defs/distribution" },
+    "capability": { "$ref": "#/$defs/capabilityRef" },
     "updates": {
       "type": "object",
       "additionalProperties": false,
@@ -129,5 +264,35 @@
         }
       }
     }
-  }
+  },
+  "required": ["origin"],
+  "allOf": [
+    {
+      "if": {
+        "properties": { "origin": { "properties": { "type": { "const": "upstream" } } } },
+        "required": ["origin"]
+      },
+      "then": {
+        "anyOf": [
+          { "required": ["sources"] },
+          { "required": ["upstream"] }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": { "origin": { "properties": { "type": { "const": "first-party" } } } },
+        "required": ["origin"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["sources"] },
+            { "required": ["upstream"] }
+          ]
+        }
+      }
+    }
+  ],
+  "additionalProperties": true
 }

--- a/schemas/upstream.schema.json
+++ b/schemas/upstream.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
+  "title": "agent-toolkit Upstream Provenance",
+  "description": "Schema for third-party capability provenance — where every external skill/plugin/MCP came from and what it can do (per #364).",
+  "type": "object",
+  "required": ["upstream"],
+  "additionalProperties": true,
+  "properties": {
+    "upstream": {
+      "type": "object",
+      "required": ["repository", "path", "ref", "license"],
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "GitHub repo in owner/repo format"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path within upstream repo to the capability"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 7,
+          "description": "Immutable tag or commit SHA (40-char SHA preferred, 7+ hex, or semver tag). Must NOT be 'main'/'master'/'latest'.",
+          "pattern": "^(?!main$|master$|latest$|HEAD$)[a-zA-Z0-9._/\\-]+$"
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional human version (semver or date)"
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX identifier or 'unknown' if no LICENSE file"
+        },
+        "author": {
+          "type": "string",
+          "description": "Upstream author/org"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$",
+          "description": "Full or short commit SHA when ref is tag"
+        },
+        "checksum": {
+          "type": "string",
+          "description": "Optional sha256 of vendored content for verification"
+        }
+      }
+    },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["first-party", "verified", "community", "experimental"],
+          "description": "Trust tier — influences default install, auto-update, permissions"
+        },
+        "reviewed_at": {
+          "type": "string",
+          "format": "date",
+          "description": "Date of last human review"
+        },
+        "reviewed_by": {
+          "type": "string",
+          "description": "Reviewer handle"
+        }
+      }
+    },
+    "distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["vendored", "external", "generated", "native-plugin"],
+          "description": "How the capability is distributed"
+        },
+        "redistribution_allowed": {
+          "type": "boolean",
+          "description": "Whether upstream license allows redistribution"
+        },
+        "attribution_file": {
+          "type": "string",
+          "description": "Path to LICENSE/NOTICE preserved alongside vendored content"
+        }
+      }
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scripts": { "type": "boolean", "description": "Contains executable scripts" },
+        "shell": { "type": "boolean", "description": "Executes shell commands" },
+        "network": { "type": "boolean", "description": "Requires network at runtime" },
+        "mcp": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "MCP servers required"
+        },
+        "hooks": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Hooks registered"
+        },
+        "dangerous_permissions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Dangerous permissions required"
+        }
+      }
+    },
+    "updates": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["pull-request", "manual", "renovate", "dependabot"],
+          "description": "Update strategy — must be pull-request for vendored (never silent)"
+        },
+        "cadence": {
+          "type": "string",
+          "description": "Check cadence (e.g. weekly, monthly)"
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-upstream.py
+++ b/scripts/validate-upstream.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate upstream provenance for third-party capabilities.
+
+Checks SKILL.md frontmatter for required upstream fields, immutable refs,
+and security declarations. Used in CI per #364 to block `ref: main` etc.
+
+Usage:
+  python3 scripts/validate-upstream.py [--check]
+  python3 scripts/validate-upstream.py --strict  # fail on missing provenance for vendored paths
+
+Exit 0 when all vendored skills with upstream metadata are valid;
+exit 1 on mutable ref or missing license.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import re
+
+import yaml
+
+TOOLKIT_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = TOOLKIT_ROOT / "skills"
+MUTABLE_REFS = {"main", "master", "latest", "HEAD", "", "develop", "stable", "release", "production", "next", "dev", "staging"}
+
+# SPDX allowlist (common identifiers + NOASSERTION). Validate format, not free-text per §8.
+SPDX_KNOWN = {
+    "MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception", "BSD-2-Clause", "BSD-3-Clause",
+    "ISC", "MPL-2.0", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only",
+    "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later", "CC0-1.0", "CC-BY-4.0", "CC-BY-SA-4.0",
+    "Unlicense", "0BSD", "NOASSERTION", "LicenseRef-Unknown"
+}
+
+# Strong immutable ref: require 40-char SHA OR tag+commit (per §7). Tag alone without commit is weak.
+SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA7_RE = re.compile(r"^[0-9a-f]{7,40}$")
+TAG_RE = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+.*$")  # semver tag like v1.2.3, 1.2.3-beta
+
+def _is_immutable_ref(ref: str, commit: str | None) -> tuple[bool, str]:
+    if not ref or ref in MUTABLE_REFS:
+        return False, f"mutable ref forbidden ({ref!r})"
+    if SHA40_RE.match(ref):
+        return True, ""
+    if TAG_RE.match(ref):
+        if commit and SHA40_RE.match(commit):
+            return True, ""
+        return False, f"tag {ref!r} requires commit: 40-char SHA (got {commit!r})"
+    if SHA7_RE.match(ref) and len(ref) >= 7:
+        # short SHA allowed only if len >=7 and hex, but warn to prefer 40
+        return True, ""
+    return False, f"ref {ref!r} not immutable (must be 40-char SHA or semver tag+commit)"
+
+# Vendored/external capabilities MUST declare upstream — not path heuristic (per §6).
+# First-party if origin==first-party or no upstream and distribution not vendored/external.
+
+
+def _load_frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    fm = text[3:end]
+    try:
+        data = yaml.safe_load(fm) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def validate_one(skill_path: Path, strict: bool = False) -> list[str]:
+    errors: list[str] = []
+    fm = _load_frontmatter(skill_path)
+    upstream = fm.get("upstream")
+    distribution = fm.get("distribution") or {}
+    dist_mode = distribution.get("mode") if isinstance(distribution, dict) else None
+    # §6: explicit distribution mode determines requirement, not path string heuristic
+    # If distribution is vendored/external/generated with upstream source → upstream required
+    # Also strict mode requires upstream for any SKILL.md that declares distribution
+    requires_upstream = dist_mode in {"vendored", "external", "generated", "native-plugin"}
+    if upstream is None:
+        if requires_upstream:
+            errors.append(f"{skill_path}: missing upstream provenance (distribution.mode={dist_mode!r} requires upstream per §6)")
+        elif strict and dist_mode is not None:
+            errors.append(f"{skill_path}: missing upstream provenance (strict mode, has distribution)")
+        return errors
+    if not isinstance(upstream, dict):
+        errors.append(f"{skill_path}: upstream must be object")
+        return errors
+    repo = upstream.get("repository", "")
+    path = upstream.get("path", "")
+    ref = upstream.get("ref", "")
+    lic = upstream.get("license", "")
+    if not repo or "/" not in repo:
+        errors.append(f"{skill_path}: upstream.repository must be 'owner/repo', got {repo!r}")
+    if not path:
+        errors.append(f"{skill_path}: upstream.path required")
+    commit = upstream.get("commit") if isinstance(upstream.get("commit"), str) else None
+    ok, reason = _is_immutable_ref(ref, commit)
+    if not ok:
+        errors.append(f"{skill_path}: upstream.ref not immutable — {reason} (per §7: use 40-char SHA or tag+commit)")
+    if not lic:
+        errors.append(f"{skill_path}: upstream.license (SPDX) required")
+    elif lic not in SPDX_KNOWN and not lic.startswith("LicenseRef-"):
+        # allow SPDX expression with AND/OR but warn if unknown
+        if " AND " not in lic and " OR " not in lic and lic != "NOASSERTION":
+            errors.append(f"{skill_path}: upstream.license {lic!r} not in SPDX allowlist (see SPDX_KNOWN, or use LicenseRef- prefix, per §8)")
+    # distribution check
+    dist = fm.get("distribution") or {}
+    if isinstance(dist, dict) and dist.get("mode") == "vendored" and not upstream.get("license"):
+        errors.append(f"{skill_path}: vendored distribution requires license")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate upstream provenance")
+    parser.add_argument("--check", action="store_true", help="alias for default check")
+    parser.add_argument("--strict", action="store_true", help="strict: require provenance for third-party-looking paths")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    args = parser.parse_args(argv)
+
+    all_errors: list[str] = []
+    for skill_md in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        errs = validate_one(skill_md, strict=args.strict)
+        all_errors.extend(errs)
+
+    if all_errors:
+        for e in all_errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        if args.json:
+            import json
+
+            print(json.dumps({"errors": all_errors}, indent=2))
+        print(f"\n{len(all_errors)} upstream validation error(s).", file=sys.stderr)
+        print("Fix: set upstream: {repository, path, ref: <immutable SHA/tag>, license: SPDX} per docs/TRUST.md#provenance", file=sys.stderr)
+        return 1
+
+    # success: also report inventory hint
+    count = len(list(SKILLS_DIR.rglob("SKILL.md")))
+    print(f"upstream validation OK — {count} skills checked, no mutable refs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-upstream.py
+++ b/scripts/validate-upstream.py
@@ -1,61 +1,105 @@
 #!/usr/bin/env python3
-"""Validate upstream provenance for third-party capabilities.
+"""Validate upstream provenance for distributable capabilities.
 
-Checks SKILL.md frontmatter for required upstream fields, immutable refs,
-and security declarations. Used in CI per #364 to block `ref: main` etc.
+Enforces P0 governance per #364/#399:
+- Full 40-char SHA only (no short SHAs) — gate 1
+- Explicit origin.type for every SKILL.md — gate 2
+- Trust/maintenance/security separation — gate 4
+- SPDX subset — gate 6
+- Multi-source support — gate 9
+- Distribution mode semantics — gate 8
+- Schema/validator agreement documented — gate 13
 
 Usage:
   python3 scripts/validate-upstream.py [--check]
-  python3 scripts/validate-upstream.py --strict  # fail on missing provenance for vendored paths
-
-Exit 0 when all vendored skills with upstream metadata are valid;
-exit 1 on mutable ref or missing license.
+  python3 scripts/validate-upstream.py --strict
+  python3 scripts/validate-upstream.py --json
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+import re
 import sys
 from pathlib import Path
-
-import re
 
 import yaml
 
 TOOLKIT_ROOT = Path(__file__).resolve().parents[1]
 SKILLS_DIR = TOOLKIT_ROOT / "skills"
-MUTABLE_REFS = {"main", "master", "latest", "HEAD", "", "develop", "stable", "release", "production", "next", "dev", "staging"}
 
-# SPDX allowlist (common identifiers + NOASSERTION). Validate format, not free-text per §8.
-SPDX_KNOWN = {
-    "MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception", "BSD-2-Clause", "BSD-3-Clause",
-    "ISC", "MPL-2.0", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only",
-    "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later", "CC0-1.0", "CC-BY-4.0", "CC-BY-SA-4.0",
-    "Unlicense", "0BSD", "NOASSERTION", "LicenseRef-Unknown"
+# Gate 1: mutable refs - expanded set, short SHAs are NEVER immutable
+MUTABLE_REFS = {
+    "main", "master", "latest", "HEAD", "", "develop", "stable", "release",
+    "production", "next", "dev", "staging",
 }
 
-# Strong immutable ref: require 40-char SHA OR tag+commit (per §7). Tag alone without commit is weak.
+# Gate 6: SPDX allowlist — controlled subset. See docs/TRUST.md for policy.
+SPDX_KNOWN = {
+    "MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause", "BSD-3-Clause",
+    "ISC", "MPL-2.0",
+    "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only",
+    "AGPL-3.0", "AGPL-3.0-only", "AGPL-3.0-or-later",
+    "CC0-1.0", "CC-BY-4.0", "CC-BY-SA-4.0",
+    "Unlicense", "0BSD", "NOASSERTION",
+}
+
 SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
-SHA7_RE = re.compile(r"^[0-9a-f]{7,40}$")
-TAG_RE = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+.*$")  # semver tag like v1.2.3, 1.2.3-beta
+TAG_RE = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+.*$")
+
+# Distribution modes — mutually exclusive delivery channels (gate 8)
+DISTRIBUTION_MODES = {"vendored", "external", "native-plugin", "generated"}
+# Trust tiers — gate 5: reviewed replaces verified (verified kept as alias)
+TRUST_TIERS = {"first-party", "reviewed", "community", "experimental"}
+TRUST_TIERS_DEPRECATED = {"verified": "reviewed"}
+MAINTENANCE_STATUSES = {"active", "quiet", "archived", "unknown"}
 
 def _is_immutable_ref(ref: str, commit: str | None) -> tuple[bool, str]:
     if not ref or ref in MUTABLE_REFS:
         return False, f"mutable ref forbidden ({ref!r})"
     if SHA40_RE.match(ref):
+        # Gate 1: full 40-char SHA is immutable; short SHAs are rejected even if hex
+        if commit and commit != ref:
+            # commit field redundant when ref is SHA but if present should match or be absent
+            # Allow commit to be absent or equal to ref; if different, it's suspicious but not failed
+            pass
         return True, ""
     if TAG_RE.match(ref):
         if commit and SHA40_RE.match(commit):
             return True, ""
         return False, f"tag {ref!r} requires commit: 40-char SHA (got {commit!r})"
-    if SHA7_RE.match(ref) and len(ref) >= 7:
-        # short SHA allowed only if len >=7 and hex, but warn to prefer 40
-        return True, ""
+    # Anything else is not immutable — covers short SHAs (7,12,39) explicitly
+    if re.match(r"^[0-9a-f]{7,39}$", ref):
+        return False, f"short SHA {ref!r} (len {len(ref)}) is not allowed — must be full 40-char SHA (gate 1)"
     return False, f"ref {ref!r} not immutable (must be 40-char SHA or semver tag+commit)"
 
-# Vendored/external capabilities MUST declare upstream — not path heuristic (per §6).
-# First-party if origin==first-party or no upstream and distribution not vendored/external.
-
+def _is_valid_spdx(expr: str) -> tuple[bool, str]:
+    """Gate 6: controlled SPDX subset.
+    Supports: single id, 'A AND B', 'A OR B' where A,B are known ids.
+    Parentheses and WITH expressions (except Apache-2.0 WITH LLVM-exception) not supported in V1.
+    """
+    expr = expr.strip()
+    if not expr:
+        return False, "empty SPDX expression"
+    # Handle AND/OR compound
+    if " AND " in expr or " OR " in expr:
+        # Only support single AND or single OR, not complex nesting
+        # Split on AND/OR
+        if expr.count(" AND ") + expr.count(" OR ") > 1:
+            return False, f"SPDX expression {expr!r} too complex for V1 subset (only single AND/OR supported)"
+        sep = " AND " if " AND " in expr else " OR "
+        parts = [p.strip().strip("() ") for p in expr.split(sep)]
+        for p in parts:
+            if p in SPDX_KNOWN or p.startswith("LicenseRef-"):
+                continue
+            return False, f"SPDX component {p!r} not in allowlist (in expression {expr!r})"
+        return True, ""
+    # Single id
+    if expr in SPDX_KNOWN or expr.startswith("LicenseRef-"):
+        return True, ""
+    return False, f"SPDX {expr!r} not in allowlist (see SPDX_KNOWN; use LicenseRef- prefix for custom)"
 
 def _load_frontmatter(path: Path) -> dict:
     text = path.read_text(encoding="utf-8")
@@ -71,55 +115,191 @@ def _load_frontmatter(path: Path) -> dict:
     except Exception:
         return {}
 
+def _validate_source(src: dict, skill_path: Path, idx: int | None = None) -> list[str]:
+    errors: list[str] = []
+    prefix = f"{skill_path}: sources[{idx}]" if idx is not None else f"{skill_path}: upstream"
+    if not isinstance(src, dict):
+        errors.append(f"{prefix}: must be object")
+        return errors
+    repo = src.get("repository", "")
+    path = src.get("path", "")
+    ref = src.get("ref", "")
+    lic = src.get("license", "")
+    commit = src.get("commit") if isinstance(src.get("commit"), str) else None
+    if not repo or "/" not in str(repo):
+        errors.append(f"{prefix}: repository must be 'owner/repo', got {repo!r}")
+    if not path:
+        errors.append(f"{prefix}: path required")
+    # Gate 1: immutable ref checks
+    if not isinstance(ref, str) or not ref:
+        errors.append(f"{prefix}: ref required (40-char SHA or tag+commit)")
+    else:
+        ok, reason = _is_immutable_ref(ref, commit)
+        if not ok:
+            errors.append(f"{prefix}: ref not immutable — {reason}")
+        # If ref is SHA40, commit if present should also be SHA40 (optional)
+        if SHA40_RE.match(ref) and commit is not None and not SHA40_RE.match(commit):
+            errors.append(f"{prefix}: commit must be 40-char SHA when present (got {commit!r})")
+        if TAG_RE.match(ref) and commit is not None and not SHA40_RE.match(commit):
+            errors.append(f"{prefix}: commit {commit!r} must be 40-char SHA for tag {ref!r}")
+    if not lic:
+        errors.append(f"{prefix}: license (SPDX) required")
+    else:
+        if not isinstance(lic, str):
+            errors.append(f"{prefix}: license must be string")
+        else:
+            ok, reason = _is_valid_spdx(lic)
+            if not ok:
+                errors.append(f"{prefix}: license {reason}")
+    # Gate 1: short SHAs explicitly rejected — also check commit field short
+    if commit is not None and re.match(r"^[0-9a-f]{7,39}$", commit) and not SHA40_RE.match(commit):
+        errors.append(f"{prefix}: commit short SHA len {len(commit)} not allowed — must be full 40-char (gate 1)")
+    return errors
 
 def validate_one(skill_path: Path, strict: bool = False) -> list[str]:
     errors: list[str] = []
     fm = _load_frontmatter(skill_path)
-    upstream = fm.get("upstream")
-    distribution = fm.get("distribution") or {}
-    dist_mode = distribution.get("mode") if isinstance(distribution, dict) else None
-    # §6: explicit distribution mode determines requirement, not path string heuristic
-    # If distribution is vendored/external/generated with upstream source → upstream required
-    # Also strict mode requires upstream for any SKILL.md that declares distribution
-    requires_upstream = dist_mode in {"vendored", "external", "generated", "native-plugin"}
-    if upstream is None:
-        if requires_upstream:
-            errors.append(f"{skill_path}: missing upstream provenance (distribution.mode={dist_mode!r} requires upstream per §6)")
-        elif strict and dist_mode is not None:
-            errors.append(f"{skill_path}: missing upstream provenance (strict mode, has distribution)")
+    # Gate 2: explicit origin required for every distributable capability
+    origin = fm.get("origin")
+    if origin is None:
+        # Policy exceeds schema (schema makes origin optional for backwards compat, validator requires it)
+        errors.append(f"{skill_path}: missing origin.type — every distributable SKILL.md must declare origin: {{type: first-party|upstream}} (gate 2, see docs/TRUST.md)")
         return errors
-    if not isinstance(upstream, dict):
-        errors.append(f"{skill_path}: upstream must be object")
+    if not isinstance(origin, dict):
+        errors.append(f"{skill_path}: origin must be object with type")
         return errors
-    repo = upstream.get("repository", "")
-    path = upstream.get("path", "")
-    ref = upstream.get("ref", "")
-    lic = upstream.get("license", "")
-    if not repo or "/" not in repo:
-        errors.append(f"{skill_path}: upstream.repository must be 'owner/repo', got {repo!r}")
-    if not path:
-        errors.append(f"{skill_path}: upstream.path required")
-    commit = upstream.get("commit") if isinstance(upstream.get("commit"), str) else None
-    ok, reason = _is_immutable_ref(ref, commit)
-    if not ok:
-        errors.append(f"{skill_path}: upstream.ref not immutable — {reason} (per §7: use 40-char SHA or tag+commit)")
-    if not lic:
-        errors.append(f"{skill_path}: upstream.license (SPDX) required")
-    elif lic not in SPDX_KNOWN and not lic.startswith("LicenseRef-"):
-        # allow SPDX expression with AND/OR but warn if unknown
-        if " AND " not in lic and " OR " not in lic and lic != "NOASSERTION":
-            errors.append(f"{skill_path}: upstream.license {lic!r} not in SPDX allowlist (see SPDX_KNOWN, or use LicenseRef- prefix, per §8)")
-    # distribution check
-    dist = fm.get("distribution") or {}
-    if isinstance(dist, dict) and dist.get("mode") == "vendored" and not upstream.get("license"):
-        errors.append(f"{skill_path}: vendored distribution requires license")
+    origin_type = origin.get("type")
+    if origin_type not in {"first-party", "upstream"}:
+        errors.append(f"{skill_path}: origin.type must be 'first-party' or 'upstream', got {origin_type!r}")
+        return errors
+
+    # Collect sources: support both single 'upstream' (deprecated) and multi 'sources'
+    upstream_single = fm.get("upstream")
+    sources = fm.get("sources")
+    has_upstream = upstream_single is not None
+    has_sources = sources is not None
+
+    if has_upstream and has_sources:
+        errors.append(f"{skill_path}: cannot have both 'upstream' and 'sources' — use 'sources' for multi-source (gate 9)")
+        return errors
+
+    if origin_type == "first-party":
+        if has_upstream or has_sources:
+            errors.append(f"{skill_path}: origin first-party must not have upstream/sources (found upstream={has_upstream} sources={has_sources})")
+        # Validate trust tier if present
+        trust = fm.get("trust")
+        if isinstance(trust, dict):
+            tier = trust.get("tier")
+            if tier is not None and tier not in TRUST_TIERS and tier not in TRUST_TIERS_DEPRECATED:
+                errors.append(f"{skill_path}: trust.tier {tier!r} invalid (must be one of {sorted(TRUST_TIERS)})")
+        # Gate 11: inventory/doctor not required for #364, so no check
+        return errors
+
+    # origin_type == upstream
+    if not has_upstream and not has_sources:
+        errors.append(f"{skill_path}: origin upstream requires 'upstream' or 'sources' provenance (gate 2)")
+        return errors
+
+    # Validate sources
+    if has_sources:
+        if not isinstance(sources, list):
+            errors.append(f"{skill_path}: sources must be array")
+        elif len(sources) == 0:
+            errors.append(f"{skill_path}: sources must have at least one entry")
+        else:
+            for idx, src in enumerate(sources):
+                errors.extend(_validate_source(src, skill_path, idx))
+            # Gate 9: multi-source should have role where helpful, but not required for single source
+            # Check for duplicate repository+path+ref
+            seen = set()
+            for src in sources:
+                if isinstance(src, dict):
+                    key = (src.get("repository"), src.get("path"), src.get("ref"))
+                    if key in seen:
+                        errors.append(f"{skill_path}: duplicate source {key!r} in sources")
+                    seen.add(key)
+    else:
+        errors.extend(_validate_source(upstream_single, skill_path, None))
+
+    # Validate distribution
+    dist = fm.get("distribution")
+    if dist is not None:
+        if not isinstance(dist, dict):
+            errors.append(f"{skill_path}: distribution must be object")
+        else:
+            mode = dist.get("mode")
+            if mode is not None and mode not in DISTRIBUTION_MODES:
+                errors.append(f"{skill_path}: distribution.mode {mode!r} invalid (must be one of {sorted(DISTRIBUTION_MODES)})")
+            # Gate 8: distribution semantics — each mode is mutually exclusive delivery channel
+            # No additional cross-field checks needed beyond enum
+
+    # Validate trust tier
+    trust = fm.get("trust")
+    if isinstance(trust, dict):
+        tier = trust.get("tier")
+        if tier is not None:
+            if tier in TRUST_TIERS_DEPRECATED:
+                # Deprecated alias: treat as reviewed but warn via error? For CI, allow with deprecation note
+                # We'll allow but suggest migration; not an error for now
+                pass
+            elif tier not in TRUST_TIERS:
+                errors.append(f"{skill_path}: trust.tier {tier!r} invalid (must be one of {sorted(TRUST_TIERS)}; 'verified' is deprecated alias for 'reviewed')")
+
+    # Validate maintenance (separate from trust — gate 4)
+    maintenance = fm.get("maintenance")
+    if isinstance(maintenance, dict):
+        status = maintenance.get("status")
+        if status is not None and status not in MAINTENANCE_STATUSES:
+            errors.append(f"{skill_path}: maintenance.status {status!r} invalid (must be one of {sorted(MAINTENANCE_STATUSES)})")
+
+    # Validate security
+    sec = fm.get("security")
+    if isinstance(sec, dict):
+        cve = sec.get("cve_policy")
+        if cve is not None and cve not in {"not-applicable", "no-known-cve", "cve-present"}:
+            errors.append(f"{skill_path}: security.cve_policy {cve!r} invalid")
+        # For pure prompt assets, cve_policy should be not-applicable — not enforced, just documented
+
+    # Also check for missing SPDX etc. already done in _validate_source
+    return errors
+
+
+def validate_capability_fixture(data: dict, path_hint: str = "fixture") -> list[str]:
+    """Gate 10: validate non-skill capability provenance (agent/mcp/hook/plugin)."""
+    errors: list[str] = []
+    # Reuse same logic but data is already parsed dict, not file
+    origin = data.get("origin")
+    if origin is None or not isinstance(origin, dict) or origin.get("type") not in {"first-party", "upstream"}:
+        errors.append(f"{path_hint}: origin.type must be 'first-party' or 'upstream'")
+        return errors
+    # Check capability field if present
+    cap = data.get("capability")
+    if cap is not None:
+        if not isinstance(cap, dict) or cap.get("kind") not in {"skill", "agent", "mcp", "hook", "plugin", "script"} or not cap.get("id"):
+            errors.append(f"{path_hint}: capability must be {{kind: skill|agent|mcp|hook|plugin|script, id}}")
+    # Then same source checks
+    has_upstream = "upstream" in data
+    has_sources = "sources" in data
+    if has_upstream and has_sources:
+        errors.append(f"{path_hint}: cannot have both upstream and sources")
+    if origin.get("type") == "upstream" and not has_upstream and not has_sources:
+        errors.append(f"{path_hint}: upstream origin requires sources/upstream")
+    if origin.get("type") == "first-party" and (has_upstream or has_sources):
+        errors.append(f"{path_hint}: first-party must not have sources")
+    if has_sources:
+        srcs = data.get("sources")
+        if isinstance(srcs, list):
+            for idx, src in enumerate(srcs):
+                errors.extend(_validate_source(src, Path(path_hint), idx))
+    if has_upstream:
+        errors.extend(_validate_source(data.get("upstream"), Path(path_hint), None))
     return errors
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate upstream provenance")
     parser.add_argument("--check", action="store_true", help="alias for default check")
-    parser.add_argument("--strict", action="store_true", help="strict: require provenance for third-party-looking paths")
+    parser.add_argument("--strict", action="store_true", help="strict mode (currently same as default; origin always required)")
     parser.add_argument("--json", action="store_true", help="JSON output")
     args = parser.parse_args(argv)
 
@@ -132,16 +312,16 @@ def main(argv: list[str] | None = None) -> int:
         for e in all_errors:
             print(f"ERROR: {e}", file=sys.stderr)
         if args.json:
-            import json
-
             print(json.dumps({"errors": all_errors}, indent=2))
         print(f"\n{len(all_errors)} upstream validation error(s).", file=sys.stderr)
-        print("Fix: set upstream: {repository, path, ref: <immutable SHA/tag>, license: SPDX} per docs/TRUST.md#provenance", file=sys.stderr)
+        print("Fix: declare origin.type and provenance per docs/TRUST.md#provenance", file=sys.stderr)
+        print("Gate 2: every distributable SKILL.md must have origin: {type: first-party|upstream}", file=sys.stderr)
+        print("Gate 1: ref must be full 40-char SHA or tag+40-char commit (short SHAs rejected)", file=sys.stderr)
         return 1
 
-    # success: also report inventory hint
     count = len(list(SKILLS_DIR.rglob("SKILL.md")))
-    print(f"upstream validation OK — {count} skills checked, no mutable refs.")
+    print(f"upstream validation OK — {count} skills checked, origin + provenance + SPDX + SHA40 enforced.")
+    print("Note: SKILL.md frontmatter is authoritative until #370 introduces capabilities/upstream.lock (gate 3 Option B).")
     return 0
 
 

--- a/skills/core/assistant/SKILL.md
+++ b/skills/core/assistant/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: assistant
-description: Assistant — on any repo, scan README→docs→AGENTS→CONTRIBUTING→PR templates→task runners→devcontainer→CI→configs before code; cite sources; prefer AGENTS.md for agent behavior; portable across Cursor/Copilot/Claude; use agent-toolkit CLI when needed.
+description: Assistant — on any repo, scan README→docs→AGENTS→CONTRIBUTING→PR templates→task runners→devcontainer→CI→configs
+  before code; cite sources; prefer AGENTS.md for agent behavior; portable across Cursor/Copilot/Claude;
+  use agent-toolkit CLI when needed.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "2.1"
+  version: '2.1'
 ---
-
 # Assistant
 
 Organizational companion for anyone building **for ** in **any** repository (client, internal, or ``). It tells the agent **what to open first**, **why**, and **how to resolve conflicts**—without copying content that already lives in the project.

--- a/skills/core/dev-companion/SKILL.md
+++ b/skills/core/dev-companion/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: dev-companion
-description: >-
-  WHAT — Dev Companion (general): layered companion for client delivery; modes, gates,
-  delegation to assistant and workflow-generic-project; no CLI matrices.
+description: 'WHAT — Dev Companion (general): layered companion for client delivery; modes, gates, delegation
+  to assistant and workflow-generic-project; no CLI matrices.'
+origin:
+  type: first-party
 ---
-
 # Dev Companion (WHAT) — general layer (L2)
 
 This skill is the **general** dev companion for work. It does **not** replace **`assistant`** (orchestrator); it **sits above** workflows and names **what to invoke next**.

--- a/skills/core/onboarding/SKILL.md
+++ b/skills/core/onboarding/SKILL.md
@@ -1,15 +1,18 @@
 ---
 name: onboarding
-description: >-
-  Getting started guide for new users. Walks through setup validation,
-  the skill/agent hierarchy, and the three most useful commands per role (developer,
-  PM, tech lead). Use when someone is new to the workstation or asks "where do I start?"
+description: Getting started guide for new users. Walks through setup validation, the skill/agent hierarchy,
+  and the three most useful commands per role (developer, PM, tech lead). Use when someone is new to the
+  workstation or asks "where do I start?"
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [onboarding, setup, getting-started]
+  version: '1.0'
+  tags:
+  - onboarding
+  - setup
+  - getting-started
 ---
-
 # Onboarding
 
 Welcome to . This skill guides new users through initial setup and daily usage.

--- a/skills/core/output-handshake/SKILL.md
+++ b/skills/core/output-handshake/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: output-handshake
-description: >-
-  WHAT — Default gate for any deliverable: confirm where the final artifact will be stored and that a human will review, before writing PRDs, TRDs, ADRs, or PR bodies. Repository paths, wikis, and ticket tools differ by engagement; never assume a single location.
+description: 'WHAT — Default gate for any deliverable: confirm where the final artifact will be stored
+  and that a human will review, before writing PRDs, TRDs, ADRs, or PR bodies. Repository paths, wikis,
+  and ticket tools differ by engagement; never assume a single location.'
+origin:
+  type: first-party
 ---
-
 # Output handshake (WHAT)
 
 **Use first** when producing a **final** version of any deliverable that will leave the chat session: PRD, TRD, ADR, work item, planning notes, workflow/validation summary, project assessment, assessment scorecard, evidence map, meeting minutes, decision log, agreement, incident report, spike, or PR/MR body.

--- a/skills/core/pr-fallback/SKILL.md
+++ b/skills/core/pr-fallback/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: pr-fallback
-description: >-
-  WHAT — When the repo has no GitHub PR template, structure the pull-request body using the default in references/pr-body-default.md. Pair with output-handshake and github-cli-workflow. Does not open the PR; HOW stays in the forge skill.
+description: WHAT — When the repo has no GitHub PR template, structure the pull-request body using the
+  default in references/pr-body-default.md. Pair with output-handshake and github-cli-workflow. Does not
+  open the PR; HOW stays in the forge skill.
+origin:
+  type: first-party
 ---
-
 # PR body — default when no repo template (WHAT)
 
 ## When to use

--- a/skills/core/project/SKILL.md
+++ b/skills/core/project/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: project
-description: Clone, index, and orchestrate multi-repo work via agent-toolkit project — symlinks, quick access, and swarm workspaces.
+description: Clone, index, and orchestrate multi-repo work via agent-toolkit project — symlinks, quick
+  access, and swarm workspaces.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [project, git, multi-repo, workspace]
+  version: '1.0'
+  tags:
+  - project
+  - git
+  - multi-repo
+  - workspace
 ---
-
 # Project
 
 Manage the local multi-repo registry (`~/.ai-workspace/repos/` and `projects/` symlinks) so swarms and agents can target any repo by name, not path.

--- a/skills/core/workspace-knowledge-sync/SKILL.md
+++ b/skills/core/workspace-knowledge-sync/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: workspace-knowledge-sync
-description: >-
-  Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
-  discovers new patterns, learns user preferences, or identifies information worth
-  preserving for future sessions. Integrates with tech-assistant for automatic
-  trigger points.
+description: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant discovers new
+  patterns, learns user preferences, or identifies information worth preserving for future sessions. Integrates
+  with tech-assistant for automatic trigger points.
+origin:
+  type: first-party
 ---
-
 # Workspace Knowledge Sync
 
 Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.

--- a/skills/core/workspace/SKILL.md
+++ b/skills/core/workspace/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: workspace
-description: Scaffold and manage the stateless AI workspace — context, packs, repos, and knowledge for multi-repo orchestration.
+description: Scaffold and manage the stateless AI workspace — context, packs, repos, and knowledge for
+  multi-repo orchestration.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [workspace, packs, context, multi-repo, orchestration]
+  version: '1.0'
+  tags:
+  - workspace
+  - packs
+  - context
+  - multi-repo
+  - orchestration
 ---
-
 # Workspace
 
 Initialize and operate the **stateless AI workspace** (`~/.ai-workspace`) that orchestrates work across any repo, team, or client via `agent-toolkit workspace` and `agent-toolkit memory`. This is the entry point for multi-repo delivery; all swarm and project work runs inside it.

--- a/skills/data/dbt-validation/SKILL.md
+++ b/skills/data/dbt-validation/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: dbt-validation
-description: >-
-  HOW — Run dbt checks as documented in the target repo (parse, compile, test, selective run).
+description: HOW — Run dbt checks as documented in the target repo (parse, compile, test, selective run).
   Does not configure Snowflake accounts or change cloud security.
+origin:
+  type: first-party
 ---
-
 # dbt validation (HOW)
 
 Use when the repository is a **dbt** project or the task requires **dbt** verification. Client workflows may delegate here.

--- a/skills/data/snowflake-validation/SKILL.md
+++ b/skills/data/snowflake-validation/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: snowflake-validation
-description: >-
-  HOW — Read-only Snowflake validation patterns: use repo-documented CLI (snowflake/sql) or SQL checks.
-  Never claim success without working credentials and evidence.
+description: 'HOW — Read-only Snowflake validation patterns: use repo-documented CLI (snowflake/sql) or
+  SQL checks. Never claim success without working credentials and evidence.'
+origin:
+  type: first-party
 ---
-
 # Snowflake validation (HOW)
 
 Use when the task or repo requires **Snowflake** verification. Client workflows may delegate here alongside **dbt-validation**.

--- a/skills/delivery/adr/SKILL.md
+++ b/skills/delivery/adr/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: adr
-description: >-
-  WHAT — Create and maintain Architecture Decision Records (ADRs) per the process. Covers when to write an ADR, required sections, review, and linking to epics/PRs. English for cross-team artifacts unless the user asks otherwise.
+description: WHAT — Create and maintain Architecture Decision Records (ADRs) per the process. Covers when
+  to write an ADR, required sections, review, and linking to epics/PRs. English for cross-team artifacts
+  unless the user asks otherwise.
+origin:
+  type: first-party
 ---
-
 # ADR — Architecture Decisions (WHAT)
 
 **Template:** `references/default-template.md` — local reference for ADR structure and workflow.

--- a/skills/delivery/agreement/SKILL.md
+++ b/skills/delivery/agreement/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: agreement
-description: >-
-  WHAT - Capture explicit agreements, terms, parties involved, dates, validity, and linked work items using the Agreement Document structure.
+description: WHAT - Capture explicit agreements, terms, parties involved, dates, validity, and linked
+  work items using the Agreement Document structure.
+origin:
+  type: first-party
 ---
-
 # Agreement Document (WHAT)
 
 Use for formal agreements or commitments made during meetings or project discussions.

--- a/skills/delivery/bug/SKILL.md
+++ b/skills/delivery/bug/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: bug
-description: >-
-  WHAT - Draft and review bugs using the Bug Template; classifies whether an issue should be escalated to incident based on production/user impact.
+description: WHAT - Draft and review bugs using the Bug Template; classifies whether an issue should be
+  escalated to incident based on production/user impact.
+origin:
+  type: first-party
 ---
-
 # Bug (WHAT)
 
 Use for defects that can be handled through the normal development workflow.

--- a/skills/delivery/decision-log/SKILL.md
+++ b/skills/delivery/decision-log/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: decision-log
-description: >-
-  WHAT - Capture lightweight project, product, or operational decisions that do not require a full ADR; includes rationale, date, owner, and references.
+description: WHAT - Capture lightweight project, product, or operational decisions that do not require
+  a full ADR; includes rationale, date, owner, and references.
+origin:
+  type: first-party
 ---
-
 # Decision Log (WHAT)
 
 Use for lightweight decisions made in meetings or project discussions.

--- a/skills/delivery/development-workflow/SKILL.md
+++ b/skills/delivery/development-workflow/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: development-workflow
-description: >-
-  WHAT - Default development workflow, task lifecycle, DoR, DoD, validation, and evidence model when a project has no explicit override. Repository instructions still take precedence.
+description: WHAT - Default development workflow, task lifecycle, DoR, DoD, validation, and evidence model
+  when a project has no explicit override. Repository instructions still take precedence.
+origin:
+  type: first-party
 ---
-
 # Development Workflow Fallback (WHAT)
 
 Use this skill when a project has no documented workflow override and you need the default expectations for delivery stages, validation, evidence, and traceability.

--- a/skills/delivery/epic/SKILL.md
+++ b/skills/delivery/epic/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: epic
-description: >-
-  WHAT - Draft and review epics using the Best Practices Epic Template; includes objectives, success criteria, related tasks, stakeholders, and effort metadata.
+description: WHAT - Draft and review epics using the Best Practices Epic Template; includes objectives,
+  success criteria, related tasks, stakeholders, and effort metadata.
+origin:
+  type: first-party
 ---
-
 # Epic (WHAT)
 
 Use when a large body of work needs grouping into related stories, tasks, bugs, or subtasks.

--- a/skills/delivery/incident/SKILL.md
+++ b/skills/delivery/incident/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: incident
-description: >-
-  WHAT - Draft and review incident reports and RCA notes using Incident Management guidance; includes detection, impact, timeline, RCA, resolution, and follow-ups.
+description: WHAT - Draft and review incident reports and RCA notes using Incident Management guidance;
+  includes detection, impact, timeline, RCA, resolution, and follow-ups.
+origin:
+  type: first-party
 ---
-
 # Incident (WHAT)
 
 Use for unplanned events that disrupt or degrade production systems, live users, or critical operations.

--- a/skills/delivery/management-unit-assessment/SKILL.md
+++ b/skills/delivery/management-unit-assessment/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: management-unit-assessment
-description: >-
-  WHAT - Evidence-based management unit assessment for governance, delivery,
-  collaboration, culture, and AI-native management readiness. Interactive and
-  source-driven before any score is assigned.
+description: WHAT - Evidence-based management unit assessment for governance, delivery, collaboration,
+  culture, and AI-native management readiness. Interactive and source-driven before any score is assigned.
+origin:
+  type: first-party
 ---
-
 # Management Unit Assessment (WHAT)
 
 Use this skill to assess a management unit: project management, delivery execution, governance, stakeholder alignment, team collaboration, cultural health, and management-layer AI readiness.

--- a/skills/delivery/meeting-minutes/SKILL.md
+++ b/skills/delivery/meeting-minutes/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: meeting-minutes
-description: >-
-  WHAT - Create structured meeting minutes from notes or transcripts using meeting templates, with redaction, action items, decisions, and traceability.
+description: WHAT - Create structured meeting minutes from notes or transcripts using meeting templates,
+  with redaction, action items, decisions, and traceability.
+origin:
+  type: first-party
 ---
-
 # Meeting Minutes (WHAT)
 
 Use for meeting notes, validation meetings, or AI-assisted transcript summarization.

--- a/skills/delivery/planning/SKILL.md
+++ b/skills/delivery/planning/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: planning
-description: >-
-  WHAT - Planning, estimation, task breakdown, and iteration capacity fallback based on Best Practices. Use before finalizing backlog scope, story/task estimates, or iteration commitments.
+description: WHAT - Planning, estimation, task breakdown, and iteration capacity fallback based on Best
+  Practices. Use before finalizing backlog scope, story/task estimates, or iteration commitments.
+origin:
+  type: first-party
 ---
-
 # Planning and Estimation (WHAT)
 
 Use this skill when work needs planning, breakdown, estimation, or capacity validation before it becomes final backlog content.

--- a/skills/delivery/prd/SKILL.md
+++ b/skills/delivery/prd/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: prd
-description: >-
-  WHAT — Draft and review a Product Requirements Document (PRD) using the template. Business-level requirements, acceptance criteria, and traceability. Does not replace the product owner. English for tickets, PRs, and client-facing text unless the user asks otherwise.
+description: WHAT — Draft and review a Product Requirements Document (PRD) using the template. Business-level
+  requirements, acceptance criteria, and traceability. Does not replace the product owner. English for
+  tickets, PRs, and client-facing text unless the user asks otherwise.
+origin:
+  type: first-party
 ---
-
 # PRD — Product Requirements (WHAT)
 
 **Template:** `references/default-template.md` — local reference, kept up to date with the standard structure.

--- a/skills/delivery/project-assessment-evidence/SKILL.md
+++ b/skills/delivery/project-assessment-evidence/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: project-assessment-evidence
-description: >-
-  WHAT - Interactive evidence intake for project assessments. Ask the user where
-  each evidence source lives, build an evidence map, track missing evidence,
-  assumptions, freshness, and confidence before any scoring happens.
+description: WHAT - Interactive evidence intake for project assessments. Ask the user where each evidence
+  source lives, build an evidence map, track missing evidence, assumptions, freshness, and confidence
+  before any scoring happens.
+origin:
+  type: first-party
 ---
-
 # Project Assessment Evidence (WHAT)
 
 Use this skill before scoring a project assessment. It turns scattered project knowledge into a structured evidence map.

--- a/skills/delivery/project-assessment/SKILL.md
+++ b/skills/delivery/project-assessment/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: project-assessment
-description: >-
-  WHAT - Interactive project assessment router: define assessment scope and units,
-  collect evidence through project-assessment-evidence, then delegate to
-  technical or management unit assessment skills. Always evidence-based and human-reviewed.
+description: 'WHAT - Interactive project assessment router: define assessment scope and units, collect
+  evidence through project-assessment-evidence, then delegate to technical or management unit assessment
+  skills. Always evidence-based and human-reviewed.'
+origin:
+  type: first-party
 ---
-
 # Project Assessment (WHAT)
 
 Use this skill when the user asks for a project assessment, maturity assessment, delivery audit, technical assessment, management assessment, quality indicator review, or improvement roadmap.

--- a/skills/delivery/spike/SKILL.md
+++ b/skills/delivery/spike/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: spike
-description: >-
-  WHAT - Produce spike and research findings using the spike template; captures purpose, findings, implementation strategy, risks, tradeoffs, open questions, and references.
+description: WHAT - Produce spike and research findings using the spike template; captures purpose, findings,
+  implementation strategy, risks, tradeoffs, open questions, and references.
+origin:
+  type: first-party
 ---
-
 # Spike and Research Findings (WHAT)
 
 Use for technical exploration, feasibility validation, architecture assessment, or research outputs that should influence design or implementation.

--- a/skills/delivery/task/SKILL.md
+++ b/skills/delivery/task/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: task
-description: >-
-  WHAT - Draft and review technical tasks using the Best Practices Task Template; includes summary, technical notes, AC, estimate, owner, and due date.
+description: WHAT - Draft and review technical tasks using the Best Practices Task Template; includes
+  summary, technical notes, AC, estimate, owner, and due date.
+origin:
+  type: first-party
 ---
-
 # Task (WHAT)
 
 Use for technical or operational work that is not best represented as a user story.

--- a/skills/delivery/technical-unit-assessment/SKILL.md
+++ b/skills/delivery/technical-unit-assessment/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: technical-unit-assessment
-description: >-
-  WHAT - Evidence-based technical unit assessment for repositories, platforms,
-  frontend, backend, infrastructure, data, UI/UX, and AI-native structural readiness.
+description: WHAT - Evidence-based technical unit assessment for repositories, platforms, frontend, backend,
+  infrastructure, data, UI/UX, and AI-native structural readiness.
+origin:
+  type: first-party
 ---
-
 # Technical Unit Assessment (WHAT)
 
 Assess a technical unit: frontend app, backend API, data platform, infrastructure/IaC scope,

--- a/skills/delivery/trd/SKILL.md
+++ b/skills/delivery/trd/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: trd
-description: >-
-  WHAT — Draft and review a Technical Requirements Document (TRD) using the template, typically from an agreed PRD. Covers architecture, data contracts, technical decisions, risks, and test strategy. English for technical artifacts and tickets unless the user asks otherwise.
+description: WHAT — Draft and review a Technical Requirements Document (TRD) using the template, typically
+  from an agreed PRD. Covers architecture, data contracts, technical decisions, risks, and test strategy.
+  English for technical artifacts and tickets unless the user asks otherwise.
+origin:
+  type: first-party
 ---
-
 # TRD — Technical Requirements (WHAT)
 
 **Template:** `references/default-template.md` — local reference, kept up to date with the standard structure.

--- a/skills/delivery/user-story/SKILL.md
+++ b/skills/delivery/user-story/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: user-story
-description: >-
-  WHAT - Draft and review user stories using the task template plus the As a/I want/so that format from Best Practices examples.
+description: WHAT - Draft and review user stories using the task template plus the As a/I want/so that
+  format from Best Practices examples.
+origin:
+  type: first-party
 ---
-
 # User Story (WHAT)
 
 Use for user-centered requirements that need business value, technical notes, and acceptance criteria.

--- a/skills/delivery/work-item/SKILL.md
+++ b/skills/delivery/work-item/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: work-item
-description: >-
-  WHAT - Router for creating and refining epics, user stories, tasks, bugs, and incidents using Best Practices work item hierarchy.
+description: WHAT - Router for creating and refining epics, user stories, tasks, bugs, and incidents using
+  Best Practices work item hierarchy.
+origin:
+  type: first-party
 ---
-
 # Work Item Router (WHAT)
 
 Use this skill when the user asks to create, refine, or evaluate work items.

--- a/skills/delivery/workflow-client-bootstrap/SKILL.md
+++ b/skills/delivery/workflow-client-bootstrap/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workflow-client-bootstrap
-description: >-
-  WHAT — Interactive interview to capture client delivery context and store it inside the user's
-  ~/.ai-workspace (or similar) as packs + knowledge (no client skills). Use when onboarding a
-  new client project or updating an existing workspace context.
+description: WHAT — Interactive interview to capture client delivery context and store it inside the user's
+  ~/.ai-workspace (or similar) as packs + knowledge (no client skills). Use when onboarding a new client
+  project or updating an existing workspace context.
+origin:
+  type: first-party
 ---
-
 # Workflow Client Bootstrap
 
 Use this skill to **create or update** a client-specific delivery context for any project.

--- a/skills/delivery/workflow-generic-project/SKILL.md
+++ b/skills/delivery/workflow-generic-project/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: workflow-generic-project
-description: >-
-  WHAT — Generic client delivery: Jira or ClickUp, full repo context, human gates, English traceability
-  on tickets, draft PR via delegated forge skills. Use workspace packs for client/account overlays.
+description: 'WHAT — Generic client delivery: Jira or ClickUp, full repo context, human gates, English
+  traceability on tickets, draft PR via delegated forge skills. Use workspace packs for client/account
+  overlays.'
+origin:
+  type: first-party
 ---
-
 # Workflow — Generic Project (WHAT)
 
 **All skill instructions, ticket comments, and PR text must be in English.**

--- a/skills/design/figma-code-connect-components/SKILL.md
+++ b/skills/design/figma-code-connect-components/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: figma-code-connect-components
-description: Connects Figma design components to code components using Code Connect mapping tools. Use when user says "code connect", "connect this component to code", "map this component", "link component to code", "create code connect mapping", or wants to establish mappings between Figma designs and code implementations. For canvas writes (Plugin API), install the opt-in `figma-use` pack documented in `docs/SKILLS.md`.
+description: Connects Figma design components to code components using Code Connect mapping tools. Use
+  when user says "code connect", "connect this component to code", "map this component", "link component
+  to code", "create code connect mapping", or wants to establish mappings between Figma designs and code
+  implementations. For canvas writes (Plugin API), install the opt-in `figma-use` pack documented in `docs/SKILLS.md`.
+origin:
+  type: first-party
 ---
-
 # Code Connect Components
 
 ## Overview

--- a/skills/design/figma-create-design-system-rules/SKILL.md
+++ b/skills/design/figma-create-design-system-rules/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: figma-create-design-system-rules
-description: Generates custom design system rules for the user's codebase. Use when user says "create design system rules", "generate rules for my project", "set up design rules", "customize design system guidelines", or wants to establish project-specific conventions for Figma-to-code workflows. Requires Figma MCP server connection.
+description: Generates custom design system rules for the user's codebase. Use when user says "create
+  design system rules", "generate rules for my project", "set up design rules", "customize design system
+  guidelines", or wants to establish project-specific conventions for Figma-to-code workflows. Requires
+  Figma MCP server connection.
+origin:
+  type: first-party
 ---
-
 # Create Design System Rules
 
 ## Overview

--- a/skills/design/figma-create-new-file/SKILL.md
+++ b/skills/design/figma-create-new-file/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: figma-create-new-file
-description: Create a new blank Figma file. Use when the user wants to create a new Figma design or FigJam file, or when you need a new file before calling use_figma. Handles plan resolution via whoami if needed. Usage — /figma-create-new-file [editorType] [fileName] (e.g. /figma-create-new-file figjam My Whiteboard)
+description: Create a new blank Figma file. Use when the user wants to create a new Figma design or FigJam
+  file, or when you need a new file before calling use_figma. Handles plan resolution via whoami if needed.
+  Usage — /figma-create-new-file [editorType] [fileName] (e.g. /figma-create-new-file figjam My Whiteboard)
+origin:
+  type: first-party
 ---
-
 # create_new_file — Create a New Figma File
 
 Use the `create_new_file` MCP tool to create a new blank Figma file in the user's drafts folder. This is typically used before `use_figma` when you need a fresh file to work with.

--- a/skills/design/figma-implement-design/SKILL.md
+++ b/skills/design/figma-implement-design/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: figma-implement-design
-description: Translates Figma designs into production-ready application code with 1:1 visual fidelity. Use when implementing UI code from Figma files, when user mentions "implement design", "generate code", "implement component", provides Figma URLs, or asks to build components matching Figma specs. For Figma canvas writes (Plugin API), see the opt-in `figma-use` pack documented in `docs/SKILLS.md`.
+description: Translates Figma designs into production-ready application code with 1:1 visual fidelity.
+  Use when implementing UI code from Figma files, when user mentions "implement design", "generate code",
+  "implement component", provides Figma URLs, or asks to build components matching Figma specs. For Figma
+  canvas writes (Plugin API), see the opt-in `figma-use` pack documented in `docs/SKILLS.md`.
+origin:
+  type: first-party
 ---
-
 # Implement Design
 
 ## Overview

--- a/skills/design/figma/SKILL.md
+++ b/skills/design/figma/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: figma
-description: Use the Figma MCP server to fetch design context, screenshots, variables, and assets, and to translate Figma nodes into production code. Trigger when a task involves Figma URLs, node IDs, design-to-code implementation, or Figma MCP setup and troubleshooting.
+description: Use the Figma MCP server to fetch design context, screenshots, variables, and assets, and
+  to translate Figma nodes into production code. Trigger when a task involves Figma URLs, node IDs, design-to-code
+  implementation, or Figma MCP setup and troubleshooting.
+origin:
+  type: first-party
 ---
-
 # Figma MCP
 
 Use the Figma MCP server for Figma-driven implementation. For setup and

--- a/skills/forge/gh-address-comments/SKILL.md
+++ b/skills/forge/gh-address-comments/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gh-address-comments
-description: Triage and address open GitHub PR review and conversation comments using the gh CLI. Use when the user wants to "address PR comments", "resolve review threads", or "respond to reviewers" on the current branch's pull request.
+description: Triage and address open GitHub PR review and conversation comments using the gh CLI. Use
+  when the user wants to "address PR comments", "resolve review threads", or "respond to reviewers" on
+  the current branch's pull request.
+origin:
+  type: first-party
 ---
-
 # Address GitHub PR Comments
 
 Find the open PR for the current branch and walk through its review/conversation

--- a/skills/forge/gh-contribution-planner/SKILL.md
+++ b/skills/forge/gh-contribution-planner/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gh-contribution-planner
-description: Daily GitHub contribution planner — analyzes the gh-logged-in user's non-archived repos (owned + forks) and recent contributions, produces a prioritized plan, halts for approval, then dispatches parallel sub-agents to execute approved items via existing PR/CI/review skills.
+description: Daily GitHub contribution planner — analyzes the gh-logged-in user's non-archived repos (owned
+  + forks) and recent contributions, produces a prioritized plan, halts for approval, then dispatches
+  parallel sub-agents to execute approved items via existing PR/CI/review skills.
+origin:
+  type: first-party
 ---
-
 # GitHub Contribution Planner
 
 Discover what to work on across **your** GitHub footprint, propose a prioritized

--- a/skills/forge/gh-fix-ci/SKILL.md
+++ b/skills/forge/gh-fix-ci/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: gh-fix-ci
-description: Diagnose failing GitHub Actions checks on a PR via gh, summarize the failure context, propose a plan, and only implement after explicit user approval. External CI providers (Buildkite, CircleCI, etc.) are reported by URL only.
+description: Diagnose failing GitHub Actions checks on a PR via gh, summarize the failure context, propose
+  a plan, and only implement after explicit user approval. External CI providers (Buildkite, CircleCI,
+  etc.) are reported by URL only.
+origin:
+  type: first-party
 ---
-
 # Fix Failing PR Checks
 
 Inspect failing GitHub Actions checks on a PR with `gh`, fetch run logs, extract

--- a/skills/forge/github-cli-workflow/SKILL.md
+++ b/skills/forge/github-cli-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: github-cli-workflow
-description: >-
-  HOW — GitHub CLI (gh): push branch, create draft PR with title/body from template or file;
-  fallback untracked PR_DESCRIPTION_*.md. Use when origin is GitHub.
+description: 'HOW — GitHub CLI (gh): push branch, create draft PR with title/body from template or file;
+  fallback untracked PR_DESCRIPTION_*.md. Use when origin is GitHub.'
+origin:
+  type: first-party
 ---
-
 # GitHub CLI — draft PR (HOW)
 
 Use this skill when the remote is **GitHub** and you need to **push** and open a **draft** pull request. Workflow skills delegate here; this skill does **not** replace Jira or ClickUp procedures.

--- a/skills/forge/gitlab-cli-workflow/SKILL.md
+++ b/skills/forge/gitlab-cli-workflow/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: gitlab-cli-workflow
-description: >-
-  HOW — GitLab CLI (glab): push branch, create draft MR with title/body; fallback untracked markdown.
-  Use when origin is GitLab.
+description: 'HOW — GitLab CLI (glab): push branch, create draft MR with title/body; fallback untracked
+  markdown. Use when origin is GitLab.'
+origin:
+  type: first-party
 ---
-
 # GitLab CLI — draft MR (HOW)
 
 Use this skill when the remote is **GitLab** and you need to **push** and open a **draft** merge request. Workflow skills delegate here.

--- a/skills/forge/workflow-client-bootstrap/SKILL.md
+++ b/skills/forge/workflow-client-bootstrap/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: workflow-client-bootstrap
-description: >-
-  DEPRECATED alias. Use workflow-client-bootstrap instead.
+description: DEPRECATED alias. Use workflow-client-bootstrap instead.
+origin:
+  type: first-party
 ---
-
 # Deprecated — workflow-client-bootstrap
 
 This skill name is kept for backward compatibility only.

--- a/skills/forge/workflow-generic-project/SKILL.md
+++ b/skills/forge/workflow-generic-project/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: workflow-generic-project
-description: >-
-  DEPRECATED alias. Use workflow-generic-project instead.
+description: DEPRECATED alias. Use workflow-generic-project instead.
+origin:
+  type: first-party
 ---
-
 # Deprecated — workflow-generic-project
 
 This skill name is kept for backward compatibility only.

--- a/skills/forge/worktree/SKILL.md
+++ b/skills/forge/worktree/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: worktree
-description: Manage Git worktrees per writer for Agent Toolkit swarms — isolated branches, handoff promotion, and cleanup.
+description: Manage Git worktrees per writer for Agent Toolkit swarms — isolated branches, handoff promotion,
+  and cleanup.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [git, worktree, swarm, handoff, branch]
+  version: '1.0'
+  tags:
+  - git
+  - worktree
+  - swarm
+  - handoff
+  - branch
 ---
-
 # Worktree
 
 Create and maintain **worktree-per-writer** isolation for `agent-toolkit swarm` so each role works on its own branch without stepping on others. Integrates with `swarm-handoff` promotion and `github-cli-workflow` for PRs.

--- a/skills/integrations/clickup-cli/SKILL.md
+++ b/skills/integrations/clickup-cli/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: clickup-cli
-description: ClickUp CLI for managing tasks, sprints, comments, statuses, and Docs. Use when the user needs to interact with ClickUp — creating/editing tasks, checking sprint status, adding comments, linking PRs, managing Docs and pages, or searching tasks. Prefer this CLI over raw API calls.
+description: ClickUp CLI for managing tasks, sprints, comments, statuses, and Docs. Use when the user
+  needs to interact with ClickUp — creating/editing tasks, checking sprint status, adding comments, linking
+  PRs, managing Docs and pages, or searching tasks. Prefer this CLI over raw API calls.
+origin:
+  type: first-party
 ---
-
 # ClickUp CLI (`clickup`)
 
 Use the `clickup` CLI instead of raw ClickUp API calls. Handles authentication, git integration,

--- a/skills/integrations/linear/SKILL.md
+++ b/skills/integrations/linear/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: linear
-description: Manage Linear issues, projects and cycles via the Linear MCP server. Use when the user wants to read, triage, create or update Linear tickets, plan a sprint, audit Linear documentation, or rebalance team workload.
+description: Manage Linear issues, projects and cycles via the Linear MCP server. Use when the user wants
+  to read, triage, create or update Linear tickets, plan a sprint, audit Linear documentation, or rebalance
+  team workload.
+origin:
+  type: first-party
 ---
-
 # Linear
 
 Structured workflow for managing Linear issues, projects and cycles through the

--- a/skills/integrations/mcp/SKILL.md
+++ b/skills/integrations/mcp/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: mcp
-description: Configure and manage MCP providers for Agent Toolkit — setup, list, doctor, and per-tool deployment.
+description: Configure and manage MCP providers for Agent Toolkit — setup, list, doctor, and per-tool
+  deployment.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [mcp, integrations, github, slack, context]
+  version: '1.0'
+  tags:
+  - mcp
+  - integrations
+  - github
+  - slack
+  - context
 ---
-
 # MCP
 
 Wire **Model Context Protocol** servers so agents can call external tools (GitHub, ClickUp, Slack, etc.) natively. This skill wraps `agent-toolkit mcp` and the MCP definitions in `mcp/` and `~/.local/share/agent-toolkit/mcp/`.

--- a/skills/integrations/slack-assistant/SKILL.md
+++ b/skills/integrations/slack-assistant/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: slack-assistant
-description: Interact with Slack workspaces for reading channels/messages, sending messages, adding reactions, and browsing canvases. Use when the user asks about Slack channels, messages, or notifications — NOT for Slack app development (use the slack-cli skill for that).
+description: Interact with Slack workspaces for reading channels/messages, sending messages, adding reactions,
+  and browsing canvases. Use when the user asks about Slack channels, messages, or notifications — NOT
+  for Slack app development (use the slack-cli skill for that).
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-compatibility: Requires slackcli (shaharia-lab) — install via run_onchange_45 script. Authenticate with `slackcli auth login` before first use.
+  version: '1.0'
+compatibility: Requires slackcli (shaharia-lab) — install via run_onchange_45 script. Authenticate with
+  `slackcli auth login` before first use.
 ---
-
 # Slack Assistant (`slackcli`)
 
 Use the `slackcli` CLI (from [shaharia-lab/slackcli](https://github.com/shaharia-lab/slackcli))

--- a/skills/integrations/slack-cli/SKILL.md
+++ b/skills/integrations/slack-cli/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: slack-cli
-description: Interact with the official Slack CLI to create, run, deploy, and manage Slack apps, environments, manifests, and triggers. Use when the user asks about Slack app development workflows, not workspace chat automation.
+description: Interact with the official Slack CLI to create, run, deploy, and manage Slack apps, environments,
+  manifests, and triggers. Use when the user asks about Slack app development workflows, not workspace
+  chat automation.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-compatibility: Requires official Slack CLI from docs.slack.dev (not rockymadden/slack-cli), plus curl and jq. See references/INSTALLATION.md.
+  version: '1.0'
+compatibility: Requires official Slack CLI from docs.slack.dev (not rockymadden/slack-cli), plus curl
+  and jq. See references/INSTALLATION.md.
 ---
-
 # Slack CLI (Official Slack Developer CLI)
 
 Use the official Slack Developer CLI documented at `docs.slack.dev/tools/slack-cli/`.

--- a/skills/loops/loop-runner/SKILL.md
+++ b/skills/loops/loop-runner/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: loop-runner
-description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via bin/loop CLI.
+description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding
+  session via bin/loop CLI.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
+  version: '1.0'
 ---
-
 # loop-runner
 
 > Execute and manage loop engineering primitives from an AI coding session.

--- a/skills/ops/docs-generator/SKILL.md
+++ b/skills/ops/docs-generator/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: docs-generator
-description: >-
-  WHAT — Generate or update documentation from code: README.md from repo structure,
-  CHANGELOG.md from git history, API reference from OpenAPI/GraphQL schemas,
-  and AGENTS.md starters for new projects.
+description: 'WHAT — Generate or update documentation from code: README.md from repo structure, CHANGELOG.md
+  from git history, API reference from OpenAPI/GraphQL schemas, and AGENTS.md starters for new projects.'
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [docs, readme, changelog, api-reference, agents]
+  version: '1.0'
+  tags:
+  - docs
+  - readme
+  - changelog
+  - api-reference
+  - agents
 ---
-
 # Docs Generator (WHAT)
 
 Generate or refresh documentation from the actual code, schema, and git history.

--- a/skills/ops/llm-cost-advisor/SKILL.md
+++ b/skills/ops/llm-cost-advisor/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: llm-cost-advisor
-description: >-
-  WHAT — Recommend the most cost-effective LLM provider for a given task type.
-  Shows estimated cost per run across available providers and integrates with
-  devcompanion llm-status to show what is actually available.
+description: WHAT — Recommend the most cost-effective LLM provider for a given task type. Shows estimated
+  cost per run across available providers and integrates with devcompanion llm-status to show what is
+  actually available.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [llm, cost, provider, optimization]
+  version: '1.0'
+  tags:
+  - llm
+  - cost
+  - provider
+  - optimization
 ---
-
 # LLM Cost Advisor (WHAT)
 
 Recommend the right provider for the task at hand — balancing quality, cost, and privacy.

--- a/skills/ops/swarm-handoff/SKILL.md
+++ b/skills/ops/swarm-handoff/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: swarm-handoff
-description: Create artifact/commit file handoffs for Agent Toolkit swarms with worktree-per-writer, branch, and promotion integration.
+description: Create artifact/commit file handoffs for Agent Toolkit swarms with worktree-per-writer, branch,
+  and promotion integration.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [swarm, handoff, worktree, artifact, promotion]
+  version: '1.0'
+  tags:
+  - swarm
+  - handoff
+  - worktree
+  - artifact
+  - promotion
 ---
-
 # Swarm Handoff
 
 Create correct file handoffs between swarm roles so work moves via **Git + filesystem**, not chat copy. Every writer gets an isolated worktree/branch; the filesystem `state.json` is authoritative.

--- a/skills/ops/swarm-observer/SKILL.md
+++ b/skills/ops/swarm-observer/SKILL.md
@@ -1,12 +1,20 @@
 ---
 name: swarm-observer
-description: Observe, diagnose, and recover Agent Toolkit swarm runs via status, handoffs, logs, and attach with worktree and shell awareness.
+description: Observe, diagnose, and recover Agent Toolkit swarm runs via status, handoffs, logs, and attach
+  with worktree and shell awareness.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [swarm, observer, herdr, tmux, handoff, worktree]
+  version: '1.0'
+  tags:
+  - swarm
+  - observer
+  - herdr
+  - tmux
+  - handoff
+  - worktree
 ---
-
 # Swarm Observer
 
 Monitor any `agent-toolkit swarm` run, diagnose stuck handoffs or backend drift, and recover without losing windows. Works for both **Herdr** (tabs) and **tmux** (isolated socket `agent-toolkit-swarm-<run-id>`). Integrates with swarm's eager-window model (every role starts as `Waiting for handoff: <pred> -> <role>` with `agent_waiting` trace).

--- a/skills/ops/swarm/SKILL.md
+++ b/skills/ops/swarm/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: swarm
-description: Launch an Agent Toolkit swarm from a natural language request using agent-toolkit swarm CLI with Herdr/tmux eager windows and file handoffs.
+description: Launch an Agent Toolkit swarm from a natural language request using agent-toolkit swarm CLI
+  with Herdr/tmux eager windows and file handoffs.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [swarm, herdr, tmux, orchestration, multi-agent]
+  version: '1.0'
+  tags:
+  - swarm
+  - herdr
+  - tmux
+  - orchestration
+  - multi-agent
 ---
-
 # Swarm
 
 Launch a production Agent Toolkit swarm from any natural language request via the `agent-toolkit swarm` CLI. Herdr is the default UI for an excellent interactive experience; tmux is the isolated fallback.

--- a/skills/ops/triage/SKILL.md
+++ b/skills/ops/triage/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: triage
-description: Workstation health triage — validate tooling, directory layout, and run doctor with remediation suggestions.
+description: Workstation health triage — validate tooling, directory layout, and run doctor with remediation
+  suggestions.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.1"
+  version: '1.1'
 ---
-
 # Workstation Triage ()
 
 Use when the user reports workstation issues, install problems, tool failures, or needs a health check before starting work.

--- a/skills/tooling/herdr/SKILL.md
+++ b/skills/tooling/herdr/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: herdr
-description: Manage Herdr workspaces, tabs, and panes for Agent Toolkit swarms with eager windows, shell-aware execution, and reuse.
+description: Manage Herdr workspaces, tabs, and panes for Agent Toolkit swarms with eager windows, shell-aware
+  execution, and reuse.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [herdr, swarm, workspace, tmux, orchestration]
+  version: '1.0'
+  tags:
+  - herdr
+  - swarm
+  - workspace
+  - tmux
+  - orchestration
 ---
-
 # Herdr
 
 Operate Herdr as the primary UI for `agent-toolkit swarm` — eager tabs, shell-consistent execution (`zsh`/`bash` via `_user_shell()`), and clean reuse of windows. This skill is the Herdr complement to `swarm` and `swarm-observer`.

--- a/skills/tooling/inventory/SKILL.md
+++ b/skills/tooling/inventory/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: inventory
-description: Discover installed skills, agents, loops, and platform capabilities via agent-toolkit inventory, matrix, and skills list.
+description: Discover installed skills, agents, loops, and platform capabilities via agent-toolkit inventory,
+  matrix, and skills list.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
-  tags: [inventory, matrix, catalog, discovery]
+  version: '1.0'
+  tags:
+  - inventory
+  - matrix
+  - catalog
+  - discovery
 ---
-
 # Inventory
 
 Discover what the toolkit can do before you build — **skills, agents, loops, MCP, and platform support** — via `agent-toolkit inventory`, `matrix`, `build --check`, and `skills list`.

--- a/skills/tooling/jupyter-notebook/SKILL.md
+++ b/skills/tooling/jupyter-notebook/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: jupyter-notebook
-description: Create, scaffold, or refactor Jupyter notebooks (.ipynb) for experiments and tutorials. Prefer the bundled templates and the helper script (`new_notebook.py`, also exposed as `newnotebook`) to generate a clean starting notebook instead of authoring raw notebook JSON.
+description: Create, scaffold, or refactor Jupyter notebooks (.ipynb) for experiments and tutorials. Prefer
+  the bundled templates and the helper script (`new_notebook.py`, also exposed as `newnotebook`) to generate
+  a clean starting notebook instead of authoring raw notebook JSON.
+origin:
+  type: first-party
 ---
-
 # Jupyter Notebook
 
 Create clean, reproducible Jupyter notebooks for two primary modes:

--- a/skills/tooling/playwright-cli/SKILL.md
+++ b/skills/tooling/playwright-cli/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: playwright-cli
-description: Drive a real browser from the terminal using the Playwright CLI (snapshot, click, fill, screenshots, traces). Use when the task is CLI-first browser automation (data extraction, UI debugging, form fills, multi-tab work). For Playwright **test specs**, use `e2e-runner` instead.
+description: Drive a real browser from the terminal using the Playwright CLI (snapshot, click, fill, screenshots,
+  traces). Use when the task is CLI-first browser automation (data extraction, UI debugging, form fills,
+  multi-tab work). For Playwright **test specs**, use `e2e-runner` instead.
+origin:
+  type: first-party
 ---
-
 # Playwright CLI
 
 Drive a real browser from the terminal using `playwright-cli`. The bundled

--- a/tests/test_validate_upstream.py
+++ b/tests/test_validate_upstream.py
@@ -1,0 +1,343 @@
+"""Regression tests for P0 provenance governance (gates 1-13).
+
+Covers:
+- first-party valid, upstream with provenance valid, missing provenance invalid
+- full 40-char SHA valid, short SHAs (7,12,39) invalid
+- mutable branch invalid, tag without commit invalid, tag+commit valid
+- SPDX subset
+- multi-source
+- pure prompt with cve_policy not-applicable
+- schema vs validator agreement
+- non-skill capability types
+- origin explicit (gate 2)
+"""
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+import jsonschema
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).parent.parent
+UPSTREAM_SCHEMA = json.loads((REPO_ROOT / "schemas/upstream.schema.json").read_text())
+SKILL_FRONTMATTER_SCHEMA = json.loads((REPO_ROOT / "schemas/skill-md-frontmatter.schema.json").read_text())
+
+# Import validator functions
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("validate_upstream", REPO_ROOT / "scripts" / "validate-upstream.py")
+vu = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vu)
+
+SHA40 = "f" * 40
+SHORT7 = "abc1234"
+SHORT12 = "abc123456789"
+SHORT39 = "f" * 39
+TAG = "v1.2.3"
+
+def make_frontmatter(data: dict) -> str:
+    return yaml.safe_dump(data, sort_keys=False)
+
+def write_skill(tmp_path: Path, fm: dict) -> Path:
+    p = tmp_path / "SKILL.md"
+    p.write_text(f"---\n{make_frontmatter(fm)}---\n\n# Test\n", encoding="utf-8")
+    return p
+
+# ---- Gate 2: origin explicit ----
+
+def test_first_party_valid(tmp_path):
+    fm = {"name": "test", "description": "desc", "origin": {"type": "first-party"}}
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+def test_first_party_with_upstream_invalid(tmp_path):
+    fm = {"name": "test", "description": "desc", "origin": {"type": "first-party"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    assert any("first-party must not have" in e for e in errs)
+
+def test_first_party_missing_origin_invalid(tmp_path):
+    fm = {"name": "test", "description": "desc"}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    assert any("missing origin" in e for e in errs)
+
+def test_upstream_with_provenance_valid(tmp_path):
+    fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+def test_upstream_without_provenance_invalid(tmp_path):
+    fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    assert any("requires 'upstream' or 'sources'" in e for e in errs)
+
+def test_external_without_provenance_invalid(tmp_path):
+    # Same as upstream — external is distribution mode, but origin is upstream
+    fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}, "distribution": {"mode": "external"}}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    assert any("requires 'upstream'" in e for e in errs)
+
+def test_vendored_without_provenance_invalid(tmp_path):
+    fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}, "distribution": {"mode": "vendored"}}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    assert any("requires" in e for e in errs)
+
+def test_undeclared_third_party_cannot_pass(tmp_path):
+    # New third-party skill that omits origin and upstream — must fail gate 2
+    fm = {"name": "third-party-skill", "description": "desc", "upstream": {"repository": "evil/repo", "path": "x", "ref": SHA40, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    # Missing origin -> fails, even though upstream present
+    assert any("missing origin" in e for e in errs)
+    # Also test completely missing both -> fails
+    fm2 = {"name": "third-party-skill", "description": "desc"}
+    p2 = write_skill(tmp_path, fm2)
+    errs2 = vu.validate_one(p2)
+    assert any("missing origin" in e for e in errs2)
+
+# ---- Gate 1: Full SHA ----
+
+def test_40_char_sha_valid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+def test_short_sha_7_invalid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    assert any("short SHA" in e or "40-char" in e for e in errs)
+
+def test_short_sha_12_invalid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT12, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    assert any("short SHA" in e or "40-char" in e for e in vu.validate_one(p))
+
+def test_short_sha_39_invalid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT39, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    assert any("short SHA" in e for e in vu.validate_one(p))
+
+def test_mutable_branch_invalid(tmp_path):
+    for ref in ["main", "master", "latest", "develop", "stable"]:
+        fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": ref, "license": "MIT"}}
+        p = write_skill(tmp_path, fm)
+        assert any("mutable" in e or "40-char" in e for e in vu.validate_one(p)), f"ref {ref} should be rejected"
+
+def test_tag_without_commit_invalid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": TAG, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    assert any("requires commit" in e for e in vu.validate_one(p))
+
+def test_tag_with_40_char_commit_valid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": TAG, "commit": SHA40, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+def test_tag_with_short_commit_invalid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": TAG, "commit": SHORT7, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    assert any("40-char" in e for e in vu.validate_one(p))
+
+# ---- Gate 6: SPDX ----
+
+@pytest.mark.parametrize("spdx,should_pass", [
+    ("MIT", True),
+    ("Apache-2.0", True),
+    ("AGPL-3.0-only", True),
+    ("MIT OR Apache-2.0", True),
+    ("MIT AND CC-BY-4.0", True),
+    ("LicenseRef-Unknown", True),
+    ("LicenseRef-Custom-1.0", True),
+    ("NOASSERTION", True),
+    ("garbage-license", False),
+    ("MIT OR", False),
+    ("UNKNOWN", False),
+    ("MIT AND CC-BY-4.0 AND Apache-2.0", False),  # too complex for V1
+])
+def test_spdx_subset(tmp_path, spdx, should_pass):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": spdx}}
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    has_license_error = any("license" in e.lower() or "spdx" in e.lower() for e in errs)
+    assert (not has_license_error) == should_pass, f"SPDX {spdx!r} expected {'pass' if should_pass else 'fail'} got errs={errs}"
+
+# ---- Gate 9: Multi-source ----
+
+def test_multi_source_valid(tmp_path):
+    fm = {
+        "name": "t", "description": "d",
+        "origin": {"type": "upstream"},
+        "sources": [
+            {"role": "wrapper", "repository": "vercel-labs/agent-skills", "path": "skills/web-design-guidelines", "ref": SHA40, "license": "MIT"},
+            {"role": "rules", "repository": "vercel-labs/web-interface-guidelines", "path": "command.md", "ref": SHA40, "license": "MIT"},
+        ]
+    }
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+def test_multi_source_missing_license_invalid(tmp_path):
+    fm = {
+        "name": "t", "description": "d",
+        "origin": {"type": "upstream"},
+        "sources": [
+            {"role": "wrapper", "repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+            {"role": "rules", "repository": "c/d", "path": "y", "ref": SHA40, "license": ""},
+        ]
+    }
+    p = write_skill(tmp_path, fm)
+    assert any("license" in e for e in vu.validate_one(p))
+
+def test_both_upstream_and_sources_invalid(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}, "sources": [{"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}]}
+    p = write_skill(tmp_path, fm)
+    assert any("cannot have both" in e for e in vu.validate_one(p))
+
+# ---- Pure prompt with no CVE ----
+
+def test_pure_prompt_cve_not_applicable_valid(tmp_path):
+    fm = {
+        "name": "t", "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+        "security": {"scripts": False, "shell": False, "network": False, "cve_policy": "not-applicable"}
+    }
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+# ---- Trust / maintenance separation ----
+
+def test_trust_reviewed_maintenance_quiet_valid(tmp_path):
+    fm = {
+        "name": "t", "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+        "trust": {"tier": "reviewed", "reviewed_at": "2026-08-11", "reviewed_by": "alice"},
+        "maintenance": {"status": "quiet", "last_activity": "2025-01-01"},
+    }
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+def test_deprecated_verified_alias_still_passes(tmp_path):
+    fm = {
+        "name": "t", "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+        "trust": {"tier": "verified"}
+    }
+    p = write_skill(tmp_path, fm)
+    # verified is deprecated alias for reviewed — should not error
+    assert vu.validate_one(p) == []
+
+# ---- Distribution mode semantics ----
+
+@pytest.mark.parametrize("mode", ["vendored", "external", "native-plugin", "generated"])
+def test_distribution_modes_valid(tmp_path, mode):
+    fm = {"name": "t", "description": "d", "origin": {"type": "first-party"}, "distribution": {"mode": mode}}
+    # first-party with distribution is allowed (mode indicates how it's delivered)
+    p = write_skill(tmp_path, fm)
+    # For first-party, distribution mode is okay
+    assert vu.validate_one(p) == []
+
+def test_distribution_invalid_mode(tmp_path):
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}, "distribution": {"mode": "bundled"}}
+    p = write_skill(tmp_path, fm)
+    assert any("distribution.mode" in e for e in vu.validate_one(p))
+
+# ---- Gate 10: Non-skill fixtures ----
+
+def test_non_skill_agent_provenance():
+    data = {
+        "origin": {"type": "upstream"},
+        "capability": {"kind": "agent", "id": "security-reviewer"},
+        "upstream": {"repository": "example/agents", "path": "agents/security", "ref": SHA40, "license": "MIT"}
+    }
+    assert vu.validate_capability_fixture(data, "agent") == []
+
+def test_non_skill_mcp_provenance():
+    data = {
+        "origin": {"type": "upstream"},
+        "capability": {"kind": "mcp", "id": "slack"},
+        "sources": [
+            {"repository": "example/mcp", "path": "servers/slack", "ref": SHA40, "license": "Apache-2.0"}
+        ]
+    }
+    assert vu.validate_capability_fixture(data, "mcp") == []
+
+def test_non_skill_hook_provenance():
+    data = {
+        "origin": {"type": "first-party"},
+        "capability": {"kind": "hook", "id": "pre-commit-validate"}
+    }
+    assert vu.validate_capability_fixture(data, "hook") == []
+
+def test_non_skill_plugin_provenance():
+    data = {
+        "origin": {"type": "upstream"},
+        "capability": {"kind": "plugin", "id": "my-plugin"},
+        "upstream": {"repository": "example/plugin", "path": "plugin", "ref": "v2.0.0", "commit": SHA40, "license": "MIT"}
+    }
+    assert vu.validate_capability_fixture(data, "plugin") == []
+
+# ---- Gate 13: Schema vs validator agreement ----
+
+def test_schema_and_validator_agree_on_valid_skill(tmp_path):
+    from referencing import Registry, Resource
+    registry = Registry().with_resource(
+        uri="https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
+        resource=Resource.from_contents(UPSTREAM_SCHEMA)
+    )
+    registry = registry.with_resource(uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA))
+    validator = Draft202012Validator(SKILL_FRONTMATTER_SCHEMA, registry=registry)
+    # Valid first-party
+    instance = {"name": "test", "description": "d", "origin": {"type": "first-party"}}
+    validator.validate(instance)  # should not raise
+    fm = {"name": "test", "description": "d", "origin": {"type": "first-party"}}
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+def test_schema_rejects_short_sha_validator_also(tmp_path):
+    from referencing import Registry, Resource
+    registry = Registry().with_resource(
+        uri="https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
+        resource=Resource.from_contents(UPSTREAM_SCHEMA)
+    )
+    registry = registry.with_resource(uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA))
+    validator = Draft202012Validator(SKILL_FRONTMATTER_SCHEMA, registry=registry)
+    instance_bad = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"}}
+    schema_fails = False
+    try:
+        validator.validate(instance_bad)
+    except jsonschema.ValidationError:
+        schema_fails = True
+    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"}}
+    p = write_skill(tmp_path, fm)
+    validator_fails = len(vu.validate_one(p)) > 0
+    assert schema_fails and validator_fails, "both schema and validator should reject short SHA"
+
+def test_policy_exceeds_schema_documented(tmp_path):
+    # Policy: origin required for every skill, but schema makes it optional for backwards compat.
+    # Documented in validator: schema allows missing origin, validator rejects.
+    from referencing import Registry, Resource
+    registry = Registry().with_resource(
+        uri="https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
+        resource=Resource.from_contents(UPSTREAM_SCHEMA)
+    )
+    registry = registry.with_resource(uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA))
+    validator = Draft202012Validator(SKILL_FRONTMATTER_SCHEMA, registry=registry)
+    instance_no_origin = {"name": "t", "description": "d"}
+    # Schema should pass (optional)
+    validator.validate(instance_no_origin)
+    # Validator should fail (policy)
+    fm = {"name": "t", "description": "d"}
+    p = write_skill(tmp_path, fm)
+    assert len(vu.validate_one(p)) > 0
+    # This is intentional documented divergence per gate 13

--- a/tests/test_validate_upstream.py
+++ b/tests/test_validate_upstream.py
@@ -11,27 +11,29 @@ Covers:
 - non-skill capability types
 - origin explicit (gate 2)
 """
+
 from __future__ import annotations
 
+import importlib.util
 import json
-import re
-import tempfile
 from pathlib import Path
 
+import jsonschema
 import pytest
 import yaml
-import jsonschema
 from jsonschema import Draft202012Validator
 
 REPO_ROOT = Path(__file__).parent.parent
 UPSTREAM_SCHEMA = json.loads((REPO_ROOT / "schemas/upstream.schema.json").read_text())
-SKILL_FRONTMATTER_SCHEMA = json.loads((REPO_ROOT / "schemas/skill-md-frontmatter.schema.json").read_text())
+SKILL_FRONTMATTER_SCHEMA = json.loads(
+    (REPO_ROOT / "schemas/skill-md-frontmatter.schema.json").read_text()
+)
 
-# Import validator functions
-import importlib.util, sys
-spec = importlib.util.spec_from_file_location("validate_upstream", REPO_ROOT / "scripts" / "validate-upstream.py")
+spec = importlib.util.spec_from_file_location(
+    "validate_upstream", REPO_ROOT / "scripts" / "validate-upstream.py"
+)
 vu = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(vu)
+spec.loader.exec_module(vu)  # type: ignore[attr-defined]
 
 SHA40 = "f" * 40
 SHORT7 = "abc1234"
@@ -39,26 +41,37 @@ SHORT12 = "abc123456789"
 SHORT39 = "f" * 39
 TAG = "v1.2.3"
 
+
 def make_frontmatter(data: dict) -> str:
     return yaml.safe_dump(data, sort_keys=False)
+
 
 def write_skill(tmp_path: Path, fm: dict) -> Path:
     p = tmp_path / "SKILL.md"
     p.write_text(f"---\n{make_frontmatter(fm)}---\n\n# Test\n", encoding="utf-8")
     return p
 
+
 # ---- Gate 2: origin explicit ----
+
 
 def test_first_party_valid(tmp_path):
     fm = {"name": "test", "description": "desc", "origin": {"type": "first-party"}}
     p = write_skill(tmp_path, fm)
     assert vu.validate_one(p) == []
 
+
 def test_first_party_with_upstream_invalid(tmp_path):
-    fm = {"name": "test", "description": "desc", "origin": {"type": "first-party"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}}
+    fm = {
+        "name": "test",
+        "description": "desc",
+        "origin": {"type": "first-party"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     errs = vu.validate_one(p)
     assert any("first-party must not have" in e for e in errs)
+
 
 def test_first_party_missing_origin_invalid(tmp_path):
     fm = {"name": "test", "description": "desc"}
@@ -66,10 +79,17 @@ def test_first_party_missing_origin_invalid(tmp_path):
     errs = vu.validate_one(p)
     assert any("missing origin" in e for e in errs)
 
+
 def test_upstream_with_provenance_valid(tmp_path):
-    fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}}
+    fm = {
+        "name": "test",
+        "description": "desc",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     assert vu.validate_one(p) == []
+
 
 def test_upstream_without_provenance_invalid(tmp_path):
     fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}}
@@ -77,22 +97,39 @@ def test_upstream_without_provenance_invalid(tmp_path):
     errs = vu.validate_one(p)
     assert any("requires 'upstream' or 'sources'" in e for e in errs)
 
+
 def test_external_without_provenance_invalid(tmp_path):
     # Same as upstream — external is distribution mode, but origin is upstream
-    fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}, "distribution": {"mode": "external"}}
+    fm = {
+        "name": "test",
+        "description": "desc",
+        "origin": {"type": "upstream"},
+        "distribution": {"mode": "external"},
+    }
     p = write_skill(tmp_path, fm)
     errs = vu.validate_one(p)
     assert any("requires 'upstream'" in e for e in errs)
 
+
 def test_vendored_without_provenance_invalid(tmp_path):
-    fm = {"name": "test", "description": "desc", "origin": {"type": "upstream"}, "distribution": {"mode": "vendored"}}
+    fm = {
+        "name": "test",
+        "description": "desc",
+        "origin": {"type": "upstream"},
+        "distribution": {"mode": "vendored"},
+    }
     p = write_skill(tmp_path, fm)
     errs = vu.validate_one(p)
     assert any("requires" in e for e in errs)
 
+
 def test_undeclared_third_party_cannot_pass(tmp_path):
     # New third-party skill that omits origin and upstream — must fail gate 2
-    fm = {"name": "third-party-skill", "description": "desc", "upstream": {"repository": "evil/repo", "path": "x", "ref": SHA40, "license": "MIT"}}
+    fm = {
+        "name": "third-party-skill",
+        "description": "desc",
+        "upstream": {"repository": "evil/repo", "path": "x", "ref": SHA40, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     errs = vu.validate_one(p)
     # Missing origin -> fails, even though upstream present
@@ -103,121 +140,231 @@ def test_undeclared_third_party_cannot_pass(tmp_path):
     errs2 = vu.validate_one(p2)
     assert any("missing origin" in e for e in errs2)
 
+
 # ---- Gate 1: Full SHA ----
 
+
 def test_40_char_sha_valid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     assert vu.validate_one(p) == []
 
+
 def test_short_sha_7_invalid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     errs = vu.validate_one(p)
     assert any("short SHA" in e or "40-char" in e for e in errs)
 
+
 def test_short_sha_12_invalid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT12, "license": "MIT"}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHORT12, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     assert any("short SHA" in e or "40-char" in e for e in vu.validate_one(p))
 
+
 def test_short_sha_39_invalid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT39, "license": "MIT"}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHORT39, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     assert any("short SHA" in e for e in vu.validate_one(p))
 
+
 def test_mutable_branch_invalid(tmp_path):
     for ref in ["main", "master", "latest", "develop", "stable"]:
-        fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": ref, "license": "MIT"}}
+        fm = {
+            "name": "t",
+            "description": "d",
+            "origin": {"type": "upstream"},
+            "upstream": {"repository": "a/b", "path": "x", "ref": ref, "license": "MIT"},
+        }
         p = write_skill(tmp_path, fm)
-        assert any("mutable" in e or "40-char" in e for e in vu.validate_one(p)), f"ref {ref} should be rejected"
+        assert any("mutable" in e or "40-char" in e for e in vu.validate_one(p)), (
+            f"ref {ref} should be rejected"
+        )
+
 
 def test_tag_without_commit_invalid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": TAG, "license": "MIT"}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": TAG, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     assert any("requires commit" in e for e in vu.validate_one(p))
 
+
 def test_tag_with_40_char_commit_valid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": TAG, "commit": SHA40, "license": "MIT"}}
-    p = write_skill(tmp_path, fm)
-    assert vu.validate_one(p) == []
-
-def test_tag_with_short_commit_invalid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": TAG, "commit": SHORT7, "license": "MIT"}}
-    p = write_skill(tmp_path, fm)
-    assert any("40-char" in e for e in vu.validate_one(p))
-
-# ---- Gate 6: SPDX ----
-
-@pytest.mark.parametrize("spdx,should_pass", [
-    ("MIT", True),
-    ("Apache-2.0", True),
-    ("AGPL-3.0-only", True),
-    ("MIT OR Apache-2.0", True),
-    ("MIT AND CC-BY-4.0", True),
-    ("LicenseRef-Unknown", True),
-    ("LicenseRef-Custom-1.0", True),
-    ("NOASSERTION", True),
-    ("garbage-license", False),
-    ("MIT OR", False),
-    ("UNKNOWN", False),
-    ("MIT AND CC-BY-4.0 AND Apache-2.0", False),  # too complex for V1
-])
-def test_spdx_subset(tmp_path, spdx, should_pass):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": spdx}}
-    p = write_skill(tmp_path, fm)
-    errs = vu.validate_one(p)
-    has_license_error = any("license" in e.lower() or "spdx" in e.lower() for e in errs)
-    assert (not has_license_error) == should_pass, f"SPDX {spdx!r} expected {'pass' if should_pass else 'fail'} got errs={errs}"
-
-# ---- Gate 9: Multi-source ----
-
-def test_multi_source_valid(tmp_path):
     fm = {
-        "name": "t", "description": "d",
+        "name": "t",
+        "description": "d",
         "origin": {"type": "upstream"},
-        "sources": [
-            {"role": "wrapper", "repository": "vercel-labs/agent-skills", "path": "skills/web-design-guidelines", "ref": SHA40, "license": "MIT"},
-            {"role": "rules", "repository": "vercel-labs/web-interface-guidelines", "path": "command.md", "ref": SHA40, "license": "MIT"},
-        ]
+        "upstream": {
+            "repository": "a/b",
+            "path": "x",
+            "ref": TAG,
+            "commit": SHA40,
+            "license": "MIT",
+        },
     }
     p = write_skill(tmp_path, fm)
     assert vu.validate_one(p) == []
 
+
+def test_tag_with_short_commit_invalid(tmp_path):
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {
+            "repository": "a/b",
+            "path": "x",
+            "ref": TAG,
+            "commit": SHORT7,
+            "license": "MIT",
+        },
+    }
+    p = write_skill(tmp_path, fm)
+    assert any("40-char" in e for e in vu.validate_one(p))
+
+
+# ---- Gate 6: SPDX ----
+
+
+@pytest.mark.parametrize(
+    "spdx,should_pass",
+    [
+        ("MIT", True),
+        ("Apache-2.0", True),
+        ("AGPL-3.0-only", True),
+        ("MIT OR Apache-2.0", True),
+        ("MIT AND CC-BY-4.0", True),
+        ("LicenseRef-Unknown", True),
+        ("LicenseRef-Custom-1.0", True),
+        ("NOASSERTION", True),
+        ("garbage-license", False),
+        ("MIT OR", False),
+        ("UNKNOWN", False),
+        ("MIT AND CC-BY-4.0 AND Apache-2.0", False),  # too complex for V1
+    ],
+)
+def test_spdx_subset(tmp_path, spdx, should_pass):
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": spdx},
+    }
+    p = write_skill(tmp_path, fm)
+    errs = vu.validate_one(p)
+    has_license_error = any("license" in e.lower() or "spdx" in e.lower() for e in errs)
+    assert (not has_license_error) == should_pass, (
+        f"SPDX {spdx!r} expected {'pass' if should_pass else 'fail'} got errs={errs}"
+    )
+
+
+# ---- Gate 9: Multi-source ----
+
+
+def test_multi_source_valid(tmp_path):
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "sources": [
+            {
+                "role": "wrapper",
+                "repository": "vercel-labs/agent-skills",
+                "path": "skills/web-design-guidelines",
+                "ref": SHA40,
+                "license": "MIT",
+            },
+            {
+                "role": "rules",
+                "repository": "vercel-labs/web-interface-guidelines",
+                "path": "command.md",
+                "ref": SHA40,
+                "license": "MIT",
+            },
+        ],
+    }
+    p = write_skill(tmp_path, fm)
+    assert vu.validate_one(p) == []
+
+
 def test_multi_source_missing_license_invalid(tmp_path):
     fm = {
-        "name": "t", "description": "d",
+        "name": "t",
+        "description": "d",
         "origin": {"type": "upstream"},
         "sources": [
             {"role": "wrapper", "repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
             {"role": "rules", "repository": "c/d", "path": "y", "ref": SHA40, "license": ""},
-        ]
+        ],
     }
     p = write_skill(tmp_path, fm)
     assert any("license" in e for e in vu.validate_one(p))
 
+
 def test_both_upstream_and_sources_invalid(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}, "sources": [{"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}]}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+        "sources": [{"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}],
+    }
     p = write_skill(tmp_path, fm)
     assert any("cannot have both" in e for e in vu.validate_one(p))
 
+
 # ---- Pure prompt with no CVE ----
+
 
 def test_pure_prompt_cve_not_applicable_valid(tmp_path):
     fm = {
-        "name": "t", "description": "d",
+        "name": "t",
+        "description": "d",
         "origin": {"type": "upstream"},
         "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
-        "security": {"scripts": False, "shell": False, "network": False, "cve_policy": "not-applicable"}
+        "security": {
+            "scripts": False,
+            "shell": False,
+            "network": False,
+            "cve_policy": "not-applicable",
+        },
     }
     p = write_skill(tmp_path, fm)
     assert vu.validate_one(p) == []
 
+
 # ---- Trust / maintenance separation ----
+
 
 def test_trust_reviewed_maintenance_quiet_valid(tmp_path):
     fm = {
-        "name": "t", "description": "d",
+        "name": "t",
+        "description": "d",
         "origin": {"type": "upstream"},
         "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
         "trust": {"tier": "reviewed", "reviewed_at": "2026-08-11", "reviewed_by": "alice"},
@@ -226,76 +373,118 @@ def test_trust_reviewed_maintenance_quiet_valid(tmp_path):
     p = write_skill(tmp_path, fm)
     assert vu.validate_one(p) == []
 
+
 def test_deprecated_verified_alias_still_passes(tmp_path):
     fm = {
-        "name": "t", "description": "d",
+        "name": "t",
+        "description": "d",
         "origin": {"type": "upstream"},
         "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
-        "trust": {"tier": "verified"}
+        "trust": {"tier": "verified"},
     }
     p = write_skill(tmp_path, fm)
     # verified is deprecated alias for reviewed — should not error
     assert vu.validate_one(p) == []
 
+
 # ---- Distribution mode semantics ----
+
 
 @pytest.mark.parametrize("mode", ["vendored", "external", "native-plugin", "generated"])
 def test_distribution_modes_valid(tmp_path, mode):
-    fm = {"name": "t", "description": "d", "origin": {"type": "first-party"}, "distribution": {"mode": mode}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "first-party"},
+        "distribution": {"mode": mode},
+    }
     # first-party with distribution is allowed (mode indicates how it's delivered)
     p = write_skill(tmp_path, fm)
     # For first-party, distribution mode is okay
     assert vu.validate_one(p) == []
 
+
 def test_distribution_invalid_mode(tmp_path):
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"}, "distribution": {"mode": "bundled"}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHA40, "license": "MIT"},
+        "distribution": {"mode": "bundled"},
+    }
     p = write_skill(tmp_path, fm)
     assert any("distribution.mode" in e for e in vu.validate_one(p))
 
+
 # ---- Gate 10: Non-skill fixtures ----
+
 
 def test_non_skill_agent_provenance():
     data = {
         "origin": {"type": "upstream"},
         "capability": {"kind": "agent", "id": "security-reviewer"},
-        "upstream": {"repository": "example/agents", "path": "agents/security", "ref": SHA40, "license": "MIT"}
+        "upstream": {
+            "repository": "example/agents",
+            "path": "agents/security",
+            "ref": SHA40,
+            "license": "MIT",
+        },
     }
     assert vu.validate_capability_fixture(data, "agent") == []
+
 
 def test_non_skill_mcp_provenance():
     data = {
         "origin": {"type": "upstream"},
         "capability": {"kind": "mcp", "id": "slack"},
         "sources": [
-            {"repository": "example/mcp", "path": "servers/slack", "ref": SHA40, "license": "Apache-2.0"}
-        ]
+            {
+                "repository": "example/mcp",
+                "path": "servers/slack",
+                "ref": SHA40,
+                "license": "Apache-2.0",
+            }
+        ],
     }
     assert vu.validate_capability_fixture(data, "mcp") == []
+
 
 def test_non_skill_hook_provenance():
     data = {
         "origin": {"type": "first-party"},
-        "capability": {"kind": "hook", "id": "pre-commit-validate"}
+        "capability": {"kind": "hook", "id": "pre-commit-validate"},
     }
     assert vu.validate_capability_fixture(data, "hook") == []
+
 
 def test_non_skill_plugin_provenance():
     data = {
         "origin": {"type": "upstream"},
         "capability": {"kind": "plugin", "id": "my-plugin"},
-        "upstream": {"repository": "example/plugin", "path": "plugin", "ref": "v2.0.0", "commit": SHA40, "license": "MIT"}
+        "upstream": {
+            "repository": "example/plugin",
+            "path": "plugin",
+            "ref": "v2.0.0",
+            "commit": SHA40,
+            "license": "MIT",
+        },
     }
     assert vu.validate_capability_fixture(data, "plugin") == []
 
+
 # ---- Gate 13: Schema vs validator agreement ----
+
 
 def test_schema_and_validator_agree_on_valid_skill(tmp_path):
     from referencing import Registry, Resource
+
     registry = Registry().with_resource(
         uri="https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
-        resource=Resource.from_contents(UPSTREAM_SCHEMA)
+        resource=Resource.from_contents(UPSTREAM_SCHEMA),
     )
-    registry = registry.with_resource(uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA))
+    registry = registry.with_resource(
+        uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA)
+    )
     validator = Draft202012Validator(SKILL_FRONTMATTER_SCHEMA, registry=registry)
     # Valid first-party
     instance = {"name": "test", "description": "d", "origin": {"type": "first-party"}}
@@ -304,34 +493,52 @@ def test_schema_and_validator_agree_on_valid_skill(tmp_path):
     p = write_skill(tmp_path, fm)
     assert vu.validate_one(p) == []
 
+
 def test_schema_rejects_short_sha_validator_also(tmp_path):
     from referencing import Registry, Resource
+
     registry = Registry().with_resource(
         uri="https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
-        resource=Resource.from_contents(UPSTREAM_SCHEMA)
+        resource=Resource.from_contents(UPSTREAM_SCHEMA),
     )
-    registry = registry.with_resource(uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA))
+    registry = registry.with_resource(
+        uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA)
+    )
     validator = Draft202012Validator(SKILL_FRONTMATTER_SCHEMA, registry=registry)
-    instance_bad = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"}}
+    instance_bad = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"},
+    }
     schema_fails = False
     try:
         validator.validate(instance_bad)
     except jsonschema.ValidationError:
         schema_fails = True
-    fm = {"name": "t", "description": "d", "origin": {"type": "upstream"}, "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"}}
+    fm = {
+        "name": "t",
+        "description": "d",
+        "origin": {"type": "upstream"},
+        "upstream": {"repository": "a/b", "path": "x", "ref": SHORT7, "license": "MIT"},
+    }
     p = write_skill(tmp_path, fm)
     validator_fails = len(vu.validate_one(p)) > 0
     assert schema_fails and validator_fails, "both schema and validator should reject short SHA"
+
 
 def test_policy_exceeds_schema_documented(tmp_path):
     # Policy: origin required for every skill, but schema makes it optional for backwards compat.
     # Documented in validator: schema allows missing origin, validator rejects.
     from referencing import Registry, Resource
+
     registry = Registry().with_resource(
         uri="https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
-        resource=Resource.from_contents(UPSTREAM_SCHEMA)
+        resource=Resource.from_contents(UPSTREAM_SCHEMA),
     )
-    registry = registry.with_resource(uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA))
+    registry = registry.with_resource(
+        uri="upstream.schema.json", resource=Resource.from_contents(UPSTREAM_SCHEMA)
+    )
     validator = Draft202012Validator(SKILL_FRONTMATTER_SCHEMA, registry=registry)
     instance_no_origin = {"name": "t", "description": "d"}
     # Schema should pass (optional)

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,7 @@ requires-dist = [{ name = "agent-toolkit-cli", editable = "packages/agent-toolki
 [package.metadata.requires-dev]
 dev = [
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "mypy", specifier = ">=1.10.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },


### PR DESCRIPTION
Closes #364 — [EPIC] Third-party capability governance & supply-chain security foundation (P0).

## Context
P0 foundation blocking all later vendoring (frontend-design #371, web-guidelines #372, MegaLinter #382, agentic-security #378-#381). No provenance/trust tiers/mutable-ref guard existed; adding any external skill was unreviewable.

## Hardening 2026-08-12 — Gates 1-15 addressed

**Gate 1 — Full SHA:** `validate-upstream.py` now rejects 7/12/39-char short SHAs — only `^[0-9a-f]{40}$` or `tag + 40-char commit` is immutable. Schema enforces `sha40` pattern. Negative fixtures added.

**Gate 2 — Explicit origin:** Every `SKILL.md` now requires `origin.type: first-party|upstream` (no inference). 60 existing skills patched with `origin: first-party`. Validator rejects missing origin and undeclared third-party (tested).

**Gate 3 — upstream.lock reconciled (Option B):** `SKILL.md` frontmatter is authoritative now; `capabilities/upstream.lock` will be canonical in #370. `docs/TRUST.md` now says “Implemented now / Planned in #370 / Planned in #387” — no longer claims lock as already implemented.

**Gate 4 — Trust split:** `trust` (review tier) / `maintenance` (freshness: active|quiet|archived|unknown) / `security` (privilege/CVE). `reviewed` does not decay after 90d. `cve_policy: not-applicable` for pure prompt assets.

**Gate 5 — Verified→Reviewed:** Tier renamed to `reviewed` (precise definition: human-reviewed immutable pin + SPDX + security surface, not certification). `verified` kept as deprecated alias.

**Gate 6 — SPDX subset:** Controlled allowlist + single `AND`/`OR` expressions. Tests for MIT, Apache-2.0, AGPL-3.0-only, MIT OR, MIT AND, LicenseRef-, garbage.

**Gate 7 — Single-source schemas:** `skill-md-frontmatter.schema.json` now `$ref`s `upstream.schema.json#/$defs/*` for origin/trust/maintenance/security/distribution/source.

**Gate 8 — Distribution mode:** Documented as mutually exclusive delivery channel — `vendored`=copy-in-repo, `external`=fetch externally pinned, `native-plugin`=marketplace, `generated`=build-time codegen.

**Gate 9 — Multi-source:** `sources[]` with `role` for Vercel-style dual upstream (wrapper + rules). Validator accepts `upstream` (single) or `sources` (multi) but not both.

**Gate 10 — Non-skill:** Fixtures for agent/mcp/hook/plugin via `validate_capability_fixture` and schema `capability: {kind, id}`.

**Gate 11 — Close semantics (Option A):** Inventory/doctor wiring moved from #364 to #387. #364 now tracks only P0 schema/validator/docs/tests. This PR legitimately closes #364.

**Gate 14 — CI:** `validate.yml` `validate-upstream` (and siblings) now use `uv sync --all-extras` + `uv run` (no ad-hoc `pip install pyyaml`).

**Gate 15 — TRUST.md:** No stale claims; marks implemented-now vs planned; Anthropic example remains Apache-2.0 with 40-char SHA; distribution and provenance sections match implementation.

See #364 “Hardening update — 2026-08-12” for full details.

## Changes
- `schemas/upstream.schema.json` — canonical `$defs` (sha40, spdx, origin, source, trust, maintenance, security, distribution, capabilityRef), multi-source `sources[]`, origin-aware conditionals, single-source schemas via `$ref`
- `schemas/skill-md-frontmatter.schema.json` — now `$ref`s upstream defs (gate 7), supports `origin` + `upstream`/`sources` + `trust`/`maintenance`/`distribution`/`security`
- `scripts/validate-upstream.py` — full SHA enforcement (gate 1), origin explicit + undeclared-third-party rejection (gate 2), SPDX subset parser (gate 6), multi-source (gate 9), trust/maintenance/security split (gate 4), distribution exclusive (gate 8), `validate_capability_fixture` for non-skills (gate 10), schema/validator agreement notes (gate 13)
- `skills/**/*/SKILL.md` (60 files) — added `origin: type: first-party`
- `plugins/**/skills/*` — regenerated via `gen-surfaces.py` (surfaces in sync)
- `.github/workflows/validate.yml` — `validate-upstream`/`validate-skills`/`check-surfaces`/`check-skill-matrix` now use `setup-uv` + `uv sync` + `uv run` (gate 14)
- `docs/TRUST.md` — Option B architecture, reviewed/maintenance/security split (gate 4+5), distribution semantics (gate 8), multi-source example (gate 9), implemented/planned markers (gate 15)
- `tests/test_validate_upstream.py` — 46 regression tests covering all required vectors (gate 12) + schema/validator agreement (gate 13) + non-skill fixtures (gate 10)

## Validation (actual, 2026-08-12)

```bash
uv run python scripts/validate-upstream.py --check
# upstream validation OK — 60 skills checked, origin + provenance + SPDX + SHA40 enforced.

python3 scripts/validate-skills.py
# ✅ All SKILL.md files are valid! (60)

python3 scripts/gen-surfaces.py --check
# ✅ All plugin surfaces are in sync!

uv run pytest tests/test_validate_upstream.py -q
# 46 passed

uv run pytest tests/ -q
# see full suite below — all required gates pass

python3 -c "import json, jsonschema; s=json.load(open('schemas/upstream.schema.json')); jsonschema.Draft202012Validator.check_schema(s)"
# schema meta valid
```

## Acceptance criteria (per #364, gate 11 Option A)

- [x] Schema extension merged & single-source (gate 7)
- [x] `validate-upstream.py --check` blocks mutable refs & short SHAs (gate 1), requires origin (gate 2), SPDX subset (gate 6), multi-source (gate 9)
- [x] `docs/TRUST.md` trust/maintenance/security split (gate 4), reviewed tier (gate 5), distribution semantics (gate 8), multi-source (gate 9), implemented/planned markers (gate 15)
- [x] No existing skill breaks (60 patched, surfaces synced)
- [x] Regression tests + schema/validator agreement (gates 12+13) — 46 tests
- [x] Non-skill fixtures (gate 10) — agent/mcp/hook/plugin
- [x] CI uses uv locked deps (gate 14)
- [x] Inventory/doctor explicitly deferred to #387 (gate 11) — TRUST.md says planned in #387, #364 updated accordingly

**Closes #364 — no unchecked item remains that this PR claims.**

## Follow-ups (not in this PR)

- #370 — canonical `capabilities/upstream.lock` registry
- #387 — `inventory`/`doctor` provenance wiring
- CONTRIBUTING.md external-capability guide polish
