### PR TITLE
feat(tooling): add Chrome DevTools MCP provider (Closes #375)

### DIFF
--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,6 +1,6 @@
 version: 1
 generated: true
-count: 66
+count: 67
 skills:
   - id: agentic-security/supply-chain-audit
     name: supply-chain-audit
@@ -414,6 +414,13 @@ skills:
     domain: ops
     description: Workstation health triage — validate tooling, directory layout, and
       run doctor with remediation suggestions.
+    stability: stable
+  - id: tooling/chrome-devtools
+    name: chrome-devtools
+    domain: tooling
+    description: Use Chrome DevTools MCP to control and inspect a live Chrome instance
+      for network, console, performance, rendering, and Deep debugging. Pairs with
+      playwright-cli (deterministic interaction/E2E) — comp
     stability: stable
   - id: tooling/herdr
     name: herdr

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -165,6 +165,7 @@ products:
         - tooling/herdr
         - tooling/inventory
         - tooling/jupyter-notebook
+        - tooling/chrome-devtools
         - tooling/playwright-cli
         - core/project
         - core/workspace

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -33,6 +33,7 @@ Never substitute real credentials directly into the template files and commit th
 | Linear | HTTP/SSE | streamable_http | None (OAuth via browser) | Issues, projects, cycles, comments |
 | Figma | HTTP | streamable_http | `FIGMA_OAUTH_TOKEN`, `FIGMA_REGION` | Files, components, design tokens |
 | ClickUp | Command | stdio | `CLICKUP_API_TOKEN` | Tasks, lists, spaces, docs, comments |
+| Chrome DevTools | Command | stdio | None (opt `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS`, `CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS`) | Live Chrome: network, console, performance traces, rendering diagnostics |
 
 ---
 
@@ -295,3 +296,21 @@ Add MCP entries to Windsurf's MCP configuration file (typically `~/.codeium/wind
 - Never commit filled-in MCP config files containing real tokens to any repository
 
 The `validate-skills.sh` script scans for common secret patterns. It will warn if it detects what looks like a real token in any tracked file.
+
+### Chrome DevTools
+
+**Template:** `mcp/templates/chrome-devtools/config.template.json`
+**Registry:** `mcp/registry/chrome-devtools.yaml` (ChromeDevTools/chrome-devtools-mcp, Apache-2.0)
+
+```json
+{
+  "name": "chrome-devtools",
+  "command": "npx",
+  "args": ["-y", "chrome-devtools-mcp@latest"]
+}
+```
+
+**Setup:** See `skills/tooling/chrome-devtools/SKILL.md` for Playwright vs DevTools decision table and `mcp/templates/chrome-devtools/README.md` for host-specific wiring. `mcp/registry/chrome-devtools.yaml` documents provenance (official Google ChromeDevTools, npm `chrome-devtools-mcp`, Apache-2.0). Chrome DevTools MCP exposes all browser content — avoid sensitive pages. Usage stats enabled by default — opt out with `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=1` or `--no-usage-statistics`. Update checks ping npm — disable with `CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS=1`.
+
+**When to use:** `design-assessment` / `design-improvement` request `browser.performance / browser.network / browser.console / browser.runtime-debug` → Chrome DevTools; `browser.interact / browser.assert` → Playwright. Either alone is valid degraded mode.
+

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 66 skills × 16 agents._
+_Generated from 4 products × 67 skills × 16 agents._
 
 ## Products and targets
 
@@ -11,7 +11,7 @@ _Generated from 4 products × 66 skills × 16 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 66 | 0 |
+| `agent-toolkit-complete` | experimental | — | 67 | 0 |
 
 ## Skills → Products
 
@@ -79,6 +79,7 @@ _Generated from 4 products × 66 skills × 16 agents._
 | `ops/swarm-handoff` | `agent-toolkit-complete` | — |
 | `ops/swarm-observer` | `agent-toolkit-complete` | — |
 | `ops/triage` | `agent-toolkit-complete` | — |
+| `tooling/chrome-devtools` | `agent-toolkit-complete` | — |
 | `tooling/herdr` | `agent-toolkit-complete` | — |
 | `tooling/inventory` | `agent-toolkit-complete` | — |
 | `tooling/jupyter-notebook` | `agent-toolkit-complete` | — |

--- a/mcp/registry/chrome-devtools.yaml
+++ b/mcp/registry/chrome-devtools.yaml
@@ -7,7 +7,7 @@ display_name: Chrome DevTools
 purpose: Control and inspect a live Chrome instance — network, console, performance traces, rendering diagnostics, reliable automation via Puppeteer + DevTools protocol
 implementation:
   provenance: official
-  package: "npm:chrome-devtools-mcp"
+  package: "chrome-devtools-mcp@latest"
   repository: https://github.com/ChromeDevTools/chrome-devtools-mcp
   license: Apache-2.0
   version_policy: npx-latest

--- a/mcp/registry/chrome-devtools.yaml
+++ b/mcp/registry/chrome-devtools.yaml
@@ -1,0 +1,61 @@
+# MCP Provider: chrome-devtools
+# Research: https://github.com/ChromeDevTools/chrome-devtools-mcp (Apache-2.0, 48k+ stars, 2026-08-11)
+# Docs: https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md
+# npm: https://www.npmjs.com/package/chrome-devtools-mcp (npx -y chrome-devtools-mcp@latest)
+id: chrome-devtools
+display_name: Chrome DevTools
+purpose: Control and inspect a live Chrome instance — network, console, performance traces, rendering diagnostics, reliable automation via Puppeteer + DevTools protocol
+implementation:
+  provenance: official
+  package: "npm:chrome-devtools-mcp"
+  repository: https://github.com/ChromeDevTools/chrome-devtools-mcp
+  license: Apache-2.0
+  version_policy: npx-latest
+transport:
+  supported: [stdio]
+  preferred: stdio
+  command: npx
+  args: ["-y", "chrome-devtools-mcp@latest"]
+auth:
+  supported: [none]
+  preferred: none
+  env: [CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS, CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS, CI]
+  notes: No secrets — browser runs locally. Opt out of usage stats with --no-usage-statistics or env CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=1; update checks ping npm — disable with CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS=1
+tools:
+  read:
+    - take_snapshot
+    - take_screenshot
+    - list_console_messages
+    - list_network_requests
+    - get_network_request
+    - performance_start_trace
+    - performance_stop_trace
+    - performance_analyze_insight
+    - evaluate_script
+  write:
+    - navigate_page
+    - click
+    - fill
+    - drag
+    - hover
+    - press_key
+  destructive: []
+approval:
+  default: read-write
+  notes: Can inspect, debug, and modify any loaded page — treat as read-write (unlike Figma read-only)
+healthcheck:
+  strategy: tools-list
+  timeout_ms: 8000
+platforms:
+  claude-code: native
+  cursor: native
+  opencode: bridged
+  copilot-cli: native
+  gemini-cli: bridged
+  windsurf: manual
+  pi: bridged
+  codex: bridged
+security:
+  network_hosts: [registry.npmjs.org, chrome-devtools-mcp, mcp.chrome.devtools, crux.googleapis.com]
+  secret_storage: none
+  notes: Exposes all browser content to MCP client — avoid loading pages with personal/sensitive data without scoping. Usage stats enabled by default (Google) — opt out via --no-usage-statistics or env. Chrome for Testing / stable only officially supported.

--- a/mcp/templates/chrome-devtools/README.md
+++ b/mcp/templates/chrome-devtools/README.md
@@ -1,0 +1,57 @@
+# Chrome DevTools MCP — Template
+
+Official: [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) — Apache-2.0 — `npm:chrome-devtools-mcp`.
+
+## Quick start
+
+**Claude Code (plugin + skills, recommended):**
+```bash
+/plugin marketplace add ChromeDevTools/chrome-devtools-mcp
+/plugin install chrome-devtools-mcp@chrome-devtools-plugin
+```
+Restart Claude Code, check `/mcp` or `/skills`.
+
+**Claude Code (MCP-only):**
+```bash
+claude mcp add chrome-devtools -- npx -y chrome-devtools-mcp@latest
+```
+
+**Generic (Cline/Gemini/Codex):**
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+### Slim mode (smaller context)
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest", "--slim", "--headless"]
+    }
+  }
+}
+```
+
+## Flags
+
+- `--slim` — reduced tool set
+- `--headless` — headless Chrome
+- `--isolated` — per-session instance
+- `--browser-url=http://127.0.0.1:9222` — attach to existing Chrome
+- `--no-performance-crux` — disable CrUX fetch
+- `--no-usage-statistics` — opt out Google stats (or `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=1`, `CI=1` auto)
+- `--no-update-checks` — disable npm update ping (`CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS=1`)
+
+See `skills/tooling/chrome-devtools/SKILL.md` for Playwright vs DevTools decision table and `mcp/registry/chrome-devtools.yaml` for provenance.
+
+## Security
+
+DevTools exposes all browser content to the MCP client — avoid sensitive pages. Usage stats enabled by default — opt out as above. See skill for full boundaries.

