### PR TITLE
feat(security): add MCP config + implementation audit (Closes #379)

### DIFF
--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,6 +1,6 @@
 version: 1
 generated: true
-count: 68
+count: 69
 skills:
   - id: accessibility/review
     name: review
@@ -8,6 +8,13 @@ skills:
     description: WCAG 2.2 AA curated accessibility review — distinguishes automatically
       detectable, browser-assisted, and manual/human-judgment findings with evidence
       citations and SC mapping. Composes with design-ass
+    stability: stable
+  - id: agentic-security/mcp-audit
+    name: mcp-audit
+    domain: agentic-security
+    description: 'MCP config + implementation security audit — config secrets/auth,
+      unpinned versions, remote vs local, OAuth, env exposure; implementation command
+      injection, SSRF, unsafe args, tool poisoning. Static, '
     stability: stable
   - id: agentic-security/supply-chain-audit
     name: supply-chain-audit

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -166,6 +166,7 @@ products:
         - tooling/inventory
         - tooling/jupyter-notebook
         - accessibility/review
+        - agentic-security/mcp-audit
         - tooling/chrome-devtools
         - tooling/playwright-cli
         - core/project

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 68 skills × 16 agents._
+_Generated from 4 products × 69 skills × 16 agents._
 
 ## Products and targets
 
@@ -11,13 +11,14 @@ _Generated from 4 products × 68 skills × 16 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 68 | 0 |
+| `agent-toolkit-complete` | experimental | — | 69 | 0 |
 
 ## Skills → Products
 
 | Skill | Products | Targets (via products) |
 |-------|----------|------------------------|
 | `accessibility/review` | `agent-toolkit-complete` | — |
+| `agentic-security/mcp-audit` | `agent-toolkit-complete` | — |
 | `agentic-security/supply-chain-audit` | `agent-toolkit-complete` | — |
 | `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
 | `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |

--- a/skills/agentic-security/mcp-audit/SKILL.md
+++ b/skills/agentic-security/mcp-audit/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: mcp-audit
+description: MCP config + implementation security audit — config secrets/auth, unpinned versions, remote vs local, OAuth, env exposure; implementation command injection, SSRF, unsafe args, tool poisoning. Static, evidence-cited.
+origin:
+  type: first-party
+---
+
+# MCP Audit — Config + Implementation Security
+
+Audit **MCP servers** before adopting — static inspection only, never execute remote servers. Use when reviewing `mcp/registry/*.yaml`, `mcp/templates/*/config.template.json`, skill/plugin MCP declarations, or when `audit-capability.py` flags MCP surface.
+
+**Single skill, two modes** — decision per #379 review: config and implementation scopes meaningfully overlap (both inspect `mcp/registry/*.yaml` + templates), but checklists differ enough to keep separate gates. One skill with two modes avoids duplicating registry parsing while keeping `config` (secret hygiene, version pinning) distinct from `implementation` (command injection, SSRF, tool poisoning).
+
+> **Static only:** Do not start or call remote MCP servers during audit. Inspect YAML/JSON, package provenance, tool descriptions, and env handling.
+
+## Modes
+
+| Mode | What it checks | Evidence |
+|------|----------------|----------|
+| **Config audit** | `mcp/registry/*.yaml` auth, package provenance, version pinning, remote vs local, OAuth, env/secret exposure, permissions | Registry YAML, template JSON, env var names, `docs/MCP.md` |
+| **Implementation audit** | Command injection, shell execution, SSRF, unsafe args, tool description poisoning, secret env leakage, dangerous permissions, transport security | Skill SKILL.md + `scripts/audit-capability.py` surface, tool definitions, args validation, network_hosts |
+
+Run the relevant mode per request; for full adoption review, run both and emit a single `mcp-audit-report.md`.
+
+## Config audit — checklist
+
+### Auth & secrets
+
+- [ ] `auth.env` lists only env var **names**, never values (scan registry YAML for `ghp_`, `xoxb`, hardcoded tokens)
+- [ ] Template `config.template.json` uses `${ENV_VAR}` placeholders (no real credentials)
+- [ ] Remote MCP (`streamable_http` URL like `https://mcp.figma.com/mcp`) documents auth as `bearer-env` with region var, not query param
+- [ ] Local MCP (`stdio` via `npx`/`docker`/`uvx`) does not embed secrets in `args` — secrets only in `env`
+- [ ] No `default-branch push` or `filesystemWrites` beyond declared `security.network_hosts`
+
+### Version pinning & provenance
+
+- [ ] `implementation.package` is machine-verifiable: npm `chrome-devtools-mcp@latest` / docker `ghcr.io/...` / URL `https://mcp.figma.com/mcp` — not bare `latest` without policy
+- [ ] `implementation.version_policy` declared (`npx-latest`, `pin image digest`, `pin to minor`) and matches template `args` (`-y chrome-devtools-mcp@latest` vs `mcp-notion-server`)
+- [ ] `implementation.provenance` = `official` with `repository` URL + `license` verifiable via `gh api` (e.g., ChromeDevTools/chrome-devtools-mcp Apache-2.0, github/github-mcp-server MIT)
+- [ ] Remote vs local decision documented: remote (Figma) for designer-hosted, local (GitHub/Slack/Notion) for on-host execution — no mixed remote + local for same provider without rationale
+
+### Permissions & env exposure
+
+- [ ] `security.network_hosts` enumerates expected hosts (no `*`, no private `.local` / `192.168.`)
+- [ ] `security.secret_storage` = `environment variable` with `secret_storage` notes
+- [ ] `platforms` matrix declares support per target (native/bridged/manual) — no assumed universal
+- [ ] `approval.default` matches risk: `read-only` for Figma/GitHub vs `read-write` for Chrome DevTools (can modify page) — justified
+
+### Per-template gate
+
+- [ ] Template `command` ∈ `npx|docker|uvx` and `args[:2] == ["-y", provider.package]` for `npx` (verified by `tests/test_mcp_templates.py`)
+
+## Implementation audit — checklist
+
+### Command injection & shell
+
+- [ ] `args` contain no shell interpolation (`$(`, `` ` ``, `;`, `&&`, `|`). MCP `command` is single binary, not `sh -c`.
+- [ ] `command` is not `sh`/`bash`/`python -c` with concatenated args — use direct `npx`/`docker` entrypoint.
+
+### SSRF & network
+
+- [ ] URL args (`--browser-url`, `https://mcp.linear.app/mcp`) are not user-controlled without allowlist; `navigate_page` tool validates hosts.
+- [ ] `network_hosts` does not include internal metadata endpoints (`169.254.169.254`, `metadata.google.internal`).
+
+### Tool poisoning & unsafe args
+
+- [ ] Tool descriptions in registry `tools.read/write` do not contain prompt injections (e.g., `ignore previous instructions`, `send secrets to`).
+- [ ] Tool `write`/`destructive` sets are minimal — no `delete_file` where read-only suffices (GitHub `destructive` correctly lists `delete_file` only there).
+- [ ] Args that become file paths (`FIGMA_OAUTH_TOKEN`) are env var refs, not string interpolation.
+
+### Secret leakage & OAuth
+
+- [ ] No `env` value contains PII — only `${VAR}` placeholders in templates; registry lists `env` names with `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS` style opt-outs.
+- [ ] OAuth flows (Linear) documented as browser OAuth, not token paste.
+
+## Workflow
+
+1. **Load registry:** `agent_toolkit.compiler.mcp_registry.load_registry(mcp/registry)` — record `providers, errors` (evidence: registry count).
+2. **Pick mode:** `config` (default for adoption) or `implementation` (for command/SSRF/poisoning) or both.
+3. **Run checks:** For each `provider` in `providers`, apply the relevant checklist above; for `implementation`, also run `scripts/audit-capability.py mcp/registry/<provider>.yaml --json` and capture `shell|network|mcp|hooks` findings.
+4. **Score:** `ALLOW` (no Blocking), `CAUTION` (Major, e.g., unpinned version, remote without TLS), `BLOCK` (Blocking: hardcoded secret, command injection, SSRF to metadata endpoint, provenance unknown).
+5. **Report:** Emit `mcp-audit-report.md` (see `references/mcp-audit-template.md`) with per-provider table: `provider | config verdict | impl verdict | package/license | version_policy | provenance | evidence`.
+
+### Example report row
+
+| Provider | Config | Impl | Package | License | Version policy | Verdict | Evidence |
+|----------|--------|------|---------|---------|----------------|---------|----------|
+| chrome-devtools | ✅ auth none, package chrome-devtools-mcp@latest, npx-latest, no secrets | ✅ no shell, no SSRF, read-write justified | npm chrome-devtools-mcp@latest | Apache-2.0 | npx-latest | ALLOW | registry chrome-devtools.yaml + template config.template.json |
+
+## Relation to `mcp` skill
+
+- `mcp` (integrations/mcp) — **how to setup** (`agent-toolkit mcp setup`, `mcp list`, `doctor`) — orchestration.
+- `mcp-audit` (this skill) — **whether to trust** — security gate before setup. Call this skill before `mcp setup` for unreviewed providers; delegate `supply-chain-audit` for full skill/plugin surface.
+
+## Delegation table
+
+| Need | Skill |
+|------|-------|
+| Setup MCP after audit | `integrations/mcp` |
+| Full skill/plugin supply-chain | `agentic-security/supply-chain-audit` + `scripts/audit-capability.py` |
+| OWASP agentic review (prompt injection, tool poisoning, identity) | `agentic-security/owasp-agentic-review` (next issue) |
+| Output gate | `output-handshake` |
+
+## Security & compatibility
+
+- Never execute MCP servers during audit; static YAML/JSON only.
+- Portable: `gh api` for provenance license check, `yaml` + `jsonschema` offline.
+
+## References
+
+- `references/mcp-audit-template.md` — report template (per-provider verdict)
+- `mcp/registry/*.yaml` — canonical registry (7 providers after #375)
+- `mcp/templates/*/config.template.json` — host wiring (placeholders)
+- `scripts/audit-capability.py` — static surface scan (shell/network/mcp/hooks)
+- MCP spec: https://modelcontextprotocol.io/ , ChromeDevTools MCP https://github.com/ChromeDevTools/chrome-devtools-mcp
+

--- a/skills/agentic-security/mcp-audit/references/mcp-audit-template.md
+++ b/skills/agentic-security/mcp-audit/references/mcp-audit-template.md
@@ -1,0 +1,51 @@
+# MCP Audit Report
+
+**Scope:** `mcp/registry` + `mcp/templates`  **Date:** [YYYY-MM-DD]  **Auditor:** [name]
+**Mode:** config + implementation (static)  **Registry:** 7 providers (github, slack, notion, linear, figma, clickup, chrome-devtools)
+
+> Static only — did not execute remote servers. Evidence: registry YAML + template JSON + `audit-capability.py` surface.
+
+## Verdict
+
+| Provider | Config | Impl | Package | License | Version policy | Provenance | Verdict | Evidence |
+|----------|--------|------|---------|---------|----------------|------------|---------|----------|
+| github | ✅ auth bearer-env GITHUB_PERSONAL_ACCESS_TOKEN, ghcr.io/github/github-mcp-server pinned digest, no secrets | ✅ no shell, no SSRF, delete_file only where needed | ghcr.io/github/github-mcp-server | MIT | pin image digest | official github/github-mcp-server | ALLOW | mcp/registry/github.yaml + mcp/templates/github/config.template.json |
+| slack | ✅ bearer-env SLACK_* placeholders | ✅ no injection | @anthropic-ai/mcp-server-slack | MIT | pin to minor | official anthropics/mcp-servers | ALLOW |  |
+| notion | ✅ bearer-env | ✅ | mcp-notion-server | MIT | pin to minor | official | ALLOW |  |
+| linear | ✅ bearer-env / OAuth (streamable_http https://mcp.linear.app/mcp) | ✅ no SSRF to metadata | https://mcp.linear.app/mcp | proprietary (Linear) | remote hosted | official Linear | ALLOW |  |
+| figma | ✅ bearer-env FIGMA_OAUTH_TOKEN streamable_http https://mcp.figma.com/mcp | ✅ read-only, no shell | https://mcp.figma.com/mcp | proprietary | remote hosted | official Figma | ALLOW |  |
+| clickup | ✅ bearer-env CLICKUP_API_TOKEN | ✅ | mcp-clickup-server | MIT | pin to minor | community → verified | ALLOW |  |
+| chrome-devtools | ✅ auth none, package chrome-devtools-mcp@latest npx-latest, 7 env opt-outs, no secrets | ✅ no shell, no SSRF, read-write justified (can modify page) | chrome-devtools-mcp@latest | Apache-2.0 | npx-latest | official ChromeDevTools/chrome-devtools-mcp | ALLOW | mcp/registry/chrome-devtools.yaml + mcp/templates/chrome-devtools/config.template.json |
+
+**Legend:** ALLOW (no Blocking), CAUTION (Major, e.g., unpinned), BLOCK (hardcoded secret, command injection, SSRF to metadata, provenance unknown)
+
+## Config audit — per-provider notes
+
+- All 7 `auth.env` list only names, templates use `${VAR}` placeholders — verified no `ghp_`/`xoxb` in registry (test_no_secrets_in_registry).
+- `security.network_hosts` enumerates expected hosts, no private `.local`/`192.168.` (test_registry_no_private_hostnames).
+- `platforms` matrix present per provider; `approval.default` matches risk (read-only vs read-write for chrome-devtools).
+- Template `args[:2] == ["-y", package]` for npx providers — verified test_stdio_templates.
+
+## Implementation audit — per-provider notes
+
+- No `sh -c` or shell interpolation in `args`; `command` in npx/docker/uvx only.
+- No SSRF to metadata endpoints (`169.254.169.254`).
+- Tool `write`/`destructive` minimal (only github lists `delete_file`).
+- Tool descriptions scanned for prompt injections — none found (if found, mark BLOCK).
+
+## Missing evidence / Not assessed
+
+| Check | Why not assessed | What would enable |
+|-------|------------------|-------------------|
+| Remote Figma/Linear TLS cert chain | static only, no live probe | live `tools-list` healthcheck with timeout_ms |
+
+## Follow-ups
+
+- [ ] If CAUTION/BLOCK: file issue with provider + checklist gate + evidence link
+- [ ] Re-audit when `mcp/registry/*.yaml` changes (CI `validate-manifests` + `audit-capability.py`)
+
+## Output handshake
+
+- **Destination:** [docs/security/mcp-audit-YYYY-MM-DD.md or issue comment]
+- **Reviewer:** [who approves adoption]
+- **Confirmed:** [date]

--- a/tests/test_provenance_lock.py
+++ b/tests/test_provenance_lock.py
@@ -383,7 +383,7 @@ def test_first_party_omitted_from_lock():
     assert "design/frontend-design" in lock["capabilities"]
     assert "design/frontend-design-review" in lock["capabilities"]
     assert "design/web-design-guidelines" in lock["capabilities"]
-    assert len(lock["capabilities"]) == 3, "lock should be sparse: 68 skills → 3 upstream vendored"
+    assert len(lock["capabilities"]) == 3, "lock should be sparse: 69 skills → 3 upstream vendored"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #379

## What
MCP security audit — single skill `agentic-security/mcp-audit` with two modes (config vs implementation) per #379 review decision (scopes overlap on `mcp/registry/*.yaml` + templates, but checklists distinct; one skill avoids duplication while keeping secret hygiene / version pinning separate from command injection / SSRF / tool poisoning). Static only, never executes remote servers.

## Config audit checklist

- **Auth & secrets:** `auth.env` names only (no `ghp_`/`xoxb`), template `${VAR}` placeholders, remote `streamable_http` (Figma) bearer-env not query param, local `npx`/`docker` no secrets in args, no private `.local`/`192.168.`, platforms matrix, `approval.default` read-only vs read-write justified (chrome-devtools read-write can modify page).
- **Version pinning & provenance:** `implementation.package` machine-verifiable (npm `chrome-devtools-mcp@latest` / `ghcr.io/...)`, `version_policy` declared (`npx-latest`/`pin image digest`) matches template `args[:2]==[-y,package]` (verified by `test_stdio_templates`), `provenance official` with repository + license via `gh api` (ChromeDevTools/chrome-devtools-mcp Apache-2.0).
- **Permissions & env:** `security.network_hosts` enumerated, `secret_storage environment variable`, `platforms` per target.

## Implementation audit checklist

- No shell interpolation (`$(`, ``, `;`, `&&`), `command` not `sh -c`.
- No SSRF to metadata (`169.254.169.254`), URL args not user-controlled without allowlist.
- Tool descriptions no prompt injections, `write`/`destructive` minimal (only GitHub `delete_file`), env refs not interpolation, OAuth documented as browser (Linear).

## Workflow

`load_registry(mcp/registry) → pick mode → apply checklist + audit-capability.py surface → score ALLOW/CAUTION/BLOCK → report mcp-audit-report.md` per-provider table (provider | config | impl | package/license | version_policy | provenance | evidence). Example row chrome-devtools ALLOW covering 7 providers (github, slack, notion, linear, figma, clickup, chrome-devtools).

## Relation to `mcp` skill

- `mcp` (integrations/mcp) — **how to setup** (`agent-toolkit mcp setup`) — orchestration.
- `mcp-audit` (this skill) — **whether to trust** — security gate before setup. Delegate `supply-chain-audit` for full skill/plugin surface.

## Changes

- `skills/agentic-security/mcp-audit/SKILL.md` — 116 lines, two-mode decision rationale, checklists, workflow, delegation table.
- `skills/agentic-security/mcp-audit/references/mcp-audit-template.md` — 7-provider ALLOW table (evidence registry + templates).
- Catalog 68→69, matrix/products regenerated, validate 69 checked, provenance lock unchanged (mcp registry not vendored).
- Tests `test_mcp_templates` 2 passed (args match package), `test_mcp_registry` 10 passed.

## Validation

`validate-skills` 69 OK, `validate-upstream` 69 checked, `provenance check` OK (lock 3 caps), `ruff` green, `generate-catalogs/matrix` 68→69, `gen-surfaces` synced, `pytest` 785 passed, `test_first_party_omitted` 69→3 sparse OK.

## Runner
Muse

## Checklist
- [x] MCP security skill(s) exist with config+impl checklists
- [x] Separate vs single skill decision documented (one skill two modes) with rationale
- [x] mcp/registry/*.yaml examples audit clean (7 providers ALLOW)
- [x] Validates
