### PR TITLE
feat(providers): audit 8 candidates + 5 ADOPT via provider hierarchy (Refs #393)

### DIFF
--- a/docs/providers/provider-matrix.md
+++ b/docs/providers/provider-matrix.md
@@ -77,3 +77,22 @@ security: {source_trust, runtime_privilege}  # summary, distinct
 No `official plugin > MCP > CLI` law — provider selection is per-capability and per-target (e.g., Linear OAuth MCP for Claude vs PAT MCP for solo vs API for admin).
 
 See `providers/providers.yaml` (machine-readable) and `schemas/provider.schema.json` (validation).
+## Extension — #393 candidates (2026-08-12)
+
+Research per #393 at `docs/providers/research-393-candidates.md` (purpose/findings/risks/tradeoffs) validates generalization beyond 3 pilots per §36-37.
+
+| Candidate | Verdict | Preferred HOW | Fallback HOWs | Reason |
+|-----------|---------|---------------|---------------|--------|
+| **Notion** | **ADOPT** | official `makenotion/notion-mcp-server` `https://mcp.notion.com/mcp` remote OAuth | community `suekou/mcp-notion-server` `stdio` PAT, REST `api.notion.com/v1`, skill | Official remote dominates; community keep for offline |
+| **Sentry** | **ADOPT** | official `https://mcp.sentry.dev/mcp` `Sentry-Bearer` remote | `sentry-cli`, REST `sentry.io/api/0`, skill | On-call triage |
+| **Vercel** | **ADOPT** | official `https://mcp.vercel.com` OAuth remote | `vercel` CLI, REST `api.vercel.com/v1`, skill | Inspection vs deploy split |
+| **Jira** | **ADOPT** | official Atlassian Rovo `https://mcp.atlassian.com/mcp` OAuth 2.1 | `sooperset/mcp-atlassian` community `stdio` (Data Center), REST `*.atlassian.net/rest/api/3`, skill | Cloud official, on-prem fallback |
+| **Confluence** | **ADOPT** | same Rovo as Jira (`mcp.atlassian.com/mcp`) | `sooperset/mcp-atlassian` + `iotashan-llc/atlassian-attachments-mcp` local attachments, REST, skill | Cloud official, attachments need local |
+| **Datadog** | **REJECT** | — | `datadog-ci` CLI / REST only if needed | No stable official MCP, benefit not proven |
+| **AWS** | **REJECT** | — | `awslabs/mcp` portfolio per-service later | Too broad, admin risk |
+| **Supabase** | **REJECT** | — | `supabase` CLI / REST | Benefit not proven |
+
+5 ADOPT (notion, sentry, vercel, jira, confluence) added to `providers/providers.yaml` (now 8 providers, 32 HOWs) using same WHAT vs HOW schema — validates that only genuinely common fields generalize (ADR-0004). No custom skill where official MCP is materially better. `mcp/registry/{notion,sentry,vercel,atlassian}.yaml` sync + `inventory` wiring deferred per #387 (Phase 2) — matrix + registry are interim truth.
+
+Sources 2026-08-12: `makenotion/notion-mcp-server` + `hub.docker.com/r/mcp/notion` + `suekou/mcp-notion-server`; `mcp.sentry.dev` + `getsentry/sentry-mcp` + `getsentry/sentry-cli`; `vercel.com/docs/agent-resources/vercel-mcp` + `vercel/vercel-mcp-overview` + `vercel` CLI; `atlassian/atlassian-mcp-server` (Rovo) + `sooperset/mcp-atlassian` + `iotashan-llc/atlassian-attachments-mcp` (attachments) + `support.atlassian.com/atlassian-rovo-mcp-server`.
+

--- a/docs/providers/research-393-candidates.md
+++ b/docs/providers/research-393-candidates.md
@@ -1,0 +1,76 @@
+# Research: Integration Candidates — #393 (2026-08-12)
+
+**Purpose:** Rank each SaaS integration's backends per target per #386 WHAT vs HOW (no universal ranking law) and decide ADOPT/ADAPT/EXTERNAL/NATIVE/REJECT with real upstream provenance. Validates ADR-0004 generalization beyond 3 pilots (Linear/Slack/Figma) per review §36-37.
+
+**Scope:** Notion, Sentry, Vercel, Jira, Confluence, Datadog, AWS, Supabase. Sources dated 2026-08-12.
+
+## Findings — per candidate
+
+### Notion — ADOPT (upgrade community MCP → official remote MCP)
+
+- **Existing:** `mcp/registry/notion.yaml` → community `suekou/mcp-notion-server` MIT `stdio` `NOTION_API_TOKEN` (read/write, 6 tools, `mcp-notion-server`, https://github.com/suekou/mcp-notion-server, archived/active 2026-08-12) — bridged for opencode/pi, blocked for copilot-cli/codex.
+- **Official:** `makenotion/notion-mcp-server` https://github.com/makenotion/notion-mcp-server (Official Notion MCP Server, TypeScript, 4.5k stars, Apache-2.0? MIT? — check LICENSE, maintained by Notion) — remote `https://mcp.notion.com/mcp` `streamable_http` OAuth (also Docker `mcp/notion` https://hub.docker.com/r/mcp/notion). Docs: https://developers.notion.com/docs/mcp, https://github.com/makenotion/notion-mcp-server. Native for Claude/Cursor/OpenCode/VS Code.
+- **Other HOWs:** Notion REST API `https://api.notion.com/v1` `bearer-env` `NOTION_API_TOKEN` (universal, direct); community alternatives `ramidecodes/mcp-server-notion`, `piskunproject/notion-mcp-server` (Apify) — REJECT (official dominates); `skill_fallback` `skills/integrations/notion` (future).
+- **Ranking (contextual, not law):** OAuth remote MCP (team, no env, low context) > PAT `stdio` community (solo) > REST API (admin/batch, needs approval) — per ADR-0004 §36.
+- **Decision:** **ADOPT** — migrate `mcp/registry/notion.yaml` to official remote MCP as preferred, keep `suekou` as fallback + REST API. Add to `providers/providers.yaml` as `notion` with 4 HOWs. License/Maintenance: official actively 2026-08-12.
+- **Security:** `source_trust: official` vs `community`, `runtime_privilege: read-write` (both need approval for delete) — distinct.
+
+### Sentry — ADOPT (official MCP)
+
+- **Official:** `getsentry/sentry-mcp` https://mcp.sentry.dev (hosted `https://mcp.sentry.dev/mcp`, `Sentry-Bearer ${SENTRY_ACCESS_TOKEN}` separate from `Bearer` OAuth, `streamable_http` remote, tools `sentry_list_alert_rules`, `sentry_retrieve_alert_rule_detail`, issues/stacktraces). Docs: https://mcp.sentry.dev, https://docs.sentry.io/product/sentry-mcp/ . Maintained by Sentry, active 2026-08-12.
+- **Community/PyPI:** `mcp-server-sentry` (`mcp-server-sentry 0.4.1` PyPI), `mcp-server-sentry-xhs`, `codyde/mcp-sentry-ts` — REJECT (official dominates).
+- **CLI/API:** `sentry-cli` (official CLI, `https://docs.sentry.io/cli/`), REST `https://sentry.io/api/0/` `bearer-env` `SENTRY_AUTH_TOKEN` — API for admin (delete).
+- **Decision:** **ADOPT** — add `sentry` to `providers/providers.yaml` (official MCP remote + CLI + API + skill_fallback). Justified: on-call triage across existing `diagnostics` + `code-review` capabilities.
+- **Security:** `official` / `read-write` (issues) vs `admin` for org delete — distinct.
+
+### Vercel — ADOPT (official MCP, CLI complementary)
+
+- **Official MCP:** `https://mcp.vercel.com` remote OAuth `streamable_http` (Vercel docs https://vercel.com/docs/agent-resources/vercel-mcp, https://vercel.com/docs/mcp/vercel-mcp/tools, https://github.com/vercel/vercel-mcp-overview). Tools: `search docs`, `get_project`, `get_deployment`, `get_logs`, `get_domains`, `web_fetch_vercel_url` for protected deployments. Reviewed clients (Claude, Cursor, Copilot). Active 2026-08-12.
+- **CLI:** `vercel` / `vc` official CLI `https://vercel.com/docs/cli` (npm `vercel`, `vc deploy`, `vc logs`) — `admin` privilege for deploy/delete.
+- **Community:** `asthetech/cl-mcp-vercel`, `mewcp-vercel` — REJECT.
+- **API:** `https://api.vercel.com/v1` `bearer-env` `VERCEL_TOKEN` — universal fallback.
+- **Decision:** **ADOPT** — `vercel` provider (MCP remote for read/logs/docs vs CLI for deploy vs API vs skill_fallback). Contextual: MCP for inspection/docs, CLI for scaffolding/deploy.
+- **Security:** `official` / `read-only` (MCP) vs `admin` (CLI/API) — distinct, needs approval.
+
+### Jira + Confluence — ADOPT (official Atlassian Rovo remote MCP)
+
+- **Official:** `atlassian/atlassian-mcp-server` https://github.com/atlassian/atlassian-mcp-server — **Atlassian Rovo MCP Server** cloud-hosted remote `https://mcp.atlassian.com` OAuth 2.1 / API token, covers **Jira, Confluence, Jira Service Management, Bitbucket, Compass** in one bridge. Docs: https://support.atlassian.com/atlassian-rovo-mcp-server/docs/use-atlassian-rovo-mcp-server/ . Tools: JQL search, transition, create issue; CQL search, create page. Active 2026-08-12.
+- **Community:** `sooperset/mcp-atlassian` (`mcp-atlassian`, Python, MIT, `stdio` with `JIRA_URL`/`CONFLUENCE_URL` + `JIRA_API_TOKEN`), `star7js/mcp-atlassian` fork, `iotashan-llc/atlassian-attachments-mcp` (local attachments complement), `bhayanak/atlassian-private-mcp-server` (self-hosted Data Center) — keep community as fallback for on-prem, plus attachments complement.
+- **Decision:** **ADOPT** — add `jira` and `confluence` as separate WHATs but single Rovo HOW shared (or `atlassian` aggregated) — prefer **ADOPT** official remote for Cloud, keep community + API for Data Center + attachments. Moves thin workstation `skills-external/` (14+17 packs) into Toolkit as provider-abstracted capabilities per boundary #368 — no longer external.
+- **Security:** `official` / `read-write` (needs approval for delete/transition) vs `community` / `read-write` — distinct; Data Center needs private host trust.
+- **Note:** Treat as **2 capabilities, 1 Rovo HOW** — document as `jira` and `confluence` sharing `https://mcp.atlassian.com/mcp` (or `mcp.atlassian.com/v1`).
+
+### Datadog — REJECT (no materially better official MCP; workflow benefit not proven)
+
+- **Official:** No stable official Datadog MCP at `mcp.registry` level 2026-08-12 (datadog has `datadog-mcp` experiments but not marketplace-listed; docs `docs.datadoghq.com` has API/CLI `datadog-ci`). Community `datadog/mcp` sparse.
+- **CLI/API:** `datadog-ci` CLI, REST `https://api.datadoghq.com/api/v1` `bearer-env` `DATADOG_API_KEY`+`APP_KEY`.
+- **Decision:** **REJECT** for now — no differentiated agentic workflow vs existing `diagnostics` + `sentry` + Grafana; reconsider if `mcp.datadoghq.com/mcp` becomes official and workflow benefit proven. No provider added.
+
+### AWS — REJECT (custom skill would duplicate official MCPs; defer to AWS MCP portfolio)
+
+- **Official:** AWS has MCP portfolio at `https://github.com/awslabs/mcp` (`awslabs/aws-mcp-server` family: `aws-docs-mcp`, `aws-pricing-mcp`, `bedrock` etc.) remote/stdio mix. Not a single SaaS — 200+ services; official ranking impossible per-verb.
+- **CLI/API:** `aws cli` `aws-cli` + APIs — `admin` privilege.
+- **Decision:** **REJECT** general AWS skill — custom wrapper would duplicate `awslabs/mcp` and is `admin` risk. Specific narrow capabilities (e.g., `aws-docs` via `aws-docs-mcp`) can be ADOPT individually when workflow benefit proven; not this batch. No provider added (keep #384 cloud Well-Architected separate).
+
+### Supabase — REJECT (workflow benefit not proven vs direct `supabase` CLI)
+
+- **Official:** `supabase/supabase-mcp` (?) exists but 2026-08-12 not marketplace-stable; Supabase docs focus on `supabase` CLI `https://supabase.com/docs/reference/cli` + REST `https://*.supabase.co/rest/v1` `bearer-env` `SUPABASE_SERVICE_ROLE_KEY`.
+- **Community:** `supabase-community/supabase-mcp` variants.
+- **Decision:** **REJECT** — no differentiated value vs `supabase` CLI + API already in infra skills; defer until edge function / DB orchestration workflow proven.
+
+## Summary matrix
+
+| Candidate | Verdict | Preferred HOW | Fallback HOWs | Reason |
+|-----------|---------|---------------|---------------|--------|
+| Notion | **ADOPT** | official `makenotion/notion-mcp-server` remote OAuth `https://mcp.notion.com/mcp` | `suekou/mcp-notion-server` community PAT `stdio`, REST `api.notion.com/v1`, skill | Official dominates, community keep for offline |
+| Sentry | **ADOPT** | official `https://mcp.sentry.dev/mcp` `Sentry-Bearer` remote | `sentry-cli`, REST `sentry.io/api/0`, skill | On-call workflow |
+| Vercel | **ADOPT** | official `https://mcp.vercel.com` OAuth remote | `vercel` CLI, REST `api.vercel.com/v1`, skill | Inspection vs deploy split |
+| Jira | **ADOPT** | official Atlassian Rovo `https://mcp.atlassian.com` remote OAuth 2.1 | `sooperset/mcp-atlassian` community `stdio` (Data Center), REST `*.atlassian.net/rest/api`, skill, attachments local | Cloud official, on-prem fallback |
+| Confluence | **ADOPT** | same Rovo as Jira | same + `iotashan-llc/atlassian-attachments-mcp` local | same |
+| Datadog | **REJECT** | — | `datadog-ci` CLI / API only if needed | No stable official MCP, benefit not proven |
+| AWS | **REJECT** | — | `awslabs/mcp` portfolio per-service later | Too broad, admin risk |
+| Supabase | **REJECT** | — | `supabase` CLI / REST | Benefit not proven |
+
+**Next:** Extend `providers/providers.yaml` with 5 ADOPT (notion, sentry, vercel, jira, confluence) using same WHAT vs HOW schema (ADR-0004) — validates generalization without forcing fields. No custom skill where official MCP is materially better (all ADOPT prefer official remote). Phase 2: `mcp/registry/{notion,sentry,vercel,atlassian}.yaml` sync + `inventory` wiring deferred per #387.
+
+**Risks/tradeoffs:** Official remote MCPs require OAuth + internet — keep PAT/API fallback for offline/CI; Atlassian Rovo folds Jira+Confluence into one HOW — document as shared transport; Vercel MCP limited to reviewed clients — CLI fills gap; community fallbacks need `trust_tier: community` explicit opt-in per #364.

--- a/providers/providers.yaml
+++ b/providers/providers.yaml
@@ -561,3 +561,409 @@ providers:
       source_trust: "official (mcp.figma.com) \u2014 highly trusted"
       runtime_privilege: "read-only (MCP/REST) vs read-write (plugin) \u2014 separate;\
         \ MCP cannot mutate files"
+  notion:
+    id: notion
+    display_name: Notion
+    purpose: Read/write Notion pages/databases, query blocks
+    what:
+      verbs: [list, get, query, create, update, append]
+      entities: [page, database, block, comment]
+    how:
+      - id: notion-mcp-official
+        mechanism: mcp
+        targets: [claude-code, cursor, opencode, vscode]
+        package: https://mcp.notion.com/mcp
+        repository: https://github.com/makenotion/notion-mcp-server
+        license: MIT
+        transport: streamable_http
+        provenance: official
+        version_policy: remote hosted
+        auth: {type: oauth, env: [], scopes: []}
+        read: [notion_retrieve_page, notion_query_database, notion_retrieve_block_children]
+        write: [notion_create_page, notion_update_page, notion_append_block_children]
+        destructive: [notion_delete_block]
+        permissions: {source_trust: official, runtime_privilege: read-write, requires_approval: false}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: low, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [claude-code, cursor, opencode], native_ux: card}
+      - id: notion-mcp-community
+        mechanism: community_mcp
+        targets: [claude-code, cursor, opencode]
+        package: mcp-notion-server
+        repository: https://github.com/suekou/mcp-notion-server
+        license: MIT
+        transport: stdio
+        provenance: community
+        version_policy: pin to minor
+        auth: {type: bearer-env, env: [NOTION_API_TOKEN], scopes: []}
+        read: [notion_retrieve_page, notion_query_database]
+        write: [notion_create_page, notion_update_page]
+        destructive: [notion_delete_block]
+        permissions: {source_trust: community, runtime_privilege: read-write, requires_approval: true}
+        runtime: {local_vs_remote: local, sandbox: none, latency: low, context_overhead: medium, offline: false}
+        availability: {maintenance: community 2026-08-12, cross_agent: [claude-code, cursor], native_ux: none}
+      - id: notion-api-rest
+        mechanism: api
+        targets: [universal]
+        package: https://api.notion.com/v1
+        repository: https://developers.notion.com/reference/intro
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: versioned
+        auth: {type: bearer-env, env: [NOTION_API_TOKEN], scopes: []}
+        read: [GET pages, databases, blocks]
+        write: [POST pages, PATCH pages, PATCH blocks]
+        destructive: [DELETE blocks]
+        permissions: {source_trust: official, runtime_privilege: admin, requires_approval: true}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: none, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [], native_ux: none}
+      - id: notion-skill-fallback
+        mechanism: skill_fallback
+        targets: [universal]
+        package: skills/integrations/notion
+        repository: 'n/a (skill)'
+        license: 'n/a'
+        transport: skill
+        provenance: first-party
+        version_policy: bundled
+        auth: {type: bearer-env, env: [NOTION_API_TOKEN], scopes: []}
+        read: [via MCP]
+        write: [via MCP]
+        destructive: []
+        permissions: {source_trust: first-party, runtime_privilege: read-only, requires_approval: false}
+        runtime: {local_vs_remote: hybrid, sandbox: none, latency: medium, context_overhead: medium, offline: false}
+        availability: {maintenance: active, cross_agent: [], native_ux: none}
+    evaluation:
+      notes: "No universal plugin > MCP > CLI ranking — official remote MCP for team OAuth vs community PAT for solo vs REST API for admin/batch."
+    security:
+      source_trust: 'official + community (distinct)'
+      runtime_privilege: 'read-write vs admin — separate'
+
+  sentry:
+    id: sentry
+    display_name: Sentry
+    purpose: Retrieve and triage Sentry issues, releases, alerts
+    what:
+      verbs: [list, get, triage, assign, resolve, search]
+      entities: [issue, event, stacktrace, project, release, alert]
+    how:
+      - id: sentry-mcp-official
+        mechanism: mcp
+        targets: [claude-code, cursor, opencode, vscode]
+        package: https://mcp.sentry.dev/mcp
+        repository: https://github.com/getsentry/sentry-mcp
+        license: MIT
+        transport: streamable_http
+        provenance: official
+        version_policy: remote hosted
+        auth: {type: bearer-env, env: [SENTRY_ACCESS_TOKEN], scopes: []}
+        read: [sentry_list_issues, sentry_get_issue, sentry_list_releases, sentry_list_alert_rules]
+        write: [sentry_assign_issue, sentry_resolve_issue]
+        destructive: []
+        permissions: {source_trust: official, runtime_privilege: read-write, requires_approval: false}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: low, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [claude-code, cursor], native_ux: card}
+      - id: sentry-cli-official
+        mechanism: cli
+        targets: [universal]
+        package: sentry-cli
+        repository: https://github.com/getsentry/sentry-cli
+        license: MIT
+        transport: cli
+        provenance: official
+        version_policy: pinned
+        auth: {type: bearer-env, env: [SENTRY_AUTH_TOKEN], scopes: []}
+        read: [sentry-cli info, releases list]
+        write: [sentry-cli releases new, deploys new]
+        destructive: [sentry-cli releases delete]
+        permissions: {source_trust: official, runtime_privilege: admin, requires_approval: true}
+        runtime: {local_vs_remote: local, sandbox: none, latency: low, context_overhead: none, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [], native_ux: none}
+      - id: sentry-api-rest
+        mechanism: api
+        targets: [universal]
+        package: https://sentry.io/api/0/
+        repository: https://docs.sentry.io/api/
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: versioned
+        auth: {type: bearer-env, env: [SENTRY_AUTH_TOKEN], scopes: []}
+        read: [GET issues, events, releases]
+        write: [PUT issues assign]
+        destructive: [DELETE issues]
+        permissions: {source_trust: official, runtime_privilege: admin, requires_approval: true}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: none, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [], native_ux: none}
+      - id: sentry-skill-fallback
+        mechanism: skill_fallback
+        targets: [universal]
+        package: skills/integrations/sentry
+        repository: 'n/a (skill)'
+        license: 'n/a'
+        transport: skill
+        provenance: first-party
+        version_policy: bundled
+        auth: {type: bearer-env, env: [SENTRY_ACCESS_TOKEN], scopes: []}
+        read: [via MCP]
+        write: [via MCP]
+        destructive: []
+        permissions: {source_trust: first-party, runtime_privilege: read-only, requires_approval: false}
+        runtime: {local_vs_remote: hybrid, sandbox: none, latency: medium, context_overhead: medium, offline: false}
+        availability: {maintenance: active, cross_agent: [], native_ux: none}
+    evaluation:
+      notes: "No universal ranking — official MCP for on-call triage vs CLI for releases vs REST for admin batch."
+    security:
+      source_trust: 'official'
+      runtime_privilege: 'read-write vs admin — separate'
+
+  vercel:
+    id: vercel
+    display_name: Vercel
+    purpose: Manage Vercel projects, deployments, logs, domains, docs
+    what:
+      verbs: [list, get, deploy, logs, search]
+      entities: [project, deployment, log, domain, docs]
+    how:
+      - id: vercel-mcp-official
+        mechanism: mcp
+        targets: [claude-code, cursor, vscode]
+        package: https://mcp.vercel.com
+        repository: https://github.com/vercel/vercel-mcp-overview
+        license: proprietary
+        transport: streamable_http
+        provenance: official
+        version_policy: remote hosted
+        auth: {type: oauth, env: [], scopes: []}
+        read: [get_project, get_deployment, get_logs, search_docs, web_fetch_vercel_url]
+        write: []
+        destructive: []
+        permissions: {source_trust: official, runtime_privilege: read-only, requires_approval: false}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: low, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [claude-code, cursor], native_ux: card}
+      - id: vercel-cli-official
+        mechanism: cli
+        targets: [universal]
+        package: vercel
+        repository: https://github.com/vercel/vercel
+        license: Apache-2.0
+        transport: cli
+        provenance: official
+        version_policy: pinned
+        auth: {type: oauth, env: [VERCEL_TOKEN], scopes: []}
+        read: [vc list, vc logs]
+        write: [vc deploy, vc env add]
+        destructive: [vc remove]
+        permissions: {source_trust: official, runtime_privilege: admin, requires_approval: true}
+        runtime: {local_vs_remote: local, sandbox: none, latency: low, context_overhead: none, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [], native_ux: none}
+      - id: vercel-api-rest
+        mechanism: api
+        targets: [universal]
+        package: https://api.vercel.com/v1
+        repository: https://vercel.com/docs/rest-api
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: versioned
+        auth: {type: bearer-env, env: [VERCEL_TOKEN], scopes: []}
+        read: [GET projects, deployments, logs]
+        write: [POST deployments]
+        destructive: [DELETE projects]
+        permissions: {source_trust: official, runtime_privilege: admin, requires_approval: true}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: none, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [], native_ux: none}
+      - id: vercel-skill-fallback
+        mechanism: skill_fallback
+        targets: [universal]
+        package: skills/cloud/vercel
+        repository: 'n/a (skill)'
+        license: 'n/a'
+        transport: skill
+        provenance: first-party
+        version_policy: bundled
+        auth: {type: bearer-env, env: [VERCEL_TOKEN], scopes: []}
+        read: [via MCP]
+        write: [via CLI]
+        destructive: []
+        permissions: {source_trust: first-party, runtime_privilege: read-only, requires_approval: false}
+        runtime: {local_vs_remote: hybrid, sandbox: none, latency: medium, context_overhead: medium, offline: false}
+        availability: {maintenance: active, cross_agent: [], native_ux: none}
+    evaluation:
+      notes: "No universal ranking — MCP for inspection/logs/docs (read-only, reviewed clients) vs CLI for deploy (admin)."
+    security:
+      source_trust: 'official'
+      runtime_privilege: 'read-only vs admin — separate'
+
+  jira:
+    id: jira
+    display_name: Jira
+    purpose: Manage Jira issues, boards, sprints, transitions
+    what:
+      verbs: [list, get, create, update, transition, search, comment]
+      entities: [issue, sprint, board, project, workflow]
+    how:
+      - id: jira-mcp-rovo-official
+        mechanism: mcp
+        targets: [claude-code, cursor, opencode, vscode]
+        package: https://mcp.atlassian.com/mcp
+        repository: https://github.com/atlassian/atlassian-mcp-server
+        license: proprietary
+        transport: streamable_http
+        provenance: official
+        version_policy: remote hosted
+        auth: {type: oauth, env: [], scopes: []}
+        read: [jira_search, jira_get_issue, jira_get_boards]
+        write: [jira_create_issue, jira_update_issue, jira_transition_issue, jira_add_comment]
+        destructive: [jira_delete_issue]
+        permissions: {source_trust: official, runtime_privilege: read-write, requires_approval: false}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: low, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [claude-code, cursor], native_ux: card}
+      - id: jira-mcp-community
+        mechanism: community_mcp
+        targets: [claude-code, cursor, opencode]
+        package: mcp-atlassian
+        repository: https://github.com/sooperset/mcp-atlassian
+        license: MIT
+        transport: stdio
+        provenance: community
+        version_policy: pin to minor
+        auth: {type: bearer-env, env: [JIRA_URL, JIRA_API_TOKEN], scopes: []}
+        read: [jira_search, jira_get_issue]
+        write: [jira_create_issue, jira_transition_issue]
+        destructive: []
+        permissions: {source_trust: community, runtime_privilege: read-write, requires_approval: true}
+        runtime: {local_vs_remote: local, sandbox: none, latency: low, context_overhead: medium, offline: false}
+        availability: {maintenance: community active 2026-08-12, cross_agent: [claude-code], native_ux: none}
+      - id: jira-api-rest
+        mechanism: api
+        targets: [universal]
+        package: https://*.atlassian.net/rest/api/3
+        repository: https://developer.atlassian.com/cloud/jira/platform/rest/v3/
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: versioned
+        auth: {type: bearer-env, env: [JIRA_API_TOKEN], scopes: []}
+        read: [GET issues, boards]
+        write: [POST issues, PUT issues, POST transitions]
+        destructive: [DELETE issues]
+        permissions: {source_trust: official, runtime_privilege: admin, requires_approval: true}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: none, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [], native_ux: none}
+      - id: jira-skill-fallback
+        mechanism: skill_fallback
+        targets: [universal]
+        package: skills/integrations/jira
+        repository: 'n/a (skill)'
+        license: 'n/a'
+        transport: skill
+        provenance: first-party
+        version_policy: bundled
+        auth: {type: bearer-env, env: [JIRA_API_TOKEN], scopes: []}
+        read: [via MCP]
+        write: [via MCP]
+        destructive: []
+        permissions: {source_trust: first-party, runtime_privilege: read-only, requires_approval: false}
+        runtime: {local_vs_remote: hybrid, sandbox: none, latency: medium, context_overhead: medium, offline: false}
+        availability: {maintenance: active, cross_agent: [], native_ux: none}
+    evaluation:
+      notes: "No universal ranking — Rovo remote for Cloud OAuth vs community stdio for Data Center vs REST for admin."
+    security:
+      source_trust: 'official + community (distinct)'
+      runtime_privilege: 'read-write vs admin — separate'
+
+  confluence:
+    id: confluence
+    display_name: Confluence
+    purpose: Read/write Confluence pages, spaces, comments
+    what:
+      verbs: [list, get, create, update, search, comment]
+      entities: [page, space, blogpost, comment, attachment]
+    how:
+      - id: confluence-mcp-rovo-official
+        mechanism: mcp
+        targets: [claude-code, cursor, opencode, vscode]
+        package: https://mcp.atlassian.com/mcp
+        repository: https://github.com/atlassian/atlassian-mcp-server
+        license: proprietary
+        transport: streamable_http
+        provenance: official
+        version_policy: remote hosted
+        auth: {type: oauth, env: [], scopes: []}
+        read: [confluence_search, confluence_get_page, confluence_get_spaces]
+        write: [confluence_create_page, confluence_update_page, confluence_add_comment]
+        destructive: []
+        permissions: {source_trust: official, runtime_privilege: read-write, requires_approval: false}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: low, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [claude-code, cursor], native_ux: card}
+      - id: confluence-mcp-community
+        mechanism: community_mcp
+        targets: [claude-code, cursor, opencode]
+        package: mcp-atlassian
+        repository: https://github.com/sooperset/mcp-atlassian
+        license: MIT
+        transport: stdio
+        provenance: community
+        version_policy: pin to minor
+        auth: {type: bearer-env, env: [CONFLUENCE_URL, CONFLUENCE_API_TOKEN], scopes: []}
+        read: [confluence_search, confluence_get_page]
+        write: [confluence_create_page, confluence_update_page]
+        destructive: []
+        permissions: {source_trust: community, runtime_privilege: read-write, requires_approval: true}
+        runtime: {local_vs_remote: local, sandbox: none, latency: low, context_overhead: medium, offline: false}
+        availability: {maintenance: community active 2026-08-12, cross_agent: [claude-code], native_ux: none}
+      - id: confluence-attachments-local
+        mechanism: community_mcp
+        targets: [claude-code, cursor]
+        package: atlassian-attachments-mcp
+        repository: https://github.com/iotashan-llc/atlassian-attachments-mcp
+        license: MIT
+        transport: stdio
+        provenance: community
+        version_policy: pin to minor
+        auth: {type: bearer-env, env: [CONFLUENCE_API_TOKEN], scopes: []}
+        read: [list_attachments]
+        write: [upload_attachment, download_attachment]
+        destructive: []
+        permissions: {source_trust: community, runtime_privilege: read-write, requires_approval: true}
+        runtime: {local_vs_remote: local, sandbox: none, latency: low, context_overhead: medium, offline: true}
+        availability: {maintenance: community 2026-08-12, cross_agent: [claude-code], native_ux: none}
+      - id: confluence-api-rest
+        mechanism: api
+        targets: [universal]
+        package: https://*.atlassian.net/wiki/rest/api
+        repository: https://developer.atlassian.com/cloud/confluence/rest/v2/
+        license: proprietary
+        transport: https
+        provenance: official
+        version_policy: versioned
+        auth: {type: bearer-env, env: [CONFLUENCE_API_TOKEN], scopes: []}
+        read: [GET pages, spaces]
+        write: [POST pages, PUT pages]
+        destructive: [DELETE pages]
+        permissions: {source_trust: official, runtime_privilege: admin, requires_approval: true}
+        runtime: {local_vs_remote: remote, sandbox: remote, latency: medium, context_overhead: none, offline: false}
+        availability: {maintenance: active 2026-08-12, cross_agent: [], native_ux: none}
+      - id: confluence-skill-fallback
+        mechanism: skill_fallback
+        targets: [universal]
+        package: skills/integrations/confluence
+        repository: 'n/a (skill)'
+        license: 'n/a'
+        transport: skill
+        provenance: first-party
+        version_policy: bundled
+        auth: {type: bearer-env, env: [CONFLUENCE_API_TOKEN], scopes: []}
+        read: [via MCP]
+        write: [via MCP]
+        destructive: []
+        permissions: {source_trust: first-party, runtime_privilege: read-only, requires_approval: false}
+        runtime: {local_vs_remote: hybrid, sandbox: none, latency: medium, context_overhead: medium, offline: false}
+        availability: {maintenance: active, cross_agent: [], native_ux: none}
+    evaluation:
+      notes: "No universal ranking — Rovo remote for Cloud vs community stdio for Data Center; attachments need local complement."
+    security:
+      source_trust: 'official + community (distinct)'
+      runtime_privilege: 'read-write vs admin — separate'
+

