### PR TITLE
feat(quality): add CodeQL operational workflow (Closes #383)

### DIFF
--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -1,6 +1,6 @@
 version: 1
 generated: true
-count: 72
+count: 73
 skills:
   - id: accessibility/review
     name: review
@@ -442,6 +442,13 @@ skills:
     domain: ops
     description: Workstation health triage — validate tooling, directory layout, and
       run doctor with remediation suggestions.
+    stability: stable
+  - id: quality/codeql
+    name: codeql
+    domain: quality
+    description: CodeQL operational workflow — discover/config, run/inspect, triage
+      SARIF findings (rule/query ID, source→sink, evidence), remediate, re-validate.
+      Distinguishes broad MegaLinter linting from semantic s
     stability: stable
   - id: quality/megalinter
     name: megalinter

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -170,6 +170,7 @@ products:
         - agentic-security/owasp-agentic-review
         - agentic-security/threat-modeling
         - quality/megalinter
+        - quality/codeql
         - tooling/chrome-devtools
         - tooling/playwright-cli
         - core/project

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 72 skills × 17 agents._
+_Generated from 4 products × 73 skills × 17 agents._
 
 ## Products and targets
 
@@ -11,7 +11,7 @@ _Generated from 4 products × 72 skills × 17 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 72 | 0 |
+| `agent-toolkit-complete` | experimental | — | 73 | 0 |
 
 ## Skills → Products
 
@@ -83,6 +83,7 @@ _Generated from 4 products × 72 skills × 17 agents._
 | `ops/swarm-handoff` | `agent-toolkit-complete` | — |
 | `ops/swarm-observer` | `agent-toolkit-complete` | — |
 | `ops/triage` | `agent-toolkit-complete` | — |
+| `quality/codeql` | `agent-toolkit-complete` | — |
 | `quality/megalinter` | `agent-toolkit-complete` | — |
 | `tooling/chrome-devtools` | `agent-toolkit-complete` | — |
 | `tooling/herdr` | `agent-toolkit-complete` | — |

--- a/skills/quality/codeql/SKILL.md
+++ b/skills/quality/codeql/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: codeql
+description: CodeQL operational workflow — discover/config, run/inspect, triage SARIF findings (rule/query ID, source→sink, evidence), remediate, re-validate. Distinguishes broad MegaLinter linting from semantic security analysis.
+origin:
+  type: first-party
+---
+
+# CodeQL — Operational Security Analysis Workflow
+
+Help coding agents **operate** CodeQL, not just explain syntax. Covers discovery of existing setup, config review, scan execution/inspection, SARIF triage with evidence discipline, remediation, and targeted re-validation.
+
+> **Sources:** GitHub Docs Code Scanning with CodeQL (2026-08-12, https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql), CodeQL CLI (`github/codeql` MIT, CLI binaries separate), `github/codeql-action` (https://github.com/github/codeql-action), and this repo's `.github/workflows/codeql.yml` (Analyze Python via `codeql-action/init@v4` + `analyze@v4`).
+
+**Relationship to MegaLinter:**
+- **MegaLinter:** broad linting/formatting/static quality orchestration (50+ linters, Docker-based, `.mega-linter.yml`, fast feedback on style, config, IaC).
+- **CodeQL:** semantic security analysis / dataflow / vulnerability classes (source→sink taint, e.g., `python/sql-injection`, `js/xss`, SARIF alerts).
+- Neither replaces the other. Composition: `code-quality / secure-delivery → { MegaLinter, CodeQL }` without a giant orchestrator.
+
+## When to use
+
+- Repo has or needs CodeQL code scanning (`.github/workflows/codeql.yml`, `codeql-action`, SARIF alerts)
+- Need to triage a CodeQL alert (security tab, SARIF file, CI log) with evidence
+- Need to fix a finding and re-validate
+- Workflow failing (timeout, OOM, build failure for compiled languages, config error)
+- Need custom query / query-pack guidance (when to write vs reuse)
+
+## Modes (one skill, contextual)
+
+| Mode | Trigger | What it does |
+|------|---------|--------------|
+| **SETUP / CONFIG REVIEW** | No CodeQL workflow, or outdated `codeql-action` version, or new language to add | Inspect `.github/workflows/codeql.yml`, `languages:`, `queries:`, `paths:`, `paths-ignore:`, schedule, permissions (`security-events: write`); recommend `init@v4`/`analyze@v4` (or `codeql-action` latest), language matrix, `build-mode` for compiled (manual/autobuild/none) |
+| **FINDING TRIAGE** | SARIF file, alert URL, or `Run CodeQL` log with failure | Parse SARIF (`runs[].tool.driver.rules[]`, `runs[].results[]`), map `ruleId` → query help, extract `locations[0].physicalLocation`, `codeFlows` (source→sink), `message.text`, `level`/`category`, `partialFingerprints`; produce evidence table |
+| **REMEDIATION** | Triaged finding with fix needed | Propose minimal fix (sanitize, parameterized query, escape), show diff, reference query docs, note confidence/severity, and how to suppress via `// lgtm[…]` or `codeql-config.yml` only when justified (ask before suppress) |
+| **WORKFLOW TROUBLESHOOTING** | `analyze` job failed, no alerts, or `out of memory` | Check `codeql-action` logs, `AUTOBUILD` vs manual build, `ram:` / `threads:`, `debug: true`, `upload-sarif` fallback, `category` duplication |
+| **CUSTOM QUERY** | Need to detect a repo-specific pattern beyond standard packs | Guide when to reuse `security-and-quality` vs `security-extended` vs write custom QL (pack `codeql/<lang>-queries`), use `codeql pack create` + `codeql query run` locally, test with `codeql test run` |
+
+Do not split into separate skills — routing is via the mode table above.
+
+## Workflow (operational loop)
+
+```
+DISCOVER existing CodeQL setup (workflow, languages, queries, schedule)
+      ↓
+RUN or INSPECT scan (CI `analyze` job or local `codeql database create` + `codeql database analyze`)
+      ↓
+TRIAGE findings (SARIF: ruleId, location, source→sink, evidence, confidence, severity)
+      ↓
+PLAN remediation (fix vs suppress vs needs investigation)
+      ↓
+IMPLEMENT fix (minimal, preserve semantics)
+      ↓
+RE-VALIDATE targeted (re-run that query / re-upload SARIF / re-check alert)
+      ↓
+DOCUMENT residual (fixed / suppressed with justification / needs investigation)
+```
+
+1. **Discover:** `ls .github/workflows/codeql.yml` + `cat` (languages, `on: push/pull_request/schedule`, `permissions`, `strategy.matrix.language` if present). Check GitHub Security tab API (`gh api repos/{owner}/{repo}/code-scanning/alerts`) for open alerts, or `find . -name "*.sarif"` locally.
+2. **Run / Inspect:**
+   - **CI:** Trigger workflow (`gh workflow run codeql.yml`) or watch latest run (`gh run list --workflow=codeql.yml`, `gh run view <id>`, `gh run view <id> --log-failed`). Prefer CI when available (no local DB build needed).
+   - **Local (fallback):** `codeql database create --language=python --source-root=. /tmp/codeql-db` (compiled: add `--build-mode` or manual build command), then `codeql database analyze /tmp/codeql-db codeql/python-queries:codeql-suites/python-security-and-quality.qls --format=sarif-latest --output=/tmp/results.sarif`. Use `codeql pack download` for custom packs. Local needs CodeQL CLI installed (`gh codeql` or `codeql` binary, Java for DB).
+3. **Triage (evidence discipline):**
+   - For each `result` in SARIF: extract `ruleId` (e.g., `py/sql-injection`), `message.text`, `locations[0].physicalLocation.artifactLocation.uri` + `region` (line/col), `codeFlows[0].threadFlows[0].locations` (source→sink), `partialFingerprints.primaryLocationLineHash` (stable ID), `properties.severity` / `security-severity`, `level` (error/warning/note).
+   - Do not dismiss as false positive without evidence. If source→sink lacks a sanitizer, mark `Needs investigation` and propose confirming with query help link (`https://codeql.github.com/codeql-query-help/python/py-sql-injection`).
+   - Table columns: `# | ruleId | location (file:line) | source→sink | code evidence (snippet) | severity/confidence | remediation | validation | status`.
+4. **Remediate:** Propose minimal fix with diff. For `py/sql-injection`: use parameterized `cursor.execute("SELECT ... WHERE id = %s", (user_id,))` not `f"SELECT ... {user_id}"`. For `js/xss`: escape via `textContent` or DOMPurify. For `java/sql-injection`: use `PreparedStatement`. Ask before adding `// lgtm[py/sql-injection]` or `codeql-config.yml` `query-filters: - exclude: py/sql-injection` — suppress only with justification.
+5. **Re-validate:** Re-run that single query pack (`codeql database analyze --query-suite=... --sarif-category=python`) or push branch and re-check Security tab alert state (`open` → `fixed` after merge to default branch, or `dismissed` if suppressed). For CI, watch new `analyze` run; for local, `codeql database analyze` with `--rerun`.
+6. **Document residual:** `fixed` (with commit), `dismissed` (reason + `dismissedReason: false positive` + comment), or `needs investigation` (insufficient evidence, e.g., custom sanitizer not modeled).
+
+## Evidence discipline (per finding)
+
+| Field | Required | Example |
+|-------|----------|---------|
+| `ruleId` / `query ID` | Yes | `py/sql-injection`, `java/sql-injection` |
+| `location` | Yes | `src/app.py:42:12` (uri + region) |
+| `source → sink` | Yes when taint query | `request.args.get("id")` (source, line 38) → `cursor.execute(…)` (sink, line 42) via `codeFlows` |
+| `code evidence` | Yes | Snippet `cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")` |
+| `confidence` | Yes | High/Med/Low (from `properties.precision`: `very-high`/`high`/`medium`) |
+| `severity` | Yes | `error` / `warning` + `security-severity: 8.5` |
+| `remediation` | Yes | Parameterized query, or `needs investigation` if sanitizer unknown |
+| `validation` | Yes | `re-ran py/security-and-quality on /tmp/db → 0 results for py/sql-injection` or `CI analyze #123 green` |
+
+If evidence insufficient: status `Needs investigation` is valid — do not mark `fixed` or `false positive` without code proof.
+
+## MegaLinter vs CodeQL (documented)
+
+| Aspect | MegaLinter | CodeQL |
+|--------|------------|--------|
+| Scope | Broad linting/formatting/IaC (100+ linters, `.mega-linter.yml`) | Semantic security / dataflow (SARIF, `codeql/*` packs) |
+| Runtime | Docker `ghcr.io/oxsecurity/megalinter:v10` via `npx mega-linter-runner` | `github/codeql-action` (init/analyze) or `codeql` CLI + DB |
+| Output | Console + `megalinter-reports/mega-linter-report.json` + logs | SARIF `results.sarif` + GitHub Security alerts |
+| Fix loop | ≤3 bounded (safe auto-fix → targeted re-check) | One finding at a time, re-analyze DB after fix |
+| When to use | Every PR for hygiene | Every push/PR for security, plus scheduled weekly |
+
+**Do not duplicate workflows.** When both are needed, run `megalinter-check` for hygiene and `codeql` triage for security; share the same branch but keep SARIF vs linter reports separate.
+
+## Safety
+
+- Never auto-suppress a CodeQL alert without user confirmation — suppression hides a security finding.
+- Never push to `main` to fix a CodeQL alert — create branch `codeql/fix-<rule>-<id>`, fix, push, verify `analyze` passes.
+- For custom queries, keep them in `codeql-query-pack/` with `qlpack.yml` and `codeql test` — do not edit `github/codeql` directly.
+
+## References
+
+- `references/codeql-queries.md` — curated query packs (`security-and-quality`, `security-extended`, `security-experimental`), per-language `codeql/<lang>-queries` locations, and when to write custom QL
+- GitHub Docs: Code scanning with CodeQL (2026-08-12), CodeQL CLI, `github/codeql-action` (https://github.com/github/codeql-action, MIT), `github/codeql` (MIT, queries)
+- This repo: `.github/workflows/codeql.yml` (Analyze Python, `init@v4` + `analyze@v4`, schedule `0 6 * * 1`)

--- a/skills/quality/codeql/references/codeql-queries.md
+++ b/skills/quality/codeql/references/codeql-queries.md
@@ -1,0 +1,43 @@
+# CodeQL Query Packs — 2026-08-12
+
+**Upstream:** `github/codeql` (MIT, https://github.com/github/codeql) — standard QL libraries and queries. Packs per language under `codeql/<lang>-queries` (e.g., `python`, `javascript`, `java`, `go`, `cpp`). Suites: `codeql-suites/<lang>-security-and-quality.qls`, `security-extended.qls`, `security-experimental.qls`.
+
+**GitHub Docs (2026-08-12):** CodeQL code scanning for compiled languages (build modes), CodeQL CLI (`codeql database create` / `analyze`), `github/codeql-action` (https://github.com/github/codeql-action, MIT, `init@v4` + `analyze@v4`).
+
+## Curated suites
+
+| Suite | What it contains | When to use |
+|-------|------------------|-------------|
+| `security-and-quality` | Security + correctness (precision `very-high`/`high`) | Default for CI — `Analyze Python` in this repo uses `codeql/python-queries:codeql-suites/python-security-and-quality.qls` implicitly via `codeql-action` without custom `queries:` |
+| `security-extended` | Additional security with more false positives (`medium` precision) | When you need broader coverage and can triage |
+| `security-experimental` | Experimental queries | Only for research, not CI gate |
+
+**Per-language pack locations (examples):**
+- `codeql/python-queries` — `py/sql-injection`, `py/xss`, `py/path-injection`, etc. Help: https://codeql.github.com/codeql-query-help/python/
+- `codeql/javascript-queries` — `js/sql-injection`, `js/xss`, etc.
+- `codeql/java-queries` — `java/sql-injection`, etc.
+- `codeql/cpp-queries`, `codeql/go-queries`, `codeql/ruby-queries`, `codeql/csharp-queries`
+
+## This repo
+
+- `.github/workflows/codeql.yml`: `languages: python` via `github/codeql-action/init@v4` + `analyze@v4`, `on: push[main] + pull_request[main] + schedule 0 6 * * 1`, `permissions: security-events: write`.
+- No custom `queries:` yet — uses default `security-and-quality` pack.
+- To add a language: add to `matrix.language` or separate job with `language: java` + build spec (`autobuild` for Maven/Gradle, manual `mvn package` for custom).
+
+## When to write custom QL
+
+- Reuse `security-and-quality` first. Only write custom when you need a repo-specific pattern (e.g., internal sanitizer, framework-specific sink).
+- Create `codeql-query-pack/qlpack.yml`:
+  ```yaml
+  name: my-org/my-queries
+  version: 0.0.1
+  dependencies:
+    codeql/python-queries: "*"
+  ```
+- Write `my-query.ql` with `import python`, `from DataFlow::Node source, sink where ... select sink, "message"`, add `metadata` (`id`, `kind: path-problem`, `severity`, `precision`), help docs.
+- Test: `codeql test run codeql-query-pack/`, then `codeql pack create` + `codeql database analyze --query-suite=my-suite.qls`.
+
+## References
+
+- `github/codeql` README (MIT, 2026-08-11), `github/codeql-action` README (MIT)
+- GitHub Docs: Code scanning with CodeQL, CodeQL CLI, CodeQL query help

--- a/tests/test_quality_codeql.py
+++ b/tests/test_quality_codeql.py
@@ -1,0 +1,73 @@
+"""Tests for quality/codeql first-party workflow — #383."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills/quality/codeql/SKILL.md"
+
+
+def _fm(path):
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r"^---\n(.*?)\n---\n", text, re.DOTALL | re.MULTILINE)
+    return yaml.safe_load(m.group(1)), text
+
+
+def test_frontmatter_first_party():
+    fm, _ = _fm(SKILL_PATH)
+    assert fm["origin"]["type"] == "first-party"
+    assert fm["name"] == "codeql"
+
+
+def test_workflow_modes():
+    t = SKILL_PATH.read_text()
+    for mode in [
+        "SETUP / CONFIG REVIEW",
+        "FINDING TRIAGE",
+        "REMEDIATION",
+        "WORKFLOW TROUBLESHOOTING",
+        "CUSTOM QUERY",
+    ]:
+        assert mode in t, f"missing mode {mode}"
+    # Should not be split into separate skills
+    assert "Do not split into separate skills" in t
+
+
+def test_evidence_discipline():
+    t = SKILL_PATH.read_text()
+    for field in ["ruleId", "source → sink", "code evidence", "confidence", "severity"]:
+        assert field in t, f"missing evidence field {field}"
+    assert "Needs investigation" in t
+    # Table columns
+    assert "ruleId | location" in t or "ruleId" in t
+
+
+def test_megalinter_distinction():
+    t = SKILL_PATH.read_text()
+    assert "MegaLinter" in t
+    assert "broad linting" in t.lower() or "Broad linting" in t
+    assert "semantic security" in t.lower()
+    assert "Neither replaces the other" in t
+
+
+def test_operational_loop():
+    t = SKILL_PATH.read_text()
+    assert "DISCOVER existing CodeQL setup" in t
+    assert "RUN or INSPECT scan" in t
+    assert "TRIAGE findings" in t
+    assert "RE-VALIDATE" in t
+
+
+def test_safety():
+    t = SKILL_PATH.read_text()
+    assert "Never auto-suppress" in t
+    assert "Never push to `main`" in t or "Never push to" in t
+
+
+def test_references():
+    assert (REPO_ROOT / "skills/quality/codeql/references/codeql-queries.md").exists()
+    txt = (REPO_ROOT / "skills/quality/codeql/references/codeql-queries.md").read_text()
+    assert "security-and-quality" in txt
+    assert "github/codeql" in txt


### PR DESCRIPTION
Closes #383

First-party skill `quality/codeql` — operational workflow for CodeQL, not just syntax.

- **Discovery:** `.github/workflows/codeql.yml` (`Analyze Python` via `codeql-action/init@v4` + `analyze@v4`, `on: push[main]/pull_request/schedule 0 6 * * 1`, `permissions: security-events: write`), languages/queries/paths, Security tab `gh api repos/{owner}/{repo}/code-scanning/alerts` or local `*.sarif`
- **Modes (one skill, contextual):** `SETUP / CONFIG REVIEW`, `FINDING TRIAGE`, `REMEDIATION`, `WORKFLOW TROUBLESHOOTING`, `CUSTOM QUERY` — do not split
- **Workflow:** `DISCOVER → RUN/INSPECT (CI analyze job or local codeql database create/analyze) → TRIAGE (SARIF ruleId, location, source→sink codeFlows, message, severity/confidence) → PLAN → IMPLEMENT → RE-VALIDATE targeted → DOCUMENT residual`
- **Evidence discipline per finding:** `ruleId`, `location`, `source→sink`, `code evidence`, `confidence` (precision), `severity` (security-severity), `remediation`, `validation`; `Needs investigation` valid when insufficient
- **MegaLinter vs CodeQL:** broad linting (Docker, `megalinter-reports/`) vs semantic dataflow (SARIF, `codeql/*` packs) — neither replaces, composition `code-quality / secure-delivery → {MegaLinter, CodeQL}` without giant orchestrator
- **Safety:** never auto-suppress without confirmation, never push `main` (branch `codeql/fix-*`), custom queries in `codeql-query-pack/`

- `references/codeql-queries.md` — curated suites (`security-and-quality`/`extended`/`experimental`), per-language `codeql/<lang>-queries`, this repo's default pack
- Sources: GitHub Docs Code Scanning with CodeQL (2026-08-12), `github/codeql` MIT, `github/codeql-action` MIT, `github/codeql-cli-binaries`
- Validates: `validate-skills.py` 73 OK, `pytest` 7 new tests passed, `ruff` clean
- Product: `quality/codeql` added to `agent-toolkit-complete`