### PR TITLE
feat(design): add design-assessment orchestration (Closes #373)

### DIFF
--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,6 +1,6 @@
 version: 1
 generated: true
-count: 64
+count: 65
 skills:
   - id: agentic-security/supply-chain-audit
     name: supply-chain-audit
@@ -216,6 +216,13 @@ skills:
     description: 'WHAT — Generic client delivery: Jira or ClickUp, full repo context,
       human gates, English traceability on tickets, draft PR via delegated forge skills.
       Use workspace packs for client/account overlays.'
+    stability: stable
+  - id: design/design-assessment
+    name: design-assessment
+    domain: design
+    description: WHAT - Evidence-based design-unit assessment orchestrated by project-assessment.
+      Evaluates visual hierarchy, UX friction, interaction, a11y, responsiveness,
+      design-system compliance, and distinctivene
     stability: stable
   - id: design/figma
     name: figma

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -138,6 +138,7 @@ products:
         - design/figma-create-design-system-rules
         - design/figma-create-new-file
         - design/figma-implement-design
+        - design/design-assessment
         - design/frontend-design
         - design/frontend-design-review
         - design/web-design-guidelines

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 64 skills × 16 agents._
+_Generated from 4 products × 65 skills × 16 agents._
 
 ## Products and targets
 
@@ -11,7 +11,7 @@ _Generated from 4 products × 64 skills × 16 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 64 | 0 |
+| `agent-toolkit-complete` | experimental | — | 65 | 0 |
 
 ## Skills → Products
 
@@ -49,6 +49,7 @@ _Generated from 4 products × 64 skills × 16 agents._
 | `delivery/work-item` | `agent-toolkit-complete` | — |
 | `delivery/workflow-client-bootstrap` | `agent-toolkit-complete` | — |
 | `delivery/workflow-generic-project` | `agent-toolkit-complete` | — |
+| `design/design-assessment` | `agent-toolkit-complete` | — |
 | `design/figma` | `agent-toolkit-complete` | — |
 | `design/figma-code-connect-components` | `agent-toolkit-complete` | — |
 | `design/figma-create-design-system-rules` | `agent-toolkit-complete` | — |

--- a/skills/design/design-assessment/SKILL.md
+++ b/skills/design/design-assessment/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: design-assessment
+description: WHAT - Evidence-based design-unit assessment orchestrated by project-assessment. Evaluates visual hierarchy, UX friction, interaction, a11y, responsiveness, design-system compliance, and distinctiveness with severity/confidence evidence citations. Reuses project-assessment-evidence semantics — no second framework.
+origin:
+  type: first-party
+---
+
+# Design Assessment (WHAT)
+
+Assess a product's interface as a **design unit** delegated by `project-assessment`. Use this skill when the user asks for a design audit, visual review, UX assessment, accessibility evaluation, design-system compliance check, or distinctive-identity review.
+
+**Router contract (ADR-0002 Option A):** `project-assessment` collects evidence via `project-assessment-evidence`, then delegates to this skill alongside `technical-unit-assessment` / `management-unit-assessment` when UI/design is in scope. This skill is also directly invokable for single-page or multi-screen UI audits. It **reuses** the single evidence framework — do not re-ask evidence already in the map.
+
+## Default guardrails
+
+1. Apply **`project-assessment-evidence`** before scoring. If calling via `project-assessment`, reuse its evidence map — do not duplicate intake questions.
+2. Apply **`output-handshake`** before producing any final design assessment report, scorecard, or roadmap.
+3. **Never assign a maturity score without evidence.** If evidence is missing, mark the indicator as **Not assessed** or score with **Low confidence** and state the assumption. Never emit fake precision like `72/100` — use rating bands + severity/confidence.
+4. **Screenshots must not capture secrets.** Observe-only, L1. Redact private data. Keep sensitive details out of reusable artifacts.
+5. **Generic-template risk (distinctiveness)** must be context-aware — `rounded cards = bad` is not a rule. Evaluate whether the aesthetic is distinctive for *this* product's subject and tone, not via a checklist.
+6. **Vision fallback:** This skill is `vision-required` for full visual critique. If the harness cannot render screenshots/recordings, perform a text-only heuristic review (code, tokens, a11y attributes) and flag each finding with **Low confidence — vision unavailable**.
+
+## Design-unit intake
+
+Ask before scoring (or reuse from router evidence map):
+
+- **Product & purpose:** product name, audience, single job the page/ flow does
+- **Scope:** screens/flows/components in scope, Figma files / variables, Storybook, Tailwind/config, design-system entry points
+- **Repositories & assets:** app repo(s), component library, token files, asset locations
+- **Systems of record for design evidence:** Figma, Storybook, WCAG reports, performance reports, screenshots, recordings, product analytics, UX research
+- **Assessment period & audience:** who will act on findings
+- **Decision ownership:** who validates subjective visual judgments
+
+Evidence sources already covered by `project-assessment-evidence` include: `design files, UX research, accessibility reports, performance reports, screenshots, recordings, product analytics` — ask where each lives instead of assuming.
+
+## Orchestration workflow
+
+```
+UNDERSTAND PRODUCT → DISCOVER DESIGN SYSTEM → INSPECT APP → CAPTURE SCREENS/STATES
+  → VISUAL REVIEW → UX REVIEW → A11Y → RESPONSIVE → DESIGN-SYSTEM CONSISTENCY
+  → DISTINCTIVENESS → PERF → FIGMA COMPARE → PRIORITIZED FINDINGS → ROADMAP
+```
+
+### Phase 1 — Understand & Discover
+
+1. **Understand product:** audience, job-to-be-done, tone, constraints (framework, performance, a11y target WCAG 2.2 AA). Ask the user if not in evidence map.
+2. **Discover design system:** locate tokens (Figma variables, Style Dictionary, Tailwind config, CSS variables), component library (Storybook), Figma Dev Mode specs. Record freshness and owner per `project-assessment-evidence` quality rules (Direct/Indirect/Stale/Missing).
+
+### Phase 2 — Inspect & Capture
+
+3. **Inspect app:** verify app builds and routes enumerated in scope; enumerate states (empty, loading, error, dense, mobile).
+4. **Capture screens/states:** use `playwright-cli` (or Chrome DevTools) to screenshot each screen/state at breakpoints (mobile, tablet, desktop). If capturing elsewhere, delegate to `browser` reviewer. Record capture metadata (viewport, theme, date) as evidence.
+
+### Phase 3 — Parallel review (vision where possible)
+
+Fan out where the harness supports subagents — shared evidence map is authority; sequential fallback is always valid:
+
+| Reviewer | Delegates to | Focus |
+|----------|--------------|-------|
+| Visual / hierarchy | `frontend-design-review` | Layout, typography, color, motion, three pillars (Frictionless / Quality Craft / Trustworthy), design-system compliance vs Figma tokens |
+| UX friction | `web-design-guidelines` + heuristic | Interaction path ≤3 steps, single primary action, progressive disclosure, onboarding |
+| A11y | `accessibility` / `frontend-design-review` (a11y modifier) | Keyboard, screen reader, contrast (WCAG 2.2 A = Grade C, AA = Grade B), 200% zoom, light/dark/high-contrast |
+| Responsive | `playwright-cli` + `frontend-design-review` | Reflow, token usage not hardcoded values, variants/states |
+| Design-system consistency | `figma` / `figma-implement-design` + tokens | Token usage, spacing vs Figma Dev Mode, deviations with rationale |
+| Distinctiveness | `frontend-design` + `frontend-design-review` (creative mode) | Aesthetic direction distinctive for this subject, avoids generic AI template |
+| Performance (UI) | `playwright-cli` / Chrome DevTools | Load, reflow, motion cost (CSS-only preferred) — citation not synthetic score |
+
+**Swarm mapping (advisory):** `design-assessment: a11y-reviewer || visual-reviewer || browser-perf-reviewer || design-system-reviewer` (shared evidence map). Sequential execution produces identical findings — only slower.
+
+For each finding see **Scorecard & findings** below.
+
+### Phase 4 — Figma compare
+
+5. Compare implementation side-by-side with Figma using Dev Mode specs: spacing, typography, color, variants. Document deviations with link and whether design approval exists.
+
+### Phase 5 — Findings & Roadmap
+
+6. **Prioritize findings** by `severity × user impact × effort` with confidence. Separate confirmed vs assumed vs missing-evidence.
+7. **Roadmap:** group by `quick win / next sprint / needs design`. Do not create tickets or update docs without explicit user approval — delegate ticket creation to the relevant ticket skill after approval.
+8. **Output handshake** before final artifact.
+
+## Scorecard & findings (no fake precision)
+
+Use the 1–5 scale from `technical-unit-assessment` `references/indicator-groups.md` **only where an indicator has evidence**. Score 3 = defined/partially mature. Record confidence per score (High/Medium/Low/Not assessed) and evidence link. Do not average unrelated indicators without explaining weighting.
+
+Prefer **severity bands** for actionable review output (from `frontend-design-review`):
+
+- **Blocking** — must fix before merge/release (user task broken, WCAG failure, design-system violation)
+- **Major** — should fix (measurable UX friction, generic aesthetic without direction)
+- **Minor** — consider for refinement
+
+### Design indicators (1–5, Not assessed if missing evidence)
+
+| Indicator | What to observe (evidence) |
+|-----------|----------------------------|
+| Visual identity / distinctiveness | Typography pair, palette with CSS variables, spatial composition, motion; distinctive for *this* subject, not a template |
+| Hierarchy & layout | Information structure, primary action per view, progressive disclosure, spacing vs tokens |
+| UX friction / interaction | Task completion steps, navigation entry/exit, onboarding, error messages actionable |
+| Consistency | Component reuse, token usage, variants/states match Figma |
+| A11y | Contrast, keyboard, screen reader, ARIA, 200% zoom, theme testing |
+| Responsiveness | Breakpoints, reflow, no hardcoded values |
+| Design-system compliance | Matches Figma specs, no deviation without rationale |
+| Performance (UI) | Motion orchestrated, not scattered; CSS-only preferred where possible |
+
+### Per-finding record
+
+Every finding must cite:
+
+- **Observation** — what you saw (screen/region, code line `file:line`, token mismatch, screenshot anchor)
+- **Impact** — user/task consequence
+- **Effort** — S/M/L
+- **Confidence** — High/Medium/Low (downgrade to Low if vision unavailable)
+- **Affected screens / components**
+- **Recommended fix** — design-system link or token reference or Figma link
+- **Evidence** — link to screenshot, Figma node, WCAG run, Storybook entry
+- **Severity** — Blocking / Major / Minor
+
+See `references/design-scorecard-template.md` for the full template. Mark **Not assessed** when screenshot/code unavailable rather than inventing a rating.
+
+## Delegation table
+
+| Need | Skill |
+|------|-------|
+| Evidence intake (single framework) | `project-assessment-evidence` |
+| Multi-unit routing (technical/mgmt/design) | `project-assessment` |
+| Procedural visual critique (three pillars, checklist) | `frontend-design-review` (delegate of this skill — Visual Review phase) |
+| Web Interface Guidelines rules (a11y, focus, forms, animation) | `web-design-guidelines` (frozen `references/web-interface-guidelines.md`) |
+| Screenshot & browser states | `playwright-cli` / Chrome DevTools |
+| Figma variables / Dev Mode compare | `figma` / `figma-implement-design` / `figma-create-design-system-rules` |
+| Distinctive visual direction | `frontend-design` |
+| Repository discovery | `assistant` |
+| Final output gate | `output-handshake` |
+| Parallel large-product review | `swarm` (optional; sequential fallback valid) |
+
+## Security & compatibility
+
+- No mutation; observe-only. Screenshots must not capture secrets — coordinate capture scope.
+- Portable: no tool-specific paths (uses local `references/` and evidence map).
+- Swarm optional; vision gracefully degrades to text-only heuristic with lower confidence.
+
+## References
+
+- `references/design-scorecard-template.md` — design-unit scorecard + findings template (this skill)
+- `project-assessment` — router and scope (delegates to this skill)
+- `project-assessment-evidence` — evidence map and source-by-source intake (single framework)
+- `technical-unit-assessment` + `references/indicator-groups.md` — 1–5 scale, confidence, Not assessed, output-handshake contract
+- `frontend-design-review` — pillar assessment and review-output format (delegate)
+- `web-design-guidelines` — Web Interface Guidelines frozen reference
+- `playwright-cli` / `figma` — capture and compare
+

--- a/skills/design/design-assessment/references/design-scorecard-template.md
+++ b/skills/design/design-assessment/references/design-scorecard-template.md
@@ -1,0 +1,78 @@
+# Design Assessment Scorecard Template
+
+**Product:** [name]  **Period:** [dates]  **Assessor:** [name]  
+**Purpose:** [baseline / periodic / due-diligence]  **Audience:** [who acts]  
+**Evidence map:** [link to project-assessment-evidence artifact]  **Figma:** [link]  **Storybook:** [link]
+
+> Uses 1–5 scale from `technical-unit-assessment` `references/indicator-groups.md` (3 = defined). Confidence High/Medium/Low/Not assessed. Never score without evidence — use Not assessed. Findings use Blocking/Major/Minor.
+
+## Evidence summary (from evidence map)
+
+| Source | Location | Freshness | Strength (Direct/Indirect/Stale/Missing) | Confidence | Indicators |
+|--------|----------|-----------|------------------------------------------|------------|------------|
+| Figma  | [link]   | [date]    | Direct                                   | High       | Visual identity, Consistency |
+| Screenshots (Playwright) | [path] | [date] | Direct | High | Hierarchy, A11y, Responsive |
+| WCAG report | [tool] | [date] | Indirect | Medium | A11y |
+| Performance trace | [path] | [date] | Indirect | Medium | Performance (UI) |
+
+## Design-unit scorecard (1–5, Not assessed if missing evidence)
+
+| Indicator | Score | Confidence | Evidence | Notes |
+|-----------|-------|------------|----------|-------|
+| Visual identity / distinctiveness | 3 / Not assessed | High / Low | [Figma node, screenshot] | [why] |
+| Hierarchy & layout |  |  |  |  |
+| UX friction / interaction |  |  |  |  |
+| Consistency |  |  |  |  |
+| A11y |  |  |  | WCAG 2.2 A = 3 (Grade C), AA = 4 (Grade B) |
+| Responsiveness |  |  |  |  |
+| Design-system compliance |  |  |  |  |
+| Performance (UI) |  |  |  |  |
+
+**Overall:** [narrative, not averaged — explain weighting if combining]
+
+## Findings (severity-ranked, evidence-cited)
+
+### Blocking (must fix before merge/release)
+
+1. **[Pillar/Indicator] Title**
+   - **Observation:** [screen/region, file:line, token mismatch, screenshot anchor]
+   - **Impact:** [user/task consequence]
+   - **Effort:** S/M/L  **Severity:** Blocking  **Confidence:** High/Medium/Low
+   - **Affected:** [screens/components]
+   - **Recommended fix:** [design-system link, token, Figma node]
+   - **Evidence:** [screenshot, Figma, WCAG run]
+
+### Major (should fix)
+
+1. ...
+
+### Minor (consider)
+
+1. ...
+
+### Not assessed (missing evidence)
+
+| Indicator | Reason | What would enable assessment |
+|-----------|--------|------------------------------|
+| [e.g. A11y — screen reader] | No recording / report | Provide NVDA/JAWS run |
+
+## Missing evidence register
+
+| Indicator | Evidence needed | Location if exists | Owner |
+|-----------|-----------------|--------------------|-------|
+|  |  |  |  |
+
+## Roadmap
+
+| Priority | Finding | Effort | Owner | Evidence link |
+|----------|---------|--------|-------|---------------|
+| Quick win |  | S |  |  |
+| Next sprint |  | M |  |  |
+| Needs design |  | L |  |  |
+
+## Output handshake
+
+- **Destination:** [path/URL where artifact lives]
+- **Reviewer:** [who approves]
+- **Confirmed:** [date]
+

--- a/tests/test_provenance_lock.py
+++ b/tests/test_provenance_lock.py
@@ -383,7 +383,7 @@ def test_first_party_omitted_from_lock():
     assert "design/frontend-design" in lock["capabilities"]
     assert "design/frontend-design-review" in lock["capabilities"]
     assert "design/web-design-guidelines" in lock["capabilities"]
-    assert len(lock["capabilities"]) == 3, "lock should be sparse: 64 skills → 3 upstream vendored"
+    assert len(lock["capabilities"]) == 3, "lock should be sparse: 65 skills → 3 upstream vendored"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #373

## What
Evidence-based **design-unit assessment** per ADR-0002 Option A — `project-assessment` delegates to this skill alongside `technical/management-unit-assessment` when UI/design is in scope; also directly invokable.

## Router contract (ADR-0002)
- **Reuses single framework:** `project-assessment-evidence` evidence map (source link/owner/freshness/strength/confidence) + `technical-unit-assessment` 1–5 scale (3 = defined, Not assessed if missing, output-handshake). No second scoring model.
- Evidence model already lists `design files, UX research, accessibility reports, performance reports, screenshots, recordings, product analytics` — ask where each lives, do not re-ask if router already collected it.

## Orchestration
`UNDERSTAND PRODUCT → DISCOVER DESIGN SYSTEM (Figma variables, Tailwind, Storybook, tokens) → INSPECT APP → CAPTURE SCREENS/STATES (playwright-cli) → VISUAL/UX/A11Y/RESPONSIVE/DESIGN-SYSTEM/DISTINCTIVENESS/PERF → FIGMA COMPARE → FINDINGS → ROADMAP`

- **Parallel review (advisory):** `a11y-reviewer || visual-reviewer || browser-perf-reviewer || design-system-reviewer` with shared evidence map; sequential fallback valid. Model routing: vision-required vs reasoning-heavy maps to swarm `economy/balanced/quality`.

## Guardrails
- Never score without evidence; never emit fake precision `72/100` — use rating bands + severity `Blocking/Major/Minor` + `severity×impact×effort`.
- Distinctiveness context-aware (`rounded cards = bad` is not a rule).
- **Vision-required** with graceful fallback: text-only heuristic + Low confidence — vision unavailable.
- Screenshots observe-only, no secrets.

## Scorecard & findings
- Design indicators 1–5 (Visual identity / distinctiveness, Hierarchy & layout, UX friction / interaction, Consistency, A11y, Responsiveness, Design-system compliance, Performance UI) — each needs evidence link + confidence.
- Per-finding record: observation (screen/region, file:line, token mismatch), impact, effort S/M/L, confidence, affected screens/components, recommended fix (design-system/Figma link), evidence link, severity — plus missing-evidence register and roadmap quick-win/next-sprint/needs-design.
- Template: `references/design-scorecard-template.md`.

## Delegation table
| Need | Skill |
|------|-------|
| Evidence intake | `project-assessment-evidence` |
| Router | `project-assessment` |
| Visual critique (three pillars) | `frontend-design-review` |
| WIG rules | `web-design-guidelines` |
| Capture | `playwright-cli` / Chrome DevTools |
| Figma compare | `figma` / `figma-implement-design` |
| Distinctive direction | `frontend-design` |
| Output gate | `output-handshake` |

## Dependencies / upstream
Collaborates with `frontend-design-review` (#391 merged), `web-design-guidelines` (#372 merged), `playwright-cli`, `figma` — all present per ADR-0002.

## Validation
`validate-skills` 65 OK, `validate-upstream` 65 checked, `provenance check` OK (first-party — lock unchanged 3 caps), `ruff` green, `generate-catalogs/matrix` regenerated (65 skills, complete 65), `pytest` 785 passed.

## Runner
Muse

## Checklist
- [x] Reuses evidence semantics (no second framework)
- [x] Scorecard with evidence citations, no fake precision
- [x] Findings typed severity/impact/effort/confidence/component/screen/fix
- [x] Vision-required + fallback declared
- [x] Delegation table vs frontend-design-review / web-design-guidelines / playwright documented