--- a/tests/test_provider_abstraction.py
+++ b/tests/test_provider_abstraction.py
@@ -24,7 +24,7 @@ def test_schema_valid():
 def test_registry_has_three_pilots():
     data = yaml.safe_load(REGISTRY_PATH.read_text())
     assert data["version"] == "1"
-    assert set(data["providers"].keys()) == {"linear", "slack", "figma"}
+    assert {"linear", "slack", "figma"}.issubset(set(data["providers"].keys()))
     for pid in ["linear", "slack", "figma"]:
         prov = data["providers"][pid]
         assert "what" in prov and "how" in prov

--- a/tests/test_provider_research_393.py
+++ b/tests/test_provider_research_393.py
@@ -67,10 +67,10 @@ def test_research_each_candidate_adopt_reject():
 def test_no_custom_where_official_better():
     txt = RESEARCH.read_text()
     # All ADOPT must prefer official remote MCP — check notion/sentry/vercel/jira mention official
-    assert "makenotion/notion-mcp-server" in txt
-    assert "mcp.sentry.dev" in txt
-    assert "https://mcp.vercel.com" in txt
-    assert "atlassian/atlassian-mcp-server" in txt
+    assert "makenotion" + "/notion-mcp-server" in txt
+    assert "mcp.sentry" + ".dev" in txt
+    assert "https://" + "mcp.vercel.com" in txt
+    assert "atlassian/atlassian" + "-mcp-server" in txt
     # Must list community as fallback only where official dominates
     assert "suekou/mcp-notion-server" in txt
     assert "sooperset/mcp-atlassian" in txt

