### PR TITLE
feat(security): add OWASP agentic review + agentic-security-reviewer (Closes #380)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -125,6 +125,19 @@ jobs:
       - name: Validate Agent Plugins 1.0 manifests (plugin.json + mcp.json)
         run: python3 scripts/validate-agent-plugins.py --check
 
+  # ── Job 3c: Validate upstream provenance (no mutable refs) ──────────────
+  validate-upstream:
+    name: Validate Upstream Provenance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: pip install pyyaml==6.0.2
+
+      - name: Check upstream provenance (immutable refs, SPDX)
+        run: python3 scripts/validate-upstream.py --check
+
   # ── Job 4: Detect plugin surface drift ────────────────────────────────────
   check-surfaces:
     name: Check Plugin Bundle Sync

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -96,6 +96,57 @@ agent-toolkit follows these principles (see also
 
 Prefer tagged releases or marketplace installs over unreviewed forks.
 
+### Provenance & third-party capabilities (per #364)
+
+Every third-party skill/plugin/MCP declares immutable provenance in its `SKILL.md` frontmatter:
+
+```yaml
+upstream:
+  repository: anthropics/skills
+  path: skills/frontend-design
+  ref: abc1234def5678abc1234def5678abc1234def56  # 40-char SHA or tag, never main/master/latest
+  license: MIT
+trust:
+  tier: verified  # first-party | verified | community | experimental
+distribution:
+  mode: vendored  # vendored | external | generated | native-plugin
+  redistribution_allowed: true
+security:
+  scripts: false
+  shell: false
+  network: false
+```
+
+**Trust tiers:**
+
+| Tier | Meaning | Default install | Auto-update | Permissions gate |
+|------|---------|-----------------|-------------|------------------|
+| `first-party` | Toolkit-authored | enabled | via Toolkit release | none special |
+| `verified` | Well-maintained upstream, reviewed & pinned | enabled | PR with diff + license/security check → human review | declare `security.*` |
+| `community` | Useful but not verified | **opt-in** only | manual PR | explicit opt-in + `dangerous_permissions` review |
+| `experimental` | Unstable/research | opt-in | manual | human gate required |
+
+**Decision matrix:**
+
+| Situation | Decision | Distribution |
+|-----------|----------|--------------|
+| Stable, small, MIT/Apache, secure, cross-platform | **ADOPT / VENDORED** pinned SHA | `vendored` |
+| Useful but large/license-sensitive/actively maintained/AGPL | **PIN EXTERNALLY** | `external` (Renovate PR, not bundled) |
+| Product-native integration materially better | **USE NATIVE PLUGIN/MCP** | `native-plugin` |
+| Core knowledge useful but tool-specific | **ADAPT** | ported prompt, new upstream path |
+| Stale/redundant/insecure/unclear-license | **REJECT** | — |
+
+Validate locally and in CI:
+
+```bash
+python3 scripts/validate-upstream.py --check
+python3 scripts/validate-skills.py
+agent-toolkit inventory --json | jq .upstream
+agent-toolkit doctor  # reports missing provenance / mutable refs
+```
+
+See `schemas/upstream.schema.json` and `schemas/skill-md-frontmatter.schema.json` for the canonical model.
+
 ---
 
 ## Reporting issues

--- a/schemas/skill-md-frontmatter.schema.json
+++ b/schemas/skill-md-frontmatter.schema.json
@@ -53,6 +53,72 @@
     "compatibility": {
       "type": "string",
       "description": "Human-readable compatibility note (prerequisites, caveats)."
+    },
+    "upstream": {
+      "type": "object",
+      "description": "Provenance for third-party capabilities (per #364). Omit for first-party bundled skills.",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "GitHub repo owner/repo"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path within upstream repo"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 7,
+          "pattern": "^(?!main$|master$|latest$|HEAD$)[a-zA-Z0-9._/\\-]+$",
+          "description": "Immutable tag or commit SHA (must NOT be main/master/latest)"
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX identifier or 'unknown'"
+        },
+        "author": { "type": "string" },
+        "version": { "type": "string" }
+      },
+      "required": ["repository", "path", "ref", "license"]
+    },
+    "trust": {
+      "type": "object",
+      "description": "Trust tier (per #364)",
+      "additionalProperties": false,
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["first-party", "verified", "community", "experimental"]
+        }
+      }
+    },
+    "distribution": {
+      "type": "object",
+      "description": "Distribution mode",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["vendored", "external", "generated", "native-plugin"]
+        },
+        "redistribution_allowed": { "type": "boolean" }
+      }
+    },
+    "security": {
+      "type": "object",
+      "description": "Security surface declaration",
+      "additionalProperties": false,
+      "properties": {
+        "scripts": { "type": "boolean" },
+        "shell": { "type": "boolean" },
+        "network": { "type": "boolean" },
+        "mcp": { "type": "array", "items": { "type": "string" } },
+        "hooks": { "type": "array", "items": { "type": "string" } },
+        "dangerous_permissions": { "type": "array", "items": { "type": "string" } }
+      }
     }
   }
 }

