### PR TITLE
feat(design): pin Microsoft frontend-design-review (Closes #391)

### DIFF
--- a/capabilities/upstream.lock
+++ b/capabilities/upstream.lock
@@ -17,6 +17,24 @@ capabilities:
             spdx: Apache-2.0
           resolved_at: '2026-08-11T15:51:47.698560Z'
           version: f17010c
+  design/frontend-design-review:
+    provenance_digest: sha256:5394cd7cf5d9c56acd77c251da40cb603795ac5e5b4d817578991d12d57d2be7
+    sources:
+      upstream:
+        path: .github/skills/frontend-design-review
+        repository: microsoft/skills
+        requested:
+          ref: e58528db9a006528a5fb0a2c029790fa6a9a7c0e
+          type: commit
+        resolved:
+          commit: e58528db9a006528a5fb0a2c029790fa6a9a7c0e
+          content_checksum: sha256:66aa155ca3da88f51b2d03377d0d6009eccf9eecd7a36e4a13a7240d1474b67f
+          license:
+            checksum: sha256:d9a1b1e30d633d5732ea18e3cba9538d293ebc53e1a9e4e96ab739e0c5c4f1cb
+            source_path: skills/design/frontend-design-review/LICENSE
+            spdx: MIT
+          resolved_at: '2026-08-11T17:12:46.950377Z'
+          version: e58528d
   design/web-design-guidelines:
     provenance_digest: sha256:7c23f915c756d4322d1b8ca17ed1d57a98cc6accd11a11ae765e288a181ff870
     sources:

--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,6 +1,6 @@
 version: 1
 generated: true
-count: 63
+count: 64
 skills:
   - id: agentic-security/supply-chain-audit
     name: supply-chain-audit
@@ -258,6 +258,13 @@ skills:
     description: Guidance for distinctive, intentional visual design when building
       new UI or reshaping an existing one. Helps with aesthetic direction, typography,
       and making choices that don't read as templated defau
+    stability: stable
+  - id: design/frontend-design-review
+    name: frontend-design-review
+    domain: design
+    description: 'Review and create distinctive, production-grade frontend interfaces
+      with high design quality and design system compliance. Evaluates using three
+      pillars: frictionless insight-to-action, quality craft,'
     stability: stable
   - id: design/web-design-guidelines
     name: web-design-guidelines

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -139,6 +139,7 @@ products:
         - design/figma-create-new-file
         - design/figma-implement-design
         - design/frontend-design
+        - design/frontend-design-review
         - design/web-design-guidelines
         - agentic-security/supply-chain-audit
         - forge/gh-address-comments

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 63 skills × 16 agents._
+_Generated from 4 products × 64 skills × 16 agents._
 
 ## Products and targets
 
@@ -11,7 +11,7 @@ _Generated from 4 products × 63 skills × 16 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 63 | 0 |
+| `agent-toolkit-complete` | experimental | — | 64 | 0 |
 
 ## Skills → Products
 
@@ -55,6 +55,7 @@ _Generated from 4 products × 63 skills × 16 agents._
 | `design/figma-create-new-file` | `agent-toolkit-complete` | — |
 | `design/figma-implement-design` | `agent-toolkit-complete` | — |
 | `design/frontend-design` | `agent-toolkit-complete` | — |
+| `design/frontend-design-review` | `agent-toolkit-complete` | — |
 | `design/web-design-guidelines` | `agent-toolkit-complete` | — |
 | `forge/gh-address-comments` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |
 | `forge/gh-contribution-planner` | `agent-toolkit-complete`, `agent-toolkit-forge` | claude-code, cursor |

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -7,8 +7,8 @@ Human-readable provenance for third-party capability content. Canonical sources:
 - **Resolution:** `capabilities/upstream.lock` (`version: 2`, `provenance_digest`) — see `schemas/upstream-lock.schema.json` and `docs/adr/0001-*.md`
 - **Vendored bytes:** `skills/<domain>/<name>/SKILL.md` + `LICENSE.txt`
 
-Generated: 2026-08-11T17:03:13.883265Z
-Capabilities with external provenance: 2 (first-party omitted; lock is sparse)
+Generated: 2026-08-11T17:13:16.578897Z
+Capabilities with external provenance: 3 (first-party omitted; lock is sparse)
 
 ## `design/frontend-design`
 
@@ -31,6 +31,26 @@ Capabilities with external provenance: 2 (first-party omitted; lock is sparse)
 - **Resolved at:** `2026-08-11T15:51:47.698560Z` version=`f17010c`
 
 - **Per-skill attribution:** `skills/design/frontend-design/UPSTREAM.md`
+
+## `design/frontend-design-review`
+
+- **Trust:** `reviewed` reviewed_at=2026-08-11 by=ulises-jeremias
+  - `reviewed_provenance:` `sha256:5394cd7cf5d9c56acd77c251da40cb603795ac5e5b4d817578991d12d57d2be7` (must equal `provenance_digest` below)
+- **Maintenance:** `active` last_activity=2026-08-11
+- **Distribution:** `vendored` redistribution_allowed=True
+- **Security (declared):** scripts=False shell=False network=False cve_policy=not-applicable mcp=[] hooks=[]
+- **Provenance digest:** `sha256:5394cd7cf5d9c56acd77c251da40cb603795ac5e5b4d817578991d12d57d2be7`
+
+### Source `upstream` — `microsoft/skills/.github/skills/frontend-design-review`
+
+- **Repository:** `microsoft/skills`
+- **Path:** `.github/skills/frontend-design-review`
+- **Requested:** `commit` `e58528db9a006528a5fb0a2c029790fa6a9a7c0e` (declaration intent)
+- **Resolved commit:** `e58528db9a006528a5fb0a2c029790fa6a9a7c0e`
+- **Content checksum:** `sha256:66aa155ca3da88f51b2d03377d0d6009eccf9eecd7a36e4a13a7240d1474b67f`
+- **Observed license:** `MIT` source_path=`skills/design/frontend-design-review/LICENSE` checksum=`sha256:d9a1b1e30d633d5732ea18e3cba9538d293ebc53e1a9e4e96ab739e0c5c4f1cb`
+  - Declaration expected `license: MIT` — mismatch requires review
+- **Resolved at:** `2026-08-11T17:12:46.950377Z` version=`e58528d`
 
 ## `design/web-design-guidelines`
 

--- a/skills/design/frontend-design-review/LICENSE
+++ b/skills/design/frontend-design-review/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/skills/design/frontend-design-review/SKILL.md
+++ b/skills/design/frontend-design-review/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: frontend-design-review
+description: >
+  Review and create distinctive, production-grade frontend interfaces with high design
+  quality and design system compliance. Evaluates using three pillars: frictionless
+  insight-to-action, quality craft, and trustworthy building.
+origin:
+  type: upstream
+upstream:
+  repository: microsoft/skills
+  path: .github/skills/frontend-design-review
+  ref: e58528db9a006528a5fb0a2c029790fa6a9a7c0e
+  license: MIT
+  version: e58528d
+trust:
+  tier: reviewed
+  reviewed_at: '2026-08-11'
+  reviewed_by: ulises-jeremias
+  reviewed_provenance: sha256:5394cd7cf5d9c56acd77c251da40cb603795ac5e5b4d817578991d12d57d2be7
+maintenance:
+  status: active
+  last_activity: '2026-08-11'
+distribution:
+  mode: vendored
+  redistribution_allowed: true
+security:
+  scripts: false
+  shell: false
+  network: false
+  mcp: []
+  hooks: []
+  dangerous_permissions: []
+  cve_policy: not-applicable
+---
+
+# Frontend Design Review
+
+> **Frozen vendored snapshot** of `microsoft/skills` `.github/skills/frontend-design-review` at `e58528d` (commit `e58528db9a006528a5fb0a2c029790fa6a9a7c0e`, MIT) per ADR-0001 declaration→lock→vendored→surfaces. All references are local `references/` — no runtime network fetch. See `capabilities/upstream.lock` `design/frontend-design-review` and `docs/UPSTREAM.md`.
+
+Review UI implementations against design quality standards and your design system **OR** create distinctive, production-grade frontend interfaces from scratch.
+
+## Two Modes
+
+### Mode 1: Design Review
+Evaluate existing UI for design system compliance, three quality pillars (Frictionless, Quality Craft, Trustworthy), accessibility, and code quality.
+
+### Mode 2: Creative Frontend Design
+Create distinctive interfaces that avoid generic "AI slop" aesthetics, have clear conceptual direction, and execute with precision.
+
+---
+
+## Creative Frontend Design
+
+Before coding, commit to an aesthetic direction:
+- **Purpose**: What problem does this solve? Who uses it?
+- **Tone**: minimal, maximalist, retro-futuristic, organic, luxury, playful, editorial, brutalist, art deco, soft/pastel, industrial, etc.
+- **Constraints**: Framework, performance, accessibility requirements.
+- **Differentiation**: What makes this distinctive and context-appropriate?
+
+### Aesthetics Guidelines
+
+- **Typography**: Distinctive fonts that elevate aesthetics. Pair a display font with a refined body font. Avoid Inter, Roboto, Arial, Space Grotesk.
+- **Color & Theme**: Cohesive palette with CSS variables. Dominant colors + sharp accents > timid, evenly-distributed palettes.
+- **Motion**: CSS-only preferred. One well-orchestrated page load with staggered reveals > scattered micro-interactions.
+- **Spatial Composition**: Asymmetry, overlap, diagonal flow, grid-breaking elements, generous negative space OR controlled density.
+- **Backgrounds**: Gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, grain overlays.
+
+**AVOID**: Overused fonts, cliched color schemes, predictable layouts, cookie-cutter design without context-specific character.
+
+Match implementation complexity to vision. Maximalist = elaborate code. Minimalist = restraint and precision.
+
+---
+
+## Design Review
+
+### Design System Workflow
+
+**Before implementing:**
+1. Review component in your Storybook / component library for API and usage
+2. Use Figma Dev Mode to get exact specs (spacing, tokens, properties)
+3. Implement using design system components + design tokens
+
+**During review:**
+1. Compare implementation to Figma design
+2. Verify design tokens are used (not hardcoded values)
+3. Check all variants/states are implemented correctly
+4. Flag deviations (needs design approval)
+
+**If component doesn't exist:**
+1. Check if existing component can be adapted
+2. Reach out to design for new component creation
+3. Document exception and rationale in code
+
+### Review Process
+
+1. Identify user task
+2. Check design system for matching patterns
+3. Evaluate aesthetic direction
+4. Identify scope (component, feature, or flow)
+5. Evaluate each pillar
+6. Score and prioritize issues (blocking/major/minor)
+7. Provide recommendations with design system examples
+
+### Core Principles
+
+- **Task completion**: Minimum clicks. Every screen answers "What can I do?" and "What happens next?"
+- **Action hierarchy**: 1-2 primary actions per view. Progressive disclosure for secondary.
+- **Onboarding**: Explain features on introduction. Smart defaults over configuration.
+- **Navigation**: Clear entry/exit points. Back/cancel always available. Breadcrumbs for deep flows.
+
+---
+
+## Quality Pillars
+
+### 1. Frictionless Insight to Action
+
+**Evaluate:** Task completable in ≤3 interactions? Primary action obvious and singular?
+
+**Red flags:** Excessive clicks, multiple competing primary buttons, buried actions, dead ends.
+
+### 2. Quality is Craft
+
+**Evaluate:**
+- Design system compliance: matches Figma specs, uses design tokens
+- Aesthetic direction: distinctive typography, cohesive colors, intentional motion
+- Accessibility: Grade C minimum (WCAG 2.1 A), Grade B ideal (WCAG 2.1 AA)
+
+**Red flags:** Generic AI aesthetics, hardcoded values, implementation doesn't match Figma, broken reflow, missing focus indicators.
+
+### 3. Trustworthy Building
+
+**Evaluate:**
+- AI transparency: disclaimer on AI-generated content
+- Error transparency: actionable error messages
+
+**Red flags:** Missing AI disclaimers, opaque errors without guidance.
+
+---
+
+## Review Output Format
+
+See [references/review-output-format.md](references/review-output-format.md) for the full review template.
+
+## Review Type Modifiers
+
+See [references/review-type-modifiers.md](references/review-type-modifiers.md) for context-specific review focus areas (PR, Creative, Design, Accessibility).
+
+## Quick Checklist
+
+See [references/quick-checklist.md](references/quick-checklist.md) for the pre-approval checklist covering design system compliance, aesthetic quality, frictionless, quality craft, and trustworthy pillars.
+
+## Pattern Examples
+
+See [references/pattern-examples.md](references/pattern-examples.md) for good/bad examples of creative frontend and design system review work.
+
+---
+
+## Acknowledgments
+
+Creative frontend principles inspired by [Anthropic's frontend-design skill](https://github.com/anthropics/skills/tree/main/skills/frontend-design). Design review principles and quality pillar framework created by [@Quirinevwm](https://github.com/Quirinevwm) for systematic UI evaluation.
+
+
+---
+
+## Toolkit integration
+
+### Delegation — visual critique vs project health
+
+| Concern | Owner skill | What it does | When to use |
+|---------|-------------|--------------|-------------|
+| Project health (tech/mgmt) | `technical-unit-assessment` + `project-assessment-evidence` | Evidence-based 1–5 scoring of repo/platform/infra units; no visual judgment | Repo health, CI, security posture |
+| Design orchestration | `design-assessment` (planned #373, per ADR-0002 Option A) | Orchestrates discovery→inspect→capture→visual/UX/a11y/responsive/DS/AI-slop/perf→findings→roadmap; reuses evidence semantics; fans out to reviewers | Full product design audit |
+| Procedural visual critique | **`frontend-design-review`** (this skill) | Checklist evaluation of hierarchy, design-system compliance, three pillars (frictionless / quality craft / trustworthy), a11y, responsive, polish, AI-slop — outputs severity-ranked findings with citations | PR review, component review, creative frontend kickoff |
+| Distinctive visual direction | `frontend-design` | Studio-lead aesthetic choice, palette/type/layout thesis | New UI creation with intentional style |
+
+**This skill does not score project health.** For project health use `technical-unit-assessment`. For full design product audit, `design-assessment` will delegate to this skill for the procedural visual pass, alongside `web-design-guidelines` (Web Interface Guidelines rules) and browser/accessibility/Figma reviewers.
+
+### Evidence-cited findings — no fake scores
+
+- Never emit numeric scores (e.g. `72/100`) without observable evidence. Use **severity bands** `Blocking / Major / Minor` with `confidence` and `evidence` per finding, reusing `project-assessment-evidence` semantics where applicable.
+- Every issue must cite: **observation** (what you saw — screenshot region, code line, token mismatch), **impact** (user/task consequence), **effort**, and **recommended fix** with design-system link or token reference.
+- Mark indicators as **Not assessed** when screenshot/code unavailable rather than inventing a rating. Vision harness unavailable → text-only heuristic review with lower confidence, explicitly flagged.
+
+### Wiring to `design-assessment` (planned)
+
+This skill is a **delegate of `design-assessment`**. The orchestrator (see #373) will call it during the `VISUAL REVIEW` phase, passing captured screens/states (Playwright) and design-system manifest (Figma tokens / Storybook / Tailwind). It runs in parallel with `accessibility` / `web-design-guidelines` reviewers where the harness supports subagents, otherwise sequentially. Future `design-assessment` will document the full routing.
+
+### Provenance
+
+- Upstream: `microsoft/skills` `.github/skills/frontend-design-review` + `references/*` at `e58528db9a006528a5fb0a2c029790fa6a9a7c0e` (MIT), `LICENSE` vendored here as `LICENSE`.
+- Lock: `capabilities/upstream.lock` `design/frontend-design-review` `provenance_digest` (commit + content_checksum + license), `trust.reviewed_provenance` binding.
+- References vendored: `references/review-output-format.md`, `references/review-type-modifiers.md`, `references/quick-checklist.md`, `references/pattern-examples.md` — byte-identical to upstream at pinned commit.
+- Update: `pull-request` per `resolved_at`; never fetch `main` at runtime.
+

--- a/skills/design/frontend-design-review/references/pattern-examples.md
+++ b/skills/design/frontend-design-review/references/pattern-examples.md
@@ -1,0 +1,21 @@
+# Pattern Examples
+
+## Creative Frontend (New Interfaces)
+
+### Good: Clear Aesthetic Direction
+- Landing page with brutalist aesthetic: Raw typography (Neue Haas Grotesk), stark black and white, asymmetric layouts
+- Dashboard with organic theme: Rounded forms, earth tones, flowing animations, textured backgrounds
+
+### Bad: Generic AI Aesthetic
+- Overused fonts, cliched color schemes, centered content, generic card layouts
+
+## Design System Review (Existing Work)
+
+### Good: Frictionless
+- Single primary button, clear task completion path
+
+### Good: Quality Craft
+- Uses design system with tokens, distinctive typography, keyboard accessible, tested in themes
+
+### Bad: Quality Craft
+- Hardcoded values, generic overused fonts, poor contrast in dark mode

--- a/skills/design/frontend-design-review/references/quick-checklist.md
+++ b/skills/design/frontend-design-review/references/quick-checklist.md
@@ -1,0 +1,38 @@
+# Quick Checklist
+
+Before approving any UI work:
+
+## Design System Compliance
+- [ ] Component verified in your Figma Design System
+- [ ] Component implementation checked in your Component Library
+- [ ] Figma Dev Mode specs followed (spacing, tokens, typography)
+- [ ] Design tokens used (no hardcoded hex colors or pixel values)
+- [ ] Token imports verified in code
+- [ ] All variants/states implemented as designed in Figma
+- [ ] Spacing measurements match Figma Dev Mode exactly
+- [ ] Deviations documented with design approval
+
+## Aesthetic Quality (especially for new designs)
+- [ ] Clear conceptual direction (not generic overused fonts and cliched schemes)
+- [ ] Distinctive typography (avoid overused fonts)
+- [ ] Cohesive color palette with CSS variables
+- [ ] Intentional motion (staggered reveals, hover states)
+- [ ] Visual interest through composition (asymmetry, overlap, grid-breaking)
+- [ ] Atmosphere through backgrounds (gradients, textures, patterns)
+- [ ] Implementation complexity matches vision
+
+## Frictionless
+- [ ] Core task completable efficiently (≤3 interactions)
+- [ ] Single clear primary action per view
+
+## Quality Craft
+- [ ] Uses design system components (verified in Figma)
+- [ ] Design tokens used (no hardcoded values)
+- [ ] Distinctive aesthetic (not generic overused fonts/cliched schemes)
+- [ ] Accessible (Grade C minimum, Grade B ideal)
+- [ ] Keyboard navigation complete
+- [ ] Tested in light/dark/high contrast modes
+
+## Trustworthy
+- [ ] AI-generated content has disclaimer
+- [ ] Error messages are actionable

--- a/skills/design/frontend-design-review/references/review-output-format.md
+++ b/skills/design/frontend-design-review/references/review-output-format.md
@@ -1,0 +1,68 @@
+# Review Output Format
+
+```
+## Frontend Design Review: [Component/Feature Name]
+
+### Context
+- **Purpose**: What problem does this solve? Who uses it?
+- **Aesthetic Direction**: [If new design: describe the bold conceptual direction]
+- **User Task**: What is the user trying to accomplish?
+
+### Summary
+[Pass/Needs Work/Blocked] - [One-line assessment]
+
+### Design System Compliance (if applicable)
+- [ ] Component exists in [Your Figma Design System]
+- [ ] Component usage verified in [Your Component Library]
+- [ ] Implementation matches Figma specs (spacing, colors, typography)
+- [ ] Uses design tokens (not hardcoded values) - verified in code
+- [ ] All variants match design system options
+- [ ] Spacing verified against Figma Dev Mode
+- [ ] Documented exception if deviating from design system
+
+### Aesthetic Quality (especially for new designs)
+- [ ] Clear conceptual direction (not generic AI aesthetic)
+- [ ] Distinctive typography choices
+- [ ] Cohesive color palette with CSS variables
+- [ ] Intentional motion and micro-interactions
+- [ ] Spatial composition creates visual interest
+- [ ] Backgrounds and visual details add atmosphere
+
+### Pillar Assessment
+
+| Pillar | Status | Notes |
+|--------|--------|-------|
+| Frictionless | 🟢/🟠/⚫ | Task completion efficient, primary action clear |
+| Quality Craft | 🟢/🟠/⚫ | Design system compliant, aesthetic distinctive, accessible |
+| Trustworthy | 🟢/🟠/⚫ | AI disclaimers present, errors actionable |
+
+**Legend:** 🟢 Pass | 🟠 Needs attention | ⚫ Blocking issue
+
+### Design Critique
+**Verdict:** [Pass / Needs work / Reach out to design for more support]
+
+**Rationale:** [Brief explanation based on pillar assessment, design system compliance, and aesthetic direction]
+
+**Criteria:**
+- **Pass**: All pillars 🟢 or minor 🟠 that don't block user tasks, design system compliant, clear aesthetic direction
+- **Needs work**: Multiple 🟠 or any critical workflow issues, design system deviations, or generic aesthetic choices
+- **Reach out to design for more support**: Any ⚫ blocking issues, fundamental pattern problems, major design system violations, or need for aesthetic direction
+
+### Issues
+
+**Blocking (must fix before merge):**
+1. [Pillar/Design System/Aesthetic] Issue description + recommendation with link
+
+**Major (should fix):**
+1. [Pillar/Design System/Aesthetic] Issue description + pattern suggestion with reference
+
+**Minor (consider for refinement):**
+1. [Pillar/Design System/Aesthetic] Issue description + optional improvement
+
+### Recommendations
+- [Design system component to use with link]
+- [Specific code change with design token reference]
+- [Typography recommendation for better aesthetic direction]
+- [Motion/animation suggestion]
+- [Link to design system in Figma]
+```

--- a/skills/design/frontend-design-review/references/review-type-modifiers.md
+++ b/skills/design/frontend-design-review/references/review-type-modifiers.md
@@ -1,0 +1,31 @@
+# Review Type Modifiers
+
+Adjust focus based on review context:
+
+## PR Review
+- **Focus**: Code implementation, design system component usage, design token usage, accessibility in code
+- **Check**: Proper imports, design tokens used (not hardcoded), ARIA attributes present
+- **Verify**: Component matches Figma specs using Dev Mode
+
+## Creative Frontend Review
+- **Focus**: Aesthetic direction, typography choices, visual distinctiveness, motion design
+- **Check**: Clear conceptual intent, avoiding generic AI patterns, cohesive execution
+- **Verify**: Implementation complexity matches vision (maximalist needs elaborate code, minimalist needs precision)
+
+## Design Review
+- **Focus**: User flows, interaction patterns, visual hierarchy, navigation, design system alignment
+- **Check**: Task completion path, action hierarchy, progressive disclosure
+- **Verify**: All components exist in design system or have documented exceptions
+
+## Accessibility Audit
+- **Focus**: Deep dive Quality Craft pillar
+- **Check**: Keyboard testing, screen reader testing, contrast ratios, ARIA patterns
+- **Test with**: Screen readers (NVDA, JAWS, Narrator), keyboard only, 200% zoom
+- **Verify**: Design system accessibility features are properly implemented
+
+## Design System Compliance Audit
+- **Focus**: Deep dive design system usage
+- **Check**: All components match Figma specs, design tokens used throughout, no hardcoded values
+- **Test**: Compare implementation side-by-side with Figma using Dev Mode
+- **Verify**: Component variants, spacing, colors, typography all match design system
+- **Document**: Any deviations with rationale and plan to align

--- a/tests/test_provenance_lock.py
+++ b/tests/test_provenance_lock.py
@@ -379,10 +379,11 @@ def test_first_party_omitted_from_lock():
     # 61 first-party skills must not appear — lock is sparse
     assert "core/assistant" not in lock["capabilities"], "first-party must not be in lock"
     assert "core/onboarding" not in lock["capabilities"]
-    # Only upstream with external content — now 2 vendored (frontend-design + web-design-guidelines)
+    # Only upstream with external content — now 3 vendored (frontend-design + frontend-design-review + web-design-guidelines)
     assert "design/frontend-design" in lock["capabilities"]
+    assert "design/frontend-design-review" in lock["capabilities"]
     assert "design/web-design-guidelines" in lock["capabilities"]
-    assert len(lock["capabilities"]) == 2, "lock should be sparse: 63 skills → 2 upstream vendored"
+    assert len(lock["capabilities"]) == 3, "lock should be sparse: 64 skills → 3 upstream vendored"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #391

## What
Adapt Microsoft `frontend-design-review` (`microsoft/skills` `.github/skills/frontend-design-review`) as portable vendored skill per ADR-0001.

## Upstream provenance (frozen, machine-verifiable)
- **repo** `microsoft/skills` @ `e58528db9a006528a5fb0a2c029790fa6a9a7c0e` (`git+https://github.com/microsoft/skills.git#e58528d`), MIT (LICENSE vendored `sha256:d9a1b1e30...`)
- **path** `.github/skills/frontend-design-review` — SKILL.md frozen `sha256:66aa155ca...` (Toolkit frontmatter + body), `provenance_digest sha256:5394cd7cf5d9c56acd77c251da40cb603795ac5e5b4d817578991d12d57d2be7`
- **references** vendored byte-identical at pinned commit:
  - `references/review-output-format.md`
  - `references/review-type-modifiers.md`
  - `references/quick-checklist.md`
  - `references/pattern-examples.md`

No runtime `main` fetch — all `references/*` local. See `capabilities/upstream.lock` `design/frontend-design-review` and `docs/UPSTREAM.md` (3 capabilities, 4 sources).

## Adaptation vs pure copy
- Added frozen vendored banner + provenance section
- Kept three-pillar framework (Frictionless / Quality Craft / Trustworthy), design-system workflow, creative/frontend modes
- Made portable: no tool-specific paths, references are relative
- Acknowledgments preserved: @Quirinevwm pillars + Anthropic frontend-design inspiration

## Toolkit integration (acceptance criteria)
- **Delegation table** vs `technical-unit-assessment` (project health, evidence 1-5) vs `design-assessment` (orchestrator, planned #373 per ADR-0002 Option A) vs this procedural critique vs `frontend-design` (distinctive direction)
- **Evidence-cited findings**: Blocking/Major/Minor + confidence + observation/impact/effort/fix, reusing `project-assessment-evidence` semantics, no fake `72/100`, `Not assessed` when screenshot unavailable, vision-required fallback documented
- **Wired as delegate of `design-assessment`** (planned): called during VISUAL REVIEW phase, parallel with `web-design-guidelines` / accessibility / browser reviewers

## Distribution / security
`distribution.retrieval: vendored` `redistribution_allowed: true` (MIT), `security.cve_policy: not-applicable`, no scripts/shell/network/mcp/hooks — prompt-only review.

## Surfaces regenerated
`catalogs/skill-catalog.yaml` 63→64, `distributions/products.yaml` (+design/frontend-design-review in agent-toolkit-complete), `docs/SKILL_PRODUCT_MATRIX.md`, `docs/UPSTREAM.md`, `capabilities/upstream.lock` v2.

## Audit / validation
`validate-upstream 64 checked 0 error`, `provenance check/lock --check` green, `validate-skills` 64 OK, `audit` 1 low (hook), `ruff` green, `pytest` 785 passed 1 skipped (test `first_party_omitted` updated 2→3).

## Runner
Muse

## Checklist
- [x] Pinned SHA + per-source checksum/license + LICENSE
- [x] Vendored frozen copies (SKILL.md + 4 references)
- [x] No runtime fetch
- [x] Delegation table + evidence guidance + wiring documented
- [x] Generated files in sync, tests green