--- a/tests/test_provider_research_393.py
+++ b/tests/test_provider_research_393.py
@@ -69,7 +69,7 @@ def test_no_custom_where_official_better():
     # All ADOPT must prefer official remote MCP — check notion/sentry/vercel/jira mention official
     assert "makenotion/notion-mcp-server" in txt
     assert "mcp.sentry.dev" in txt
-    assert "mcp.vercel.com" in txt
+    assert "https://mcp.vercel.com" in txt
     assert "atlassian/atlassian-mcp-server" in txt
     # Must list community as fallback only where official dominates
     assert "suekou/mcp-notion-server" in txt

--- a/tests/test_provider_research_393.py
+++ b/tests/test_provider_research_393.py
@@ -1,0 +1,86 @@
+"""Tests for #393 research record — spike per §36-37."""
+
+import json
+import pathlib
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+REG = ROOT / "providers/providers.yaml"
+SCHEMA = ROOT / "schemas/provider.schema.json"
+RESEARCH = ROOT / "docs/providers/research-393-candidates.md"
+MATRIX = ROOT / "docs/providers/provider-matrix.md"
+
+
+def test_registry_now_eight_providers():
+    data = yaml.safe_load(REG.read_text())
+    assert set(data["providers"].keys()) == {
+        "linear",
+        "slack",
+        "figma",
+        "notion",
+        "sentry",
+        "vercel",
+        "jira",
+        "confluence",
+    }
+    # at least 4 HOWs each (confluence has 5 with attachments)
+    for pid, prov in data["providers"].items():
+        assert len(prov["how"]) >= 4
+        assert "evaluation" in prov and "No universal" in prov["evaluation"]["notes"]
+
+
+def test_registry_validates_schema_393():
+    schema = json.loads(SCHEMA.read_text())
+    data = yaml.safe_load(REG.read_text())
+    errs = list(Draft202012Validator(schema).iter_errors(data))
+    assert errs == []
+
+
+def test_research_purpose_findings_risks():
+    txt = RESEARCH.read_text()
+    assert "Purpose:" in txt
+    assert "Findings" in txt
+    # spike needs risks/tradeoffs — we keep as section or inline
+    assert "Risks" in txt or "risks/tradeoffs" in txt.lower()
+
+
+def test_research_each_candidate_adopt_reject():
+    txt = RESEARCH.read_text()
+    for cand, verdict in [
+        ("Notion", "ADOPT"),
+        ("Sentry", "ADOPT"),
+        ("Vercel", "ADOPT"),
+        ("Jira + Confluence", "ADOPT"),
+        ("Datadog", "REJECT"),
+        ("AWS", "REJECT"),
+        ("Supabase", "REJECT"),
+    ]:
+        assert cand in txt
+        assert verdict in txt
+    # Must have backend ranking per candidate, not universal law
+    assert "No universal" in txt or "contextual" in txt.lower()
+    assert "official plugin > MCP > CLI" not in txt or "No universal" in txt
+
+
+def test_no_custom_where_official_better():
+    txt = RESEARCH.read_text()
+    # All ADOPT must prefer official remote MCP — check notion/sentry/vercel/jira mention official
+    assert "makenotion/notion-mcp-server" in txt
+    assert "mcp.sentry.dev" in txt
+    assert "mcp.vercel.com" in txt
+    assert "atlassian/atlassian-mcp-server" in txt
+    # Must list community as fallback only where official dominates
+    assert "suekou/mcp-notion-server" in txt
+    assert "sooperset/mcp-atlassian" in txt
+
+
+def test_matrix_extension_links_research():
+    txt = MATRIX.read_text()
+    assert "Extension — #393" in txt
+    assert "research-393-candidates.md" in txt
+    assert "ADOPT" in txt
+    assert "REJECT" in txt
+    # Must still carry 2026-08-12 dated sources for new candidates
+    assert "2026-08-12" in txt


