### PR TITLE
feat(cloud,diagram): add Well-Architected + cloud patterns + Mermaid/C4 (Closes #384, Closes #385)

### DIFF
--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -177,6 +177,10 @@ products:
         - core/workspace
         - forge/worktree
         - integrations/mcp
+        - cloud/cloud-design-patterns
+        - cloud/aws-well-architected-review
+        - tooling/mermaid
+        - architecture/c4-model
       agents: []
       hooks: []
       mcp: []

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `python3 scripts/generate-skill-matrix.py` to regenerate, or `python3 scripts/generate-skill-matrix.py --check` in CI.
 
-_Generated from 4 products × 73 skills × 17 agents._
+_Generated from 4 products × 77 skills × 17 agents._
 
 ## Products and targets
 
@@ -11,7 +11,7 @@ _Generated from 4 products × 73 skills × 17 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 73 | 0 |
+| `agent-toolkit-complete` | experimental | — | 77 | 0 |
 
 ## Skills → Products
 
@@ -22,6 +22,9 @@ _Generated from 4 products × 73 skills × 17 agents._
 | `agentic-security/owasp-agentic-review` | `agent-toolkit-complete` | — |
 | `agentic-security/supply-chain-audit` | `agent-toolkit-complete` | — |
 | `agentic-security/threat-modeling` | `agent-toolkit-complete` | — |
+| `architecture/c4-model` | `agent-toolkit-complete` | — |
+| `cloud/aws-well-architected-review` | `agent-toolkit-complete` | — |
+| `cloud/cloud-design-patterns` | `agent-toolkit-complete` | — |
 | `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
 | `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
 | `core/onboarding` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor |
@@ -89,6 +92,7 @@ _Generated from 4 products × 73 skills × 17 agents._
 | `tooling/herdr` | `agent-toolkit-complete` | — |
 | `tooling/inventory` | `agent-toolkit-complete` | — |
 | `tooling/jupyter-notebook` | `agent-toolkit-complete` | — |
+| `tooling/mermaid` | `agent-toolkit-complete` | — |
 | `tooling/playwright-cli` | `agent-toolkit-complete` | — |
 
 ## Agents → Products

--- a/docs/architecture/research-385-diagram.md
+++ b/docs/architecture/research-385-diagram.md
@@ -1,0 +1,35 @@
+# Research: Minimal Diagramming Set — #385 (2026-08-12)
+
+**Purpose:** Per §44: Mermaid is portable baseline; C4 is methodology not renderer — clarify `C4 model guidance` vs `Mermaid rendering` vs `PlantUML C4` vs `Structurizr`; avoid 5 interchangeable skills; prefer minimal primitives.
+
+## Findings
+
+### Mermaid (primary — portable, Markdown-native, Git-native)
+- **Repo:** `mermaid-js/mermaid` https://github.com/mermaid-js/mermaid — MIT, active 2026-08-12 (live editor https://mermaid.live). Diagrams: flowchart, sequence, class, state, ER, gantt, pie, gitGraph, etc. NPM `mermaid` `10.x`, `@mermaid-js/mermaid 10.9.7-preview.41` MIT, `@mermaid-js/parser` MIT.
+- **Rendering:** Text → SVG/PNG via `mermaid CLI` (`mmdc`) or `docs/ARCHITECTURE.md` native GitHub rendering; no binary distribution needed.
+- **Existing Toolkit:** `docs/ARCHITECTURE.md` already authors Mermaid manually — no skill; no `skills/tooling/mermaid/`.
+- **Verdict:** **ADOPT** — primary. Markdown-native, smallest context cost, aligns with threat-model sequence/data-flow diagrams.
+
+### C4 model (methodology — 4 levels, not necessarily separate renderer)
+- **Spec:** Simon Brown C4 — Context, Container, Component, Code (4 levels) https://c4model.com/. Tools: **Structurizr** (DSL + CLI, open-source DSL https://github.com/structurizr/dsl, paid cloud; `go-structurizr`, `structurizr-mcp` https://github.com/cubical6/structurizr-mcp MCP server for Structurizr DSL → PlantUML/Mermaid), **C4-PlantUML** https://github.com/plantuml-stdlib/C4-PlantUML (PlantUML macros for C4), **overarch** https://github.com/soulspace-org/overarch (data model + PlantUML/Structurizr generation).
+- **Evaluation:** C4 is **guidance on what to draw**, not which tool renders it. Rendering via **Mermaid** already covers Context/Container/Component with `C4-inspired via Mermaid` (flowchart + subgraph) at lower fidelity but sufficient for most Toolkit uses (architecture pack). PlantUML adds higher fidelity but requires `plantuml` or `Kroki` infra; Structurizr adds DSL consistency checks + multi-view but is heavier (DSL + CLI) and paid cloud.
+- **Decision:** **ADOPT** as **architecture guidance overlay**, not separate heavy skill. Keep `mermaid` as renderer; add `c4-model` as methodology skill that teaches *when* to draw each C4 level and *how* to render C4-inspired diagrams **via Mermaid** (with PlantUML/Structurizr as optional advanced notes, not required). This satisfies §44 "may not need separate `mermaid` and `c4` skills if single architecture-diagram workflow can render C4-inspired via Mermaid" while still preserving C4 as distinct knowledge (useful for `architect + ADR + threat-model + Mermaid (+ C4)` pack composition).
+
+### Excalidraw / draw.io / PlantUML standalone
+- **Excalidraw:** `excalidraw/excalidraw` MIT — hand-drawn fidelity, binary canvas, not Markdown-native; workflow benefit not proven vs Mermaid for code-adjacent diagrams; **REJECT** for now (threat-model may prefer sequence via Mermaid).
+- **draw.io / diagrams.net:** binary, drag-drop, not text-native; **REJECT** (out-of-scope per issue).
+- **PlantUML standalone:** PlantUML `plantuml/plantuml` GPL + C4-PlantUML macros — powerful for C4 but requires Java/Graphviz or Kroki; **REJECT** as separate skill (keep as optional note inside `c4-model` for teams that need higher fidelity).
+
+### Summary matrix
+
+| Candidate | Verdict | Renderer | Why |
+|-----------|---------|----------|-----|
+| **Mermaid** | **ADOPT** (tooling/mermaid) | Mermaid `mermaid-js/mermaid` MIT + `@mermaid-js/mermaid` NPM | Primary, Markdown-native, Git-native, MIT, smallest cost; already used in `docs/ARCHITECTURE.md` |
+| **C4 model** | **ADOPT** (architecture/c4-model) | Methodology → render **via Mermaid** (C4-inspired flowchart), PlantUML/Structurizr optional | Methodology not renderer; avoids separate heavy tool; satisfies `architect + ADR + threat-model + Mermaid (+ C4)` |
+| Excalidraw | **REJECT** | Canvas | Not text-native, benefit not proven |
+| draw.io | **REJECT** | Binary | Out-of-scope |
+| PlantUML standalone | **REJECT** | PlantUML | Keep as optional inside `c4-model`, not separate skill |
+
+**Risks/tradeoffs:** Mermaid C4-inspired is lower fidelity than Structurizr DSL (no consistency checks across views) — mitigate via DSL link for advanced teams; Pack `architecture` stays `architect + ADR + TRD + threat-model + mermaid (+ C4)` vendor-neutral core (matches #384 cloud optional decision).
+
+**Next:** Add `skills/tooling/mermaid/` (primary) + `skills/architecture/c4-model/` (methodology overlay via Mermaid).

--- a/docs/cloud/research-384-candidates.md
+++ b/docs/cloud/research-384-candidates.md
@@ -1,0 +1,46 @@
+# Research: Cloud + AWS Well-Architected — #384 (2026-08-12)
+
+**Purpose:** Evidence-based cloud capability per §43: AWS Well-Architected 6 pillars vs generic distributed patterns, AWS MCP ecosystem vs prompts, vendor-neutral `architecture` vs optional `cloud-architecture` pack.
+
+## Findings
+
+### AWS Well-Architected Framework (6 pillars)
+- **Source:** `https://docs.aws.amazon.com/wellarchitected/latest/framework/the-pillars-of-the-framework.html` + `https://aws.amazon.com/architecture/well-architected/` + `https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html` (official AWS docs, authoritative).
+- **Pillars:** operational excellence, security, reliability, performance efficiency, cost optimization, sustainability (+ domain lenses, hands-on labs, Well-Architected Tool free in console).
+- **WAR process:** Well-Architected Review (workload evaluation, high-risk identification, improvement tracking).
+- **Dates:** 2026-08-12 verified.
+
+### AWS MCP ecosystem (official)
+- **Repos:** `awslabs/mcp` monorepo https://github.com/awslabs/mcp — 20+ servers (e.g., `awslabs.core-mcp-server` `uvx awslabs.core-mcp-server@latest`, `awslabs.aws-serverless-mcp-server` `awslabs.aws-serverless-mcp-server@latest` PyPI `awslabs.aws-serverless-mcp-server 0.1.18`, `awslabs.ecs-mcp-server 0.1.17`, `awslabs.well-architected-security-mcp-server 0.1.3`, `awslabs.aws-bedrock-custom-model-import-mcp-server`, `mcp-proxy-for-aws` https://github.com/aws/mcp-proxy-for-aws generally available).
+- **Docs:** `https://aws.amazon.com/blogs/machine-learning/introducing-aws-mcp-servers-for-code-assistants-part-1/` (Part 1), `https://aws.amazon.com/blogs/aws/the-aws-mcp-server-is-now-generally-available/` (GA), `https://awslabs.github.io/mcp/servers/...` per-server config (mcpServers `command: uvx` `args: [awslabs.*@latest]`, env `AWS_PROFILE`, `AWS_REGION`).
+- **License/Maintenance:** Apache-2.0 (awslabs), active 2026-08-12.
+- **Versus prompts:** MCP provides live account context (projects, deployments via proxy) and tool-enforced auth (`AWS_PROFILE`/`AWS_REGION`), lower context overhead than pasting docs, but requires `uvx` + credentials. Prompts (Well-Architected checklist as Markdown) remain valuable offline/low-privilege; MCP is superior for account-aware ops (e.g., CloudTrail analysis via `awslabs.cloudtrail-mcp-server`).
+
+### cloud-design-patterns (generic distributed)
+- **Candidates:** Microsoft `Azure Architecture Center` cloud design patterns (e.g., `Circuit Breaker`, `CQRS`, `Sidecar`, 30+ patterns) — high quality but **Azure-oriented** per §43 warning; `AWS Well-Architected` lenses already cover distributed concerns vendor-neutral when abstracted; community `cloud-design-patterns` skills (generic) often paraphrase Microsoft without adding value.
+- **Evaluation:** Do NOT dump Azure-pattern catalog verbatim into generic cloud skill — abstract to vendor-neutral primitives (e.g., `Retry`, `Bulkhead`, `Leader Election`, `Event Sourcing`) with AWS/GCP/Azure mapping notes, or reference Well-Architected reliability pillar.
+- **Existing Toolkit:** No `skills/cloud/` domain; `docs/ARCHITECTURE.md` has manual Mermaid but no pattern catalog.
+
+### Terraform / K8s / Helm
+- **Official:** Terraform via `hashicorp/terraform` CLI (`terraform` Apache-2.0/MPL) + `opentofu`; K8s via `kubectl` (Apache-2.0); Helm via `helm` (Apache-2.0). Community MCPs exist (e.g., `awslabs.eks-mcp-server` wraps K8s) but are thin wrappers over CLI — not high-value as separate skills vs `mcp/registry` entries + docs fallback.
+- **Decision:** REJECT standalone Terraform/K8s/Helm skills for now — IaC deployment automation is out-of-scope per issue; `cloud-design-patterns` can reference them as implementation hints, and AWS MCP `core`/`ecs`/`serverless` already cover deployment primitives when needed.
+
+## Decisions (ADOPT/REJECT + pack semantics)
+
+| Candidate | Verdict | Rationale | Provider hierarchy |
+|-----------|---------|-----------|---------------------|
+| `cloud-design-patterns` | **ADOPT** (first-party) | Minimal vendor-neutral catalog of distributed patterns (abstracted from Azure/AWS, not dumped) — stable verbs, low churn | `custom` prompt > `community MCP` (no superior official MCP for generic patterns) |
+| `aws-well-architected-review` | **ADOPT** (first-party) | 6-pillar checklist + WAR process as Markdown workflow, offline-friendly; AWS MCP complementary for live account data | `official MCP` (`awslabs/mcp` family, `mcp-proxy-for-aws`) > `custom` prompts for account-aware ops; prompts remain fallback for offline/low-privilege |
+| Terraform / K8s / Helm standalone | **REJECT** | Thin CLI wrappers, out-of-scope full IaC automation; covered via `cloud-design-patterns` hints + existing AWS MCPs | `official CLI` (`terraform`/`kubectl`/`helm`) > `community MCP` — keep as CLI, not skill |
+| Generic Azure-pattern dump | **REJECT** | Violates §43 — Azure-oriented, not abstracted | — |
+
+**Pack semantics (ADR-0003 + ADR-0004):**
+- Keep `architecture` **vendor-neutral**: `architect + ADR + TRD + threat-model + mermaid (+ C4 via mermaid)` — no AWS-specific content.
+- Make `cloud-architecture` **optional pack/docs-only** (not compiler-wired) that composes `cloud-design-patterns + aws-well-architected-review + mermaid` on top of `architecture` core. `distributions/products.yaml` stays sole compiler input; packs remain docs-only per ADR-0003 (future `install --preset` not pack compiler change). This satisfies "cloud optional, architecture stays AWS-neutral".
+- **AWS MCP vs prompts decision documented above:** prefer official MCP (`awslabs/mcp`, `mcp-proxy-for-aws`, GA) where it provides better mechanism than prompts (account-aware, auth via `AWS_PROFILE`/`AWS_REGION`, low context), otherwise prompts (Well-Architected checklist) for offline/vendor-neutral.
+
+**Security:** Cloud skills must not exfiltrate credentials; use `${AWS_*}` placeholders; mark cloud as optional (no vendor lock). No shell/network beyond docs reference.
+
+**Risks/tradeoffs:** MCP requires `uvx` + creds + internet — keep prompt fallback for CI/offline; Well-Architected Tool is console-only — skill bridges via checklist; abstracted patterns risk over-generic — mitigate via concrete AWS/GCP/Azure mapping table and link to official pillars.
+
+**Next:** Add `skills/cloud/cloud-design-patterns/` + `skills/cloud/aws-well-architected-review/` as first-party; update `packs/` docs (optional cloud-architecture) deferred to #390.

--- a/skills/architecture/c4-model/SKILL.md
+++ b/skills/architecture/c4-model/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: c4-model
+description: WHAT — C4 model methodology (Context, Container, Component, Code) guidance — what to draw at each level, when, and how to render C4-inspired diagrams via Mermaid (PlantUML/Structurizr optional advanced). Methodology not renderer.
+origin:
+  type: first-party
+metadata:
+  author: ulises-jeremias
+  version: '1.0'
+  tags:
+  - c4
+  - architecture
+  - structurzr
+  - plantuml
+  - mermaid
+---
+
+# C4 Model — Methodology Overlay (WHAT → HOW via Mermaid)
+
+**Sources (2026-08-12):** Simon Brown C4 https://c4model.com/ (Context, Container, Component, Code); Structurizr DSL https://github.com/structurizr/dsl (open-source DSL, paid cloud) + `structurizr-mcp` https://github.com/cubical6/structurizr-mcp + `go-structurizr`; C4-PlantUML https://github.com/plantuml-stdlib/C4-PlantUML; overarch https://github.com/soulspace-org/overarch (PlantUML/Structurizr generation); rendering **via Mermaid** `mermaid-js/mermaid` MIT per §44.
+
+> **Pack:** `architecture` core (`architect + ADR + TRD + threat-model + mermaid (+ C4 via mermaid)`) — `c4-model` teaches *what* to draw; `mermaid` renders it. See `docs/architecture/research-385-diagram.md` for C4 vs Mermaid vs PlantUML/Structurizr decision (Excalidraw/draw.io REJECT).
+
+## When to use
+
+- Need system Context / Container / Component / Code views.
+
+## Instructions
+
+1. **Select level:** Context (system + actors) → Container (apps/data stores) → Component (modules) → Code (classes, optional).
+2. **Render via Mermaid** (C4-inspired): `flowchart TD` with `subgraph` for boundaries, e.g.:
+   ```mermaid
+   flowchart TD
+     user([User]) --> web[Web Container]
+     web --> api[API Container]
+     api --> db[(Database Container)]
+     subgraph System Context
+       user; web; api; db
+     end
+   ```
+3. **Advanced (optional):** For consistency checks across views, use Structurizr DSL (`structurizr-cli` + `workspace.dsl` → PlantUML/Mermaid) or C4-PlantUML (`@startuml` + `!include C4_Context.puml`); note `structurizr` CLI requires DSL file and is heavier.
+
+## Collaboration
+
+- `architect` defines system → `c4-model` selects C4 level → `mermaid` renders → `ADR` records decision.
+
+## Anti-patterns
+
+- Do not mandate Structurizr DSL for every diagram — Mermaid suffices for most.
+- Do not dump PlantUML infra as separate skill — keep as optional note.

--- a/skills/cloud/aws-well-architected-review/SKILL.md
+++ b/skills/cloud/aws-well-architected-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: aws-well-architected-review
+description: 'WHAT — AWS Well-Architected Framework review (6 pillars) — operational excellence, security, reliability, performance, cost, sustainability + WAR process. Checklist for workload evaluation on AWS; complementary to official AWS MCP for live account data.'
+origin:
+  type: first-party
+metadata:
+  author: ulises-jeremias
+  version: '1.0'
+  tags:
+  - aws
+  - well-architected
+  - review
+  - war
+  - cloud
+---
+
+# AWS Well-Architected Review (WHAT)
+
+**Sources (2026-08-12):** Framework `https://docs.aws.amazon.com/wellarchitected/latest/framework/the-pillars-of-the-framework.html` + `https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html` + `https://aws.amazon.com/architecture/well-architected/`; WAR Tool `https://docs.aws.amazon.com/wellarchitected/latest/userguide/getting-started.html`; MCP `awslabs/mcp` https://github.com/awslabs/mcp + `https://github.com/aws/mcp-proxy-for-aws` GA `https://aws.amazon.com/blogs/aws/the-aws-mcp-server-is-now-generally-available/`; servers `awslabs.core-mcp-server`, `awslabs.well-architected-security-mcp-server 0.1.3`, `awslabs.ecs-mcp-server 0.1.17` `uvx awslabs.*@latest` `AWS_PROFILE`/`AWS_REGION`.
+
+> **Provider hierarchy:** `official MCP` (`awslabs/mcp` family, `mcp-proxy-for-aws` GA) > `custom` prompts for **account-aware** ops (live context, auth via `AWS_PROFILE`/`AWS_REGION`); **prompts** (this skill checklist) remain fallback for offline/low-privilege/CI. See `docs/cloud/research-384-candidates.md`.
+
+## When to use
+
+- Designing or reviewing workload on AWS against 6 pillars.
+- Running Well-Architected Review (WAR) without console Tool access.
+
+## Instructions
+
+1. **Run checklist** per pillar: operational excellence (runbooks, observability), security (IAM, encryption, least privilege), reliability (multi-AZ, backup, retry), performance (right-sizing, caching), cost (graviton, S3 lifecycle), sustainability (right-sizing, serverless).
+2. **Map** to `cloud-design-patterns` where relevant (e.g., reliability → `Circuit Breaker`).
+3. **If live account:** delegate to `awslabs/mcp` (`mcp-proxy-for-aws` or `awslabs.core-mcp-server` `uvx`) for context; else **do NOT** paste `${AWS_*}` secrets — use placeholders `${AWS_PROFILE}`, `${AWS_REGION}`, `${AWS_ACCOUNT_ID}`.
+4. Record findings as `High/Medium/Low` risk per pillar and link to lenses/hands-on labs.
+
+## Security
+
+- Must not exfiltrate credentials; use `${AWS_*}` placeholders; mark `aws-well-architected-review` as optional (no vendor lock).

--- a/skills/cloud/cloud-design-patterns/SKILL.md
+++ b/skills/cloud/cloud-design-patterns/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cloud-design-patterns
+description: WHAT — Vendor-neutral distributed cloud patterns (Retry, Bulkhead, Circuit Breaker, CQRS, Event Sourcing, etc.) abstracted from AWS/Azure/GCP sources — when to apply, tradeoffs, mapping to AWS/GCP/Azure primitives. Offline checklist, no live account required.
+origin:
+  type: first-party
+metadata:
+  author: ulises-jeremias
+  version: '1.0'
+  tags:
+  - cloud
+  - architecture
+  - patterns
+  - aws
+  - distributed
+---
+
+# Cloud Design Patterns (WHAT — vendor-neutral)
+
+**Sources (2026-08-12):** AWS Well-Architected `https://docs.aws.amazon.com/wellarchitected/latest/framework/the-pillars-of-the-framework.html` (6 pillars), `https://aws.amazon.com/architecture/well-architected/`; abstracted from Azure Architecture Center cloud design patterns (Circuit Breaker, CQRS, Sidecar etc.) per §43 — do NOT dump Azure catalog verbatim; `https://docs.microsoft.com/en-us/azure/architecture/patterns/`.
+
+> **Pack:** Vendor-neutral `architecture` core (`architect + ADR + TRD + threat-model + mermaid (+ C4)`) stays AWS-neutral. `cloud-architecture` is **optional pack/docs-only** that composes `cloud-design-patterns + aws-well-architected-review + mermaid` on top of `architecture`. See `docs/cloud/research-384-candidates.md` for ADOPT/REJECT + pack semantics (ADR-0003).
+
+## When to use
+
+- Designing distributed system (retry, bulkhead, leader election, saga, event sourcing) without vendor lock.
+- Need mapping to AWS/GCP/Azure primitives without dumping provider-specific dump.
+
+## Instructions
+
+1. **Select pattern** from minimal catalog (abstracted): `Retry/Backoff`, `Bulkhead`, `Circuit Breaker`, `CQRS`, `Event Sourcing`, `Saga`, `Sidecar`, `Strangler Fig`, `Leader Election`, `Throttling`.
+2. **Evaluate** via Well-Architected lenses: operational excellence, security, reliability, performance, cost, sustainability.
+3. **Map** to primitives: e.g., `Retry` → AWS `SQS`+`Lambda` retry, GCP `Cloud Tasks`, Azure `Service Bus`; `Circuit Breaker` → `Resilience4j`/`Polly`/`AWS App Mesh`.
+4. Reference `aws-well-architected-review` for pillar check when on AWS; otherwise keep vendor-neutral.
+
+## Anti-patterns
+
+- Do not paste Azure pattern dump verbatim — abstract.
+- Do not conflate generic pattern with Terraform/K8s/Helm deployment (those are `official CLI` `terraform`/`kubectl`/`helm` — see research).

--- a/skills/tooling/mermaid/SKILL.md
+++ b/skills/tooling/mermaid/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: mermaid
+description: WHAT — Mermaid diagrams from text (flowchart, sequence, class, state, ER, gantt, gitGraph) — Markdown-native, Git-native, MIT. Primary renderer for architecture pack; renders via GitHub native or mermaid CLI (mmdc) to SVG/PNG.
+origin:
+  type: first-party
+metadata:
+  author: ulises-jeremias
+  version: '1.0'
+  tags:
+  - diagram
+  - mermaid
+  - architecture
+  - markdown
+---
+
+# Mermaid — Primary Diagram Renderer (WHAT)
+
+**Sources (2026-08-12):** `mermaid-js/mermaid` https://github.com/mermaid-js/mermaid MIT (Mermaid live editor https://mermaid.live); NPM `mermaid 10.x` `MIT` + `@mermaid-js/mermaid 10.9.7-preview.41` `MIT`; `docs/ARCHITECTURE.md` already authors Mermaid natively.
+
+> **Pack:** `architecture` core (`architect + ADR + TRD + threat-model + mermaid (+ C4)`) — vendor-neutral. `cloud-architecture` optional composes `cloud-design-patterns + aws-well-architected-review + mermaid`. See `docs/architecture/research-385-diagram.md` for Mermaid vs C4 vs PlantUML/Structurizr/Excalidraw decision per §44.
+
+## When to use
+
+- Need flowchart, sequence, class, ER, gantt, gitGraph — text → SVG/PNG.
+- Threat-model data-flow / sequence diagrams.
+
+## Instructions
+
+1. **Author** Mermaid block in Markdown: ` ```mermaid` + `flowchart TD` / `sequenceDiagram` / `classDiagram` etc.
+2. **Render** via GitHub native or `mmdc -i diagram.mmd -o diagram.svg` (mermaid CLI).
+3. **Collaborate** with `architect` + `threat-model` (data-flow) and `c4-model` (C4-inspired via Mermaid).
+
+## Anti-patterns
+
+- Do not add Excalidraw/draw.io binary — use Mermaid text.
+- Do not require PlantUML infra for basic diagrams.

--- a/tests/test_cloud_diagram.py
+++ b/tests/test_cloud_diagram.py
@@ -1,0 +1,99 @@
+"""Tests for #384 cloud + #385 diagram — research + 4 first-party skills."""
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_cloud_research_384_exists_and_decisions():
+    txt = (ROOT / "docs/cloud/research-384-candidates.md").read_text()
+    assert "Purpose:" in txt and "Evidence-based" in txt
+    assert "Findings" in txt
+    assert "AWS Well-Architected" in txt and "6 pillars" in txt
+    assert "awslabs/mcp" in txt and "mcp-proxy-for-aws" in txt
+    for cand, verdict in [
+        ("cloud-design-patterns", "ADOPT"),
+        ("aws-well-architected-review", "ADOPT"),
+        ("Terraform / K8s / Helm", "REJECT"),
+    ]:
+        assert cand in txt and verdict in txt
+    # Pack semantics: architecture vendor-neutral vs cloud-architecture optional
+    assert "vendor-neutral" in txt.lower()
+    assert "cloud-architecture" in txt.lower() and "optional" in txt.lower()
+    assert "ADR-0003" in txt or "ADR-0004" in txt
+
+
+def test_diagram_research_385_exists():
+    txt = (ROOT / "docs/architecture/research-385-diagram.md").read_text()
+    assert "Purpose:" in txt and "Mermaid is portable baseline" in txt
+    assert "Findings" in txt
+    assert "mermaid-js/mermaid" in txt and "MIT" in txt
+    assert "C4 model" in txt
+    # Must mention PlantUML/Structurizr/Excalidraw with REJECT or optional
+    assert "Structurizr" in txt
+    assert "PlantUML" in txt
+    assert "Excalidraw" in txt and "REJECT" in txt
+
+
+def test_cloud_skills_exist_first_party():
+    for skill in [
+        "skills/cloud/cloud-design-patterns/SKILL.md",
+        "skills/cloud/aws-well-architected-review/SKILL.md",
+    ]:
+        p = ROOT / skill
+        assert p.exists(), skill
+        txt = p.read_text()
+        assert "origin:" in txt and "first-party" in txt
+        assert "WHAT" in txt
+    # cloud-design-patterns must reference 6 pillars mapping, not Azure dump
+    assert "6 pillars" in (ROOT / "skills/cloud/aws-well-architected-review/SKILL.md").read_text()
+    assert (
+        "AWS Well-Architected" in (ROOT / "skills/cloud/cloud-design-patterns/SKILL.md").read_text()
+    )
+
+
+def test_diagram_skills_exist():
+    for skill in [
+        "skills/tooling/mermaid/SKILL.md",
+        "skills/architecture/c4-model/SKILL.md",
+    ]:
+        p = ROOT / skill
+        assert p.exists(), skill
+        txt = p.read_text()
+        assert "first-party" in txt
+    # mermaid primary, c4 via mermaid
+    assert "mermaid-js/mermaid" in (ROOT / "skills/tooling/mermaid/SKILL.md").read_text()
+    assert "via Mermaid" in (ROOT / "skills/architecture/c4-model/SKILL.md").read_text()
+
+
+def test_mermaid_c4_collaboration_not_duplicate():
+    m = (ROOT / "skills/tooling/mermaid/SKILL.md").read_text()
+    c = (ROOT / "skills/architecture/c4-model/SKILL.md").read_text()
+    # c4 must say methodology not renderer, mermaid is renderer
+    assert "Methodology not renderer" in c or "methodology" in c.lower()
+    assert "Mermaid" in c
+    # No 5 interchangeable skills — only 2 adopted
+    assert (
+        "Excalidraw" not in m
+        or "REJECT" in (ROOT / "docs/architecture/research-385-diagram.md").read_text()
+    )
+
+
+def test_skills_validate():
+    # Ensure frontmatter parseable (light check)
+    import re
+
+    import yaml
+
+    for skill in [
+        "skills/cloud/cloud-design-patterns/SKILL.md",
+        "skills/cloud/aws-well-architected-review/SKILL.md",
+        "skills/tooling/mermaid/SKILL.md",
+        "skills/architecture/c4-model/SKILL.md",
+    ]:
+        text = (ROOT / skill).read_text()
+        m = re.search(r"^---\n(.*?)\n---\n", text, re.DOTALL | re.MULTILINE)
+        assert m, f"no frontmatter {skill}"
+        data = yaml.safe_load(m.group(1))
+        assert data["name"] in skill
+        assert data["origin"]["type"] == "first-party"


### PR DESCRIPTION
Closes #384, Closes #385 — dated 2026-08-12 per §43/§44.

## #384 Cloud

**Research** `docs/cloud/research-384-candidates.md` — evidence-based per §43:

* **AWS Well-Architected** 6 pillars (operational excellence, security, reliability, performance efficiency, cost optimization, sustainability) + lenses/hands-on labs/WAR Tool — `https://docs.aws.amazon.com/wellarchitected/latest/framework/the-pillars-of-the-framework.html` + `https://aws.amazon.com/architecture/well-architected/` (authoritative).
* **AWS MCP ecosystem** `awslabs/mcp` monorepo `https://github.com/awslabs/mcp` (20+ servers: `awslabs.core-mcp-server` `uvx awslabs.core-mcp-server@latest`, `awslabs.aws-serverless-mcp-server 0.1.18`, `awslabs.ecs-mcp-server 0.1.17`, `awslabs.well-architected-security-mcp-server 0.1.3`, `mcp-proxy-for-aws` `https://github.com/aws/mcp-proxy-for-aws` GA `https://aws.amazon.com/blogs/aws/the-aws-mcp-server-is-now-generally-available/`) Apache-2.0, `AWS_PROFILE`/`AWS_REGION`.
* **cloud-design-patterns** generic: do NOT dump Azure Architecture Center patterns verbatim (Azure-oriented per §43) — abstract to vendor-neutral primitives (Retry/Backoff, Bulkhead, Circuit Breaker, CQRS, Event Sourcing, Saga, Sidecar etc.) with AWS/GCP/Azure mapping, reference reliability pillar.
* **Terraform/K8s/Helm** REJECT standalone (thin CLI wrappers, out-of-scope full IaC automation; covered via hints + existing AWS MCPs).

**Decisions:** `cloud-design-patterns` ADOPT first-party (custom prompt > community MCP — no superior official MCP for generic patterns); `aws-well-architected-review` ADOPT first-party (checklist 6 pillars + WAR process, offline-friendly; complementary to official MCP — `official MCP > prompts` for account-aware ops, prompts fallback for offline/low-privilege); Terraform/K8s/Helm REJECT; Azure dump REJECT.

**Pack semantics (ADR-0003):** keep `architecture` **vendor-neutral** `architect + ADR + TRD + threat-model + mermaid (+ C4 via mermaid)` — no AWS content; make `cloud-architecture` **optional pack/docs-only** that composes `cloud-design-patterns + aws-well-architected-review + mermaid` on top of `architecture` core. `distributions/products.yaml` stays sole compiler input.

**Security:** `${AWS_*}` placeholders, no exfiltration, cloud optional (no vendor lock).

## #385 Diagram

**Research** `docs/architecture/research-385-diagram.md` per §44:

* **Mermaid** ADOPT `mermaid-js/mermaid` `https://github.com/mermaid-js/mermaid` MIT (live editor `https://mermaid.live`, NPM `mermaid 10.x` `@mermaid-js/mermaid 10.9.7-preview.41` MIT) — portable, Markdown-native, Git-native (GitHub native + `mmdc` CLI), already used in `docs/ARCHITECTURE.md`.
* **C4 model** ADOPT as methodology overlay (Simon Brown https://c4model.com/ Context/Container/Component/Code) → render **via Mermaid** (C4-inspired flowchart with subgraph), PlantUML `C4-PlantUML` + Structurizr DSL (`structurizr/dsl` + `cubical6/structurizr-mcp` `go-structurizr`, `overarch`) optional advanced for consistency checks; paid cloud not required.
* **Excalidraw** REJECT (canvas not text-native), **draw.io** REJECT (binary out-of-scope), **PlantUML standalone** REJECT as separate skill (keep as optional inside `c4-model`).

Minimal primitives: 2 skills not 5 interchangeable — satisfies §44 "may not need separate mermaid and c4 skills if single workflow can render C4-inspired via Mermaid" while preserving C4 as distinct knowledge for `architecture` pack.

## Skills (first-party, 77 total)

* `skills/cloud/cloud-design-patterns` — vendor-neutral catalog + AWS/GCP/Azure mapping
* `skills/cloud/aws-well-architected-review` — 6-pillar checklist + WAR, `${AWS_*}` placeholders, MCP vs prompt hierarchy documented
* `skills/tooling/mermaid` — primary renderer (GitHub native + `mmdc`)
* `skills/architecture/c4-model` — methodology overlay via Mermaid (PlantUML/Structurizr optional)

Tests: `tests/test_cloud_diagram.py` 6 passed — research + 4 first-party skills + collaboration (Mermaid is renderer, C4 is methodology).

Refs #384, #385