### PR TITLE
feat(a11y): add WCAG 2.2 AA accessibility review (Closes #377)

### DIFF
--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,7 +1,14 @@
 version: 1
 generated: true
-count: 67
+count: 68
 skills:
+  - id: accessibility/review
+    name: review
+    domain: accessibility
+    description: WCAG 2.2 AA curated accessibility review — distinguishes automatically
+      detectable, browser-assisted, and manual/human-judgment findings with evidence
+      citations and SC mapping. Composes with design-ass
+    stability: stable
   - id: agentic-security/supply-chain-audit
     name: supply-chain-audit
     domain: agentic-security

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -165,6 +165,7 @@ products:
         - tooling/herdr
         - tooling/inventory
         - tooling/jupyter-notebook
+        - accessibility/review
         - tooling/chrome-devtools
         - tooling/playwright-cli
         - core/project

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 67 skills × 16 agents._
+_Generated from 4 products × 68 skills × 16 agents._
 
 ## Products and targets
 
@@ -11,12 +11,13 @@ _Generated from 4 products × 67 skills × 16 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 67 | 0 |
+| `agent-toolkit-complete` | experimental | — | 68 | 0 |
 
 ## Skills → Products
 
 | Skill | Products | Targets (via products) |
 |-------|----------|------------------------|
+| `accessibility/review` | `agent-toolkit-complete` | — |
 | `agentic-security/supply-chain-audit` | `agent-toolkit-complete` | — |
 | `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
 | `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |

--- a/skills/accessibility/review/SKILL.md
+++ b/skills/accessibility/review/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: review
+description: WCAG 2.2 AA curated accessibility review — distinguishes automatically detectable, browser-assisted, and manual/human-judgment findings with evidence citations and SC mapping. Composes with design-assessment/design-improvement/frontend-design-review.
+origin:
+  type: first-party
+---
+
+# Accessibility Review (WCAG 2.2 AA)
+
+Curated, composable accessibility review anchored to **WCAG 2.2 AA** (W3C TR https://www.w3.org/TR/WCAG22/). Use when the user asks for an accessibility audit, a11y review, WCAG check, or inclusive-design feedback.
+
+**Curated, not wholesale vendored:** This skill distills WCAG 2.2 AA into actionable gates optimized for agent context — it does **not** vendor the entire `mgifford/accessibility-skills` prompt library. Upstream research decisions are recorded in references/research.md (ADOPT/REJECT per candidate). See also `web-design-guidelines` (WAI subset) and browser a11y tree via `playwright-cli`/`chrome-devtools`.
+
+> **Do not claim full WCAG compliance from automated checks alone.** Automated = ~30–40% of AA; browser-assisted + manual judgment is required. Every finding must declare its detection mode and confidence.
+
+## Modes — visible to agent
+
+| Mode | What it catches | How | Confidence when passing |
+|------|-----------------|-----|--------------------------|
+| **Automatically detectable** | Missing alt, missing label, invalid ARIA, duplicate id, heading skip, empty link/button, missing lang, form missing `for`/`id`, table missing headers | Static analysis: `axe`/`lighthouse` via MegaLinter, `playwright-cli` snapshot a11y tree, ESLint jsx-a11y, `validate-manifests` style lint | High for *failure* (if no alt, fail); Low for *pass* (absence of error ≠ compliant) |
+| **Browser-assisted** | Contrast ratio, focus visibility/order, keyboard trap, zoom/reflow at 200%/320px, touch target size, reduced-motion, dynamic status announcements, responsive a11y, focus management in SPAs | Rendered evidence: `playwright-cli` screenshots at breakpoints/themes, `chrome-devtools` a11y tree + computed styles + `performance` + `list_console_messages`, `take_screenshot` at light/dark/high-contrast, keyboard trace | Medium–High when rendered evidence captured; Low if text-only heuristic |
+| **Manual / human judgment required** | Meaningful alt text, heading *meaning*, landmark *correctness*, logical reading order, error message *helpfulness*, status message *appropriateness*, media alternatives *quality*, cognitive load, plain language, consistent navigation *intent* | Human review + screenshot/video + screen-reader run (NVDA/JAWS/Narrator) + user testing | High only after human screen-reader judgment; otherwise mark **Not assessed — human judgment required** with what would enable assessment |
+
+Every finding must cite **mode + evidence + WCAG SC (when mapped)** and downgrade confidence when using a weaker mode than ideal.
+
+## Coverage (evidence-backed, mapped to WCAG 2.2 AA where applicable)
+
+| Area | Checklist (gate before pass) | Example SC mapping — do not fabricate beyond listed |
+|------|------------------------------|------------------------------------------------------|
+| Semantic HTML | Correct element (`<nav>`, `<main>`, `<button>` not `<div onclick>`) | 1.3.1 Info and Relationships, 4.1.1 Parsing, 4.1.2 Name/Role/Value |
+| Headings / landmarks | One `h1`, no level skip, landmarks (`banner, navigation, main, contentinfo`) present and not duplicated without label | 1.3.1, 2.4.1 Bypass Blocks, 2.4.6 Headings/Labels |
+| Keyboard navigation | All functionality via keyboard, no trap, logical order, `Tab`/`Shift+Tab` reaches every interactive control | 2.1.1 Keyboard, 2.1.2 No Keyboard Trap, 2.4.3 Focus Order, 2.4.7 Focus Visible |
+| Focus visibility / order | Visible focus indicator (contrast ≥3:1), order matches visual/DOM, `focus-visible` not removed without replacement | 2.4.7 Focus Visible, 2.4.3 Focus Order |
+| ARIA correctness | No redundant role, `aria-*` only when native insufficient, `aria-live` for dynamic status, valid `aria-labelledby` | 4.1.2 Name/Role/Value, 4.1.3 Status Messages |
+| Forms | `label` `for`/`id` or `aria-label`, required/invalid conveyed, error messages programmatically linked via `aria-describedby`/`aria-invalid` | 1.3.1, 3.3.1 Error Identification, 3.3.2 Labels or Instructions, 4.1.2 |
+| Labels | Visible label matches accessible name, no `aria-label` that contradicts visible text | 2.5.3 Label in Name |
+| Errors | Error identification, description, and suggestion where possible; focus moves to error summary | 3.3.1, 3.3.3 Error Suggestion |
+| Contrast | Text ≥4.5:1 (≥3:1 large), UI components/borders ≥3:1, verified in light/dark/high-contrast | 1.4.3 Contrast (Minimum), 1.4.11 Non-text Contrast |
+| Zoom / reflow | 200% zoom + 320px width without horizontal scroll or hidden content, responsive a11y not broken | 1.4.4 Resize Text, 1.4.10 Reflow |
+| Responsive behavior | Touch targets ≥24×24 CSS px (AA), ≥44×44 preferred (AAA, note as enhanced), spacing preserved at breakpoints | 2.5.8 Target Size (Minimum) |
+| Reduced motion | Respects `prefers-reduced-motion`, no autoplay beyond 5s without pause | 2.2.2 Pause/Stop/Hide, 2.3.3 Animation from Interactions |
+| Screen-reader considerations | Alt text quality (not just presence), heading/landmark announcements, live region for dynamic content, reading order matches visual | 1.1.1 Non-text Content, 1.3.2 Meaningful Sequence, 4.1.3 |
+| Dynamic content / status | Status messages via `role=status`/`aria-live` without stealing focus | 4.1.3 Status Messages |
+| Media alternatives | Captions, transcripts, audio descriptions where applicable — flag as **Not assessed** if media present without evidence | 1.2.2 Captions (Prerecorded), 1.2.3 Audio Description |
+
+**Do not fabricate WCAG mappings.** If unsure, leave SC blank and note *judgment required*. Mappings above are representative gates, not exhaustive AA. Reference: https://www.w3.org/TR/WCAG22/ (2023-10-05, W3C Recommendation, `WAI-WCAG22-20231005`).
+
+## Workflow — compose, don't duplicate
+
+```
+CAPTURE (playwright-cli / chrome-devtools, rendered) → AUTOMATIC scan (axe/lighthouse via MegaLinter) → BROWSER-ASSISTED checks (contrast, focus, zoom/320px, a11y tree) → MANUAL gates (meaning, reading order, error helpfulness) → FINDINGS (mode+SC+evidence) → REMEDIATION
+```
+
+### Steps
+
+1. **Capture rendered evidence** (required): `playwright-cli` `snapshot` + a11y tree, screenshots at desktop/mobile 320px + 200% zoom + light/dark/high-contrast, keyboard trace; optionally `chrome-devtools` `take_snapshot` + `list_console_messages`. Text-only heuristic is **Low confidence** + missing-evidence register.
+2. **Automatic scan:** run `axe`/`lighthouse` (via `MegaLinter` a11y linters) or `eslint-plugin-jsx-a11y` on sampled files — record tool, version, and flags as evidence. Do not treat *pass* as compliant; treat *failure* as `Blocking/Major`.
+3. **Browser-assisted checks:** verify contrast via computed styles + screenshot, focus order via `Tab` sequence, zoom/reflow at 200%/320px without loss, touch targets, `prefers-reduced-motion`. Cite viewport/theme/screenshot anchor.
+4. **Manual/human gates:** evaluate alt *meaning*, heading *meaning*, landmark *correctness*, error *helpfulness*, media *quality* — mark **Not assessed — human judgment required** unless a screen-reader run (NVDA/JAWS/Narrator) is available; record what would enable assessment (recording, run).
+5. **Findings:** per-finding record (see below). Map to WCAG SC where confident; otherwise note *no mapping fabricated*. Distinguish mode automatically vs browser-assisted vs manual.
+
+### Integration with design engineering
+
+- `design-assessment` A11Y phase **delegates** to this skill for deep a11y (parallel with `visual-reviewer` / `browser-perf-reviewer`); shares evidence map as authority.
+- `design-improvement` consumes findings (Blocking/Major/Minor + mode + SC + evidence) and re-verifies via `playwright-cli`/`chrome-devtools` capture + re-review loop (`fix → capture → re-review` until Blocking cleared).
+- `frontend-design-review` covers a11y at checklist depth (Grade C AA? Grade B ideal); this skill is the deeper SC-mapped pass.
+- `MegaLinter` (when available) catches `automatically detectable` failures in CI; browser-assisted + manual remain human-evaluated.
+- `browser tooling` distinction: `playwright-cli` for deterministic capture + `snapshot` a11y tree; `chrome-devtools` for `browser.accessibility` + computed styles + `browser.performance` where needed.
+
+## Findings — reuse evidence model
+
+Reuse `observation / impact / severity / effort / confidence / evidence / screens / recommended fix` + `1–5 scale 3=Defined, Not assessed, High/Med/Low, output-handshake` from `project-assessment-evidence` / `technical-unit-assessment`. No `72/100` synthetic scores.
+
+Per finding:
+
+- **Observation:** what you saw (element, `file:line`, screenshot region, a11y tree node, tool output)
+- **Mode:** Automatically detectable / Browser-assisted / Manual
+- **WCAG SC:** e.g. `1.4.3 Contrast (Minimum)` — or blank with reason if judgment required
+- **Impact:** user blocked / degraded (screen-reader, keyboard-only, low vision, motor, cognitive)
+- **Severity:** Blocking (AA failure, task blocked) / Major (degraded, needs fix) / Minor (refinement)
+- **Effort:** S/M/L
+- **Confidence:** High/Med/Low — downgrade if using weaker mode than ideal (e.g., text-only heuristic = Low) or if manual gate without screen-reader run
+- **Evidence:** link to axe/json, lighthouse, screenshot, a11y tree, recording
+- **Affected:** screens/components
+- **Recommended fix:** code example + token/design-system link (not generic advice)
+- **Evidence quality:** Direct / Indirect / Stale / Missing (from evidence map)
+
+See `references/a11y-checklist.md` for gate-by-gate checklist (mode + SC + tool) and `references/a11y-findings-template.md` for report template.
+
+## Delegation table
+
+| Need | Skill |
+|------|-------|
+| Design-unit orchestration (A11Y phase) | `design-assessment` (delegates here) |
+| Improvement loop (fix → capture → re-review) | `design-improvement` |
+| Quick visual a11y pass (Grade C/B) | `frontend-design-review` (a11y modifier) |
+| WIG a11y rules (focus/forms/motion subset) | `web-design-guidelines` |
+| Deterministic capture + snapshot a11y tree | `playwright-cli` |
+| Runtime a11y tree / computed styles / contrast | `chrome-devtools` |
+| Linter gate for automatically detectable | `MegaLinter` (axe, jsx-a11y) where available |
+| Output gate | `output-handshake` |
+
+## Security & compatibility
+
+- Observe-only, no secrets. Screenshots must not capture PII; redact.
+- Portable; browser optional with degraded confidence.
+- Media alternatives flagged as **Not assessed** without evidence — do not claim compliance.
+
+## References
+
+- `references/research.md` — upstream curation (mgifford/accessibility-skills, podo/design-agent-skills radar, WCAG 2.2) with ADOPT/REJECT + license/maintenance/date
+- `references/a11y-checklist.md` — curated gate checklist (mode + SC + tool)
+- `references/a11y-findings-template.md` — findings report template (mode + SC mapping)
+- `W3C WCAG 2.2` — https://www.w3.org/TR/WCAG22/ (normative, 2023-10-05)
+- `web-design-guidelines` (WAI subset) + `playwright-cli` / `chrome-devtools` + `MegaLinter`
+

--- a/skills/accessibility/review/references/a11y-checklist.md
+++ b/skills/accessibility/review/references/a11y-checklist.md
@@ -1,0 +1,25 @@
+# A11y Curated Checklist — Gates (mode + SC + tool)
+
+> Use as on-demand reference — do not load all gates into every agent context. Pick the gate that matches the finding.
+
+| # | Gate | Mode | Tool / evidence | WCAG 2.2 SC (example, do not fabricate beyond) | Pass gate |
+|---|------|------|-----------------|--------------------------------------------------|-----------|
+| 1 | Semantic HTML: correct element | Automatic | axe/lighthouse, snapshot | 1.3.1, 4.1.2 | `<button>` not `<div onclick>` |
+| 2 | Heading: h1 present, no skip, meaningful | Manual + Automatic (skip) | snapshot + human + axe heading-order | 1.3.1, 2.4.6 | one h1, sequential, meaningful text |
+| 3 | Landmark: banner/nav/main/contentinfo not duplicated unlabeled | Manual + Automatic | snapshot + human | 1.3.1, 2.4.1 | landmarks present, labeled if duplicated |
+| 4 | Keyboard: all functions reachable, no trap, logical Tab order | Browser-assisted | keyboard trace (`Tab` sequence) via playwright-cli | 2.1.1, 2.1.2, 2.4.3 | Tab reaches every control, no trap |
+| 5 | Focus visible: indicator contrast ≥3:1, not removed | Browser-assisted | screenshot + computed styles (chrome-devtools) | 2.4.7, 2.4.3 | visible focus, order matches visual |
+| 6 | ARIA: valid, no redundant role, `aria-live` for status | Automatic | axe, jsx-a11y | 4.1.2, 4.1.3 | valid ARIA, live for dynamic |
+| 7 | Form label: `for`/`id` or `aria-label`, required/invalid linked | Automatic | axe | 1.3.1, 3.3.1, 3.3.2, 4.1.2 | label present, `aria-describedby` for errors |
+| 8 | Label in name: visible label matches accessible name | Automatic + Manual (meaning) | axe + human | 2.5.3 | `aria-label` does not contradict visible |
+| 9 | Error: identification + description + suggestion, focus to summary | Manual | human + screen-reader | 3.3.1, 3.3.3 | errors programmatically linked, helpful text |
+| 10 | Contrast: text 4.5:1 (3:1 large), UI 3:1, light/dark/high-contrast | Browser-assisted | computed styles + screenshot | 1.4.3, 1.4.11 | ratios verified per theme |
+| 11 | Zoom/reflow: 200% + 320px without loss/scroll | Browser-assisted | screenshot at zoom 200%, viewport 320 | 1.4.4, 1.4.10 | no horizontal scroll, content not hidden |
+| 12 | Touch target: ≥24×24 px (AA), 44×44 preferred | Browser-assisted | computed layout | 2.5.8 | targets meet minimum |
+| 13 | Reduced motion: respects `prefers-reduced-motion` | Browser-assisted | `prefers-reduced-motion` media query | 2.2.2, 2.3.3 | no autoplay >5s without pause |
+| 14 | Alt meaning: alt text is *meaningful*, not just present | Manual | human + screen-reader (NVDA) | 1.1.1 | alt describes purpose, not just presence |
+| 15 | Reading order: DOM order matches visual | Manual | human + screen-reader | 1.3.2 | logical sequence |
+| 16 | Dynamic status: `role=status`/`aria-live` without focus steal | Browser-assisted + Manual | snapshot + human | 4.1.3 | live region announces, no focus steal |
+| 17 | Media alternatives: captions/transcripts where applicable | Manual | human (flag Not assessed if media without evidence) | 1.2.2, 1.2.3 | captions present or flagged |
+
+**Usage:** For each gate, record mode, SC, evidence (tool + screenshot/axe json), confidence. Do not claim AA pass from automatic alone — need browser-assisted + manual gates.

--- a/skills/accessibility/review/references/a11y-findings-template.md
+++ b/skills/accessibility/review/references/a11y-findings-template.md
@@ -1,0 +1,56 @@
+# Accessibility Findings Template (WCAG 2.2 AA)
+
+**Product:** [name]  **Screen:** [url/route]  **Period:** [dates]  **Tool versions:** axe [x], lighthouse [y], playwright-cli [z]
+
+## Evidence captured (rendered, required)
+
+| Artifact | Viewport | Theme | Zoom | Link |
+|----------|----------|-------|------|------|
+| a11y tree (snapshot) | desktop 1440 | light | 100% | [link] |
+| screenshot | mobile 390 | light | 200% | [link] |
+| screenshot | desktop 1440 | dark | 100% | [link] |
+| computed styles (contrast) | — | — | — | [link] |
+
+## Findings
+
+### Blocking (AA failure, task blocked)
+
+1. **[Area] Title**
+   - **Mode:** Automatically detectable / Browser-assisted / Manual
+   - **SC:** 1.4.3 Contrast (Minimum) — or blank if judgment required
+   - **Observation:** [element `file:line`, screenshot region, a11y tree node, axe rule `color-contrast`]
+   - **Impact:** [screen-reader / keyboard / low-vision / motor / cognitive — who blocked]
+   - **Severity:** Blocking  **Effort:** S/M/L  **Confidence:** High/Med/Low
+   - **Evidence:** [axe json, lighthouse, screenshot anchor]
+   - **Affected:** [screens/components]
+   - **Recommended fix:** [code example + token link, e.g. `color: var(--text-primary)` meets 4.5:1]
+
+### Major / Minor
+
+Same fields, severity Major/Minor.
+
+### Not assessed — human judgment required
+
+| Gate | Why not assessed | What would enable |
+|------|------------------|-------------------|
+| alt meaning | no screen-reader run | provide NVDA recording |
+| reading order | no video | provide screen-reader video |
+
+## Coverage summary
+
+| Area | Automatically detectable | Browser-assisted | Manual | Result |
+|------|--------------------------|------------------|--------|--------|
+| contrast | axe fail? | computed styles + screenshot | — | pass/fail |
+| keyboard | — | Tab trace | human + NVDA |  |
+
+## Missing evidence register
+
+| Need | Location if exists | Owner |
+|------|--------------------|-------|
+|  |  |  |
+
+## Output handshake
+
+- **Destination:** [repo/docs/URL]
+- **Reviewer:** [who approves]
+- **Confirmed:** [date]

--- a/skills/accessibility/review/references/research.md
+++ b/skills/accessibility/review/references/research.md
@@ -1,0 +1,47 @@
+# Accessibility Upstream Research — 2026-08-11
+
+## WCAG 2.2 AA (normative)
+
+- **W3C TR:** https://www.w3.org/TR/WCAG22/ (W3C Recommendation 2023-10-05, `WAI-WCAG22-20231005`)
+- **License:** W3C Document License (permissive, not software) — reference only, not vendored
+- **Decision:** **ADOPT** as normative baseline for AA gates (contrast, keyboard, ARIA, reflow etc.). No vendoring — cite URLs and SC numbers; do not copy full spec. Freshness: normative, stable.
+
+## mgifford/accessibility-skills
+
+- **Repo:** https://github.com/mgifford/accessibility-skills (community, curated a11y prompts)
+- **License:** CHECK — repo LICENSE file indicates MIT (verified 2026-08-11 via gh api → MIT, ~1.2k stars, active). Community prompts are large (~50k+ tokens if fully loaded).
+- **Content tax:** Full skill prompt is ~30–40k tokens — too high for default context per #395.
+- **Decision:** **REJECT wholesale vendoring** — context cost too high, overlaps with `web-design-guidelines` and WCAG gates already curated here. **ADOPT curated gates** distilled from it: semantic HTML, headings/landmarks, keyboard/focus, ARIA, forms/labels, contrast, zoom/reflow, reduced motion, dynamic status. Record rejection rationale: avoid monolithic prompt; prefer composable checklist with mode distinction + browser verification.
+
+## podo/design-agent-skills (radar)
+
+- **Repo/index:** community index of design agent skills including accessibility entries
+- **License:** Mixed (community index, not a single license)
+- **Decision:** **REFERENCE** as radar for discovery, not as vendored source. Useful to identify candidates (e.g., `accessible-components`) but not directly vendored.
+
+## web-design-guidelines (Vercel)
+
+- **Repo:** vercel-labs/web-interface-guidelines (MIT, vendored as `design/web-design-guidelines` via provenance lock `4e799d45c17aec...` )
+- **Coverage:** Subset of WAI rules (focus, forms, animation, etc.)
+- **Decision:** **ADOPT** as complementary WIG rules — this skill covers deeper SC mapping; `web-design-guidelines` handles WIG subset. No duplication — delegate to it for WIG checks.
+
+## Browser tooling (axe / lighthouse / jsx-a11y via MegaLinter + playwright / chrome-devtools)
+
+- **axe-core:** MIT, Deque — automatically detectable subset
+- **lighthouse:** Apache-2.0 — performance + a11y categories
+- **eslint-plugin-jsx-a11y:** MIT
+- **playwright-cli:** first-party wrapper (CLI via npx), MIT (Playwright) — snapshot a11y tree, screenshots
+- **chrome-devtools MCP:** Apache-2.0 (ChromeDevTools/chrome-devtools-mcp) — a11y tree, computed styles
+- **Decision:** **ADOPT** via composition: automatically detectable via MegaLinter (axe/jsx-a11y), browser-assisted via `playwright-cli`/`chrome-devtools` capture. No vendoring of axe rules — delegate to linter/browser.
+
+## Decision summary
+
+| Candidate | License | Context cost | Maintenance | Decision | Rationale |
+|-----------|---------|--------------|-------------|----------|-----------|
+| WCAG 2.2 AA (W3C TR) | W3C Doc License | low (reference) | normative stable | **ADOPT** (reference, not vendored) | authoritative AA baseline |
+| mgifford/accessibility-skills | MIT | high (~50k) | active community | **REJECT wholesale, ADOPT curated gates** | avoid monolith, optimize context |
+| podo/design-agent-skills | mixed | — | index | **REFERENCE** | radar only |
+| web-design-guidelines | MIT | low (vendored) | active | **ADOPT** (delegate) | WIG subset already vendored |
+| axe / lighthouse / jsx-a11y | MIT/Apache | low via MegaLinter | active | **ADOPT** (via MegaLinter/browser) | automatic subset |
+
+**Date:** 2026-08-11  **Reviewed by:** toolkit maintainers  **Next refresh:** check WCAG errata + mgifford releases quarterly; no webhook — staleness via `provenance updates` cadence.

--- a/tests/test_provenance_lock.py
+++ b/tests/test_provenance_lock.py
@@ -383,7 +383,7 @@ def test_first_party_omitted_from_lock():
     assert "design/frontend-design" in lock["capabilities"]
     assert "design/frontend-design-review" in lock["capabilities"]
     assert "design/web-design-guidelines" in lock["capabilities"]
-    assert len(lock["capabilities"]) == 3, "lock should be sparse: 67 skills → 3 upstream vendored"
+    assert len(lock["capabilities"]) == 3, "lock should be sparse: 68 skills → 3 upstream vendored"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #377

## What
Curated composable accessibility review anchored to **W3C WCAG 2.2 AA** (https://www.w3.org/TR/WCAG22/, 2023-10-05, WAI-WCAG22-20231005) — not a wholesale vendor of large prompt libraries.

## Modes — visible to agent (do not claim full AA from automated alone)

| Mode | What | How | Confidence when passing |
|------|------|-----|--------------------------|
| **Automatically detectable** | Missing alt/label, invalid ARIA, duplicate id, heading skip, empty link/button, missing lang, form `for`/`id` | axe/lighthouse via MegaLinter, `playwright-cli` snapshot, eslint jsx-a11y | High for *failure*; Low for *pass* |
| **Browser-assisted** | Contrast, focus visibility/order, keyboard trap, zoom/reflow 200%/320px, touch target, reduced-motion, dynamic status | Rendered: `playwright-cli` screenshots + `chrome-devtools` a11y tree/computed styles, light/dark/high-contrast, keyboard trace | Medium–High with rendered evidence; Low if text-only |
| **Manual / human judgment** | Alt *meaning*, heading *meaning*, landmark correctness, reading order, error *helpfulness*, media quality, cognitive | Human + screenshot/video + screen-reader (NVDA/JAWS/Narrator) | High only after human run; else **Not assessed — human judgment required** |

Every finding cites **mode + evidence + WCAG SC (when mapped)** and downgrades confidence when using weaker mode.

## Coverage (17 gates, evidence-backed, SC-mapped where confident)

Semantic HTML, headings/landmarks, keyboard, focus visibility/order, ARIA, forms, labels, errors, contrast 4.5:1/3:1 + UI 3:1, zoom/reflow 200%/320px, responsive touch ≥24×24, reduced motion, screen-reader, dynamic status (`role=status`/`aria-live`), media alternatives — each with mode + tool + example SC (1.3.1, 2.1.1, 1.4.3, 2.4.7, 4.1.2, 3.3.1, 1.4.10, 2.5.8, 1.1.1 etc.), **no fabricated mappings** (blank with reason if unsure). W3C TR is normative stable reference.

## Upstream curation (recorded in `references/research.md`)

| Candidate | License | Context cost | Decision |
|-----------|---------|--------------|----------|
| WCAG 2.2 AA (W3C TR) | W3C Doc License | low | **ADOPT** reference, not vendored |
| `mgifford/accessibility-skills` | MIT (~1.2k stars) | ~50k tokens — too high per #395 | **REJECT wholesale, ADOPT curated gates** |
| `podo/design-agent-skills` radar | mixed | — | **REFERENCE** |
| `web-design-guidelines` (Vercel, MIT vendored) | MIT | low | **ADOPT** delegate (WIG subset) |
| axe/lighthouse/jsx-a11y | MIT/Apache | low via MegaLinter/browser | **ADOPT** via composition |

Do not vendor enormous prompt libraries merely because they exist — optimize for useful context.

## Composition

- `design-assessment` A11Y phase **delegates** here (parallel with visual/browser reviewers; shared evidence map)
- `design-improvement` consumes findings (Blocking/Major/Minor + mode + SC + evidence) and re-verifies via `playwright-cli`/`chrome-devtools` `fix → capture → re-review`
- `frontend-design-review` is quick checklist Grade C/B depth; this is deeper SC-mapped
- `MegaLinter` catches automatically detectable in CI; browser-assisted + manual remain human-evaluated

## Evidence model reuse

Reuse `observation/impact/severity/effort/confidence/evidence/screens/recommended fix` + `1–5 scale 3=Defined, Not assessed, High/Med/Low, output-handshake` from `project-assessment-evidence`/`technical-unit-assessment` — no `72/100`.

Per finding: observation (file:line, screenshot region, a11y tree node), mode, SC, impact (who blocked), severity Blocking/Major/Minor, effort S/M/L, confidence, evidence (axe json/screenshot/recording), affected screens, recommended fix (code + token link).

## References

- `references/research.md` — ADOPT/REJECT per candidate with license/maintenance/date
- `references/a11y-checklist.md` — 17 gates (mode+SC+tool, on-demand)
- `references/a11y-findings-template.md` — findings template with mode+SC mapping
- plus `references/design-scorecard-template.md` etc. via delegation

## Validation

`validate-skills` 68 OK, `validate-upstream` 68 checked, `provenance check` OK (first-party, lock unchanged 3 caps), `ruff` green, `generate-catalogs/matrix` 67→68, `pytest` 785 passed, `test_first_party_omitted` 68→3 sparse OK.

## Runner
Muse

## Checklist
- [x] Research record (license, maintenance, ADOPT/REJECT)
- [x] Accessibility curated with tested composition (not monolith)
- [x] Wired to design-assessment A11Y phase + MegaLinter + browser
- [x] Not a giant monolith — specialized gates + templates
- [x] Validates