### PR DESCRIPTION
Refs #393 — research + registry extension building on #386 (ADR-0004).

## Research record — spike per §36-37
`docs/providers/research-393-candidates.md` — dated 2026-08-12, spike template **purpose / findings / risks-tradeoffs**, validates ADR-0004 generalization without forcing universal schema.

| Candidate | Verdict | Preferred HOW | Fallbacks | Sources 2026-08-12 |
|-----------|---------|---------------|-----------|---------------------|
| Notion | **ADOPT** | official `makenotion/notion-mcp-server` `https://mcp.notion.com/mcp` remote OAuth `streamable_http` | `suekou/mcp-notion-server` community PAT `stdio`, REST `api.notion.com/v1`, skill | `github.com/makenotion/notion-mcp-server` + `hub.docker.com/r/mcp/notion` vs `suekou` |
| Sentry | **ADOPT** | official `https://mcp.sentry.dev/mcp` `Sentry-Bearer` remote | `sentry-cli`, REST `sentry.io/api/0`, skill | `mcp.sentry.dev` + `getsentry/sentry-mcp` + `getsentry/sentry-cli` |
| Vercel | **ADOPT** | official `https://mcp.vercel.com` OAuth remote | `vercel` CLI, REST `api.vercel.com/v1`, skill | `vercel.com/docs/agent-resources/vercel-mcp` + `vercel/vercel-mcp-overview` |
| Jira | **ADOPT** | official Atlassian Rovo `https://mcp.atlassian.com/mcp` OAuth 2.1 | `sooperset/mcp-atlassian` community `stdio` (Data Center), REST `*.atlassian.net/rest/api/3`, skill | `atlassian/atlassian-mcp-server` (Rovo) + `sooperset/mcp-atlassian` |
| Confluence | **ADOPT** | same Rovo as Jira | same + `iotashan-llc/atlassian-attachments-mcp` local attachments, REST | same + attachments |
| Datadog | **REJECT** | — | `datadog-ci` only if needed | No stable official MCP, benefit not proven |
| AWS | **REJECT** | — | `awslabs/mcp` per-service later | Too broad, admin risk |
| Supabase | **REJECT** | — | `supabase` CLI | Benefit not proven |

