### PR TITLE
docs(adr): add assessment and pack semantics ADRs (Closes #396)

### DIFF
--- a/docs/adr/0002-design-assessment-as-design-unit.md
+++ b/docs/adr/0002-design-assessment-as-design-unit.md
@@ -1,0 +1,80 @@
+# ADR-0002: Design-Assessment as a Design Unit Delegated by Project-Assessment
+
+**Status:** Accepted (2026-08-11) — decides #396, unblocks #373
+
+**Deciders:** toolkit maintainers
+
+**Related:** #396 (assessment architecture), #373 (design-assessment), #365 (design-engineering epic), `project-assessment` / `project-assessment-evidence` / `technical-unit-assessment`, PR #426 (scaffold closed)
+
+---
+
+## Context
+
+Toolkit has a coherent evidence-based assessment family:
+
+- `project-assessment` — router: scope → `project-assessment-evidence` → delegate to `technical-unit-assessment` / `management-unit-assessment` → score → findings. Uses 1–5 maturity scale, score 3 = defined/partially mature, confidence High/Medium/Low/Not assessed, `output-handshake` gate, `Not assessed` for missing evidence.
+
+- `project-assessment-evidence` — interactive intake: asks where each source lives (boards, repos, docs, dashboards, interviews), builds evidence map with source link, owner, freshness, strength (Direct/Indirect/Interview-only/Stale/Missing), confidence, and never scores.
+
+- `technical-unit-assessment` — scores a technical unit (frontend/backend/infra/data/mobile/AI) after evidence intake, indicator groups + default template, delegates deep UI to `figma`.
+
+`design-assessment` (#373) would evaluate visual hierarchy, layout, spacing, typography, color, interaction, responsiveness, accessibility, design-system compliance, product appropriateness, distinctiveness with evidence/confidence/severity, WCAG 2.2 AA mapping. Risk: duplicate evidence/confidence/scoring framework and unclear swarm parallelism.
+
+Swarm recipes `pair`/`team`/`full` and Herdr/tmux backends exist but have no mapping for where parallel assessment helps (a11y || visual || browser) vs sequential.
+
+## Options Considered
+
+### Option A: project-assessment delegates to design-assessment as a design unit (SELECTED)
+
+`project-assessment` intakes evidence, then delegates to `design-assessment` alongside `technical-unit-assessment` / `management-unit-assessment` when UI/design is in scope. `design-assessment` is a **design-unit assessment** (parallel to technical/management units), not a second router.
+
+**Pros:**
+- No second scoring framework — reuses `project-assessment-evidence` intake, `technical-unit-assessment` confidence/scale semantics, `output-handshake` gate.
+- Clear routing: `project-assessment` `→ design-assessment` when UI depth needed; standalone `design-assessment` also callable for single-page audits.
+- Swarm mapping natural: `design-assessment` fans out to `a11y-reviewer` || `visual-reviewer` || `browser-perf-reviewer` || `design-system-reviewer` with shared evidence map as authority; sequential fallback valid.
+
+**Cons:**
+- `design-assessment` must not re-ask evidence already collected by router — needs intake reuse contract.
+
+### Option B: design-assessment extends technical-unit-assessment design dimension (REJECTED)
+
+Embed design as a dimension inside `technical-unit-assessment` indicator groups.
+
+**Pros:** Single skill.
+
+**Cons:** Bloats technical-unit scope (infra/data/mobile vs design are distinct audiences), forces design evidence (Figma, screenshots, WCAG reports) into generic technical intake, loses standalone UI audit use case.
+
+### Option C: design-assessment standalone with own evidence intake (REJECTED)
+
+Independent intake + scoring.
+
+**Pros:** Isolated.
+
+**Cons:** Duplicate evidence map, second confidence/scoring model, diverges from `project-assessment-evidence` freshness/quality rules, violates reuse principle.
+
+## Decision
+
+Adopt **Option A**.
+
+- `design-assessment` is a **design unit** delegated by `project-assessment` when design is in scope; also directly invokable. It **reuses** `project-assessment-evidence` intake (source types include `design files, UX research, accessibility reports, performance reports, screenshots, recordings, product analytics` already listed) and **reuses** `technical-unit-assessment` scoring semantics (1–5 scale, score 3 = defined, confidence tiers, `Not assessed` for missing evidence, `output-handshake` before report). No new scoring framework.
+
+- Evidence model (sources, freshness, quality Direct/Indirect/Stale/Missing, confidence) is single-source from `project-assessment-evidence` `references/default-template.md`. `design-assessment` frontmatter must declare `requires: [figma, playwright]`? No — `requires` is advisory; actual evidence locations are asked interactively per `project-assessment-evidence` pattern.
+
+- Swarm parallelism mapping (advisory, sequential fallback always valid):
+  ```
+  design-assessment: a11y-reviewer || visual-reviewer || browser-perf-reviewer || design-system-reviewer (shared evidence map)
+  MegaLinter-fix: python-findings || markdown-findings || terraform-findings || security-findings (per-language fixtures)
+  project-assessment: frontend-unit || backend-unit || infra-unit || design-unit (per-unit)
+  ```
+  Model/cost routing: `vision-required` capability metadata where needed; otherwise `reasoning-heavy` vs `cheap-parallel` maps to existing swarm model profiles `economy/balanced/quality`.
+
+## Consequences
+
+- `design-assessment` SKILL.md will state delegation contract, reuse evidence map, and scoring rules without duplicating indicator definitions.
+- `project-assessment` router docs will list `design-assessment` as design-unit delegate (alongside technical/management) and note swarm fan-out as optional.
+- No schema change; no new top-level pack/product needed for assessment.
+
+## References
+
+- `skills/delivery/project-assessment/SKILL.md`, `project-assessment-evidence/SKILL.md`, `technical-unit-assessment/SKILL.md`
+- #396, #373, #365

--- a/docs/adr/0003-pack-semantics-products-own-installation.md
+++ b/docs/adr/0003-pack-semantics-products-own-installation.md
@@ -1,0 +1,79 @@
+# ADR-0003: Pack Semantics — Products Own Installation, Solution Packs Remain Docs-Only
+
+**Status:** Accepted (2026-08-11) — clarifies ADR-006, unblocks #390
+
+**Deciders:** toolkit maintainers
+
+**Related:** ADR-006 (Packs docs-only), #390 (pack curation), #338, `docs/CONCEPTS.md` § Packs, `distributions/products.yaml`, `packs/README.md`
+
+---
+
+## Context
+
+ADR-006 settled that `packs/<name>/` are **docs-only workflow templates** (README + config.yaml) not loaded by `agent-toolkit build`; `distributions/products.yaml` is the sole compiler input for `plugins/` (products → targets). `docs/CONCEPTS.md` now distinguishes three pack nouns: solution packs (repo, docs-only), workspace packs (`packs/*.yaml` in a harness workspace, `workspace load`), loop `--pack` overrides (`loop run --pack`).
+
+Roadmap issue #390 then proposes `install --pack` and compiler-wired packs (`design-engineering`, `agentic-security`, `code-quality`, `architecture`) that would bundle skills for one-command install, contradicting ADR-006. #390 also asks: *What is a pack?* docs grouping vs installation preset vs capability bundle vs workspace overlay vs product composition, and *Product vs Pack vs Profile vs Workspace* responsibilities. Meanwhile `docs/PRODUCT_CURATION.md` already governs product membership (`core`/`forge`/`complete`/`agents`), and `agentic-workstation#200` expects thin workstation consumption via products, not packs.
+
+Without a decision, contributors will either (a) silently wire packs into the compiler, creating a second composition layer, or (b) leave `install --pack` as dead docs, blocking workstation product selection.
+
+## Options Considered
+
+### Option A: Wire packs into compiler (REJECTED for now)
+
+Make `packs/<name>/pack.yaml` validated against `schemas/pack.schema.json`, loaded by `agent-toolkit build`, emitted to `inventory` and `context-budget`, installable via `install --pack`.
+
+**Pros:** One-command pack install.
+
+**Cons:** Duplicates products as composition layer; every pack becomes a product variant; trust inheritance (pack max source risk) must be enforced; `products.yaml` vs `pack.yaml` confusion; requires compiler change (`loader.py` + `build.py` + adapter), `validate-packs.py`, migration for 3 existing packs; premature before community validates pack granularity.
+
+### Option B: Keep solution packs docs-only, products own installation (SELECTED)
+
+Reaffirm ADR-006: `packs/` remain **docs-only workflow templates**. Installation presets remain **products** (`distributions/products.yaml`) and future **presets** (planned `agent-toolkit.yaml` project-level, not Packs). The desired `install --pack design-engineering` is therefore `install --product` (or future `install --preset`) — not a pack compiler change. Packs document *which* products/skills/loops to combine for an outcome; products *ship* the composition.
+
+**Pros:**
+- No second composition layer; single authoritative `products.yaml` → `plugins/` pipeline.
+- Preserves vendor-neutral trust: `plugins/` stays first-party-only; packs cannot silently auto-enable experimental shell skills.
+- Low-ceremony: packs evolve as docs without blocking compiler; workstation can still compose products per team (see `agentic-workstation` `products` selection).
+- Explicit noun separation: solution pack (docs), workspace pack (harness context), loop pack (runtime overrides), product (shipped plugin), profile (deprecated), preset (future project-level).
+
+**Cons:**
+- `install --pack` as written in #390 remains unavailable — teams copy pack README guidance or set `agent-toolkit.yaml` product list manually (acceptable; Wave 5 could add `pack install` as docs-only helper that writes `agent-toolkit.yaml`, not compiler).
+
+### Option C: Rename and split (CONSIDERED, DEFERRED)
+
+Introduce `presets/` for installation presets, keep `packs/` docs-only, deprecate `install --pack` terminology entirely.
+
+**Pros:** Clear noun.
+
+**Cons:** Churn for 3 existing packs, docs, and CLI help for limited gain now; can be revisited if community demands `preset` as distinct artifact.
+
+## Decision
+
+Adopt **Option B**. Reaffirm ADR-006 and extend with explicit responsibilities:
+
+| Artifact | Location | Loaded by | Purpose | Trust |
+|---|---|---|---|---|
+| **Canonical content** | `skills/`, `agents/`, `loops/` | — | Source-of-truth definitions | Per-skill `origin`/`trust` |
+| **Products** | `distributions/products.yaml` | `agent-toolkit build` → `plugins/` | Shipped marketplace plugins (core/forge/complete/agents) | Product inherits max member risk |
+| **Solution Packs** | `packs/<name>/` | **Not loaded** (docs-only) | Workflow template for a team setup (README + config.yaml advisory) | Docs-only, no install |
+| **Workspace Packs** | `packs/*.yaml` (harness workspace) | `workspace load` | Per-client context bundle | Local |
+| **Loop Packs** | `packs/*.yaml` (workspace) | `loop run --pack` | Runtime loop override | Local |
+| **Profiles** | `profiles/` | Deprecated fallback | Legacy install layouts | Deprecated |
+| **Presets** | *(planned)* `agent-toolkit.yaml` | Future | Project-level product selection | Future |
+
+- `install --pack` is **not** a compiler feature. To ship a pack's composition, promote its member skills to a product in `distributions/products.yaml` (see `docs/PRODUCT_CURATION.md` small-PR rule) or document the product list in the pack README. A future `pack install` helper may generate `agent-toolkit.yaml` from a pack's advisory `skills:` list, but it will not teach the compiler to ingest `packs/`.
+
+- Pack trust: a pack's advisory `skills:` list inherits max source risk/permission of its members; a `reviewed` pack must not list `community`/`experimental` shell/network skills without explicit warning in the pack README.
+
+## Consequences
+
+- #390 will curate packs as **docs-only** (update `packs/<name>/README.md` + `config.yaml` advisory `skills:`/`agents:` + workflow narrative), not as `pack.yaml` compiler artifacts. Inventory/context-budget will continue to surface product membership; pack membership remains docs reference until a future `preset` ADR.
+
+- `docs/CONCEPTS.md` table already correct; no schema change.
+
+- Workstation #200 continues to consume `products` (not packs) for provisioning; no `install --pack` wiring in toolkit until a dedicated `presets` ADR.
+
+## References
+
+- `docs/adrs/ADR-006-packs-docs-only.md`, `docs/CONCEPTS.md` § Packs, `packs/README.md`, `distributions/products.yaml`, `docs/PRODUCT_CURATION.md`
+- #390, #338, #396


### PR DESCRIPTION
Closes #396 — assessment and pack semantics ADRs.

Follow-up to governance foundation (#403/#429). Unblocks #373 design-assessment and #390 packs.

## Context
#396 originally mixed assessment evidence-model reuse and swarm parallelism; #390 mixed pack installation vs docs-only. Both were blocked on architectural decisions.

## Changes
- **ADR-0002** `docs/adr/0002-design-assessment-as-design-unit.md` — `design-assessment` is a **design unit** delegated by `project-assessment` alongside `technical-unit-assessment`/`management-unit-assessment`, reuses `project-assessment-evidence` intake (Direct/Indirect/Stale/Missing + confidence High/Medium/Low/Not assessed), 1–5 scale (3 = defined), `output-handshake` gate, no second framework; swarm fan-out `a11y-reviewer || visual-reviewer || browser-perf-reviewer || design-system-reviewer` with shared evidence map, sequential fallback, `vision-required` metadata where needed. Decides Option A, rejects B (bloats technical unit) and C (duplicates evidence).

- **ADR-0003** `docs/adr/0003-pack-semantics-products-own-installation.md` — reaffirms ADR-006 `packs/` docs-only (`packs/<name>/` README+config.yaml advisory, not loaded by `build`); products own installation (`distributions/products.yaml` → `plugins/`); workspace packs (`packs/*.yaml` harness) and loop `--pack` remain distinct; `install --pack` is **not** a compiler feature (use `install --product` or future `preset`); pack trust inherits max member risk. Rejects wiring packs into compiler (duplicates products). See `docs/CONCEPTS.md` table.

## Validation
```bash
uv run pytest tests/test_provenance_lock.py -q # 30 passed
python scripts/validate-skills.py # 62 valid
```

No code change; docs-only. Follows existing ADR template from `0001`.

Related: #396, #390, ADR-006, #373, #365, #369, #387
