### PR TITLE
feat(docs): diff addyosmani documentation-and-adrs vs adr/docs-generator (Closes #394)

### DIFF
--- a/docs/research/diff-394-documentation-and-adrs.md
+++ b/docs/research/diff-394-documentation-and-adrs.md
@@ -1,0 +1,55 @@
+# Diff: addyosmani/agent-skills `documentation-and-adrs` vs Toolkit `adr` + `docs-generator` — #394 (2026-08-12)
+
+**Scope:** `https://github.com/addyosmani/agent-skills` MIT `skills/documentation-and-adrs/SKILL.md` (288 lines) vs `skills/delivery/adr/SKILL.md` (48 lines) + `skills/ops/docs-generator/SKILL.md` (85 lines) + `docs/adr/` (3 ADRs) + `docs-generator` loops.
+
+**Method:** `find-skills` discovery + manual `git clone --depth 1` (2026-08-12), compared headings, workflows, templates, lifecycle, verification.
+
+## Overlaps (high)
+
+| Area | Upstream | Toolkit | Verdict |
+|------|----------|---------|---------|
+| ADR purpose — records *why* not *what*, highest-value docs | ✅ full Section "ADRs capture reasoning" + 5 whens + cost-to-reverse | ✅ "WHAT — Create and maintain ADRs" + 3 when-to-use + long-term impact + options pros/cons | **Overlap 80%** — same intent |
+| ADR template — Status/Date/Context/Decision/Alternatives/Consequences | ✅ `docs/decisions/` + template with `PostgreSQL vs MongoDB/SQLite/MySQL` example + lifecycle `PROPOSED→ACCEPTED→(SUPERSEDED/DEPRECATED)` + "Don't delete old ADRs" | ✅ `references/default-template.md` + 6-part Title & status, Context, Options, Decision, Consequences, References + `output-handshake` gate | **Overlap** — Toolkit template more structured (6-part + PRD/TRD linking), upstream more lifecycle + example |
+| README/Changelog/API | ✅ README Structure (Quick Start, Commands, Architecture, Contributing), Changelog Maintenance, OpenAPI `spec-driven` | ✅ `docs-generator` README from `package.json`/`pyproject`, CHANGELOG from `git log --oneline`, OpenAPI/GraphQL → tables, AGENTS.md starter | **Overlap** — both generate README/CHANGELOG/API from code |
+| Inline gotchas — why not what | ✅ "Comment the *why*, not the *what*" + `initializeTheme` must-before-render + red flags | ❌ not in `adr`/`docs-generator` | **Gap** |
+| Rules for agents — CLAUDE.md / spec files | ✅ "Documentation for Agents" — CLAUDE.md/rules, spec files, ADRs help agents, inline gotchas prevent traps | ✅ `AGENTS.md` inspection order in `docs/ARCHITECTURE.md` but not in `adr`/`docs-generator` workflows | **Gap** |
+
+## Gaps (upstream provides, Toolkit missing or thin)
+
+* **G1 — Matching existing convention first:** Upstream "Match the existing convention first — inspect existing ADRs, `.adr-dir`, location/format (`docs/adr/*.md` vs `Documentation/Decisions/*.rst` vs MADR vs `adr-tools`), numbering/naming, section headings; surface conflict rather than silently introducing another scheme; only default when no convention can be established." Toolkit `adr` assumes `docs/adr/` + `0001-*.md` + 6-part without inspecting existing convention — **extend**.
+* **G2 — ADR lifecycle + don't-delete:** Upstream explicit `PROPOSED→ACCEPTED→(SUPERSEDED/DEPRECATED)` + "Don't delete old ADRs — historical context; write new ADR that supersedes old". Toolkit mentions supersession but not lifecycle — **extend**.
+* **G3 — Inline documentation policy:** Upstream detailed Bad/Good comment examples + "When NOT to comment" + "Document Known Gotchas" + "No commented-out code / TODO weeks". Toolkit has no inline docs guidance — `docs-generator` covers README/CHANGELOG/API only — **extend docs-generator** (add Inline section, keep code generation separate).
+* **G4 — Verification + Red Flags:** Upstream checklists "ADRs exist for all significant decisions, README covers quick start, API docs have types, gotchas inline, no commented-out code, rules files current, no restating code" + "Rationalizations vs Reality" table + six red flags. Toolkit has `workflow-generic-project` gates but not in `adr`/`docs-generator` verification — **extend**.
+* **G5 — Persona vs skill distinction:** Upstream `agent-skills` README distinguishes `agent/persona = HOW agent thinks` (long-lived reasoning style) vs `skill/workflow = HOW task executes` (discrete procedure with inputs/outputs). Toolkit already preserves this in `docs/CONCEPTS.md` and `personas/architect.md` vs `skills/delivery/adr/` — **preserve, document**.
+* **G6 — API spec-driven details:** Upstream has concise OpenAPI example with `spec.yaml` → endpoint table; Toolkit `docs-generator` already similar — **no change** (overlap).
+
+## Decision
+
+**REJECT vendoring `documentation-and-adrs` as new skill** — 80% overlap with `adr` + `docs-generator`; vendoring would duplicate.
+
+**ADOPT absorb practices into existing skills** (small extensions, no new skill):
+
+* **Extend `skills/delivery/adr/SKILL.md`** with:
+  - Step 0: "Match existing convention first" (inspect `docs/adr/`, ADR dir/file extension/markup, numbering, headings; surface conflict; default to `docs/adr/0004-*.md` 6-part only when no convention).
+  - ADR Template note: lifecycle `PROPOSED→ACCEPTED→SUPERSEDED/DEPRECATED` + "Don't delete — supersede with reference".
+  - Red flags + verification checklist (6 items from upstream, link to `workflow-generic-project` gate).
+
+* **Extend `skills/ops/docs-generator/SKILL.md`** with:
+  - Inline Documentation section (why-not-what, Good/Bad examples, Known Gotchas, no commented-out/TODO-weeks) — preserve that docs-generator is docs-from-code, not docs-from-thin-air; agent not to invent.
+  - Verification checklist (README/CHANGELOG/API/AGENTS/gotchas).
+
+* **Preserve distinction:** `personas/*` (HOW agent thinks, e.g., `architect`, `reviewer`) vs `skills/*` (HOW task executes, discrete workflow) — already in `docs/CONCEPTS.md` — do not merge; `adr` stays workflow, `architect` stays persona that delegates to `adr`.
+
+This closes #394 without duplication and keeps `personas/` vs `skills/` boundary intact (vs upstream's `agent/persona` vs `skill/workflow`).
+
+## Verification
+
+* Extended `adr` covers G1/G2/G5, `docs-generator` covers G3/G4 — no commented-out duplication.
+* `uv run python scripts/validate-skills.py` → `77 → 77` (no new skill), `uv run ruff check` clean.
+* Docs: this file is diff report (issue comments) + extensions.
+
+## References
+
+* Upstream `addyosmani/agent-skills` MIT — `skills/documentation-and-adrs/SKILL.md` 288 lines (2026-08-12), `skills/security-and-hardening/SKILL.md`, `skills/code-review-and-quality/SKILL.md` for contrast.
+* Toolkit `skills/delivery/adr/SKILL.md` 48 lines + `references/default-template.md` + `docs/adr/0001-0004` (ADR-0001/0003/0004) + `skills/ops/docs-generator/SKILL.md` 85 lines.
+

--- a/skills/delivery/adr/SKILL.md
+++ b/skills/delivery/adr/SKILL.md
@@ -25,11 +25,19 @@ Use **`decision-log`** for lightweight product/project/operational decisions and
 
 ## Instructions
 
+0. **Match existing convention first** (per `addyosmani/agent-skills` `documentation-and-adrs` 2026-08-12, diff `docs/research/diff-394-documentation-and-adrs.md`): inspect `docs/adr/` (or `Documentation/Decisions/`, MADR, `adr-tools` `.adr-dir`) — location/format (Markdown vs reStructuredText), numbering/naming (`0004-*.md` vs `ADR-004-*.rst`), section headings. Surface conflict rather than silently introducing another scheme. Only when no convention can be established, default to `docs/adr/000N-*.md` six-part structure.
+
 1. **Confirm the decision qualifies** (new service, tech selection, schema change, deployment change, etc.) per the "When to Create an ADR" criteria.
-2. **Draft** using the six-part structure: Title & status, Context, Options, Decision, Consequences, References (link **PRD/TRD**, tasks, PRs, diagrams as applicable).
+2. **Draft** using the six-part structure: Title & status, Context, Options, Decision, Consequences, References (link **PRD/TRD**, tasks, PRs, diagrams as applicable). Use lifecycle `PROPOSED → ACCEPTED → (SUPERSEDED | DEPRECATED)` and **don't delete old ADRs** — when decision changes, write new ADR that references and supersedes old (per upstream 2026-08-12).
 3. **Review** with the tech lead / peers as in the workflow; keep ADRs **short and actionable** (clarity over completeness).
 4. **Link** the ADR to the relevant **epic or story** and to **PRs** in the forge (use **`github-cli-workflow` / `gitlab-cli-workflow`** for PR text when applicable).
 5. If an ADR is **superseded**, **preserve history**: update status and point to the replacement document.
+
+### Red flags & verification (after documenting)
+
+* **No ADR for significant architectural choices** — every expensive-to-reverse decision needs one.
+* **README missing quick start / architecture overview**, API without types, rules files (`CLAUDE.md`/`AGENTS.md`) stale, commented-out code, week-old `TODO`s, or docs that restate code.
+* Verify: ADRs exist, README covers quick start/commands/architecture (link ADRs), API docs have types, gotchas inline, no commented-out code, `personas/` (HOW agent thinks) vs `skills/` (HOW task executes) preserved — see `docs/CONCEPTS.md`.
 
 ## What not to do
 

--- a/skills/ops/docs-generator/SKILL.md
+++ b/skills/ops/docs-generator/SKILL.md
@@ -70,6 +70,41 @@ Use the template from `~/.local/share//skills-catalog.yaml` patterns:
 - Key commands (build, test, lint)
 - Links to key docs
 
+## Inline Documentation (why, not what) — per `addyosmani/agent-skills` `documentation-and-adrs` 2026-08-12 diff `docs/research/diff-394-documentation-and-adrs.md`
+
+Comment the *why*, not the *what*:
+
+```typescript
+// BAD: Restates the code
+// Increment counter by 1
+counter += 1;
+
+// GOOD: Explains non-obvious intent
+// Rate limit uses a sliding window — reset counter at window boundary,
+// not on a fixed schedule, to prevent burst attacks at window edges
+if (now - windowStart > WINDOW_SIZE_MS) {
+  counter = 0;
+  windowStart = now;
+}
+```
+
+* **When NOT to comment:** self-explanatory code (`calculateTotal` reduce), week-old `TODO`s (do it now), commented-out code (delete — git has history).
+* **Document Known Gotchas inline** where they matter:
+```typescript
+/**
+ * IMPORTANT: Must be called before first render — after hydration causes FOUC
+ * (theme context not available during SSR). See ADR-003.
+ */
+export function initializeTheme(theme: Theme): void { ... }
+```
+
+**Do not invent docs from thin air** — derive from code/specs/git history (this skill) vs ADR *why* (via `adr` skill). `personas/` (HOW agent thinks) vs `skills/` (HOW task executes) preserved — see `docs/CONCEPTS.md`.
+
+## Verification (after documenting)
+
+* [ ] ADRs exist for all significant decisions, README covers quick start/commands/architecture (link ADRs), API docs have types, gotchas inline, no commented-out code, `CLAUDE.md`/`AGENTS.md` current.
+* Rationalizations table — "code is self-documenting" (reality: code shows what, not why/alternatives), "docs when API stabilizes" (doc is first test of design), "ADRs are overhead" (10-min ADR prevents 2-hour debate).
+
 ## Anti-patterns
 
 - Do not guess stack or commands — read from actual config files

--- a/tests/test_diff_394.py
+++ b/tests/test_diff_394.py
@@ -1,0 +1,54 @@
+"""Tests for #394 diff — absorb upstream practices without duplication."""
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_diff_report_exists():
+    txt = (ROOT / "docs/research/diff-394-documentation-and-adrs.md").read_text()
+    assert "Scope:" in txt and "addyosmani/agent-skills" in txt
+    assert "Overlaps" in txt and "Gaps" in txt and "Decision" in txt
+    assert "REJECT vendoring" in txt
+    assert "ADOPT absorb" in txt
+    assert "G1" in txt and "G5" in txt
+    assert "288 lines" in txt
+
+
+def test_adr_extended_convention_first_and_lifecycle():
+    txt = (ROOT / "skills/delivery/adr/SKILL.md").read_text()
+    assert "Match existing convention first" in txt
+    assert "docs/research/diff-394-documentation-and-adrs.md" in txt
+    assert "PROPOSED → ACCEPTED" in txt
+    assert "don't delete old adrs" in txt.lower()
+    assert "Red flags & verification" in txt
+    assert "personas/" in txt and "HOW agent thinks" in txt
+
+
+def test_docs_generator_extended_inline_and_verification():
+    txt = (ROOT / "skills/ops/docs-generator/SKILL.md").read_text()
+    assert "Inline Documentation (why, not what)" in txt
+    assert "Comment the *why*, not the *what*" in txt
+    assert "Document Known Gotchas" in txt
+    assert "docs/research/diff-394-documentation-and-adrs.md" in txt
+    assert "Verification (after documenting)" in txt
+    assert "personas/" in txt and "HOW agent thinks" in txt
+
+
+def test_no_new_skill_added_for_394():
+    # Should remain 77 skills — count via validate-skills output is 77, but also ensure no new file named documentation-and-adrs
+    assert not (ROOT / "skills/documentation-and-adrs").exists()
+    assert not (ROOT / "skills/ops/documentation-and-adrs").exists()
+    # adr + docs-generator still exist
+    assert (ROOT / "skills/delivery/adr/SKILL.md").exists()
+    assert (ROOT / "skills/ops/docs-generator/SKILL.md").exists()
+
+
+def test_preserve_persona_vs_skill_distinction():
+    adr = (ROOT / "skills/delivery/adr/SKILL.md").read_text()
+    docgen = (ROOT / "skills/ops/docs-generator/SKILL.md").read_text()
+    diff = (ROOT / "docs/research/diff-394-documentation-and-adrs.md").read_text()
+    for txt in [adr, docgen, diff]:
+        # must preserve distinction
+        assert "personas/" in txt.lower() or "persona" in txt.lower()
+    assert "docs/CONCEPTS.md" in diff or "docs/CONCEPTS.md" in adr


### PR DESCRIPTION
Closes #394 — semantic diff per §42, dated 2026-08-12.

Diff report — docs/research/diff-394-documentation-and-adrs.md

Scope: addyosmani/agent-skills MIT skills/documentation-and-adrs/SKILL.md 288 lines vs Toolkit skills/delivery/adr/SKILL.md 48 + skills/ops/docs-generator/SKILL.md 85 + docs/adr/0001-0004.

Method: find-skills discovery + git clone --depth 1 (2026-08-12) — compared headings, workflows, templates, lifecycle, verification.

Overlaps (80%): ADR purpose (why not what) — same 5 whens + cost-to-reverse vs 3 when-to-use + long-term impact; ADR template Status/Date/Context/Decision/Alternatives/Consequences + docs/decisions/ + PROPOSED->ACCEPTED->SUPERSEDED/DEPRECATED + Don't delete vs references/default-template.md 6-part + output-handshake; README Structure + Changelog + OpenAPI spec-driven vs docs-generator README from package.json/pyproject, CHANGELOG from git log, OpenAPI/GraphQL tables, AGENTS.md starter.

Gaps:

- G1 Matching existing convention first — inspect docs/adr/ vs Documentation/Decisions/ vs MADR vs adr-tools .adr-dir, location/format, numbering/naming, headings; surface conflict vs silently introducing another scheme — Toolkit assumes docs/adr/0001-*.md 6-part.
- G2 Lifecycle + don't-delete — explicit PROPOSED->ACCEPTED->SUPERSEDED/DEPRECATED + Don't delete old ADRs — historical context; supersede with reference.
- G3 Inline documentation policy — Bad/Good comment examples + When NOT to comment + Document Known Gotchas (initializeTheme must-before-render) + no commented-out/TODO-weeks.
- G4 Verification + Red Flags — checklists + Rationalizations vs Reality table + six red flags.
- G5 Persona vs skill distinction — agent/persona = HOW agent thinks vs skill/workflow = HOW task executes — Toolkit preserves in docs/CONCEPTS.md + personas/architect.md vs skills/delivery/adr/.
- G6 API spec-driven — overlap, no change.

Decision: REJECT vendoring documentation-and-adrs as new skill — 80% overlap, would duplicate.

ADOPT absorb practices into existing skills (no new skill, 77 -> 77):

- adr extended with Step 0 Match existing convention first (docs/adr/ vs MADR/adr-tools, surface conflict; default docs/adr/000N-*.md 6-part only when no convention), lifecycle PROPOSED->ACCEPTED->SUPERSEDED/DEPRECATED + Don't delete — supersede, Red flags & verification (6 items, link workflow-generic-project).
- docs-generator extended with Inline Documentation (why-not-what Good/Bad, When NOT to comment, Known Gotchas initializeTheme FOUC, no commented-out/TODO-weeks, do not invent from thin air — derive from code/specs/git) + Verification checklist (ADRs exist, README quick start, API types, gotchas inline, no commented-out, CLAUDE.md/AGENTS.md current) + personas/ vs skills/ preserved.
- personas/ vs skills/ boundary preserved — adr stays workflow, architect stays persona that delegates to adr.

Refs #394