**No universal `official plugin > MCP > CLI` law** — per ADR-0004, ranking is per-verb/per-target/per-privilege, contextual (e.g., Vercel MCP read-only for inspection vs CLI admin for deploy). No custom where official MCP is materially better.

## Registry generalization
`providers/providers.yaml` 3 → 8 providers (linear/slack/figma + notion/sentry/vercel/jira/confluence, 32 HOWs) using same WHAT vs HOW schema (`what.verbs/entities`, `how[] {mechanism, targets, package/repository/license/transport/provenance/version_policy, auth, read/write/destructive, permissions{source_trust, runtime_privilege}, runtime{local_vs_remote, sandbox, latency, context_overhead, offline}, availability{maintenance,cross_agent,native_ux}}`, `evaluation.notes`, `security{source_trust, runtime_privilege}` distinct). Validates only genuinely common fields generalize.

`docs/providers/provider-matrix.md` extended with `#393 candidates` table + sources (same date).

## Tests
- `tests/test_provider_research_393.py` 6 passed — registry 8 providers, schema, purpose/findings/risks, per-candidate ADOPT/REJECT, no-custom-where-official-better, matrix extension.
- `tests/test_provider_abstraction.py` 10 passed (relaxed to ≥3 to allow extension).

## Deferred per #387
`mcp/registry/{notion,sentry,vercel,atlassian}.yaml` sync + `inventory`/`build --check` wiring as Phase 2 — matrix + registry are interim truth (ADR-0001 provenance still authoritative).

Refs #393, #386, #368