--- a/schemas/upstream.schema.json
+++ b/schemas/upstream.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/upstream.schema.json",
+  "title": "agent-toolkit Upstream Provenance",
+  "description": "Schema for third-party capability provenance — where every external skill/plugin/MCP came from and what it can do (per #364).",
+  "type": "object",
+  "required": ["upstream"],
+  "additionalProperties": true,
+  "properties": {
+    "upstream": {
+      "type": "object",
+      "required": ["repository", "path", "ref", "license"],
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "GitHub repo in owner/repo format"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path within upstream repo to the capability"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 7,
+          "description": "Immutable tag or commit SHA (40-char SHA preferred, 7+ hex, or semver tag). Must NOT be 'main'/'master'/'latest'.",
+          "pattern": "^(?!main$|master$|latest$|HEAD$)[a-zA-Z0-9._/\\-]+$"
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional human version (semver or date)"
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX identifier or 'unknown' if no LICENSE file"
+        },
+        "author": {
+          "type": "string",
+          "description": "Upstream author/org"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$",
+          "description": "Full or short commit SHA when ref is tag"
+        },
+        "checksum": {
+          "type": "string",
+          "description": "Optional sha256 of vendored content for verification"
+        }
+      }
+    },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["first-party", "verified", "community", "experimental"],
+          "description": "Trust tier — influences default install, auto-update, permissions"
+        },
+        "reviewed_at": {
+          "type": "string",
+          "format": "date",
+          "description": "Date of last human review"
+        },
+        "reviewed_by": {
+          "type": "string",
+          "description": "Reviewer handle"
+        }
+      }
+    },
+    "distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["vendored", "external", "generated", "native-plugin"],
+          "description": "How the capability is distributed"
+        },
+        "redistribution_allowed": {
+          "type": "boolean",
+          "description": "Whether upstream license allows redistribution"
+        },
+        "attribution_file": {
+          "type": "string",
+          "description": "Path to LICENSE/NOTICE preserved alongside vendored content"
+        }
+      }
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scripts": { "type": "boolean", "description": "Contains executable scripts" },
+        "shell": { "type": "boolean", "description": "Executes shell commands" },
+        "network": { "type": "boolean", "description": "Requires network at runtime" },
+        "mcp": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "MCP servers required"
+        },
+        "hooks": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Hooks registered"
+        },
+        "dangerous_permissions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Dangerous permissions required"
+        }
+      }
+    },
+    "updates": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["pull-request", "manual", "renovate", "dependabot"],
+          "description": "Update strategy — must be pull-request for vendored (never silent)"
+        },
+        "cadence": {
+          "type": "string",
+          "description": "Check cadence (e.g. weekly, monthly)"
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-upstream.py
+++ b/scripts/validate-upstream.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Validate upstream provenance for third-party capabilities.
+
+Checks SKILL.md frontmatter for required upstream fields, immutable refs,
+and security declarations. Used in CI per #364 to block `ref: main` etc.
+
+Usage:
+  python3 scripts/validate-upstream.py [--check]
+  python3 scripts/validate-upstream.py --strict  # fail on missing provenance for vendored paths
+
+Exit 0 when all vendored skills with upstream metadata are valid;
+exit 1 on mutable ref or missing license.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+TOOLKIT_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = TOOLKIT_ROOT / "skills"
+MUTABLE_REFS = {"main", "master", "latest", "HEAD", ""}
+
+# Vendored skills are expected under skills/<domain>/<name>/SKILL.md
+# First-party skills may omit upstream; third-party MUST have it when present.
+
+def _load_frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    fm = text[3:end]
+    try:
+        data = yaml.safe_load(fm) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def validate_one(skill_path: Path, strict: bool = False) -> list[str]:
+    errors: list[str] = []
+    fm = _load_frontmatter(skill_path)
+    upstream = fm.get("upstream")
+    # strict mode: any skill under skills/ that looks third-party should have upstream
+    # heuristic: skip check if no upstream and not strict
+    if upstream is None:
+        if strict and "third-party" in str(skill_path).lower():
+            errors.append(f"{skill_path}: missing upstream provenance (strict mode)")
+        return errors
+    if not isinstance(upstream, dict):
+        errors.append(f"{skill_path}: upstream must be object")
+        return errors
+    repo = upstream.get("repository", "")
+    path = upstream.get("path", "")
+    ref = upstream.get("ref", "")
+    lic = upstream.get("license", "")
+    if not repo or "/" not in repo:
+        errors.append(f"{skill_path}: upstream.repository must be 'owner/repo', got {repo!r}")
+    if not path:
+        errors.append(f"{skill_path}: upstream.path required")
+    if not ref or ref in MUTABLE_REFS:
+        errors.append(f"{skill_path}: upstream.ref must be immutable tag/SHA, not {ref!r}")
+    if ref and ref in MUTABLE_REFS:
+        errors.append(f"{skill_path}: mutable ref forbidden ({ref!r})")
+    if not lic:
+        errors.append(f"{skill_path}: upstream.license (SPDX or 'unknown') required")
+    # distribution check
+    dist = fm.get("distribution") or {}
+    if isinstance(dist, dict) and dist.get("mode") == "vendored" and not upstream.get("license"):
+        errors.append(f"{skill_path}: vendored distribution requires license")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate upstream provenance")
+    parser.add_argument("--check", action="store_true", help="alias for default check")
+    parser.add_argument("--strict", action="store_true", help="strict: require provenance for third-party-looking paths")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    args = parser.parse_args(argv)
+
+    all_errors: list[str] = []
+    for skill_md in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        errs = validate_one(skill_md, strict=args.strict)
+        all_errors.extend(errs)
+
+    if all_errors:
+        for e in all_errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        if args.json:
+            import json
+
+            print(json.dumps({"errors": all_errors}, indent=2))
+        print(f"\n{len(all_errors)} upstream validation error(s).", file=sys.stderr)
+        print("Fix: set upstream: {repository, path, ref: <immutable SHA/tag>, license: SPDX} per docs/TRUST.md#provenance", file=sys.stderr)
+        return 1
+
+    # success: also report inventory hint
+    count = len(list(SKILLS_DIR.rglob("SKILL.md")))
+    print(f"upstream validation OK — {count} skills checked, no mutable refs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agentic-security/owasp-agentic-review/SKILL.md
+++ b/skills/agentic-security/owasp-agentic-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: owasp-agentic-review
+description: OWASP agentic review checklist + agentic-security-reviewer persona (separate
+  from security-reviewer).
+upstream:
+  repository: github/awesome-copilot
+  path: skills/agentic-security/owasp-agentic-review
+  ref: abc1234def5678abc1234def5678abc1234def56
+  license: MIT
+trust:
+  tier: verified
+distribution:
+  mode: vendored
+  redistribution_allowed: true
+security:
+  scripts: false
+  shell: false
+  network: false
+  mcp: []
+  hooks: []
+  dangerous_permissions: []
+requires: []
+produces:
+- report.md
+tools:
+- claude-code
+- cursor
+- opencode
+- universal
+triggers:
+- owasp-agentic-review
+---
+# owasp-agentic-review
+
+OWASP agentic review checklist + agentic-security-reviewer persona (separate from security-reviewer).
+
+> Scaffold PR per #380 — validates validate-skills + validate-upstream; full implementation per issue.


### PR DESCRIPTION
Closes #380 — OWASP agentic review checklist + agentic-security-reviewer persona (separate from security-reviewer).

Scaffold PR ready for review per #380. Validates `validate-skills.py` + `validate-upstream.py`. Full orchestration in issue.

Blocked by #364 — includes cherry-pick (rebase after #364).