### PR TITLE
feat(providers): add capability provider abstraction WHAT vs HOW (Closes #386)

### DIFF
--- a/docs/adr/0004-capability-provider-abstraction-what-vs-how.md
+++ b/docs/adr/0004-capability-provider-abstraction-what-vs-how.md
@@ -1,0 +1,92 @@
+# ADR-0004: Capability Provider Abstraction — WHAT vs HOW per Target
+
+**Status:** Accepted (2026-08-12) — implements #386, pilots for #393/#368
+
+**Deciders:** ulises-jeremias (owner) + toolkit maintainers
+
+**Related:** #386 (provider abstraction), #393 (integration hardening), #368 (providers epic), #364 (trust tiers), #387 (inventory/doctor — deferred wiring), PR #410 (scaffold closed), PR #4xx (this)
+
+---
+
+## Context
+
+Integrations are hard-wired to single backends (Linear via `mcp/registry/linear.yaml` → `mcp.linear.app/mcp`, Slack via `slack-cli`, Figma via `mcp.figma.com/mcp`). Capability intent and access mechanism are conflated — the registry records one provider per integration and skills hard-wire one `HOW`, so per-target strongest-backend selection is impossible and Workstation vs Toolkit cannot evolve independently.
+
+Forces:
+
+- **Per-target reality:** Official Linear MCP is OAuth + `streamable_http` (remote, no env) best for team workspaces; a PAT-based community MCP (`@ibraheem4/linear-mcp`, `stdio`) is better for solo/single-workspace; the GraphQL API (`https://api.linear.app/graphql`) is the only path for `deleteIssue` but is `admin` privilege. Slack chat automation prefers `mcp-server-slack` (Socket Mode, `stdio`, low latency) while app scaffolding prefers `slack-cli` (OAuth, admin, `Apache-2.0`). Figma read-only design context prefers `mcp.figma.com/mcp` (remote, `streamable_http`, OAuth) while writes require the Figma plugin API (local, needs approval). The stale heuristic `official plugin > official MCP > official CLI > community MCP > custom` is a starting point, not law.
+- **WHAT stability vs HOW churn:** Verbs/entities (`list, get, create, update, comment` on `issue, project`) are stable across years; transports, auth, package names, and target coverage change quarterly. Mixing them forces churn in the same file.
+- **Harness boundary:** Toolkit ships `skills/integrations/*.md` (portable) and `mcp/registry/*.yaml` (agent wiring). Pushing tool-specific backend paths into skills leaks harness concerns (ADR-0003: products own installation, packs docs-only).
+- **Security separation:** Source trust (who vouches — `official` Linear vs `community` `@ibraheem4` vs `first-party` skill) and runtime privilege (what it can do — `read-only` Figma MCP vs `admin` Slack CLI) are orthogonal. Official source does NOT imply safe privilege; read-only community can be safer than admin official.
+
+Without a decision, per-target selection must be hand-maintained in `compiler/target_registry.py` forks, and #393 cannot harden Jira/Confluence/Notion/Sentry against per-target divergence.
+
+## Options Considered
+
+### Option A: Universal backend ranking in code (REJECTED — the #386 Proposed Approach §4 heuristic)
+
+Hard-wire `official plugin > official MCP > official CLI > community MCP > custom` and generate per-target backend by ranking.
+
+**Pros:**
+- Simple `max(rank)` selection.
+- Appears conceptually clean.
+
+**Cons:**
+- Wrong in practice: Figma MCP (`read-only`) outranks Figma plugin API (`read-write` + approval) for read-only tasks; Slack `slack-cli` (`admin`) outranks `mcp-server-slack` for `slack create`. No single order satisfies all verbs.
+- Hidden coupling: ranking policy lives in compiler, not declaration; adding a target requires code change.
+- Encourages over-privilege (always pick highest-ranked, even if `admin`).
+
+### Option B: Minimal WHAT vs HOW registry, per-capability contextual evaluation (SELECTED)
+
+Separate:
+
+```
+CAPABILITY INTENT (WHAT)  — verbs[] + entities[] — stable, in providers/providers.yaml `what`
+        ↓ per-target mapping
+ACCESS MECHANISM (HOW[])  — {id, mechanism, targets[], package, repository, license, transport,
+                              provenance, version_policy,
+                              auth: {type, env[], scopes[]},
+                              read[], write[], destructive[],
+                              permissions: {source_trust, runtime_privilege, requires_approval},
+                              runtime: {local_vs_remote, sandbox, latency, context_overhead, offline},
+                              availability: {maintenance, cross_agent[], native_ux}}
+        ↓ evaluation
+CONTEXTUAL CHOICE — evaluation.notes records why no universal ranking; per-verb choice
+                     (e.g., Linear OAuth MCP for team vs PAT MCP for solo vs API for delete)
+        ↓ security reporting (distinct)
+SOURCE TRUST vs RUNTIME PRIVILEGE — reported separately in `security` + `permissions` (reuses
+                                     existing `scripts/audit-capability.py` + `mcp/registry/*.yaml`
+                                     `security`/`approval` surfaces, no new framework)
+```
+
+Machine-readable registry at `providers/providers.yaml` validated by `schemas/provider.schema.json`; human-readable per-HOW evaluation at `docs/providers/provider-matrix.md` (dated 2026-08-12) with sources.
+
+**Pros:**
+- No universal law — selection is per-verb, per-target, per-privilege; evaluation notes make tradeoffs reviewable.
+- Minimal genuinely-common fields surfaced as recurring after 3 pilots (Linear, Slack, Figma); other fields stay pilot-specific.
+- Reuses existing trust/approval surfaces; `skill_fallback` keeps skills portable (delegate, don't wire backend paths).
+- `inventory`/`build --check` wiring deferred to Phase 2 without blocking pilots (ADR-0001 provenance remains authoritative for supply-chain; provider is semantic routing).
+
+**Cons:**
+- Requires per-capability `evaluation.notes` maintenance; ranking not automated (acceptable — 3 pilots prove manual contextual choice scales to #393).
+
+## Decision
+
+Adopt **Option B**:
+
+1. **Registry:** `providers/providers.yaml` (`version: 1`, `providers: {linear, slack, figma}`) with `what`, `how[]`, `evaluation`, `security` as above. Schema at `schemas/provider.schema.json` (requires `what.verbs`, `how[].id/mechanism/targets/provenance/read/write`, `permissions.source_trust/runtime_privilege`, `auth`, `runtime`, `availability`). Validation in tests via `jsonschema Draft202012Validator`; `ruff`/`pytest` gated.
+2. **Pilots:** Linear (4 HOWs: official MCP `https://mcp.linear.app/mcp` OAuth, community MCP `@ibraheem4/linear-mcp` PAT, GraphQL API, `skills/integrations/linear` fallback), Slack (4: `mcp-server-slack` Socket, `slack-cli` `docs.slack.dev/tools/slack-cli` Apache-2.0, Web API, skill fallback), Figma (4: `mcp.figma.com/mcp` OAuth, REST `api.figma.com/v1`, plugin API, `skills/design/figma` fallback). Each evaluated on package/repository/license/transport/auth/read/write/destructive/permissions/runtime/availability/cross-agent/native UX.
+3. **Matrix:** `docs/providers/provider-matrix.md` dated `2026-08-12` with Summary + per-HOW tables + distinct `Source trust vs Runtime privilege` section. Sources cited: Linear MCP (`mcp.linear.app/mcp`, `https://linear.app/docs/mcp`), Slack (`mcp-server-slack` + `docs.slack.dev/tools/slack-cli` + `docs.slack.dev/ai/mcp-server`), Figma (`mcp.figma.com/mcp`, `https://www.figma.com/developers/mcp`), plus `mcp/registry/*.yaml`.
+4. **No law:** Must NOT encode `official plugin > MCP > CLI` as invariant; every doc asserts `No universal plugin > MCP > CLI ranking — contextual per-capability, per-target`.
+5. **Security distinct:** Report `source_trust` and `runtime_privilege` separately; reuse `security`/`approval` from existing toolkit; never conflate highly-trusted source with safe privilege.
+6. **Phase 2 deferred:** `agent-toolkit inventory` per-provider display and `build --check` per-target validation to follow #393 integration audits; current PR proves model, not compiler wiring.
+
+## Consequences
+
+- Positive: #386 acceptance criteria satisfied without compiler coupling; #393 can audit Jira/Confluence/Notion/Sentry with same WHAT/HOW template; Workstation products can select `what` without pinning `how`.
+- Negative: `inventory`/`doctor` still single-backend until Phase 2; mitigated by matrix + registry as interim truth.
+- Migration: New SaaS integrations add `providers/<id>.yaml` entry via same schema; no `mcp/registry/*.yaml` breakage — registry is additive.
+
+## Alternatives Rejected Detail
+
+See Option A above; also rejected extending `mcp/registry/*.yaml` in place (retains single-backend assumption) and making `caps/providers/*.yaml` per-tool (duplicates WHAT).

--- a/docs/providers/provider-matrix.md
+++ b/docs/providers/provider-matrix.md
@@ -1,0 +1,79 @@
+# Provider Capability Matrix — 2026-08-12
+
+**WHAT vs HOW** — capability intent (`what.verbs` + `entities`) is stable; `how` is target- and context-dependent. No universal `plugin > MCP > CLI` ranking.
+
+**Sources (2026-08-12):** Linear MCP (`mcp.linear.app/mcp`, https://linear.app/docs/mcp), Slack `mcp-server-slack` + `slack-cli` (`docs.slack.dev/tools/slack-cli`, `docs.slack.dev/ai/mcp-server`), Figma MCP (`mcp.figma.com/mcp`, https://www.figma.com/developers/mcp), plus Toolkit `mcp/registry/*.yaml` (dated 2026-08-12).
+
+## Summary
+
+| Capability | WHAT (verbs) | Preferred HOW per target | Alternative HOW |
+|------------|--------------|--------------------------|-----------------|
+| **Linear** | `list, get, create, update, comment, triage, plan` on `issue, project, cycle` | `mcp` `https://mcp.linear.app/mcp` (OAuth, `streamable_http`) for Claude/Cursor/OpenCode — native, no token env | `community_mcp` `@ibraheem4/linear-mcp` (PAT, `stdio`) for single-workspace; `api` `https://api.linear.app/graphql` (admin, needs approval) for `deleteIssue`; `skill_fallback` `skills/integrations/linear` (delegates) |
+| **Slack** | `list, post, react, create, deploy, api` on `channel, message, reaction, app` | `mcp` `@anthropic-ai/mcp-server-slack` (Socket Mode, `stdio`, `SLACK_BOT_TOKEN`+`SLACK_APP_TOKEN`) for chat automation — native, low latency | `cli` `slack-cli` (`docs.slack.dev/tools/slack-cli`, `Apache-2.0`, admin, needs approval) for app scaffolding; `api` `https://slack.com/api/chat.postMessage` (direct); `skill_fallback` |
+| **Figma** | `get_design_context, get_screenshot, get_metadata, implement` on `file, node, component` | `mcp` `https://mcp.figma.com/mcp` (OAuth, `streamable_http`, `FIGMA_OAUTH_TOKEN`+`FIGMA_REGION`) for design-to-code — remote, read-only, low context | `api` `https://api.figma.com/v1/files/:file_key` (PAT, read-only); `api` `figma plugin API` (write, Figma Desktop, needs approval); `skill_fallback` `skills/design/figma` |
+
+## Detailed per-HOW evaluation
+
+### Linear
+
+| HOW | Mechanism | Targets | Auth | Read | Write | Destructive | Trust / Privilege | Runtime | Maintenance | Notes |
+|-----|-----------|---------|------|------|-------|-------------|-------------------|---------|-------------|-------|
+| `linear-mcp-official` | `mcp` `https://mcp.linear.app/mcp` | claude-code, cursor, opencode, windsurf, vscode | `oauth` (browser, no env) | `list_issues`, `get_issue`, `list_projects`, `list_cycles` | `create_issue`, `update_issue`, `create_comment` | — | `official` / `read-write` (separate — highly trusted source but can create/update, no delete) | remote, browser OAuth, medium latency, low context, offline `false` | active 2026-08-12 | Preferred for most |
+| `linear-mcp-community-pat` | `community_mcp` `@ibraheem4/linear-mcp` | claude-code, cursor, opencode | `api_key` `LINEAR_API_KEY` | `list_issues` etc. | `create_issue`, `update_issue` | — | `community` / `read-write` | local `stdio`, low latency | community 2026-08-12 | PAT fallback |
+| `linear-api-graphql` | `api` `https://api.linear.app/graphql` | universal | `api_key` `LINEAR_API_KEY` (admin scopes) | GraphQL queries | `createIssue`, `updateIssue` | `deleteIssue` (admin) | `official` / `admin` (needs approval) | remote `https`, none context | active | Most powerful, needs approval |
+| `linear-skill-fallback` | `skill_fallback` `skills/integrations/linear` | universal | `oauth` | via MCP | via MCP | — | `first-party` / `read-only` | hybrid (delegates) | active | Skill instructs MCP workflow |
+
+*Provider choice is contextual:* OAuth MCP for team workspaces (no token env) vs PAT MCP for solo/single-workspace vs API for admin/delete.
+
+### Slack
+
+| HOW | Mechanism | Targets | Auth | Read | Write | Destructive | Trust / Privilege | Runtime | Notes |
+|-----|-----------|---------|------|------|-------|-------------|-------------------|---------|-------|
+| `slack-mcp-official` | `mcp` `@anthropic-ai/mcp-server-slack` | claude-code, cursor, opencode, vscode | `bearer-env` `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | `conversations_history` etc. | `chat_post_message`, `reactions_add` | — | `official` / `read-write` | local `stdio` Socket Mode, low latency | Chat automation |
+| `slack-cli-official` | `cli` `slack-cli` (`docs.slack.dev/tools/slack-cli`, Apache-2.0) | universal | `oauth` | `slack list`, `slack api conversations.list` | `slack create`, `slack deploy` | `slack delete` (admin) | `official` / `admin` (needs approval) | local CLI, OAuth | App dev |
+| `slack-api-web` | `api` `https://slack.com/api/chat.postMessage` | universal | `bearer-env` `SLACK_BOT_TOKEN` | `conversations.history` | `chat.postMessage` | — | `official` / `read-write` | remote `https` | Direct |
+| `slack-skill-fallback` | `skill_fallback` | universal | `bearer-env` | via delegates | via delegates | — | `first-party` / `read-only` | hybrid | Skill |
+
+*Chat automation prefers MCP (native, low latency). App scaffolding prefers CLI (admin). No universal ranking.*
+
+### Figma
+
+| HOW | Mechanism | Targets | Auth | Read | Write | Destructive | Trust / Privilege | Runtime | Notes |
+|-----|-----------|---------|------|------|-------|-------------|-------------------|---------|-------|
+| `figma-mcp-official` | `mcp` `https://mcp.figma.com/mcp` | claude-code, cursor, opencode, vscode | `bearer-env` `FIGMA_OAUTH_TOKEN`, `FIGMA_REGION` | `get_design_context`, `get_screenshot` etc. | — | — | `official` / `read-only` | remote `streamable_http`, OAuth | Preferred for design-to-code |
+| `figma-rest-api` | `api` `https://api.figma.com/v1/files/:file_key` | universal | `bearer-env` `FIGMA_PERSONAL_ACCESS_TOKEN` | `GET files, nodes` | — | — | `official` / `read-only` | remote `https` | Fallback |
+| `figma-plugin-api` | `api` `figma plugin API` | figma-plugin | `none` | `read node` | `create frames` etc. (plugin only) | — | `official` / `read-write` (needs approval) | local Figma Desktop | Write, needs Figma plugin |
+| `figma-skill-fallback` | `skill_fallback` `skills/design/figma` | universal | `bearer-env` | via MCP | — | — | `first-party` / `read-only` | hybrid | Skill |
+
+*Read-only design context prefers MCP (remote, low context). Write via plugin needs Figma Desktop + approval.*
+
+## Security — source trust vs runtime privilege (distinct)
+
+| Capability | Source trust (who vouches) | Runtime privilege (what it can do) | Separate? |
+|------------|----------------------------|-------------------------------------|-----------|
+| Linear official MCP (`mcp.linear.app`) | `official` (Linear) — highly trusted as source | `read-write` (create/update, no delete) — needs no approval for normal, approval for bulk/destructive | Yes — trusted source but still bounded privilege |
+| Slack CLI (`slack-cli`, `docs.slack.dev`) | `official` — highly trusted | `admin` (can delete apps, admin scopes) — requires approval even though source is trusted | Yes |
+| Figma MCP (`mcp.figma.com`) | `official` — highly trusted | `read-only` — cannot mutate files | Yes — high trust but low privilege |
+
+Reuse existing Toolkit `security` declarations (`scripts/audit-capability.py` surface, `mcp/registry/*.yaml` `security` + `approval` fields) rather than a new framework.
+
+## Minimal provider model (recurring fields after 3 pilots)
+
+After Linear + Slack + Figma, the genuinely common fields are:
+
+```yaml
+id, display_name, purpose
+what: {verbs[], entities[]}
+how[]: {id, mechanism, targets[], package, repository, license, transport, provenance, version_policy,
+        auth: {type, env[], scopes[]},
+        read[], write[], destructive[],
+        permissions: {source_trust, runtime_privilege, requires_approval},
+        runtime: {local_vs_remote, sandbox, latency, context_overhead, offline},
+        availability: {maintenance, cross_agent[], native_ux}}
+evaluation: {notes}
+security: {source_trust, runtime_privilege}  # summary, distinct
+```
+
+No `official plugin > MCP > CLI` law — provider selection is per-capability and per-target (e.g., Linear OAuth MCP for Claude vs PAT MCP for solo vs API for admin).
+
+See `providers/providers.yaml` (machine-readable) and `schemas/provider.schema.json` (validation).

--- a/providers/providers.yaml
+++ b/providers/providers.yaml
@@ -1,0 +1,563 @@
+version: '1'
+providers:
+  linear:
+    id: linear
+    display_name: Linear
+    purpose: Manage Linear issues, projects, cycles, and comments
+    what:
+      verbs:
+        - list
+        - get
+        - create
+        - update
+        - comment
+        - triage
+        - plan
+      entities:
+        - issue
+        - project
+        - cycle
+        - comment
+        - team
+    how:
+      - id: linear-mcp-official
+        mechanism: mcp
+        targets:
+          - claude-code
+          - cursor
+          - opencode
+          - windsurf
+          - vscode
+        package: https://mcp.linear.app/mcp
+        repository: https://linear.app/docs/mcp
+        license: proprietary
+        transport: streamable_http
+        provenance: official
+        version_policy: remote hosted
+        auth:
+          type: oauth
+          env: []
+          scopes:
+            - read
+            - write
+        read:
+          - list_issues
+          - get_issue
+          - list_projects
+          - list_cycles
+          - search_issues
+        write:
+          - create_issue
+          - update_issue
+          - create_comment
+        destructive: []
+        permissions:
+          source_trust: official
+          runtime_privilege: read-write
+          requires_approval: false
+        runtime:
+          local_vs_remote: remote
+          sandbox: browser OAuth, no token in env
+          latency: medium (HTTP)
+          context_overhead: low (tool definitions)
+          offline: false
+        availability:
+          maintenance: active (2026-08-12)
+          cross_agent:
+            - claude-code
+            - cursor
+            - opencode
+          native_ux: MCP tool calls
+      - id: linear-mcp-community-pat
+        mechanism: community_mcp
+        targets:
+          - claude-code
+          - cursor
+          - opencode
+        package: '@ibraheem4/linear-mcp'
+        repository: https://github.com/ibraheem4/linear-mcp
+        license: MIT
+        transport: stdio
+        provenance: community
+        version_policy: pin to minor
+        auth:
+          type: api_key
+          env:
+            - LINEAR_API_KEY
+          scopes:
+            - read
+            - write
+        read:
+          - list_issues
+          - get_issue
+          - list_projects
+        write:
+          - create_issue
+          - update_issue
+        destructive: []
+        permissions:
+          source_trust: community
+          runtime_privilege: read-write
+          requires_approval: false
+        runtime:
+          local_vs_remote: local
+          sandbox: stdio, env var
+          latency: low
+          context_overhead: low
+          offline: false
+        availability:
+          maintenance: community (2026-08-12)
+          cross_agent:
+            - claude-code
+          native_ux: MCP
+      - id: linear-api-graphql
+        mechanism: api
+        targets:
+          - universal
+        package: https://api.linear.app/graphql
+        repository: https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: remote hosted
+        auth:
+          type: api_key
+          env:
+            - LINEAR_API_KEY
+          scopes:
+            - read
+            - write
+            - admin
+        read:
+          - query issues (GraphQL)
+          - query projects
+        write:
+          - mutation createIssue
+          - updateIssue
+        destructive:
+          - deleteIssue
+        permissions:
+          source_trust: official
+          runtime_privilege: admin
+          requires_approval: true
+        runtime:
+          local_vs_remote: remote
+          sandbox: https, token in header
+          latency: low
+          context_overhead: none (direct)
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - universal
+          native_ux: curl/GraphQL
+      - id: linear-skill-fallback
+        mechanism: skill_fallback
+        targets:
+          - universal
+        package: skills/integrations/linear
+        repository: https://github.com/ulises-jeremias/agent-toolkit
+        license: MIT
+        transport: skill
+        provenance: first-party
+        version_policy: vendored
+        auth:
+          type: oauth
+          env: []
+          scopes: []
+        read:
+          - via MCP tools (delegates)
+        write:
+          - via MCP tools
+        destructive: []
+        permissions:
+          source_trust: first-party
+          runtime_privilege: read-only
+          requires_approval: false
+        runtime:
+          local_vs_remote: hybrid
+          sandbox: skill delegates to MCP
+          latency: n/a
+          context_overhead: skill body ~4k tokens, lazy
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - universal
+          native_ux: skill instructions
+    evaluation:
+      notes: "Official MCP (OAuth, streamable_http) is preferred for most targets\
+        \ (native, low context, no token env). Community PAT MCP is fallback for single-workspace/PAT\
+        \ use. API is most powerful but requires approval for admin/destructive. No\
+        \ universal ranking \u2014 choice depends on auth (OAuth vs PAT) and target\
+        \ (Claude/Cursor native vs pi fallback)."
+    security:
+      source_trust: "official (mcp.linear.app) \u2014 highly trusted as source"
+      runtime_privilege: "read-write (can create/update issues, no delete by default)\
+        \ \u2014 separate from trust; requires approval for bulk/destructive"
+  slack:
+    id: slack
+    display_name: Slack
+    purpose: Slack app development, channel history, messaging, and workspace automation
+    what:
+      verbs:
+        - list
+        - post
+        - react
+        - create
+        - deploy
+        - api
+      entities:
+        - channel
+        - message
+        - reaction
+        - app
+        - manifest
+        - trigger
+    how:
+      - id: slack-mcp-official
+        mechanism: mcp
+        targets:
+          - claude-code
+          - cursor
+          - opencode
+          - vscode
+        package: '@anthropic-ai/mcp-server-slack'
+        repository: https://docs.slack.dev/ai/mcp-server/
+        license: MIT
+        transport: stdio
+        provenance: official
+        version_policy: pin to minor
+        auth:
+          type: bearer-env
+          env:
+            - SLACK_BOT_TOKEN
+            - SLACK_APP_TOKEN
+          scopes:
+            - channels:history
+            - chat:write
+            - reactions:write
+        read:
+          - conversations_history
+          - conversations_list
+          - users_list
+        write:
+          - chat_post_message
+          - reactions_add
+          - conversations_create
+        destructive: []
+        permissions:
+          source_trust: official
+          runtime_privilege: read-write
+          requires_approval: false
+        runtime:
+          local_vs_remote: local
+          sandbox: stdio, Socket Mode
+          latency: low
+          context_overhead: low
+          offline: false
+        availability:
+          maintenance: active (2026-08-12)
+          cross_agent:
+            - claude-code
+            - cursor
+          native_ux: MCP tools
+      - id: slack-cli-official
+        mechanism: cli
+        targets:
+          - universal
+        package: slack-cli
+        repository: https://docs.slack.dev/tools/slack-cli/
+        license: Apache-2.0
+        transport: cli
+        provenance: official
+        version_policy: pin to minor
+        auth:
+          type: oauth
+          env: []
+          scopes:
+            - apps:write
+            - admin
+        read:
+          - slack list
+          - slack doctor
+          - slack api conversations.list
+        write:
+          - slack create
+          - slack deploy
+          - slack api chat.postMessage
+        destructive:
+          - slack delete
+        permissions:
+          source_trust: official
+          runtime_privilege: admin
+          requires_approval: true
+        runtime:
+          local_vs_remote: local
+          sandbox: CLI, OAuth
+          latency: medium
+          context_overhead: low
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - universal
+          native_ux: CLI
+      - id: slack-api-web
+        mechanism: api
+        targets:
+          - universal
+        package: https://slack.com/api/chat.postMessage
+        repository: https://docs.slack.dev/reference/methods/chat.postMessage
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: remote hosted
+        auth:
+          type: bearer-env
+          env:
+            - SLACK_BOT_TOKEN
+          scopes:
+            - chat:write
+        read:
+          - conversations.history
+          - users.list
+        write:
+          - chat.postMessage
+          - reactions.add
+        destructive: []
+        permissions:
+          source_trust: official
+          runtime_privilege: read-write
+          requires_approval: false
+        runtime:
+          local_vs_remote: remote
+          sandbox: https
+          latency: low
+          context_overhead: none
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - universal
+          native_ux: curl
+      - id: slack-skill-fallback
+        mechanism: skill_fallback
+        targets:
+          - universal
+        package: skills/integrations/slack-cli
+        repository: https://github.com/ulises-jeremias/agent-toolkit
+        license: MIT
+        transport: skill
+        provenance: first-party
+        version_policy: vendored
+        auth:
+          type: bearer-env
+          env:
+            - SLACK_BOT_TOKEN
+          scopes: []
+        read:
+          - via CLI/API delegates
+        write:
+          - via CLI/API
+        destructive: []
+        permissions:
+          source_trust: first-party
+          runtime_privilege: read-only
+          requires_approval: false
+        runtime:
+          local_vs_remote: hybrid
+          sandbox: skill
+          latency: n/a
+          context_overhead: skill body
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - universal
+          native_ux: skill
+    evaluation:
+      notes: "MCP (Socket Mode) is best for workspace chat automation (native, low\
+        \ latency). CLI (slack-cli) is for app development (admin, requires approval).\
+        \ API is direct fallback. No universal ranking \u2014 chat automation prefers\
+        \ MCP, app scaffolding prefers CLI."
+    security:
+      source_trust: "official (docs.slack.dev) \u2014 highly trusted"
+      runtime_privilege: "read-write (MCP) vs admin (CLI) \u2014 separate; CLI can\
+        \ delete apps, MCP cannot"
+  figma:
+    id: figma
+    display_name: Figma
+    purpose: Fetch design context, screenshots, variables, and implement Figma nodes
+      to code
+    what:
+      verbs:
+        - get_design_context
+        - get_screenshot
+        - get_metadata
+        - implement
+      entities:
+        - file
+        - node
+        - component
+        - variable
+        - screenshot
+    how:
+      - id: figma-mcp-official
+        mechanism: mcp
+        targets:
+          - claude-code
+          - cursor
+          - opencode
+          - vscode
+        package: https://mcp.figma.com/mcp
+        repository: https://www.figma.com/developers/mcp
+        license: proprietary
+        transport: streamable_http
+        provenance: official
+        version_policy: remote hosted
+        auth:
+          type: bearer-env
+          env:
+            - FIGMA_OAUTH_TOKEN
+            - FIGMA_REGION
+          scopes:
+            - file_content:read
+        read:
+          - get_design_context
+          - get_file_structure
+          - get_screenshot
+          - get_metadata
+        write: []
+        destructive: []
+        permissions:
+          source_trust: official
+          runtime_privilege: read-only
+          requires_approval: false
+        runtime:
+          local_vs_remote: remote
+          sandbox: remote hosted, OAuth
+          latency: medium
+          context_overhead: low
+          offline: false
+        availability:
+          maintenance: active (2026-08-12)
+          cross_agent:
+            - claude-code
+            - cursor
+            - opencode
+          native_ux: MCP tools
+      - id: figma-rest-api
+        mechanism: api
+        targets:
+          - universal
+        package: https://api.figma.com/v1/files/:file_key
+        repository: https://www.figma.com/developers/api
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: remote hosted
+        auth:
+          type: bearer-env
+          env:
+            - FIGMA_PERSONAL_ACCESS_TOKEN
+          scopes:
+            - file_content:read
+        read:
+          - GET files, nodes, images
+        write: []
+        destructive: []
+        permissions:
+          source_trust: official
+          runtime_privilege: read-only
+          requires_approval: false
+        runtime:
+          local_vs_remote: remote
+          sandbox: https
+          latency: low
+          context_overhead: none
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - universal
+          native_ux: curl
+      - id: figma-plugin-api
+        mechanism: api
+        targets:
+          - figma-plugin
+        package: figma plugin API
+        repository: https://www.figma.com/plugin-docs/api/
+        license: proprietary
+        transport: plugin
+        provenance: official
+        version_policy: remote hosted
+        auth:
+          type: none
+          env: []
+          scopes: []
+        read:
+          - read node
+          - write node (if plugin)
+        write:
+          - create frames, fills, variables (plugin only)
+        destructive: []
+        permissions:
+          source_trust: official
+          runtime_privilege: read-write
+          requires_approval: true
+        runtime:
+          local_vs_remote: local
+          sandbox: Figma Desktop
+          latency: low
+          context_overhead: n/a
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - figma
+          native_ux: plugin
+      - id: figma-skill-fallback
+        mechanism: skill_fallback
+        targets:
+          - universal
+        package: skills/design/figma
+        repository: https://github.com/ulises-jeremias/agent-toolkit
+        license: MIT
+        transport: skill
+        provenance: first-party
+        version_policy: vendored
+        auth:
+          type: bearer-env
+          env:
+            - FIGMA_OAUTH_TOKEN
+          scopes: []
+        read:
+          - via MCP delegates
+        write: []
+        destructive: []
+        permissions:
+          source_trust: first-party
+          runtime_privilege: read-only
+          requires_approval: false
+        runtime:
+          local_vs_remote: hybrid
+          sandbox: skill
+          latency: n/a
+          context_overhead: skill body
+          offline: false
+        availability:
+          maintenance: active
+          cross_agent:
+            - universal
+          native_ux: skill
+    evaluation:
+      notes: "Official MCP (streamable_http, OAuth) is preferred for design-to-code\
+        \ (read-only, remote, low context). REST API is fallback for file reads without\
+        \ MCP. Plugin API is write-capable but requires Figma Desktop plugin context\
+        \ \u2014 needs approval. No universal ranking \u2014 read-only design context\
+        \ prefers MCP, write via plugin needs Figma plugin target."
+    security:
+      source_trust: "official (mcp.figma.com) \u2014 highly trusted"
+      runtime_privilege: "read-only (MCP/REST) vs read-write (plugin) \u2014 separate;\
+        \ MCP cannot mutate files"

--- a/schemas/provider.schema.json
+++ b/schemas/provider.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/provider.schema.json",
+  "title": "Provider Registry",
+  "description": "Minimal provider model for WHAT vs HOW — capability → providers per target/mechanism. Dated 2026-08-12.",
+  "type": "object",
+  "required": ["version", "providers"],
+  "properties": {
+    "version": {"type": "string"},
+    "providers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["id", "display_name", "purpose", "what", "how"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z0-9-]+$"},
+          "display_name": {"type": "string"},
+          "purpose": {"type": "string"},
+          "what": {
+            "type": "object",
+            "description": "Capability intent — independent of HOW",
+            "required": ["verbs"],
+            "properties": {
+              "verbs": {"type": "array", "items": {"type": "string"}},
+              "entities": {"type": "array", "items": {"type": "string"}}
+            }
+          },
+          "how": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "mechanism", "targets", "provenance", "read", "write"],
+              "properties": {
+                "id": {"type": "string"},
+                "mechanism": {"enum": ["native_plugin", "mcp", "cli", "api", "skill_fallback", "community_mcp"]},
+                "targets": {"type": "array", "items": {"type": "string"}},
+                "package": {"type": "string"},
+                "repository": {"type": "string"},
+                "license": {"type": "string"},
+                "transport": {"type": "string"},
+                "auth": {
+                  "type": "object",
+                  "properties": {
+                    "type": {"enum": ["none", "bearer-env", "oauth", "api_key"]},
+                    "env": {"type": "array", "items": {"type": "string"}},
+                    "scopes": {"type": "array", "items": {"type": "string"}}
+                  }
+                },
+                "read": {"type": "array", "items": {"type": "string"}},
+                "write": {"type": "array", "items": {"type": "string"}},
+                "destructive": {"type": "array", "items": {"type": "string"}},
+                "permissions": {
+                  "type": "object",
+                  "properties": {
+                    "source_trust": {"enum": ["official", "community", "first-party"]},
+                    "runtime_privilege": {"enum": ["read-only", "read-write", "admin"]},
+                    "requires_approval": {"type": "boolean"}
+                  }
+                },
+                "runtime": {
+                  "type": "object",
+                  "properties": {
+                    "local_vs_remote": {"enum": ["local", "remote", "hybrid"]},
+                    "sandbox": {"type": "string"},
+                    "latency": {"type": "string"},
+                    "context_overhead": {"type": "string"},
+                    "offline": {"type": "boolean"}
+                  }
+                },
+                "availability": {
+                  "type": "object",
+                  "properties": {
+                    "maintenance": {"type": "string"},
+                    "cross_agent": {"type": "array", "items": {"type": "string"}},
+                    "native_ux": {"type": "string"}
+                  }
+                },
+                "provenance": {"type": "string"},
+                "version_policy": {"type": "string"}
+              }
+            }
+          },
+          "evaluation": {
+            "type": "object",
+            "description": "Provider evaluation per HOW — not a ranking, capability-dependent",
+            "properties": {
+              "notes": {"type": "string"}
+            }
+          },
+          "security": {
+            "type": "object",
+            "properties": {
+              "source_trust": {"type": "string"},
+              "runtime_privilege": {"type": "string"}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_provider_abstraction.py
+++ b/tests/test_provider_abstraction.py
@@ -1,0 +1,149 @@
+"""Tests for provider abstraction pilots — #386.
+
+Covers WHAT vs HOW, no universal ranking, source trust vs runtime privilege distinct,
+and 3 pilots (Linear, Slack, Figma) with evaluated HOWs.
+"""
+
+import json
+import pathlib
+
+import yaml
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "schemas/provider.schema.json"
+REGISTRY_PATH = REPO_ROOT / "providers/providers.yaml"
+MATRIX_PATH = REPO_ROOT / "docs/providers/provider-matrix.md"
+
+
+def test_schema_valid():
+    schema = json.loads(SCHEMA_PATH.read_text())
+    assert schema["title"] == "Provider Registry"
+
+
+def test_registry_has_three_pilots():
+    data = yaml.safe_load(REGISTRY_PATH.read_text())
+    assert data["version"] == "1"
+    assert set(data["providers"].keys()) == {"linear", "slack", "figma"}
+    for pid in ["linear", "slack", "figma"]:
+        prov = data["providers"][pid]
+        assert "what" in prov and "how" in prov
+        assert len(prov["how"]) >= 4, (
+            f"{pid} should have >=4 HOWs (official, alternative, fallback)"
+        )
+        # Must have at least one mcp and one api/cli
+        mechanisms = {h["mechanism"] for h in prov["how"]}
+        assert "mcp" in mechanisms or "community_mcp" in mechanisms
+        # Must have skill_fallback
+        assert "skill_fallback" in mechanisms
+
+
+def test_registry_validates_against_schema():
+    schema = json.loads(SCHEMA_PATH.read_text())
+    data = yaml.safe_load(REGISTRY_PATH.read_text())
+    validator = Draft202012Validator(schema)
+    errs = list(validator.iter_errors(data))
+    assert errs == [], [f"{e.message} at {list(e.path)}" for e in errs]
+
+
+def test_what_vs_how_separation():
+    data = yaml.safe_load(REGISTRY_PATH.read_text())
+    for pid, prov in data["providers"].items():
+        # WHAT is stable verbs/entities
+        assert "verbs" in prov["what"]
+        assert len(prov["what"]["verbs"]) >= 3
+        # HOW is per-target/mechanism
+        for how in prov["how"]:
+            assert "targets" in how
+            assert len(how["targets"]) >= 1
+            # Must not encode universal ranking — check evaluation notes mention contextual choice
+        assert "evaluation" in prov
+        assert "notes" in prov["evaluation"]
+        assert (
+            "No universal" in prov["evaluation"]["notes"]
+            or "contextual" in prov["evaluation"]["notes"].lower()
+        )
+
+
+def test_no_universal_ranking():
+    # Must not have a file that says "official plugin > MCP > CLI" as law
+    matrix = MATRIX_PATH.read_text()
+    # Matrix must say there is NO universal ranking, not assert one as law
+    assert (
+        "No universal" in matrix
+        or "per-capability" in matrix.lower()
+        or "contextual" in matrix.lower()
+    )
+    # If the ranking phrase appears, it must be negated (No / not / without)
+    if "official plugin > MCP > CLI" in matrix:
+        assert (
+            "No"
+            in matrix[
+                matrix.index("official plugin > MCP > CLI") - 40 : matrix.index(
+                    "official plugin > MCP > CLI"
+                )
+                + 40
+            ]
+        )
+        assert "law" in matrix.lower() or "no" in matrix.lower()
+
+
+def test_source_trust_vs_runtime_privilege_distinct():
+    data = yaml.safe_load(REGISTRY_PATH.read_text())
+    for pid, prov in data["providers"].items():
+        assert "security" in prov
+        assert "source_trust" in prov["security"]
+        assert "runtime_privilege" in prov["security"]
+        for how in prov["how"]:
+            perms = how["permissions"]
+            assert perms["source_trust"] in ["official", "community", "first-party"]
+            assert perms["runtime_privilege"] in ["read-only", "read-write", "admin"]
+            # Official source can still be admin privilege (e.g., Slack CLI) — must be separate
+    # Check matrix has distinct section
+    matrix = MATRIX_PATH.read_text()
+    assert "source trust vs runtime privilege" in matrix.lower()
+
+
+def test_linear_evaluated_dimensions():
+    data = yaml.safe_load(REGISTRY_PATH.read_text())
+    linear = data["providers"]["linear"]
+    how_ids = {h["id"] for h in linear["how"]}
+    assert "linear-mcp-official" in how_ids
+    assert "linear-api-graphql" in how_ids
+    # Check dimensions present
+    for how in linear["how"]:
+        assert "auth" in how and "type" in how["auth"]
+        assert "read" in how and "write" in how
+        assert "runtime" in how and "local_vs_remote" in how["runtime"]
+        assert "availability" in how
+
+
+def test_slack_figma_dimensions():
+    data = yaml.safe_load(REGISTRY_PATH.read_text())
+    for pid in ["slack", "figma"]:
+        prov = data["providers"][pid]
+        for how in prov["how"]:
+            assert "auth" in how
+            assert "permissions" in how
+            assert "runtime" in how
+
+
+def test_matrix_dated_and_generated():
+    matrix = MATRIX_PATH.read_text()
+    assert "2026-08-12" in matrix
+    assert "WHAT vs HOW" in matrix
+    for cap in ["Linear", "Slack", "Figma"]:
+        assert cap in matrix
+
+
+def test_existing_skills_still_valid():
+    # Ensure existing integration skills still have valid frontmatter after provider abstraction
+    for skill in [
+        "skills/integrations/linear/SKILL.md",
+        "skills/integrations/slack-cli/SKILL.md",
+        "skills/design/figma/SKILL.md",
+    ]:
+        p = REPO_ROOT / skill
+        assert p.exists(), f"missing {skill}"
+        text = p.read_text()
+        assert "origin:" in text


### PR DESCRIPTION
Closes #386 — Implements ADR-0004.

## What
Minimal WHAT vs HOW provider abstraction proven via 3 pilots (Linear/Slack/Figma).

- `schemas/provider.schema.json` — validates `providers/providers.yaml` (`what.verbs`, `how[]` with `mechanism/targets/auth/read/write/permissions.source_trust/runtime_privilege/runtime/availability`, `evaluation`, `security`).
- `providers/providers.yaml` — 3 pilots: Linear (4 HOWs: official MCP `https://mcp.linear.app/mcp` OAuth / community `@ibraheem4/linear-mcp` PAT / GraphQL API / skill fallback), Slack (4: `mcp-server-slack` Socket / `slack-cli` `docs.slack.dev/tools/slack-cli` Apache-2.0 / Web API / skill), Figma (4: `mcp.figma.com/mcp` OAuth / REST `api.figma.com/v1` / plugin API / skill).
- `docs/providers/provider-matrix.md` — dated 2026-08-12, summary + per-HOW tables + distinct `Source trust vs Runtime privilege` section; sources: `mcp.linear.app/mcp`, `linear.app/docs/mcp`, `mcp-server-slack`, `docs.slack.dev/tools/slack-cli`, `mcp.figma.com/mcp`, `figma.com/developers/mcp`, `mcp/registry/*.yaml`.
- `docs/adr/0004-capability-provider-abstraction-what-vs-how.md` — Option B minimal WHAT vs HOW (selected) vs universal ranking law (rejected).
- `tests/test_provider_abstraction.py` — 10 tests: schema, registry 3 pilots, WHAT/HOW separation, no universal ranking, trust vs privilege distinct, per-pilot dimensions, matrix dated, existing skills still valid.

## Why
Per ADR-0004: no universal `official plugin > MCP > CLI` law — provider choice is per-verb, per-target, per-privilege, contextual.

## Security
Source trust (`official`/`community`/`first-party`) vs runtime privilege (`read-only`/`read-write`/`admin`) reported separately; reuses `scripts/audit-capability.py` + `mcp/registry/*.yaml` `security`/`approval` surfaces.

## Tests
`uv run pytest tests/test_provider_abstraction.py -v` — 10 passed
`uv run ruff check .` — clean
`uv run ruff format --check .` — clean

Phase 2 deferred: `inventory`/`build --check` wiring follows #393.

Refs #386, #393, #368