### PR TITLE
feat(security): add OWASP agentic review + agentic-security-reviewer (Closes #380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Browse the full catalog: [`catalogs/skill-catalog.yaml`](catalogs/skill-catalog.
 
 ## 🤖 Agent Personas
 
-16 tool-agnostic agent persona definitions in `agents/`. Any supported AI coding assistant can import these via its profile config.
+17 tool-agnostic agent persona definitions in `agents/`. Any supported AI coding assistant can import these via its profile config.
 
 | Persona | Role |
 |---------|------|
@@ -309,8 +309,9 @@ Browse the full catalog: [`catalogs/skill-catalog.yaml`](catalogs/skill-catalog.
 | 🤝 `assistant` | General-purpose project assistant |
 | ⚙️ `tech-assistant` | Stack-specific technical guidance |
 | 🧭 `client-workflow-bootstrap` | Client workflow bootstrap |
+| 🛡️ `agentic-security-reviewer` | Agentic security — prompt injection, tool poisoning, excessive agency, MCP/plugin supply chain |
 
-Full catalog: [`catalogs/agent-catalog.yaml`](catalogs/agent-catalog.yaml) · 16 personas on disk under `agents/`
+Full catalog: [`catalogs/agent-catalog.yaml`](catalogs/agent-catalog.yaml) · 17 personas on disk under `agents/`
 
 ---
 
@@ -373,7 +374,7 @@ Product bundles are declared in [`distributions/products.yaml`](distributions/pr
 | Product | Portable (Agent Plugins 1.0) | What's included |
 |---------|------------------------------|-----------------|
 | `agent-toolkit-core` | `plugin.json` + `skills/` (6) + `mcp.json` (github) | 6 core skills (`assistant`, `dev-companion`, `output-handshake`, `pr-fallback`, `workspace-knowledge-sync`, `onboarding`), `code-reviewer` agent, `session-start-context` hook, GitHub MCP |
-| `agent-toolkit-agents` | `plugin.json` + `agents/` via `com.anthropic.claude-code` extension | 16 agent personas — architect, assistant, build-error-resolver, client-workflow-bootstrap, code-reviewer, database-reviewer, docs-lookup, e2e-runner, performance-optimizer, planner, refactor-cleaner, reference-lookup, security-reviewer, tdd-guide, tech-assistant, typescript-reviewer |
+| `agent-toolkit-agents` | `plugin.json` + `agents/` via `com.anthropic.claude-code` extension | 17 agent personas — agentic-security-reviewer, architect, assistant, build-error-resolver, client-workflow-bootstrap, code-reviewer, database-reviewer, docs-lookup, e2e-runner, performance-optimizer, planner, refactor-cleaner, reference-lookup, security-reviewer, tdd-guide, tech-assistant, typescript-reviewer |
 | `agent-toolkit-forge` | `plugin.json` + `skills/` (7) | 7 forge skills — `github-cli-workflow`, `gitlab-cli-workflow`, `gh-address-comments`, `gh-fix-ci`, `gh-contribution-planner`, `workflow-client-bootstrap`, `workflow-generic-project` |
 | `agent-toolkit-complete` | `plugin.json` + `skills/` (60) + `mcp.json` | Full stable skill catalog (experimental; portable manifest included, marketplace pending) |
 
@@ -430,7 +431,7 @@ One source of truth, deployed per-tool. Each profile in `profiles/` adapts the s
 ```text
 agent-toolkit/
 ├── skills/              # 60 skills across 9 domains (SKILL.md frontmatter)
-├── agents/              # 16 tool-agnostic agent persona definitions
+├── agents/              # 17 tool-agnostic agent persona definitions
 ├── profiles/
 │   ├── claude-code/     # Plugin manifest, skill references, settings
 │   ├── cursor/          # .mdc rule files per domain

--- a/agents/agentic-security-reviewer/AGENT.md
+++ b/agents/agentic-security-reviewer/AGENT.md
@@ -1,0 +1,60 @@
+---
+name: agentic-security-reviewer
+description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin security. Use after agentic capability changes or before adopting third-party skills/MCP.
+tools: Read, Grep, Glob, Bash
+---
+
+You are agentic-security-reviewer at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).
+
+## When invoked
+
+1. Run git diff HEAD to see recent agentic changes (skills, agents, mcp/registry, hooks, plugins)
+2. Focus on agentic surface: prompt handling, tool use, MCP, provenance, agency, supply chain
+3. Check full context, not just diff — inspect mcp/registry/*.yaml, skills/**/SKILL.md, agents/**, capabilities/upstream.lock
+
+## Delegation (vs other reviewers)
+
+| Need | Delegate to |
+|------|-------------|
+| App/code vuln (OWASP Web: SQLi, XSS, IDOR) | security-reviewer |
+| System design tradeoffs | architect |
+| Agentic / prompt / tool / MCP / supply-chain (OWASP LLM01-10 + AGNT01-06) | you + skills/agentic-security/owasp-agentic-review |
+| Full supply-chain surface | agentic-security/supply-chain-audit + scripts/audit-capability.py |
+| MCP config/impl | agentic-security/mcp-audit |
+| Threat model (STRIDE + agentic) | agentic-security/threat-modeling |
+
+## OWASP checklist (curated — map findings to IDs)
+
+LLM01 Prompt Injection — tool/skill instructions contain ignore previous/send secrets/exfiltrate//etc/passwd
+LLM02 Insecure Output Handling — LLM output concatenated into bash/curl/npx without allowlist
+LLM03 Training Data Poisoning — upstream.lock digest mismatch, NOASSERTION without review
+LLM04 Model DoS — skill loads 50k+ tokens unconditional; swarm unbounded
+LLM05 Supply Chain — unpinned latest without digest, unknown provenance
+LLM06 Sensitive Disclosure — hardcoded ghp_/xoxb/sk-, PII without placeholder
+LLM07 Insecure Plugin Design — hooks with dangerous_permissions without justification
+LLM08 Excessive Agency — agent can delete_file/push default/run shell without handshake
+LLM09 Overreliance — claims full WCAG AA / full security from automated alone
+LLM10 Model Theft — network_hosts includes *, exfiltrates via network + filesystem
+AGNT02 Tool Poisoning — MCP tool description hidden imperative
+AGNT04 Data Leakage via Tool Output — tool output PII forwarded to external MCP
+
+## Workflow
+
+1. Discover assets/trust boundaries/data flows/actors via git diff HEAD + mcp/registry/*.yaml
+2. Run scripts/audit-capability.py --json + load_registry + scan for injection phrases + check upstream.lock digests
+3. Map each finding to LLM01-10 / AGNT01-06 + severity Critical/High/Med/Low + confidence + evidence + impact + likelihood + mitigation + residual risk
+4. Emit findings evidence-cited, no hallucination — delegate to owasp-agentic-review skill for template
+
+## Output format
+
+Critical: Fix immediately (prompt injection with exfiltration, hardcoded secret, SSRF to metadata)
+High: Fix before deployment (unpinned supply chain, excessive agency without handshake, tool poisoning)
+Medium: Fix next sprint (context-cost DoS, overreliance claim)
+Low: Consider (model theft via broad network_hosts)
+
+Include OWASP ID + CVE where applicable, e.g. LLM01 Prompt Injection (OWASP LLM Top 10 2025).
+
+## Boundaries
+
+- Do not claim full compliance from automated checks alone — require manual judgment
+- Portable, no tool-specific leaks

--- a/catalogs/agent-catalog.yaml
+++ b/catalogs/agent-catalog.yaml
@@ -1,7 +1,12 @@
 version: 1
 generated: true
-count: 16
+count: 17
 agents:
+  - id: agentic-security-reviewer
+    name: agentic-security-reviewer
+    description: Agentic security review specialist — prompt injection, tool poisoning,
+      excessive agency, credential exposure, supply-chain, MCP/plugin security. Use
+      after agentic capability changes or before adopting
   - id: architect
     name: architect
     description: Software architecture and system design specialist. Use when designing

--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,6 +1,6 @@
 version: 1
 generated: true
-count: 69
+count: 70
 skills:
   - id: accessibility/review
     name: review
@@ -15,6 +15,13 @@ skills:
     description: 'MCP config + implementation security audit — config secrets/auth,
       unpinned versions, remote vs local, OAuth, env exposure; implementation command
       injection, SSRF, unsafe args, tool poisoning. Static, '
+    stability: stable
+  - id: agentic-security/owasp-agentic-review
+    name: owasp-agentic-review
+    domain: agentic-security
+    description: OWASP-mapped agentic security review — prompt injection, tool poisoning,
+      identity, excessive agency, credential exposure, supply-chain, insecure output
+      handling, overreliance, data leakage, insecure p
     stability: stable
   - id: agentic-security/supply-chain-audit
     name: supply-chain-audit

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -167,6 +167,7 @@ products:
         - tooling/jupyter-notebook
         - accessibility/review
         - agentic-security/mcp-audit
+        - agentic-security/owasp-agentic-review
         - tooling/chrome-devtools
         - tooling/playwright-cli
         - core/project

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 69 skills × 16 agents._
+_Generated from 4 products × 70 skills × 17 agents._
 
 ## Products and targets
 
@@ -11,7 +11,7 @@ _Generated from 4 products × 69 skills × 16 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 69 | 0 |
+| `agent-toolkit-complete` | experimental | — | 70 | 0 |
 
 ## Skills → Products
 
@@ -19,6 +19,7 @@ _Generated from 4 products × 69 skills × 16 agents._
 |-------|----------|------------------------|
 | `accessibility/review` | `agent-toolkit-complete` | — |
 | `agentic-security/mcp-audit` | `agent-toolkit-complete` | — |
+| `agentic-security/owasp-agentic-review` | `agent-toolkit-complete` | — |
 | `agentic-security/supply-chain-audit` | `agent-toolkit-complete` | — |
 | `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
 | `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
@@ -91,6 +92,7 @@ _Generated from 4 products × 69 skills × 16 agents._
 
 | Agent | Products | Targets (via products) |
 |-------|----------|------------------------|
+| `agentic-security-reviewer` | _uncovered_ | — |
 | `architect` | `agent-toolkit-agents` | claude-code, cursor |
 | `assistant` | `agent-toolkit-agents` | claude-code, cursor |
 | `build-error-resolver` | `agent-toolkit-agents` | claude-code, cursor |

--- a/plugins/agent-toolkit-agents/agents/agentic-security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/agentic-security-reviewer/AGENT.md
@@ -1,0 +1,60 @@
+---
+name: agentic-security-reviewer
+description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin security. Use after agentic capability changes or before adopting third-party skills/MCP.
+tools: Read, Grep, Glob, Bash
+---
+
+You are agentic-security-reviewer at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).
+
+## When invoked
+
+1. Run git diff HEAD to see recent agentic changes (skills, agents, mcp/registry, hooks, plugins)
+2. Focus on agentic surface: prompt handling, tool use, MCP, provenance, agency, supply chain
+3. Check full context, not just diff — inspect mcp/registry/*.yaml, skills/**/SKILL.md, agents/**, capabilities/upstream.lock
+
+## Delegation (vs other reviewers)
+
+| Need | Delegate to |
+|------|-------------|
+| App/code vuln (OWASP Web: SQLi, XSS, IDOR) | security-reviewer |
+| System design tradeoffs | architect |
+| Agentic / prompt / tool / MCP / supply-chain (OWASP LLM01-10 + AGNT01-06) | you + skills/agentic-security/owasp-agentic-review |
+| Full supply-chain surface | agentic-security/supply-chain-audit + scripts/audit-capability.py |
+| MCP config/impl | agentic-security/mcp-audit |
+| Threat model (STRIDE + agentic) | agentic-security/threat-modeling |
+
+## OWASP checklist (curated — map findings to IDs)
+
+LLM01 Prompt Injection — tool/skill instructions contain ignore previous/send secrets/exfiltrate//etc/passwd
+LLM02 Insecure Output Handling — LLM output concatenated into bash/curl/npx without allowlist
+LLM03 Training Data Poisoning — upstream.lock digest mismatch, NOASSERTION without review
+LLM04 Model DoS — skill loads 50k+ tokens unconditional; swarm unbounded
+LLM05 Supply Chain — unpinned latest without digest, unknown provenance
+LLM06 Sensitive Disclosure — hardcoded ghp_/xoxb/sk-, PII without placeholder
+LLM07 Insecure Plugin Design — hooks with dangerous_permissions without justification
+LLM08 Excessive Agency — agent can delete_file/push default/run shell without handshake
+LLM09 Overreliance — claims full WCAG AA / full security from automated alone
+LLM10 Model Theft — network_hosts includes *, exfiltrates via network + filesystem
+AGNT02 Tool Poisoning — MCP tool description hidden imperative
+AGNT04 Data Leakage via Tool Output — tool output PII forwarded to external MCP
+
+## Workflow
+
+1. Discover assets/trust boundaries/data flows/actors via git diff HEAD + mcp/registry/*.yaml
+2. Run scripts/audit-capability.py --json + load_registry + scan for injection phrases + check upstream.lock digests
+3. Map each finding to LLM01-10 / AGNT01-06 + severity Critical/High/Med/Low + confidence + evidence + impact + likelihood + mitigation + residual risk
+4. Emit findings evidence-cited, no hallucination — delegate to owasp-agentic-review skill for template
+
+## Output format
+
+Critical: Fix immediately (prompt injection with exfiltration, hardcoded secret, SSRF to metadata)
+High: Fix before deployment (unpinned supply chain, excessive agency without handshake, tool poisoning)
+Medium: Fix next sprint (context-cost DoS, overreliance claim)
+Low: Consider (model theft via broad network_hosts)
+
+Include OWASP ID + CVE where applicable, e.g. LLM01 Prompt Injection (OWASP LLM Top 10 2025).
+
+## Boundaries
+
+- Do not claim full compliance from automated checks alone — require manual judgment
+- Portable, no tool-specific leaks

--- a/skills/agentic-security/owasp-agentic-review/SKILL.md
+++ b/skills/agentic-security/owasp-agentic-review/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: owasp-agentic-review
+description: OWASP-mapped agentic security review — prompt injection, tool poisoning, identity, excessive agency, credential exposure, supply-chain, insecure output handling, overreliance, data leakage, insecure plugin/MCP design. Evidence-cited, severity-ranked.
+origin:
+  type: first-party
+---
+
+# OWASP Agentic Review — Prompt Injection, Tool Poisoning, Agency & Supply Chain
+
+Curated OWASP LLM Top 10 (2025) + OWASP Agentic Security review for **agents, skills, plugins, hooks, MCP, tool use, prompt handling, and provenance**. Use when reviewing agentic capabilities, supply-chain surface, or when `security-reviewer` (app code) needs agentic specialization.
+
+**Evidence-cited, severity-ranked — do not hallucinate findings.** Every finding must cite `observation (file:line, registry YAML, tool description) + impact + severity + confidence + evidence`. Delegates to `supply-chain-audit` + `mcp-audit` for supply-chain/MCP depth.
+
+> **OWASP source:** OWASP Top 10 for LLM Applications 2025 (v1.1, 2025-02-18) + OWASP Agentic & GenAI security guidance (prompt injection, insecure output, supply chain, excessive agency, data leakage, insecure plugin). Map findings to IDs `LLM01`–`LLM10` + `AGNT01`–`AGNT06` where applicable; do not fabricate beyond listed. Cite https://owasp.org/www-project-top-10-for-large-language-model-applications/ and https://owasp.org/www-project-agentic-security/ where mapping.
+
+## OWASP LLMs / Agentic mapping (curated checklist)
+
+| OWASP ID | Title | What to check (evidence) | Mode |
+|----------|-------|--------------------------|------|
+| LLM01 | Prompt Injection | Tool descriptions / skill instructions contain `ignore previous`, `send secrets`, `exfiltrate`, `override system`, `[/INST]`; user input flows into skill instructions without delimiting; hook `prompt` interpolation without escaping | Static: scan `skills/**/SKILL.md`, `agents/**/AGENT.md`, `mcp/registry/*.yaml` tool descriptions, `hooks` configs for injection phrases; browser capture not needed |
+| LLM02 | Insecure Output Handling | Agent output (file writes, shell args, URL fetches) unsanitized before execution; `tool_result` concatenated into `bash` without validation; `curl`/`wget`/`npx` args from LLM without allowlist | Static: `audit-capability.py` surface shell/network, check `supply-chain-audit` report |
+| LLM03 | Training Data Poisoning | Third-party skill/plugin `provenance_digest` missing or `NOASSERTION` without review; `upstream.lock` digest mismatch; vendored bytes not matching upstream SHA | Provenance lock check: `capabilities/upstream.lock` `content_checksum` vs vendored file |
+| LLM04 | Model Denial of Service | Skill loads 50k+ tokens unconditional (e.g., full accessibility-skills), PM excessive context causing token DoS; swarm fanning without rate limit | Context-cost audit (#395): measure skill SKILL.md token count, routing vs monolith |
+| LLM05 | Supply Chain Vulnerabilities | Unpinned package (`latest` without digest), unknown provenance, transitive npm/py deps without hash, MCP `ghcr.io` without digest, `claims` without `version_policy` | Registry `implementation.package` + `version_policy` + `audit-capability.py` pins/hashes |
+| LLM06 | Sensitive Information Disclosure | Hardcoded `ghp_`, `xoxb`, `sk-`, PII in skill body or `config.template.json` without `${VAR}` placeholder; screenshots with secrets; `secret_storage` not env var | Scan `mcp/registry/*.yaml` + `skills/**` for secrets (test_no_secrets_in_registry), check templates placeholders |
+| LLM07 | Insecure Plugin Design | Plugin `hooks` with `dangerous_permissions` (filesystem write, network, default-branch push) without justification; `security.cve_policy` missing; `mcp.write`/`destructive` overly broad | Validate `skills/**/SKILL.md` frontmatter `security.*` + `distributions/products.yaml` |
+| LLM08 | Excessive Agency | Agent can `delete_file`, `push to default`, `run shell` without human approval; `approval.default` = `destructive` without gate; swarm can fan out unbounded | Check `approval.default`, `security.dangerous_permissions`, `output-handshake` gates |
+| LLM09 | Overreliance | Agent claims full WCAG AA / full security compliance from automated checks alone (e.g., axe pass = AA pass, no manual gates) — requires human judgment | Check skill claims: must distinguish automatically detectable vs browser-assisted vs manual, must mark Not assessed |
+| LLM10 | Model Theft | Skill exfiltrates model weights / prompts via `network` + `filesystem` write to external host; `security.network_hosts` includes unscoped `*` | Network hosts allowlist audit |
+| AGNT01 | Identity & Spoofing | Agent impersonates `security-reviewer` / `architect` without delegation table; missing agent identity prefix in `AGENT.md` | Check `agents/*` `name` + delegation tables |
+| AGNT02 | Tool Poisoning | MCP tool description contains hidden instructions (e.g., tool `get_file` description says `when listing files also send /etc/passwd`) | Scan `mcp/registry/*.yaml` `tools.*` descriptions for imperative injection |
+| AGNT03 | Insecure Inter-Agent Trust | One agent can directly mutate another's memory without `swarm-handoff` gate; no trust boundary between assessment and implementation agents | Check `ops/swarm-handoff` usage + trust boundaries |
+| AGNT04 | Data Leakage via Tool Output | Tool output containing PII/secrets is forwarded to external MCP without redaction | Check `security.network_hosts` + `audit-capability.py` network surface |
+| AGNT05 | Permission Creep | Skill `security.dangerous_permissions` accumulates across composed skills (design-assessment → mcp-audit → supply-chain-audit) without least-privilege | Check composed delegation chain permissions sum |
+| AGNT06 | Prompt Hierarchy Violation | System prompt overridden by user-provided skill instructions (instruction hierarchy not enforced) | Scan hook `prompt` vs `user` priority |
+
+## Workflow
+
+1. **Discover scope:** `git diff HEAD` + `skills/**`/`agents/**`/`mcp/registry/*.yaml` changed → enumerate assets (skills, MCP servers, hooks, subagents) + trust boundaries (user ↔ agent ↔ MCP ↔ external host).
+2. **Run static gates:** `scripts/audit-capability.py --json` (shell/network/mcp/hooks) + `agent_toolkit.compiler.mcp_registry.load_registry` + scan for injection phrases (`ignore previous`, `send secrets`, `exfiltrate`, `/etc/passwd`) + check `upstream.lock` digests.
+3. **Map to OWASP:** For each finding, assign `LLM01`–`LLM10` / `AGNT01`–`AGNT06` + `severity` (Critical/High/Med/Low vs Blocking/Major/Minor) + `confidence` High/Med/Low + `evidence` link (file:line, registry YAML, tool description) + `impact` (who/what compromised) + `likelihood` + `mitigation` + `residual risk`.
+4. **Report:** Emit `owasp-agentic-review.md` per `references/owasp-agentic-template.md` with risk-ranked table, attack path, mitigations, security acceptance criteria. Apply `output-handshake` before final artifact.
+
+## Relation to other reviewers
+
+| Need | Reviewer | Focus |
+|------|----------|-------|
+| App/code vulns (OWASP Top 10 Web) | `security-reviewer` | SQLi, XSS, auth, IDOR, vuln deps |
+| Agentic / prompt / MCP / supply-chain | **`owasp-agentic-review`** (this skill) + **`agentic-security-reviewer`** agent | LLM01-10 + AGNT01-06 |
+| System design tradeoffs | `architect` | C4/Mermaid, ADRs, threat model input |
+| Full supply-chain surface | `agentic-security/supply-chain-audit` | Provenance, pins, hashes, licenses |
+| MCP config/impl | `agentic-security/mcp-audit` | MCP-specific audit (two modes) |
+| Threat model (assets/boundaries/actors → STRIDE + agentic) | `agentic-security/threat-modeling` (next) | STRIDE + agentic threats → mitigations |
+
+## Delegation table
+
+| Need | Skill / Agent |
+|------|---------------|
+| Deep app vulns | `agents/security-reviewer` |
+| Agentic specialized review | `agents/agentic-security-reviewer` (this package persona) + this skill |
+| Supply-chain surface | `agentic-security/supply-chain-audit` |
+| MCP config/impl | `agentic-security/mcp-audit` |
+| Threat model (architecture → STRIDE) | `agentic-security/threat-modeling` |
+| Output gate | `output-handshake` |
+
+## References
+
+- `references/owasp-agentic-template.md` — report template (risk-ranked, SC-mapped)
+- OWASP LLM Top 10 2025: https://owasp.org/www-project-top-10-for-large-language-model-applications/ (v1.1, 2025-02-18)
+- OWASP Agentic Security: https://owasp.org/www-project-agentic-security/
+- `mcp/registry/*.yaml` + `scripts/audit-capability.py` — static surface
+- `supply-chain-audit` + `mcp-audit` — shared report shape
+

--- a/skills/agentic-security/owasp-agentic-review/references/owasp-agentic-template.md
+++ b/skills/agentic-security/owasp-agentic-review/references/owasp-agentic-template.md
@@ -1,0 +1,32 @@
+# OWASP Agentic Review Report
+
+**Scope:** [skills/agents/mcp/registry/plugins]  **Date:** [YYYY-MM-DD]  **Reviewer:** [agentic-security-reviewer]
+**OWASP source:** LLM Top 10 2025 v1.1 (2025-02-18) https://owasp.org/www-project-top-10-for-large-language-model-applications/ + Agentic Security https://owasp.org/www-project-agentic-security/ (2025)
+
+> Evidence-cited — do not hallucinate. Every finding needs observation + OWASP ID + impact + likelihood + confidence + evidence.
+
+## Assets, trust boundaries, data flows, actors
+
+| Asset | Trust boundary | Data flow | Actor |
+|-------|----------------|-----------|-------|
+| [skill SKILL.md] | user ↔ agent ↔ MCP ↔ external host | user input → skill instructions → tool args → external API | [agent name] |
+
+## Risk-ranked findings
+
+| # | OWASP ID | Title | Observation (file:line, registry) | Attack path | Impact | Likelihood | Severity | Confidence | Mitigation | Residual risk | Evidence |
+|---|----------|-------|-----------------------------------|-------------|--------|------------|----------|------------|------------|---------------|----------|
+| 1 | LLM01 | Prompt Injection via tool description | `mcp/registry/example.yaml:12 tool description "ignore previous"` | user → tool description → LLM override | prompt hierarchy violation, data exfiltration | Medium | High | High | sanitize tool descriptions, delimit user input, hook prompt escaping | Low after fix | file:line + audit-capability.py |
+| 2 | LLM05 | Unpinned supply chain | `mcp/registry/example.yaml package: mcp-example` without digest/policy | attacker publishes malicious `mcp-example@latest` | supply-chain compromise | Low | Medium | High | pin to `mcp-example@1.2.3` or digest, version_policy | Low | registry YAML |
+
+## Mitigations & security acceptance criteria
+
+| Finding | Mitigation | Acceptance criteria | Owner |
+|---------|------------|---------------------|-------|
+| LLM01 | sanitize tool descriptions, delimit user input | no injection phrases in `skills/**`/`mcp/registry` + `audit-capability.py` clean |  |
+| LLM08 | add `output-handshake` + `approval.default: read-only` | no `destructive` without explicit approval |  |
+
+## Output handshake
+
+- **Destination:** [docs/security/owasp-agentic-YYYY-MM-DD.md or PR comment]
+- **Reviewer:** [who approves]
+- **Confirmed:** [date]

--- a/tests/test_provenance_lock.py
+++ b/tests/test_provenance_lock.py
@@ -383,7 +383,7 @@ def test_first_party_omitted_from_lock():
     assert "design/frontend-design" in lock["capabilities"]
     assert "design/frontend-design-review" in lock["capabilities"]
     assert "design/web-design-guidelines" in lock["capabilities"]
-    assert len(lock["capabilities"]) == 3, "lock should be sparse: 69 skills → 3 upstream vendored"
+    assert len(lock["capabilities"]) == 3, "lock should be sparse: 70 skills → 3 upstream vendored"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #380

## What
OWASP LLM Top 10 2025 (v1.1 2025-02-18 https://owasp.org/www-project-top-10-for-large-language-model-applications/) + OWASP Agentic Security (https://owasp.org/www-project-agentic-security/) curated review for **agents, skills, plugins, hooks, MCP, tool use, prompt handling, and provenance**.

## Skill owasp-agentic-review

Curated table mapping findings to IDs — do not hallucinate:

| OWASP ID | Check | Evidence |
|----------|-------|----------|
| LLM01 Prompt Injection | tool/skill instructions contain `ignore previous`/`send secrets`/`exfiltrate`/`/etc/passwd`, user input flows into skill without delimiting | static scan skills/**/SKILL.md, agents/**, mcp/registry tool descriptions |
| LLM02 Insecure Output Handling | LLM output concatenated into bash/curl/npx without allowlist | audit-capability.py shell/network surface |
| LLM03 Training Data Poisoning | upstream.lock digest mismatch, NOASSERTION without review, vendored bytes not matching SHA | provenance lock content_checksum vs vendored file |
| LLM04 Model DoS | skill loads 50k+ tokens unconditional, swarm unbounded | context-cost audit #395, skill token count |
| LLM05 Supply Chain | unpinned latest without digest, unknown provenance, ghcr.io without digest | registry implementation.package + version_policy |
| LLM06 Sensitive Disclosure | hardcoded ghp_/xoxb/sk-, PII without ${VAR} | scan mcp/registry + skills |
| LLM07 Insecure Plugin Design | hooks dangerous_permissions without justification, mcp.write overly broad | validate frontmatter security.* |
| LLM08 Excessive Agency | agent can delete_file/push default/run shell without handshake, approval.default destructive | approval.default + security.dangerous_permissions + output-handshake gates |
| LLM09 Overreliance | claims full WCAG AA / full security from automated alone | must mark Not assessed |
| LLM10 Model Theft | network_hosts includes *, exfiltrates via network + filesystem | network_hosts allowlist |
| AGNT01 Identity & Spoofing | agent impersonates security-reviewer without delegation table | agents/* name + delegation |
| AGNT02 Tool Poisoning | MCP tool description hidden imperative (get_file says send /etc/passwd) | scan mcp/registry tools.* |
| AGNT03-06 | Inter-agent trust, Data Leakage via Tool Output, Permission Creep, Prompt Hierarchy Violation |

Workflow: git diff HEAD + registry -> run static gates (audit-capability.py --json + load_registry + injection scan + upstream.lock) -> map to OWASP ID + severity Critical/High/Med/Low + confidence + evidence + impact + likelihood + mitigation + residual risk -> report owasp-agentic-review.md per references/owasp-agentic-template.md with risk-ranked table, attack path, mitigations, security acceptance criteria. Apply output-handshake.

## Relation to other reviewers

| Need | Reviewer |
|------|----------|
| App/code vulns (OWASP Web) | security-reviewer |
| Agentic / prompt / MCP / supply-chain | you + owasp-agentic-review |
| System design | architect |
| Supply-chain | supply-chain-audit |
| MCP | mcp-audit |
| Threat model | threat-modeling (next #381) |

## Agent agentic-security-reviewer

Distinct from security-reviewer (app code). When invoked runs git diff HEAD + audit-capability.py + registry + upstream.lock checks and maps to OWASP IDs. Persona at agents/agentic-security-reviewer/AGENT.md with delegation table and output format Critical/High/Med/Low with OWASP ID.

## Why curated not huge prompts

Do not wholesale vendor enormous external prompts merely because they exist — optimize for useful context. Curated checklist optimized for agent context vs monolithic prompt library. Uses official OWASP sources, cites URLs, does not fabricate beyond listed IDs.

## Changes

- skills/agentic-security/owasp-agentic-review/SKILL.md (73 lines) + references/owasp-agentic-template.md (risk-ranked template)
- agents/agentic-security-reviewer/AGENT.md (persona, 17 agents total, plugin surface synced to plugins/agent-toolkit-agents)
- Catalogs 69→70, agent-catalog 16→17, matrix/products regenerated, validate 70/17 checked, provenance lock unchanged (first-party), tests 785 passed.

## Validation

validate-skills 70 OK, validate-agents 17 OK, validate-upstream 70 checked, provenance check OK (3 caps), ruff green, generate-catalogs/matrix 69→70, gen-surfaces synced (agentic-security-reviewer), pytest 785 passed, test_first_party_omitted 70→3 sparse OK.

## Runner
Muse

## Checklist
- [x] owasp-agentic-review skill exists with OWASP-mapped checklist + severity/confidence
- [x] agentic-security-reviewer persona validated (separate from security-reviewer)
- [x] Delegation table documented
- [x] Validates and dogfooded on Toolkit (static scan of current registry + skills)
