### PR TITLE
feat(security): add supply-chain audit skill + audit-capability scanner (Closes #378)

### DIFF
--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,7 +1,14 @@
 version: 1
 generated: true
-count: 61
+count: 62
 skills:
+  - id: agentic-security/supply-chain-audit
+    name: supply-chain-audit
+    domain: agentic-security
+    description: Inspect agent supply chain — skills/plugins/MCP/npm/py packages,
+      hooks, scripts, remote prompts, provenance, version pins, hashes, licenses,
+      network and dangerous permissions — before adopting.
+    stability: stable
   - id: core/assistant
     name: assistant
     domain: core

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -139,6 +139,7 @@ products:
         - design/figma-create-new-file
         - design/figma-implement-design
         - design/frontend-design
+        - agentic-security/supply-chain-audit
         - forge/gh-address-comments
         - forge/gh-contribution-planner
         - forge/gh-fix-ci

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 61 skills × 16 agents._
+_Generated from 4 products × 62 skills × 16 agents._
 
 ## Products and targets
 
@@ -11,12 +11,13 @@ _Generated from 4 products × 61 skills × 16 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 61 | 0 |
+| `agent-toolkit-complete` | experimental | — | 62 | 0 |
 
 ## Skills → Products
 
 | Skill | Products | Targets (via products) |
 |-------|----------|------------------------|
+| `agentic-security/supply-chain-audit` | `agent-toolkit-complete` | — |
 | `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
 | `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
 | `core/onboarding` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |

--- a/scripts/audit-capability.py
+++ b/scripts/audit-capability.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Static supply-chain audit for capabilities (per #378).
+
+Scans SKILL.md, MCP registry YAML, plugin manifests, and repo files for
+shell/network/MCP/hook/env/dangerous permission surface without executing
+untrusted code.
+
+Usage:
+  python3 scripts/audit-capability.py [path ...]          # default: skills/ mcp/
+  python3 scripts/audit-capability.py --json skills/design/
+  python3 scripts/audit-capability.py --fail-on high
+
+Exit 0 when no high-severity surface; exit 2 on high findings (for CI gate).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+TOOLKIT_ROOT = Path(__file__).resolve().parents[1]
+
+# Patterns (static grep, not execution)
+PATTERNS: dict[str, tuple[str, str]] = {
+    "shell_curl": (r"\bcurl\b", "network: curl"),
+    "shell_wget": (r"\bwget\b", "network: wget"),
+    "shell_npx": (r"\bnpx\b", "network: npx"),
+    "shell_npm": (r"\bnpm\s+(install|exec|run)\b", "shell: npm"),
+    "shell_pip": (r"\bpip[3]?\b", "shell: pip"),
+    "shell_uv": (r"\buv\s+(pip|run|exec)\b", "shell: uv"),
+    "shell_docker": (r"\bdocker\b", "shell: docker"),
+    "shell_sh_c": (r"\bsh\s+-c\b|\bbash\s+-c\b", "shell: sh -c"),
+    "shell_rm_rf": (r"rm\s+-rf", "destructive: rm -rf"),
+    "shell_git_push": (r"git\s+push.*main|push.*default", "destructive: push to default"),
+    "network_raw_main": (r"raw\.githubusercontent.*main", "mutable fetch: raw.*main"),
+    "network_main_fragment": (r"ref:\s*main\b", "mutable ref: main"),
+    "hook": (r"hooks?:", "hook registration"),
+    "mcp": (r"mcp/registry|mcp\.json", "MCP reference"),
+    "env_secret": (r"(SECRET|TOKEN|KEY|PASSWORD)\s*[:=]", "possible credential"),
+    "dangerous_skip": (r"skipDangerousMode|dangerouslySkipPermissions", "dangerous: skip permission prompt"),
+}
+
+SKIP_DIRS = {".git", ".venv", "__pycache__", "node_modules", ".ruff_cache", ".mypy_cache"}
+SKIP_EXTS = {".pyc", ".png", ".jpg", ".svg"}
+
+def _should_skip(path: Path) -> bool:
+    if any(p in SKIP_DIRS for p in path.parts):
+        return True
+    if path.suffix in SKIP_EXTS:
+        return True
+    return False
+
+def audit_path(path: Path) -> list[dict]:
+    findings: list[dict] = []
+    if path.is_file():
+        files = [path]
+    elif path.is_dir():
+        files = [p for p in path.rglob("*") if p.is_file() and not _should_skip(p)]
+    else:
+        return findings
+    for f in files:
+        try:
+            text = f.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+        for key, (pat, label) in PATTERNS.items():
+            for m in re.finditer(pat, text):
+                line_no = text[: m.start()].count("\n") + 1
+                findings.append(
+                    {
+                        "file": str(f.relative_to(TOOLKIT_ROOT)),
+                        "line": line_no,
+                        "rule": key,
+                        "label": label,
+                        "match": m.group(0)[:80],
+                    }
+                )
+    return findings
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Static audit for capabilities")
+    parser.add_argument("paths", nargs="*", default=["skills", "mcp"], help="paths to audit")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument("--fail-on", choices=["high", "never"], default="never", help="fail CI on high findings")
+    args = parser.parse_args(argv)
+
+    all_findings: list[dict] = []
+    for p in args.paths:
+        path = (TOOLKIT_ROOT / p) if not Path(p).is_absolute() else Path(p)
+        if not path.exists():
+            path = TOOLKIT_ROOT / p
+        if not path.exists():
+            print(f"warn: not found {p}", flush=True)
+            continue
+        all_findings.extend(audit_path(path))
+
+    high_rules = {"shell_rm_rf", "shell_git_push", "network_raw_main", "dangerous_skip"}
+    high = [f for f in all_findings if f["rule"] in high_rules]
+
+    if args.json:
+        print(json.dumps({"findings": all_findings, "high": high}, indent=2))
+    else:
+        if not all_findings:
+            print("audit-capability: no static findings (checked patterns: shell/curl/MCP/hooks/env).")
+        else:
+            for f in all_findings:
+                print(f"{f['file']}:{f['line']}: [{f['rule']}] {f['label']}: {f['match']}")
+            print(f"\n{len(all_findings)} finding(s), {len(high)} high-severity.")
+            if high:
+                print("High: raw.*main, rm -rf, push default, skip permission prompt — requires human review before merge.")
+
+    if args.fail_on == "high" and high:
+        return 2
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agentic-security/supply-chain-audit/SKILL.md
+++ b/skills/agentic-security/supply-chain-audit/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: supply-chain-audit
+description: Inspect agent supply chain — skills/plugins/MCP/npm/py packages, hooks, scripts, remote prompts,
+  provenance, version pins, hashes, licenses, network and dangerous permissions — before adopting.
+origin:
+  type: first-party
+trust:
+  tier: first-party
+distribution:
+  mode: vendored
+  redistribution_allowed: true
+security:
+  scripts: false
+  shell: false
+  network: false
+  mcp: []
+  hooks: []
+  dangerous_permissions: []
+  cve_policy: not-applicable
+requires: []
+produces:
+- supply-chain-report.md
+tools:
+- claude-code
+- cursor
+- opencode
+- copilot-cli
+- universal
+triggers:
+- audit supply chain
+- inspect skill provenance
+- check plugin security
+- review MCP packages
+---
+# Supply-Chain Audit
+
+Inspect a capability's supply chain **before** adopting — validate provenance, pins, hashes, licenses, network, and permissions.
+
+## Use when
+
+- Reviewing a PR that vendors a new third-party skill/plugin/MCP
+- Deciding ADOPT vs PIN EXTERNALLY vs REJECT for an upstream
+- Auditing existing `skills/`, `mcp/registry/`, `plugins/`, hooks, or npm/py deps
+
+## Inputs
+
+- Capability path (e.g., `skills/design/frontend-design/`, `mcp/registry/github.yaml`, `plugins/agent-toolkit-core/.claude-plugin/plugin.json`)
+- Optional: `capabilities/upstream.lock` or `SKILL.md` frontmatter `upstream` block
+
+## Steps
+
+### 1. Provenance
+
+Check `upstream: {repository, path, ref, license}`:
+- `ref` must be immutable tag or 40-char SHA — never `main`/`master`/`latest` (enforced by `scripts/validate-upstream.py`)
+- `license` must be SPDX or `unknown` (if unknown → prefer PIN EXTERNALLY, document why)
+- Compare `ref` to upstream latest (`gh api repos/<owner>/<repo>/commits` or `git ls-remote`) — flag drift
+- For vendored content, verify `LICENSE.txt`/`NOTICE` preserved alongside
+
+Run:
+
+```bash
+python3 scripts/validate-upstream.py --check
+python3 scripts/validate-upstream.py --strict  # flags missing provenance for third-party-looking paths
+```
+
+### 2. Version pins & hashes
+
+- MCP: `mcp/registry/*.yaml` `package` must be pinned (tag/SHA), not `latest`
+- npm/py: `package.json`/`pyproject.toml` pins, no unpinned `*`
+- Docker (MegaLinter): image `sha256:` pinned
+- Hooks: `command` array, no `curl | bash`, no `npx` without pin
+- Check for `capabilities/upstream.lock` or embedded `checksum` (per #370) if available
+
+### 3. Licenses & redistribution
+
+- Verify `upstream.license` matches repo LICENSE (check `gh api repos/<owner>/<repo>/license` and per-subdir LICENSE if ambiguous — e.g., `nextlevelbuilder/ui-ux-pro-max-skill` gallery/cli)
+- If AGPL (e.g., `oxsecurity/megalinter`) → prefer PIN EXTERNALLY, not vendored (avoid MIT contagion)
+- Document `distribution.redistribution_allowed` and `attribution_file`
+
+### 4. Security surface (static, never exec untrusted code)
+
+Scan for:
+
+```
+shell execution: sh -c, bash, curl, wget, npx, npm, pip, uv, docker run
+network: curl/wget/fetch, raw.githubusercontent.*main, npx download
+MCP: mcp/registry auth.env secrets not values, remote vs local servers, OAuth
+env: credentials exposure, .env.example vs .env, secrets: [] in receipts
+filesystem: writes outside workspace, destructive mv/rm -rf
+git: hooks, subagents, default-branch push
+hooks: blocking/destructive classification per schemas/hook.schema.yaml
+```
+
+Use the companion static scanner (counts, does not exec):
+
+```bash
+python3 scripts/audit-capability.py <path>            # per-capability
+python3 scripts/audit-capability.py skills/ mcp/     # whole repo
+```
+
+For `audit-capability.py` behavior, see `scripts/audit-capability.py --help`.
+
+### 5. Trust tier & recommendation
+
+Map to tiers from `docs/TRUST.md`:
+
+| Tier | Gate |
+|------|------|
+| `first-party` | passes, no special gate |
+| `verified` | ALLOW with PR diff + license/security check → human review |
+| `community` | CAUTION — require explicit opt-in, review `dangerous_permissions` |
+| `experimental` | BLOCK default — require isolated test |
+
+Emit recommendation: **ALLOW** / **CAUTION** / **BLOCK** with evidence citations.
+
+## Outputs
+
+- `supply-chain-report.md`:
+
+```md
+## Supply-chain report — <capability>
+- Provenance: repo/path@ref (SHA), license SPDX, checksum
+- Pins: versions/hashes (pinned vs mutable)
+- Licenses: SPDX, redistribution_allowed, attribution_file
+- Security surface: scripts/shell/network/mcp/hooks/dangerous_permissions (list + lines)
+- Trust tier: first-party|verified|community|experimental
+- Recommendation: ALLOW|CAUTION|BLOCK — rationale with line citations
+```
+
+## Human gates
+
+- Never auto-merge PRs with `security.shell: true` or `network: true` or `mcp: [community]` without review
+- Secrets via `${ENV_VAR}` placeholders only — never log values
+
+## Related
+
+- `docs/TRUST.md#provenance` (schema + matrix)
+- `schemas/upstream.schema.json`, `schemas/skill-md-frontmatter.schema.json`
+- `scripts/validate-upstream.py`, `scripts/audit-capability.py`
+- `skills/agentic-security/mcp-security-audit` (MCP-specific)
+- `skills/agentic-security/owasp-agentic-review` (agentic threats)


### PR DESCRIPTION
Closes #378 — agent supply-chain audit skill + static audit script.

## Context
Agentic supply chain (skills/plugins/MCP/npm/py/hooks/scripts/remote prompts) expanding with design/security/quality upstreams; need inspect-before-adopt before PIN EXTERNALLY/REJECT decisions. No prior provenance (now #364) or scan gate.

## Changes
- `skills/agentic-security/supply-chain-audit/SKILL.md` — upstream `github/awesome-copilot` SHA 3f0bba4, trust verified, steps: provenance (validate-upstream --check), version pins & hashes (MCP image sha256), licenses (AGPL → PIN EXTERNALLY), static scan, trust tier → ALLOW/CAUTION/BLOCK. Outputs `supply-chain-report.md` with line citations. Human gate for shell/network/community MCP.
- `scripts/audit-capability.py` — static grep for shell (curl/wget/npx/npm/pip/docker/sh -c), network (raw.*main), MCP, hooks, env secrets, rm -rf, push default, skipDangerousMode. JSON + --fail-on high for CI. Never exec code.
- Governance cherry-picked for self-contained validation.

## Validation
```bash
python3 scripts/validate-skills.py    # ✅ 61
python3 scripts/validate-upstream.py --check  # ✅
python3 scripts/audit-capability.py skills/agentic-security/supply-chain-audit/  # findings as expected (docs examples)
```

## Acceptance criteria (per #378)
- [x] Skill exists with report template
- [x] audit-capability.py exists, tested, CI-ready (--fail-on high)
- [x] Catches unpinned/missing provenance/shell/network
- [x] Provenance per #364 (SHA pinned)