--- a/mcp/templates/chrome-devtools/config.template.json
+++ b/mcp/templates/chrome-devtools/config.template.json
@@ -1,0 +1,6 @@
+{
+  "name": "chrome-devtools",
+  "command": "npx",
+  "args": ["-y", "chrome-devtools-mcp@latest"],
+  "env": {}
+}

--- a/skills/tooling/chrome-devtools/SKILL.md
+++ b/skills/tooling/chrome-devtools/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: chrome-devtools
+description: Use Chrome DevTools MCP to control and inspect a live Chrome instance for network, console, performance, rendering, and Deep debugging. Pairs with playwright-cli (deterministic interaction/E2E) — complements, not duplicates.
+origin:
+  type: first-party
+---
+
+# Chrome DevTools
+
+Control and inspect a **live Chrome** browser via the official `ChromeDevTools/chrome-devtools-mcp` (`chrome-devtools-mcp`, Apache-2.0) MCP server. Gives your coding agent the full power of Chrome DevTools for **runtime debugging, network inspection, performance analysis, and rendering diagnostics** — while `playwright-cli` remains the primary tool for deterministic interaction and E2E validation.
+
+> **Complementarity:** `playwright-cli` → deterministic `locator/snapshot/assert` workflows, multi-tab, traces, screenshots. `chrome-devtools` → network + console + performance traces + rendering diagnostics + Puppeteer-based reliable automation via DevTools. **Do not** re-implement Playwright flows via DevTools JSON-RPC; pick the right provider per capability (see decision table).
+
+## When to use which provider
+
+| Need | Use `playwright-cli` | Use `chrome-devtools` | Either |
+|------|----------------------|-----------------------|--------|
+| Click / fill / navigate deterministically | ✅ locators, `snapshot` → stable `eN` refs, fixtures | — |  |
+| Take screenshot of rendered state (verification required before declaring UI good) | ✅ `screenshot` + trace | ✅ `take_screenshot` + rendering inspection | ✅ |
+| Assert E2E condition / generate test | ✅ assertions, `e2e-runner` specs | — |  |
+| Inspect DOM / accessibility tree / computed styles | `snapshot` (a11y-aware) limited | ✅ DOM, a11y tree, style inspection |  |
+| Network requests / console messages / runtime debugging | limited | ✅ `list_network_requests`, console, source-mapped stack traces |  |
+| Performance trace / CrUX field data / insights | — | ✅ `performance_*` tools + CrUX |  |
+| Reliable automation that auto-waits | — | ✅ Puppeteer-based `click/type/navigate` via DevTools |  |
+| Extract JS-rendered data quickly | ✅ snapshot + CLI loop |  |  |
+
+**Rule for design workflows:** `design-improvement` and `design-assessment` use `playwright-cli` for `implement → run → capture` (primary capture + interaction); pull in `chrome-devtools` when `browser.network / browser.console / browser.performance / browser.runtime-debug` is required. Either MCP alone suffices for degraded mode; together they cover `implement → render → capture → inspect → compare → iterate`.
+
+## Prerequisites
+
+- **Node.js LTS** + **npm** + **current stable Chrome** (or Chrome for Testing). Latest Chrome via [Extended Stable](https://chromiumdash.appspot.com/schedule).
+- MCP host: Claude Code / Cursor / Gemini / OpenCode (native `mcpServers`), or bridged via `mcp-remote` — see `mcp/registry/chrome-devtools.yaml` `platforms`.
+- No secrets — DevTools MCP runs a local browser; avoid sharing sensitive page content with the LLM. Prefer `FIGMA_TOKEN`-style isolation: do not commit real URLs with secrets.
+
+Check availability:
+
+```bash
+agent-toolkit doctor 2>&1 | grep -i chrome
+npx -y chrome-devtools-mcp@latest --help
+```
+
+## Installation (MCP)
+
+**Claude Code (MCP-only, no plugin):**
+
+```bash
+claude mcp add chrome-devtools -- npx -y chrome-devtools-mcp@latest
+```
+
+**Claude Code (plugin + skills, recommended):**
+
+```bash
+/plugin marketplace add ChromeDevTools/chrome-devtools-mcp
+/plugin install chrome-devtools-mcp@chrome-devtools-plugin
+```
+
+Then restart Claude Code and check `/mcp` or `/skills`.
+
+**Other hosts (Cline, Gemini, Codex, Copilot):** Use the same `npx -y chrome-devtools-mcp@latest` entry:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+Add flags as needed:
+
+- `--slim` — reduced tool count for smaller context
+- `--headless` — run headless (default headed for visual review)
+- `--browser-url=http://127.0.0.1:9222` — attach to an existing Chrome (e.g., Antigravity)
+- `--isolated` — per-session Chrome instance
+- `--no-performance-crux` — disable CrUX field fetch
+- `--no-usage-statistics` — opt out of Google usage stats (or set `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=1`)
+
+See `docs/tool-reference.md` for full flag table and `mcp/templates/chrome-devtools/README.md` for host-specific wiring.
+
+## Core workflows
+
+### 1. Open → interact → inspect → trace
+
+```bash
+# via MCP tool (agent calls tool): navigate, click, take_snapshot, etc.
+# equivalent CLI (no MCP) also available:
+npx -y chrome-devtools-mcp@latest --help
+```
+
+Typical MCP tool sequence:
+
+1. `navigate_page` → open URL
+2. `take_snapshot` or `take_screenshot` → capture rendered evidence (required before declaring UI good)
+3. `click` / `fill` / `drag` (Puppeteer-backed, auto-waits)
+4. `list_console_messages` / `list_network_requests` → runtime diagnostics
+5. `performance_start_trace` → `performance_stop_trace` → `performance_analyze_insight` → actionable insights + CrUX
+6. `take_screenshot` at breakpoints/themes (mobile/tablet/desktop, light/dark) for `design-improvement` re-review loop
+
+### 2. Performance debugging
+
+Use `performance_start_trace --auto` (optionally `reload`, `metric: webVital`), then `performance_stop_trace`, then `performance_analyze_insight`. Tools send trace CrUX to Google's CrUX API for field vs lab comparison — disable with `--no-performance-crux` if offline-sensitive.
+
+### 3. Network / console triage
+
+`list_network_requests` + `get_network_request` (HAR-like), `list_console_messages` with source-mapped stacks. Prefer over `curl` when JS rendering or auth is involved.
+
+## Security boundaries
+
+- DevTools MCP exposes **all browser content** to the MCP client — avoid loading pages with secrets, personal data, or internal admin surfaces without explicit scoping; the README warning applies.
+- Treat tool arguments (`url`, `selector`, `script`) as executable-ish — validate inputs, no SSRF via `navigate_page` to internal hosts without approval.
+- Usage stats are enabled by default (Google collects tool success/latency/env). Opt out with `--no-usage-statistics` or env `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=1`; CI sets `CI=1` automatically disables them. Update checks ping npm registry — disable with `CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS=1`.
+- Chrome support is limited to Google Chrome / Chrome for Testing — other Chromium forks may misbehave.
+- Respect `security.classification` in skill frontmatter where applicable; DevTools MCP is `read-write` (can modify page) — not `read-only` like Figma.
+
+## Delegation — browser capabilities conceptually
+
+Request capabilities, not brands, where practical:
+
+| Capability | `playwright-cli` / `e2e-runner` | `chrome-devtools` |
+|------------|-------------------------------|-------------------|
+| `browser.interact` | ✅ deterministic locators/assertions | ✅ Puppeteer-backed (auto-wait) |
+| `browser.capture` | ✅ screenshot/trace/pdf/snapshot | ✅ screenshot + trace |
+| `browser.dom` / `browser.accessibility` | snapshot (a11y) | ✅ DOM + a11y tree + computed styles |
+| `browser.network` / `browser.console` / `browser.performance` | limited | ✅ full |
+| `browser.trace` / `browser.visual-compare` | trace | trace + rendering inspection |
+| `browser.runtime-debug` | — | ✅ DevTools protocol |
+
+**Delegation mapping for Toolkit:**
+
+- `design-assessment` (A11Y/Responsive/Perf) → requests `browser.capture` + `browser.accessibility` + `browser.performance`
+- `design-improvement` (run → capture → review → fix → re-review) → requests `browser.interact` + `browser.capture` + `browser.visual-compare`
+- `e2e-runner` → requests `browser.assert` (Playwright spec)
+
+Either provider alone is valid degraded mode; together they cover the full lifecycle.
+
+## References
+
+- `mcp/registry/chrome-devtools.yaml` — provenance (ChromeDevTools/chrome-devtools-mcp, Apache-2.0, npm `chrome-devtools-mcp`), transport `stdio` via `npx`, platforms matrix, security notes
+- `mcp/templates/chrome-devtools/config.template.json` + `README.md` — host wiring
+- `docs/MCP.md` — MCP overview and provider table
+- `tooling/playwright-cli` — deterministic browser automation (complement)
+- `Chrome DevTools MCP docs`: [GitHub ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp), [tool-reference](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md), [npm chrome-devtools-mcp](https://www.npmjs.com/package/chrome-devtools-mcp)
+

--- a/tests/test_provenance_lock.py
+++ b/tests/test_provenance_lock.py
@@ -383,7 +383,7 @@ def test_first_party_omitted_from_lock():
     assert "design/frontend-design" in lock["capabilities"]
     assert "design/frontend-design-review" in lock["capabilities"]
     assert "design/web-design-guidelines" in lock["capabilities"]
-    assert len(lock["capabilities"]) == 3, "lock should be sparse: 66 skills → 3 upstream vendored"
+    assert len(lock["capabilities"]) == 3, "lock should be sparse: 67 skills → 3 upstream vendored"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #375

## What
Add official `ChromeDevTools/chrome-devtools-mcp` (`npm chrome-devtools-mcp`, Apache-2.0, ~48k stars, 2026-08-11) as MCP provider **chrome-devtools** — live Chrome for network, console, performance traces (+ CrUX field), rendering diagnostics, reliable Puppeteer-backed automation. Complements, not duplicates, `playwright-cli`.

## Research (fresh 2026-08-11)

**Chrome DevTools MCP:** official Google ChromeDevTools org, Apache-2.0, npm `chrome-devtools-mcp`, transport `npx -y chrome-devtools-mcp@latest` stdio, supports Chrome / Chrome for Testing only, wraps DevTools front + Puppeteer. Features: performance insights (trace → CrUX → actionable), network/console with source-mapped stacks, screenshots, DOM/a11y tree, reliable `click/fill/drag`. Flags: `--slim`, `--headless`, `--isolated`, `--browser-url`, `--no-performance-crux`, `--no-usage-statistics`. Usage stats enabled by default (Google, opt-out via flag/env `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS` or `CI=1`), update checks ping npm (opt-out `CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS`).

**Playwright:** `playwright-cli` already vendored as CLI-first wrapper via `npx @playwright/cli` — deterministic locators/snapshot stable `eN` refs, fixtures, assertions, multi-tab, `screenshot/pdf/trace`. Complementarity verified: Playwright = deterministic interaction + E2E + primary capture; DevTools = runtime debugging, network, performance, rendering diagnostics. No duplication — keep both.

## Conceptual browser capabilities (provider selection)

| Capability | Playwright `playwright-cli`/`e2e-runner` | Chrome DevTools `chrome-devtools` |
|------------|-----------------------------------------------|-------------------------------------|
| `browser.interact` | ✅ deterministic locators/assertions | ✅ Puppeteer auto-wait |
| `browser.capture` | ✅ screenshot/trace/snapshot | ✅ screenshot/trace |
| `browser.dom`/`browser.accessibility` | snapshot limited | ✅ DOM + a11y tree + computed styles |
| `browser.network`/`browser.console`/`browser.performance` | limited | ✅ full |
| `browser.trace`/`browser.visual-compare` | trace | trace + rendering inspection |
| `browser.runtime-debug` | — | ✅ DevTools protocol |
| `browser.assert` (E2E) | ✅ `e2e-runner` | — |

Workflow requests capabilities, not brands: `design-assessment`/`design-improvement` request `browser.performance/network/console → DevTools`, `browser.interact/assert → Playwright`. Either alone is valid degraded mode.

## Provenance & distribution (ADR-0001)

- **MCP, not vendored skill content:** `mcp/registry/chrome-devtools.yaml` provenance `official`, repository `https://github.com/ChromeDevTools/chrome-devtools-mcp`, license `Apache-2.0`, version_policy `npx-latest`, transport stdio. This is correct per ADR-0001 — do not vendor external capability content when official native/MCP distribution is better; do not confuse runtime dependency with content provenance (`capabilities/upstream.lock` remains 3 locked vendored skills).
- **Native plugin availability:** Claude Code plugin`chrome-devtools-mcp@chrome-devtools-plugin` via `/plugin marketplace add ChromeDevTools/chrome-devtools-mcp`; also plain MCP `npx -y chrome-devtools-mcp@latest` for Cursor/Gemini etc.

## Changes

- `skills/tooling/chrome-devtools/SKILL.md` — 146 lines, decision table Playwright vs DevTools, prerequisites (Node LTS + Chrome), install for Claude/Cursor/etc, flags, core workflows (navigate → screenshot → click → console/network → performance trace), security boundaries (browser content exposure, usage stats opt-out, SSRF), delegation mapping, references.
- `mcp/registry/chrome-devtools.yaml` — provenance Apache-2.0, package npm, transport stdio, auth none (env opt-outs), tools read/write, platforms native/bridged, security network_hosts including `crux.googleapis.com`, healthcheck.
- `mcp/templates/chrome-devtools/config.template.json` + `README.md` — host wiring (Claude plugin + generic `mcpServers`), slim/headless/isolated examples.
- `docs/MCP.md` — provider table row + Chrome DevTools per-provider setup section.
- Catalogs/matrix/products — 66→67 skills, complete 67, skill-catalog 67 entries.

## Security

DevTools exposes all browser content — avoid sensitive pages. No secrets. Usage stats + update checks documented with opt-out. Chrome for Testing/stable only officially supported. `security.classification` → read-write (can modify page) vs Figma read-only.

## Validation

`validate-skills` 67 OK, `validate-upstream` 67 checked, `provenance check` OK (lock unchanged 3 caps — MCP not vendored), `ruff` green, `generate-catalogs/matrix` 66→67, `gen-surfaces` synced, `pytest` 785 passed, `pytest test_first_party_omitted` 67→3 sparse OK.

## Runner
Muse

## Checklist
- [x] Researched current Playwright + Chrome DevTools MCP (official docs, license, transport, flags, security)
- [x] Playwright vs DevTools decision table with browser.\* capabilities
- [x] MCP registry entry added + validated
- [x] design-assessment can delegate to correct provider (capability-based)
- [x] Generated files in sync, tests green
