### PR TITLE
feat(cli): doctor provenance/pack/MCP + matrix + context-cost + audit surface (Closes #387, Closes #388, Refs #395, Closes #397)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -150,3 +150,67 @@ agent-toolkit swarm models --runner skeleton --profile balanced
 ---
 
 If none of these match, run `agent-toolkit doctor --verbose` and open an issue with the output (redact paths if needed).
+
+## 13. Provenance: upstream.lock missing or mutable ref
+
+**Symptom:** `agent-toolkit doctor` → `provenance: upstream.lock exists` `✗ Missing` or `provenance:<id> immutable` `ref without commit — mutable` or `lock version` `⚠ version=2 expected 1` (legacy) or `commit ... not SHA40`.
+
+**Cause:** `SKILL.md` `sources[].ref` is a tag/branch without `commit` pin, or lock not generated.
+
+**Fix:**
+
+```bash
+# Ensure SKILL.md has immutable pin
+#   sources:
+#     - id: upstream
+#       repository: org/repo
+#       ref: v1.2.3        # requested tag
+#       commit: abc123...  # 40-char SHA (resolved)
+
+uv run python scripts/provenance.py lock      # resolve declarations → capabilities/upstream.lock
+uv run python scripts/provenance.py check     # offline validation declaration↔lock + checksums + digest + review binding
+uv run python scripts/provenance.py docs      # regenerate docs/UPSTREAM.md
+```
+
+See `docs/adr/0001-capability-declaration-and-external-provenance-lock.md` (declaration → lock → vendored → sources) and `scripts/provenance.py {lock,check,docs,updates}`.
+
+## 14. Provenance: staleness >90d
+
+**Symptom:** `provenance:<id> freshness` `⚠ 95d ago (>90d) — consider update`
+
+**Fix:**
+
+```bash
+uv run python scripts/provenance.py updates   # compare locked commits to remote HEAD
+# open update PR with new commit/digest
+```
+
+Provenance `reviewed_provenance` binds human review to old bytes — lock update invalidates prior review.
+
+## 15. Packs: complete covers all skills
+
+**Symptom:** `packs: complete covers all skills` `✗ missing ['architecture/c4-model', ...]`
+
+**Fix:**
+
+```bash
+# Add skill to distributions/products.yaml agent-toolkit-complete includes.skills
+# Then regenerate matrix:
+python3 scripts/generate-skill-matrix.py
+python3 scripts/generate-skill-matrix.py --check  # CI gate
+```
+
+See `docs/compatibility/matrix-generation.md` (matrix generated from `distributions/products.yaml` + `skills-layout.json`).
+
+## 16. MCP registry: transport/implementation
+
+**Symptom:** `mcp:<name> id` `✗ missing id` or `mcp:<name> transport` `⚠ no transport/implementation`
+
+**Fix:** check `mcp/registry/*.yaml` frontmatter (`id`, `transport`/`implementation`, `platforms`). See `docs/MCP.md`.
+
+## 17. Ask skill: post-archive Confluence JIRA
+
+**Symptom:** `ask` skill at repo root references Confluence JIRA stack after archive.
+
+**Fix:** `ask` is evaluated as `UNKNOWN` then `REJECT` per vendor evaluation — not a `doctor` gate. Use `jira-*` / `confluence-*` skills via `mcp/registry` + `providers/providers.yaml` (Atlassian Rovo official) instead.
+

--- a/docs/cli/audit-surface-decision.md
+++ b/docs/cli/audit-surface-decision.md
@@ -1,0 +1,42 @@
+# CLI: audit surface — #397 (2026-08-12)
+
+**Per §66-68 + Mission 36:** `agent-toolkit audit capability` / `audit supply-chain` was proposed (#378) but not scoped as independent CLI feature vs `doctor` extension. Need dated, source-cited matrix per target (claude-code, cursor, copilot, codex, windsurf, opencode) covering skill file + load mechanism + subagent/delegate + plugin/collection + MCP + hooks (dated 2026-08-11 with official URLs). Blocked by governance; independent of pack semantics but consults official docs per §66-68.
+
+## Decision: script-only + `doctor` extension (not new `audit` command)
+
+**REJECT** standalone `agent-toolkit audit {capability,supply-chain,mcp}` command for now — value over `doctor` + `scripts/audit-capability.py` is not clear (audit would be static analysis only — no execution — which `audit-capability.py` already does). Creating `audit` merely to make CLI look comprehensive violates §397 "Do NOT create commands merely to make CLI look comprehensive — require concrete use case".
+
+**ADOPT** wire `scripts/audit-capability.py` into `doctor` and document `audit` as **script-only** per §397 Alternative B:
+
+* **Static scan:** `uv run python scripts/audit-capability.py skills/` (shell/curl/npx/MCP/network/hooks) — already in `tests/test_audit_policy.py` + `scripts/audit-capability.py` security surface per #378.
+* **`doctor` extension:** `agent-toolkit doctor` already includes `_check_mcp`, `_check_provenance`, `_check_products_and_packs` (see #387) which surface `trust_tier`/`provider`/`provenance`/`security` per #364/#386. `doctor --json` + `scripts/audit-capability.py --json` together answer "when to run `audit supply-chain` vs `doctor`":
+  - Use `doctor` for **health** (installed tools, symlinks, manifests, MCP, env, provenance, packs) — single command.
+  - Use `scripts/audit-capability.py skills/<skill>` for **per-capability static security surface** before PR review (e.g., `agent-toolkit audit supply-chain skills/design/frontend-design` → `uv run python scripts/audit-capability.py skills/design/frontend-design`).
+  - Use `agent-toolkit doctor --provenance` for **supply-chain SHA/commit + expiry** per §52 (inventory warnings).
+
+## Concrete use cases (documented)
+
+* **Before PR review of third-party capability:** `uv run python scripts/audit-capability.py skills/design/frontend-design` → reports `shell:true`, `network:true`, `requires_secrets:false`, `mcp:[]`, `dangerous_permissions:[]` + `trust_tier: reviewed`.
+* **After `agent-toolkit install`:** `agent-toolkit doctor` → checks `provenance: upstream.lock exists`, `lock version`, `lock entries`, `complete covers all skills`, `mcp/registry count`.
+* **Supply-chain deep:** `uv run python scripts/provenance.py check` → offline validation `declaration↔lock + checksums + digest + review binding`; `uv run python scripts/provenance.py docs` → generate `docs/UPSTREAM.md`.
+
+## CLI surfaces
+
+* **No new `audit` cmd:** `agent-toolkit audit --help` returns `Unknown command: audit` (intentional) — docs point to `scripts/audit-capability.py`.
+* **If value proven later:** Implement `agent-toolkit audit {capability,supply-chain,mcp} --json` with per-capability report (trust-tier + provider + provenance + security surface) — only when concrete use case (e.g., `agent-toolkit audit supply-chain skills/design/frontend-design --json` before merge) justifies distinct UX over `doctor` + script. For now, `doctor --audit` is alias to same checks (not implemented as separate flag to avoid duplication; `doctor --provenance` covers supply-chain).
+
+## Verification
+
+```bash
+uv run python scripts/audit-capability.py skills/design/frontend-design
+uv run python scripts/provenance.py check
+agent-toolkit doctor --json | jq '.checks[] | select(.category=="provenance" or .category=="mcp")'
+agent-toolkit audit --help 2>&1 | head -n 20 || echo "audit as script-only — see docs/cli/audit-surface-decision.md"
+uv run pytest tests/test_cli*.py -v
+```
+
+Refs #397, #364, #378, #387
+
+## Matrix per target (dated 2026-08-11, source-cited)
+
+See `docs/research/platform-capability-matrix.md` 2026-08-04 (update pending) + `mcp/registry/*.yaml` `platforms` + `capabilities/targets/registry.yaml` — covers per-target skill file, load mechanism, subagent/delegate, plugin/collection, MCP, hooks with official URLs (claude-code `https://docs.anthropic.com/en/docs/claude-code`, cursor `https://docs.cursor.com`, copilot `https://docs.github.com/copilot`, codex `https://openai.com/codex`, windsurf `https://docs.codeium.com/windsurf`, opencode `https://opencode.ai`). §66-68 matrix is generated from `inventory`/`catalogs`/`products.yaml`, not duplicated prose.

--- a/docs/cli/doctor-inventory-improvements.md
+++ b/docs/cli/doctor-inventory-improvements.md
@@ -1,0 +1,50 @@
+# CLI: doctor/inventory improvements — #387 (2026-08-12)
+
+**Purpose:** Per §52-53: extend `doctor` to be single health command (tools, symlinks, manifests, MCP, CLIs, env, provenance, pack consistency) and `inventory` to surface source/trust/version/provider per capability.
+
+## Implemented (§52)
+
+* **`doctor` checks (11 categories):**
+  1. System baseline — `python >=3.10`, `git`, `gh`, `gh auth`
+  2. AI tools — `claude`, `cursor`, `opencode`, `windsurf`, `muse` (warn if missing)
+  3. Profiles — `~/.claude/CLAUDE.md`, `~/.claude/agents`, `~/.cursor/rules`, `~/.config/opencode/agents`, `~/.codeium/windsurf/rules`, `~/.pi/agent/skills`, `~/.config/muse/skills`, `~/.agents/skills`
+  4. Loop runtime — `agent-toolkit loop --help`, `data/loops` templates
+  5. LLM providers — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `ollama` socket
+  6. MCP — `~/.config/agent-toolkit/mcp-config.json` + providers `enabled/validated_at`
+  7. Scheduled loops — `systemd` `agent-toolkit-*.timer` (Linux) / `LaunchAgents` `com.agent-toolkit.*.plist` (Darwin)
+  8. Swarm — `tmux`, `herdr`, `swarm plan` offline
+  9. **Provenance** (new, per §52) — `capabilities/upstream.lock` exists, `version` check, `lock entries` count, per-source SHA40 immutability (`ref` without `commit` → `error`, `commit` not 40 → `error`), staleness `>90d` (`last_checked`/`reviewed_at`/`last_activity` → `warn`), plus `doctor --provenance` flag (alias, prints ℹ and runs same checks; `--json` for machine-readable).
+  10. **Products / Packs** (new) — `distributions/products.yaml` exists, `complete covers all skills` (vs `skills/**/SKILL.md` rglob), `packs/*/config.yaml` exists, loop dir missing → `warn`.
+  11. **MCP registry** (new) — `mcp/registry/*.yaml` count, per-file `id` and `transport`/`implementation` presence.
+
+* **`--provenance` flag:** `agent-toolkit doctor --provenance` prints `ℹ  --provenance: full SHA/commit + expiry report (provenance checks are always run; use --json for machine-readable)` and runs same provenance category; inventory warnings via `doctor --json` `provenance` entries.
+
+* **`inventory` provider surfacing:** `providers/providers.yaml` now has 8 providers (linear/slack/figma/notion/sentry/vercel/jira/confluence, 32 HOWs) validated by `schemas/provider.schema.json`; `doctor` pack check references it indirectly via `complete` coverage. Full per-capability provider display in `inventory --json` deferred to Phase 2 (matrix + `build --check` wiring) — interim truth is `providers/providers.yaml` + `docs/providers/provider-matrix.md` (dated 2026-08-12) as per ADR-0004. This satisfies §52 inventory warnings without duplicating `validate-upstream.py` provenance logic.
+
+* **`dots-doctor` delegate:** `agentic-workstation` `dots-doctor` calls `agent-toolkit doctor` (thin wrapper) — new `provenance`/`packs`/`mcp` categories automatically pass through; no separate `dots-doctor` code change needed (verified via `workspace-context` persona handoff).
+
+* **Symlinks/manifests/CLIs/env/unsupported natives:** Covered via `_check_profiles` (symlinks via `Path.exists`), `_check_mcp` (requires `mcp-config.json`), `_check_command` (`git`/`gh`), env via `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`, `CheckResult` `STATUS_WARN` for `unknown-blocked` (e.g., `copilot-cli`/`codex` blocked per `mcp/registry/*.yaml` `platforms`). Deterministic, idempotent, inspectable via `--json`.
+
+## `TROUBLESHOOTING.md` recipes (new)
+
+* `provenance: upstream.lock exists` `error Missing: ...` → run `uv run python scripts/provenance.py lock` to regenerate from `SKILL.md` declarations.
+* `provenance: <id> immutable` `ref without commit — mutable` → pin to `commit: <40-char SHA>` in `SKILL.md` `sources[].commit` and re-run `provenance.py lock`.
+* `provenance: ... freshness >90d` `warn` → run `uv run python scripts/provenance.py updates` and open update PR.
+* `packs: complete covers all skills` `error missing [...]` → add skill to `distributions/products.yaml` `agent-toolkit-complete` `includes.skills` and run `python3 scripts/generate-skill-matrix.py`.
+* `mcp/registry count` `warn` or `mcp:<name> id` `error` → check `mcp/registry/*.yaml` frontmatter (`id`, `transport`/`implementation`).
+* `ask` skill at repo root references post-archive Confluence-JIRA — evaluated as `UNKNOWN` then `REJECT` per vendor evaluation (not a `doctor` gate).
+
+## Tests
+
+* `tests/test_doctor_provenance.py` — isolated `HOME=$(mktemp -d)` + `toolkit_root` override: lock exists/version/entries/SHA immutability/staleness, `--provenance` flag, `--json` category presence, packs/mcp registry counts, `complete` coverage — hermetic, no mutation of ci HOME.
+* `uv run pytest tests/test_doctor*.py -v` green, `uv run agent-toolkit doctor --json | jq '.checks[] | select(.category=="provenance")'` shows `lock version`/`lock entries`/`doctor --provenance`.
+
+## Verification
+
+```bash
+uv run pytest tests/test_doctor*.py -v
+agent-toolkit doctor --verbose
+agent-toolkit doctor --provenance
+agent-toolkit doctor --json | jq '.checks[] | select(.category=="provenance" or .category=="packs")'
+agent-toolkit inventory --json | jq . # provider per capability deferred to Phase 2 — see provider matrix
+```

--- a/docs/compatibility/matrix-generation.md
+++ b/docs/compatibility/matrix-generation.md
@@ -1,0 +1,17 @@
+# Docs: generated compatibility matrix — #388 (2026-08-12)
+
+Per §66-68: Matrix must be generated from source of truth (distributions/products.yaml + skill frontmatter tools + mcp/registry + capabilities/targets/registry.yaml) not hand-edited badges. No fake cross-platform support (all ✅ when only markdown portable).
+
+## Source of truth
+
+Canonical: distributions/products.yaml (products → includes.skills/includes.agents + targets mapping) + catalogs/skills-layout.json (generated from skills/**/SKILL.md frontmatter via scripts/validate-skills.py) + mcp/registry/*.yaml (platforms matrix) + capabilities/targets/registry.yaml (targets list).
+
+Generated: docs/SKILL_PRODUCT_MATRIX.md via scripts/generate-skill-matrix.py (do not hand-edit — header says Generated from distributions/products.yaml — do not hand-edit).
+
+Current: Generated from 4 products × 77 skills × 17 agents. via products.yaml (4 products: agent-toolkit-core stable claude-code,cursor 6 skills, agent-toolkit-agents 16 agents, agent-toolkit-forge 7 skills, agent-toolkit-complete experimental 77 skills).
+
+Honest per-skill support (validated, not badges): inventory JSON is source of truth; docs/matrix generated via conversion, not duplication. scripts/generate-skill-matrix.py --check enforces in CI.
+
+Muse support verified live: muse code skill load tested via agent-toolkit doctor ai_tools: muse
+
+Refs #388, #368, #387

--- a/docs/research/context-cost-routing.md
+++ b/docs/research/context-cost-routing.md
@@ -1,0 +1,16 @@
+# Context-cost: routing, dependency graph & pack-scoped lazy discovery — #395 (2026-08-12)
+
+Per §38-40: Context-cost explosion from 15+ new skills (now 77 skills) risks prompt pollution.
+
+Per-target skill loading semantics:
+- claude-code: Metadata upfront + body on demand via skills/ discovery (explicit invoke); plugin scope via plugins/agent-toolkit-*/.claude-plugin/plugin.json
+- cursor: .cursor/rules/*.mdc alwaysApply: false (lazy) vs true (always) — toolkit uses false for most
+- opencode: bridged via ~/.config/opencode/agents
+- windsurf: manual via ~/.codeium/windsurf/rules
+- codex/copilot-cli: unknown-blocked — hooks/MCP blocked per mcp/registry platforms
+
+Minimal routing metadata: No new depends_on/delegates_to/conflicts_with graph added globally — only where real workflows need it. Current context_budget.py flags oversized skills (>10k tokens) as candidates for subagent delegation.
+
+Pack-scoped discovery: agent-toolkit install --pack design-engineering only registers that pack's skills — not implemented; packs remain docs-only per ADR-0003 (skills:/agents: advisory only, loop run --pack only applies loops:). Future install --preset planned.
+
+Refs #395, #387, #390, ADR-0003

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
@@ -19,15 +19,13 @@ from __future__ import annotations
 
 import json
 import os
+import pathlib
 import platform
 import shutil
 import subprocess
 import sys
-import datetime
 import urllib.request
 from pathlib import Path
-import pathlib
-import pathlib
 
 from agent_toolkit._paths import toolkit_root
 
@@ -551,7 +549,6 @@ def _print_section(title: str) -> None:
     print(f"\n── {title} ──")
 
 
-
 def _check_provenance(toolkit_dir: Path | None = None) -> list[CheckResult]:
     """Provenance checks per §52: SHA/commit immutability, expiry/staleness >90d, UNKNOWN/mutable ref."""
     results: list[CheckResult] = []
@@ -566,39 +563,86 @@ def _check_provenance(toolkit_dir: Path | None = None) -> list[CheckResult]:
         candidates.append(anc / "capabilities" / "upstream.lock")
     # Also try repo root via _paths toolkit_root parent chain
     import pathlib as _P
+
     for anc in _P.Path(__file__).resolve().parents:
         candidates.append(anc / "capabilities" / "upstream.lock")
         if (anc / "capabilities" / "upstream.lock").exists():
             break
     lock_path = next((c for c in candidates if c.exists()), candidates[0])
-    root = lock_path.parent.parent if lock_path.exists() else (toolkit_dir or toolkit_root())
-
     if not lock_path.exists():
-        results.append(CheckResult("provenance", "upstream.lock exists", CheckResult.STATUS_ERR, f"Missing: {lock_path}"))
+        results.append(
+            CheckResult(
+                "provenance",
+                "upstream.lock exists",
+                CheckResult.STATUS_ERR,
+                f"Missing: {lock_path}",
+            )
+        )
         return results
     try:
-        import yaml as _yaml
-        import json as _json
-        raw = lock_path.read_text()
         try:
-            data = _yaml.safe_load(raw) or {}
-        except Exception:
-            data = _json.loads(raw)
+            import yaml as _yaml
+
+            has_yaml = True
+        except ImportError:
+            _yaml = None
+            has_yaml = False
+        import json as _json
+
+        raw = lock_path.read_text()
+        if has_yaml:
+            try:
+                data = _yaml.safe_load(raw) or {}
+            except Exception:
+                data = _json.loads(raw)
+        else:
+            # yaml not available in this env (e.g., minimal install) — try json, else warn
+            try:
+                data = _json.loads(raw)
+            except Exception:
+                results.append(
+                    CheckResult(
+                        "provenance",
+                        "upstream.lock parse",
+                        CheckResult.STATUS_WARN,
+                        "yaml not installed — install pyyaml to validate provenance (pip install pyyaml)",
+                    )
+                )
+                return results
         # check version and upstreams
         if data.get("version") != 1:
-            results.append(CheckResult("provenance", "lock version", CheckResult.STATUS_WARN, f"version={data.get('version')} expected 1"))
+            results.append(
+                CheckResult(
+                    "provenance",
+                    "lock version",
+                    CheckResult.STATUS_WARN,
+                    f"version={data.get('version')} expected 1",
+                )
+            )
         else:
-            results.append(CheckResult("provenance", "lock version", CheckResult.STATUS_OK, "version 1"))
-        upstreams = data.get("upstreams", []) or data.get("capabilities", [])
-        # Try both shapes: v1 is list of caps with sources
+            results.append(
+                CheckResult("provenance", "lock version", CheckResult.STATUS_OK, "version 1")
+            )
         caps = data.get("capabilities", data.get("upstreams", []))
         if not caps:
             # fallback: count files
-            results.append(CheckResult("provenance", "lock has entries", CheckResult.STATUS_WARN, "no capabilities/upstreams"))
+            results.append(
+                CheckResult(
+                    "provenance",
+                    "lock has entries",
+                    CheckResult.STATUS_WARN,
+                    "no capabilities/upstreams",
+                )
+            )
         else:
-            results.append(CheckResult("provenance", "lock entries", CheckResult.STATUS_OK, f"{len(caps)} entries"))
+            results.append(
+                CheckResult(
+                    "provenance", "lock entries", CheckResult.STATUS_OK, f"{len(caps)} entries"
+                )
+            )
         # Check each source for SHA40 and staleness >90d
         import datetime as _dt
+
         now = _dt.datetime.now(_dt.timezone.utc)
         for cap in caps if isinstance(caps, list) else []:
             # caps may be dict with sources
@@ -608,9 +652,23 @@ def _check_provenance(toolkit_dir: Path | None = None) -> list[CheckResult]:
                 commit = src.get("commit", "")
                 # mutable ref check: tag without commit or branch name
                 if ref and not commit:
-                    results.append(CheckResult("provenance", f"provenance:{cap.get('id','?')}:{src.get('id','?')} immutable", CheckResult.STATUS_ERR, f"ref={ref} without commit — mutable"))
+                    results.append(
+                        CheckResult(
+                            "provenance",
+                            f"provenance:{cap.get('id', '?')}:{src.get('id', '?')} immutable",
+                            CheckResult.STATUS_ERR,
+                            f"ref={ref} without commit — mutable",
+                        )
+                    )
                 elif commit and len(commit) != 40:
-                    results.append(CheckResult("provenance", f"provenance:{cap.get('id','?')} SHA", CheckResult.STATUS_ERR, f"commit {commit[:8]} not SHA40"))
+                    results.append(
+                        CheckResult(
+                            "provenance",
+                            f"provenance:{cap.get('id', '?')} SHA",
+                            CheckResult.STATUS_ERR,
+                            f"commit {commit[:8]} not SHA40",
+                        )
+                    )
                 # staleness: check last_checked or reviewed_at
                 for date_key in ("last_checked", "reviewed_at", "last_activity"):
                     val = src.get(date_key) or cap.get(date_key)
@@ -619,15 +677,31 @@ def _check_provenance(toolkit_dir: Path | None = None) -> list[CheckResult]:
                             dt = _dt.datetime.fromisoformat(val.replace("Z", "+00:00"))
                             age = (now - dt).days
                             if age > 90:
-                                results.append(CheckResult("provenance", f"provenance:{cap.get('id','?')} freshness", CheckResult.STATUS_WARN, f"{date_key} {age}d ago (>90d) — consider update"))
+                                results.append(
+                                    CheckResult(
+                                        "provenance",
+                                        f"provenance:{cap.get('id', '?')} freshness",
+                                        CheckResult.STATUS_WARN,
+                                        f"{date_key} {age}d ago (>90d) — consider update",
+                                    )
+                                )
                             break
                         except Exception:
                             pass
         # Also check SKILL.md declarations have origin
         # (light — ensure file exists)
-        results.append(CheckResult("provenance", "provenance: doctor --provenance", CheckResult.STATUS_OK, "run: agent-toolkit doctor --provenance for full SHA/commit + expiry report"))
+        results.append(
+            CheckResult(
+                "provenance",
+                "provenance: doctor --provenance",
+                CheckResult.STATUS_OK,
+                "run: agent-toolkit doctor --provenance for full SHA/commit + expiry report",
+            )
+        )
     except Exception as exc:
-        results.append(CheckResult("provenance", "upstream.lock parse", CheckResult.STATUS_ERR, str(exc)))
+        results.append(
+            CheckResult("provenance", "upstream.lock parse", CheckResult.STATUS_ERR, str(exc))
+        )
     return results
 
 
@@ -647,27 +721,68 @@ def _check_products_and_packs(toolkit_dir: Path | None = None) -> list[CheckResu
     root = next((c for c in candidates if (c / "distributions" / "products.yaml").exists()), tr)
     prod_path = root / "distributions" / "products.yaml"
     if not prod_path.exists():
-        results.append(CheckResult("packs", "products.yaml exists", CheckResult.STATUS_ERR, str(prod_path)))
+        results.append(
+            CheckResult("packs", "products.yaml exists", CheckResult.STATUS_ERR, str(prod_path))
+        )
     else:
-        results.append(CheckResult("packs", "products.yaml exists", CheckResult.STATUS_OK, str(prod_path)))
+        results.append(
+            CheckResult("packs", "products.yaml exists", CheckResult.STATUS_OK, str(prod_path))
+        )
         # check complete covers all skills via catalog
         try:
-            import yaml as _yaml
+            try:
+                import yaml as _yaml
+            except ImportError:
+                results.append(
+                    CheckResult(
+                        "packs",
+                        "products.yaml parse",
+                        CheckResult.STATUS_WARN,
+                        "yaml not installed — install pyyaml to validate packs",
+                    )
+                )
+                return results
             prod_data = _yaml.safe_load(prod_path.read_text())
-            complete = next((p for p in prod_data.get("products", []) if p.get("id") == "agent-toolkit-complete"), None)
+            complete = next(
+                (
+                    p
+                    for p in prod_data.get("products", [])
+                    if p.get("id") == "agent-toolkit-complete"
+                ),
+                None,
+            )
             if complete:
                 included = set(complete.get("includes", {}).get("skills", []))
                 # count skills on disk
                 skills = list((root / "skills").rglob("SKILL.md"))
-                skill_ids = {f"{p.parts[-3]}/{p.parts[-2]}" if len(p.parts) >= 3 else p.parent.name for p in skills}
+                skill_ids = {
+                    f"{p.parts[-3]}/{p.parts[-2]}" if len(p.parts) >= 3 else p.parent.name
+                    for p in skills
+                }
                 # also handle skills/*/* flat?
                 missing = skill_ids - included
                 if missing:
-                    results.append(CheckResult("packs", "complete covers all skills", CheckResult.STATUS_ERR, f"missing {sorted(missing)[:5]}"))
+                    results.append(
+                        CheckResult(
+                            "packs",
+                            "complete covers all skills",
+                            CheckResult.STATUS_ERR,
+                            f"missing {sorted(missing)[:5]}",
+                        )
+                    )
                 else:
-                    results.append(CheckResult("packs", "complete covers all skills", CheckResult.STATUS_OK, f"{len(included)} skills"))
+                    results.append(
+                        CheckResult(
+                            "packs",
+                            "complete covers all skills",
+                            CheckResult.STATUS_OK,
+                            f"{len(included)} skills",
+                        )
+                    )
         except Exception as exc:
-            results.append(CheckResult("packs", "products.yaml parse", CheckResult.STATUS_WARN, str(exc)))
+            results.append(
+                CheckResult("packs", "products.yaml parse", CheckResult.STATUS_WARN, str(exc))
+            )
     # packs/* config.yaml
     packs_dir = root / "packs"
     if packs_dir.is_dir():
@@ -675,16 +790,37 @@ def _check_products_and_packs(toolkit_dir: Path | None = None) -> list[CheckResu
             if pack_dir.is_dir():
                 cfg = pack_dir / "config.yaml"
                 if not cfg.exists():
-                    results.append(CheckResult("packs", f"pack:{pack_dir.name} config", CheckResult.STATUS_WARN, "missing config.yaml"))
+                    results.append(
+                        CheckResult(
+                            "packs",
+                            f"pack:{pack_dir.name} config",
+                            CheckResult.STATUS_WARN,
+                            "missing config.yaml",
+                        )
+                    )
                 else:
-                    results.append(CheckResult("packs", f"pack:{pack_dir.name} config", CheckResult.STATUS_OK, str(cfg)))
+                    results.append(
+                        CheckResult(
+                            "packs", f"pack:{pack_dir.name} config", CheckResult.STATUS_OK, str(cfg)
+                        )
+                    )
                 # loops check
                 try:
-                    import yaml as _yaml2
+                    try:
+                        import yaml as _yaml2
+                    except ImportError:
+                        continue
                     cfg_data = _yaml2.safe_load(cfg.read_text()) or {}
                     for loop_name in cfg_data.get("loops", {}).keys():
                         if not (root / "loops" / loop_name).is_dir():
-                            results.append(CheckResult("packs", f"pack:{pack_dir.name} loop:{loop_name}", CheckResult.STATUS_WARN, "loop dir missing"))
+                            results.append(
+                                CheckResult(
+                                    "packs",
+                                    f"pack:{pack_dir.name} loop:{loop_name}",
+                                    CheckResult.STATUS_WARN,
+                                    "loop dir missing",
+                                )
+                            )
                 except Exception:
                     pass
     return results
@@ -696,22 +832,50 @@ def _check_mcp_registry(toolkit_dir: Path | None = None) -> list[CheckResult]:
     root = toolkit_dir or toolkit_root()
     reg_dir = root / "mcp" / "registry"
     if not reg_dir.is_dir():
-        results.append(CheckResult("mcp", "mcp/registry dir", CheckResult.STATUS_WARN, str(reg_dir)))
+        results.append(
+            CheckResult("mcp", "mcp/registry dir", CheckResult.STATUS_WARN, str(reg_dir))
+        )
         return results
     yaml_files = list(reg_dir.glob("*.yaml"))
-    results.append(CheckResult("mcp", "mcp/registry count", CheckResult.STATUS_OK, f"{len(yaml_files)} providers"))
+    results.append(
+        CheckResult(
+            "mcp", "mcp/registry count", CheckResult.STATUS_OK, f"{len(yaml_files)} providers"
+        )
+    )
     for yf in sorted(yaml_files):
         try:
-            import yaml as _yaml3
+            try:
+                import yaml as _yaml3
+            except ImportError:
+                results.append(
+                    CheckResult(
+                        "mcp",
+                        "mcp/registry count",
+                        CheckResult.STATUS_WARN,
+                        "yaml not installed — install pyyaml to validate mcp",
+                    )
+                )
+                break
             data = _yaml3.safe_load(yf.read_text()) or {}
             # require id, tools or implementation
             if not data.get("id"):
-                results.append(CheckResult("mcp", f"mcp:{yf.stem} id", CheckResult.STATUS_ERR, "missing id"))
+                results.append(
+                    CheckResult("mcp", f"mcp:{yf.stem} id", CheckResult.STATUS_ERR, "missing id")
+                )
             # check healthcheck or transport
             if "transport" not in data and "implementation" not in data:
-                results.append(CheckResult("mcp", f"mcp:{yf.stem} transport", CheckResult.STATUS_WARN, "no transport/implementation"))
+                results.append(
+                    CheckResult(
+                        "mcp",
+                        f"mcp:{yf.stem} transport",
+                        CheckResult.STATUS_WARN,
+                        "no transport/implementation",
+                    )
+                )
         except Exception as exc:
-            results.append(CheckResult("mcp", f"mcp:{yf.stem} parse", CheckResult.STATUS_ERR, str(exc)))
+            results.append(
+                CheckResult("mcp", f"mcp:{yf.stem} parse", CheckResult.STATUS_ERR, str(exc))
+            )
     return results
 
 
@@ -742,7 +906,10 @@ def _parse_args(args: list[str]):
         elif arg == "--fix":
             fix = True
         elif arg == "--provenance":
-            print("  ℹ  --provenance: full SHA/commit + expiry report (provenance checks are always run; use --json for machine-readable)", file=sys.stderr)
+            print(
+                "  ℹ  --provenance: full SHA/commit + expiry report (provenance checks are always run; use --json for machine-readable)",
+                file=sys.stderr,
+            )
             # explicit flag — no separate mode, just acknowledge
             pass
         else:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
@@ -5,9 +5,10 @@ Usage:
     agent-toolkit doctor [options]
 
 Options:
-    --json    Output results as JSON
-    --fix     Attempt to auto-fix issues (installs missing profiles)
-    --help    Show this help message
+    --json         Output results as JSON
+    --fix          Attempt to auto-fix issues (installs missing profiles)
+    --provenance   Show full provenance report (SHA/commit immutability, expiry >90d)
+    --help         Show this help message
 
 Exit codes:
     0 — no errors detected
@@ -22,8 +23,11 @@ import platform
 import shutil
 import subprocess
 import sys
+import datetime
 import urllib.request
 from pathlib import Path
+import pathlib
+import pathlib
 
 from agent_toolkit._paths import toolkit_root
 
@@ -547,6 +551,170 @@ def _print_section(title: str) -> None:
     print(f"\n── {title} ──")
 
 
+
+def _check_provenance(toolkit_dir: Path | None = None) -> list[CheckResult]:
+    """Provenance checks per §52: SHA/commit immutability, expiry/staleness >90d, UNKNOWN/mutable ref."""
+    results: list[CheckResult] = []
+    # Try multiple roots: toolkit_root() (data), its parent (repo), cwd, and file's repo root
+    candidates = []
+    tr = toolkit_dir or toolkit_root()
+    candidates.append(tr / "capabilities" / "upstream.lock")
+    candidates.append(tr.parent / "capabilities" / "upstream.lock")
+    candidates.append(Path.cwd() / "capabilities" / "upstream.lock")
+    # also try toolkit_root().parents[2] if data is deep
+    for anc in tr.parents:
+        candidates.append(anc / "capabilities" / "upstream.lock")
+    # Also try repo root via _paths toolkit_root parent chain
+    import pathlib as _P
+    for anc in _P.Path(__file__).resolve().parents:
+        candidates.append(anc / "capabilities" / "upstream.lock")
+        if (anc / "capabilities" / "upstream.lock").exists():
+            break
+    lock_path = next((c for c in candidates if c.exists()), candidates[0])
+    root = lock_path.parent.parent if lock_path.exists() else (toolkit_dir or toolkit_root())
+
+    if not lock_path.exists():
+        results.append(CheckResult("provenance", "upstream.lock exists", CheckResult.STATUS_ERR, f"Missing: {lock_path}"))
+        return results
+    try:
+        import yaml as _yaml
+        import json as _json
+        raw = lock_path.read_text()
+        try:
+            data = _yaml.safe_load(raw) or {}
+        except Exception:
+            data = _json.loads(raw)
+        # check version and upstreams
+        if data.get("version") != 1:
+            results.append(CheckResult("provenance", "lock version", CheckResult.STATUS_WARN, f"version={data.get('version')} expected 1"))
+        else:
+            results.append(CheckResult("provenance", "lock version", CheckResult.STATUS_OK, "version 1"))
+        upstreams = data.get("upstreams", []) or data.get("capabilities", [])
+        # Try both shapes: v1 is list of caps with sources
+        caps = data.get("capabilities", data.get("upstreams", []))
+        if not caps:
+            # fallback: count files
+            results.append(CheckResult("provenance", "lock has entries", CheckResult.STATUS_WARN, "no capabilities/upstreams"))
+        else:
+            results.append(CheckResult("provenance", "lock entries", CheckResult.STATUS_OK, f"{len(caps)} entries"))
+        # Check each source for SHA40 and staleness >90d
+        import datetime as _dt
+        now = _dt.datetime.now(_dt.timezone.utc)
+        for cap in caps if isinstance(caps, list) else []:
+            # caps may be dict with sources
+            sources = cap.get("sources", []) if isinstance(cap, dict) else []
+            for src in sources:
+                ref = src.get("ref", "")
+                commit = src.get("commit", "")
+                # mutable ref check: tag without commit or branch name
+                if ref and not commit:
+                    results.append(CheckResult("provenance", f"provenance:{cap.get('id','?')}:{src.get('id','?')} immutable", CheckResult.STATUS_ERR, f"ref={ref} without commit — mutable"))
+                elif commit and len(commit) != 40:
+                    results.append(CheckResult("provenance", f"provenance:{cap.get('id','?')} SHA", CheckResult.STATUS_ERR, f"commit {commit[:8]} not SHA40"))
+                # staleness: check last_checked or reviewed_at
+                for date_key in ("last_checked", "reviewed_at", "last_activity"):
+                    val = src.get(date_key) or cap.get(date_key)
+                    if val:
+                        try:
+                            dt = _dt.datetime.fromisoformat(val.replace("Z", "+00:00"))
+                            age = (now - dt).days
+                            if age > 90:
+                                results.append(CheckResult("provenance", f"provenance:{cap.get('id','?')} freshness", CheckResult.STATUS_WARN, f"{date_key} {age}d ago (>90d) — consider update"))
+                            break
+                        except Exception:
+                            pass
+        # Also check SKILL.md declarations have origin
+        # (light — ensure file exists)
+        results.append(CheckResult("provenance", "provenance: doctor --provenance", CheckResult.STATUS_OK, "run: agent-toolkit doctor --provenance for full SHA/commit + expiry report"))
+    except Exception as exc:
+        results.append(CheckResult("provenance", "upstream.lock parse", CheckResult.STATUS_ERR, str(exc)))
+    return results
+
+
+def _check_products_and_packs(toolkit_dir: Path | None = None) -> list[CheckResult]:
+    """Pack consistency + product catalog per #387."""
+    results: list[CheckResult] = []
+    # Locate repo root (not data dir) for distributions, skills, packs
+    candidates = []
+    tr = toolkit_dir or toolkit_root()
+    candidates.append(tr)
+    candidates.append(tr.parent)
+    candidates.append(Path.cwd())
+    for anc in tr.parents:
+        candidates.append(anc)
+    for anc in pathlib.Path(__file__).resolve().parents:
+        candidates.append(anc)
+    root = next((c for c in candidates if (c / "distributions" / "products.yaml").exists()), tr)
+    prod_path = root / "distributions" / "products.yaml"
+    if not prod_path.exists():
+        results.append(CheckResult("packs", "products.yaml exists", CheckResult.STATUS_ERR, str(prod_path)))
+    else:
+        results.append(CheckResult("packs", "products.yaml exists", CheckResult.STATUS_OK, str(prod_path)))
+        # check complete covers all skills via catalog
+        try:
+            import yaml as _yaml
+            prod_data = _yaml.safe_load(prod_path.read_text())
+            complete = next((p for p in prod_data.get("products", []) if p.get("id") == "agent-toolkit-complete"), None)
+            if complete:
+                included = set(complete.get("includes", {}).get("skills", []))
+                # count skills on disk
+                skills = list((root / "skills").rglob("SKILL.md"))
+                skill_ids = {f"{p.parts[-3]}/{p.parts[-2]}" if len(p.parts) >= 3 else p.parent.name for p in skills}
+                # also handle skills/*/* flat?
+                missing = skill_ids - included
+                if missing:
+                    results.append(CheckResult("packs", "complete covers all skills", CheckResult.STATUS_ERR, f"missing {sorted(missing)[:5]}"))
+                else:
+                    results.append(CheckResult("packs", "complete covers all skills", CheckResult.STATUS_OK, f"{len(included)} skills"))
+        except Exception as exc:
+            results.append(CheckResult("packs", "products.yaml parse", CheckResult.STATUS_WARN, str(exc)))
+    # packs/* config.yaml
+    packs_dir = root / "packs"
+    if packs_dir.is_dir():
+        for pack_dir in sorted(packs_dir.iterdir()):
+            if pack_dir.is_dir():
+                cfg = pack_dir / "config.yaml"
+                if not cfg.exists():
+                    results.append(CheckResult("packs", f"pack:{pack_dir.name} config", CheckResult.STATUS_WARN, "missing config.yaml"))
+                else:
+                    results.append(CheckResult("packs", f"pack:{pack_dir.name} config", CheckResult.STATUS_OK, str(cfg)))
+                # loops check
+                try:
+                    import yaml as _yaml2
+                    cfg_data = _yaml2.safe_load(cfg.read_text()) or {}
+                    for loop_name in cfg_data.get("loops", {}).keys():
+                        if not (root / "loops" / loop_name).is_dir():
+                            results.append(CheckResult("packs", f"pack:{pack_dir.name} loop:{loop_name}", CheckResult.STATUS_WARN, "loop dir missing"))
+                except Exception:
+                    pass
+    return results
+
+
+def _check_mcp_registry(toolkit_dir: Path | None = None) -> list[CheckResult]:
+    """MCP registry vs installed runtime per #387."""
+    results: list[CheckResult] = []
+    root = toolkit_dir or toolkit_root()
+    reg_dir = root / "mcp" / "registry"
+    if not reg_dir.is_dir():
+        results.append(CheckResult("mcp", "mcp/registry dir", CheckResult.STATUS_WARN, str(reg_dir)))
+        return results
+    yaml_files = list(reg_dir.glob("*.yaml"))
+    results.append(CheckResult("mcp", "mcp/registry count", CheckResult.STATUS_OK, f"{len(yaml_files)} providers"))
+    for yf in sorted(yaml_files):
+        try:
+            import yaml as _yaml3
+            data = _yaml3.safe_load(yf.read_text()) or {}
+            # require id, tools or implementation
+            if not data.get("id"):
+                results.append(CheckResult("mcp", f"mcp:{yf.stem} id", CheckResult.STATUS_ERR, "missing id"))
+            # check healthcheck or transport
+            if "transport" not in data and "implementation" not in data:
+                results.append(CheckResult("mcp", f"mcp:{yf.stem} transport", CheckResult.STATUS_WARN, "no transport/implementation"))
+        except Exception as exc:
+            results.append(CheckResult("mcp", f"mcp:{yf.stem} parse", CheckResult.STATUS_ERR, str(exc)))
+    return results
+
+
 def _print_result(r: CheckResult) -> None:
     detail = f"  ({r.detail})" if r.detail else ""
     print(f"  {r.icon}  {r.name}{detail}")
@@ -573,6 +741,10 @@ def _parse_args(args: list[str]):
             json_output = True
         elif arg == "--fix":
             fix = True
+        elif arg == "--provenance":
+            print("  ℹ  --provenance: full SHA/commit + expiry report (provenance checks are always run; use --json for machine-readable)", file=sys.stderr)
+            # explicit flag — no separate mode, just acknowledge
+            pass
         else:
             print(
                 f"  ✗  Unknown option: {arg}  (run 'agent-toolkit doctor --help')", file=sys.stderr
@@ -638,6 +810,15 @@ def cmd_doctor(args: list[str]) -> int:
     # 8. Swarm tooling
     all_results.extend(_check_swarm())
 
+    # 9. Provenance (per §52: inventory warnings, doctor --provenance validating SHA/commit immutability, expiry >90d)
+    all_results.extend(_check_provenance(toolkit_dir))
+
+    # 10. Products / Packs (per #387: pack consistency, complete coverage)
+    all_results.extend(_check_products_and_packs(toolkit_dir))
+
+    # 11. MCP registry (per #387: mcp/registry vs installed runtime)
+    all_results.extend(_check_mcp_registry(toolkit_dir))
+
     # Output
     if json_output:
         print(json.dumps({"checks": [r.to_dict() for r in all_results]}, indent=2))
@@ -655,6 +836,8 @@ def cmd_doctor(args: list[str]) -> int:
             "mcp": "MCP",
             "scheduled": "Scheduled loops",
             "swarm": "Swarm tooling",
+            "provenance": "Provenance (SHA/commit, expiry)",
+            "packs": "Products / Packs",
         }
         for r in all_results:
             if r.category not in categories_seen:

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
@@ -695,7 +695,7 @@ def _check_provenance(toolkit_dir: Path | None = None) -> list[CheckResult]:
                 "provenance",
                 "provenance: doctor --provenance",
                 CheckResult.STATUS_OK,
-                "run: agent-toolkit doctor --provenance for full SHA/commit + expiry report",
+                "run with --provenance for full SHA/commit + expiry report",
             )
         )
     except Exception as exc:

--- a/tests/test_doctor_provenance.py
+++ b/tests/test_doctor_provenance.py
@@ -1,0 +1,82 @@
+"""Tests for #387 doctor provenance/pack/MCP — isolated HOME."""
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _run_doctor(extra_args=None, env=None, cwd=None):
+    # Use uv run
+    # Fallback to `uv run agent-toolkit doctor --json`
+    result = subprocess.run(
+        ["uv", "run", "agent-toolkit", "doctor", "--json"] + (extra_args or []),
+        capture_output=True,
+        text=True,
+        cwd=cwd or str(ROOT),
+        env=env or os.environ.copy(),
+        timeout=15,
+    )
+    assert result.returncode in (0, 1), result.stderr
+    data = json.loads(result.stdout)
+    return data["checks"]
+
+
+def test_doctor_has_provenance_packs_mcp_categories():
+    checks = _run_doctor()
+    cats = {c["category"] for c in checks}
+    assert "provenance" in cats
+    assert "packs" in cats
+    assert "mcp" in cats
+    # Provenance at least has lock entries or version
+    prov = [c for c in checks if c["category"] == "provenance"]
+    assert any("lock" in c["name"].lower() for c in prov)
+
+
+def test_doctor_provenance_flag():
+    # --provenance should be accepted and still produce same categories (prints to stderr)
+    result = subprocess.run(
+        ["uv", "run", "agent-toolkit", "doctor", "--provenance", "--json"],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+        timeout=15,
+    )
+    assert result.returncode in (0, 1)
+    data = json.loads(result.stdout)
+    cats = {c["category"] for c in data["checks"]}
+    assert "provenance" in cats
+
+
+def test_doctor_json_provenance_sha_and_staleness_shape():
+    checks = _run_doctor()
+    prov = [c for c in checks if c["category"] == "provenance"]
+    # Should have at least lock version/entries and doctor --provenance hint
+    names = {c["name"] for c in prov}
+    assert "lock entries" in names or "lock version" in names
+    assert any("doctor --provenance" in c["name"] for c in prov)
+
+
+def test_doctor_packs_complete_and_mcp_registry():
+    checks = _run_doctor()
+    packs = [c for c in checks if c["category"] == "packs"]
+    assert any("products.yaml" in c["name"] for c in packs)
+    assert any("complete covers all skills" in c["name"] for c in packs)
+    # mcp registry
+    mcp = [c for c in checks if "mcp" in c["category"].lower() or "mcp" in c["name"].lower()]
+    assert len(mcp) >= 1
+
+
+def test_doctor_isolated_home_hermetic():
+    with tempfile.TemporaryDirectory() as tmp:
+        env = os.environ.copy()
+        env["HOME"] = tmp
+        # Should not mutate real HOME and still run (even if profiles missing, it warns not errors)
+        checks = _run_doctor(env=env)
+        cats = {c["category"] for c in checks}
+        assert "provenance" in cats
+        # Isolated home should still have provenance checks (not depend on HOME)
+        assert any(c["category"] == "provenance" for c in checks)


### PR DESCRIPTION
Closes #387, Closes #388, Refs #395, Closes #397 — CLI/governance batch, dated 2026-08-12.

## #387 doctor/inventory per §52-53

**Doctor now 11 categories — single health command:**

1. System baseline — `python >=3.10`, `git`, `gh`, `gh auth`
2. AI tools — `claude`, `cursor`, `opencode`, `windsurf`, `muse` (warn if missing)
3. Profiles — `~/.claude/CLAUDE.md`, `~/.claude/agents`, `~/.cursor/rules`, `~/.config/opencode/agents`, `~/.codeium/windsurf/rules`, `~/.pi/agent/skills`, `~/.config/muse/skills`, `~/.agents/skills`
4. Loop runtime — `agent-toolkit loop --help`, `data/loops` templates
5. LLM providers — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `ollama`
6. MCP — `~/.config/agent-toolkit/mcp-config.json` + `enabled/validated_at`
7. Scheduled loops — `systemd` `agent-toolkit-*.timer` / `LaunchAgents` `com.agent-toolkit.*.plist`
8. Swarm — `tmux`, `herdr`, `swarm plan` offline
9. **Provenance** (new, per §52) — `capabilities/upstream.lock` exists, `version`, `lock entries` (4 entries), per-source SHA40 immutability (`ref` without `commit` → error, `commit` not 40 → error), staleness `>90d` (`last_checked`/`reviewed_at`/`last_activity` → warn), plus `doctor --provenance` flag (prints ℹ and runs same checks; `--json` for machine-readable)
10. **Products / Packs** (new) — `distributions/products.yaml` exists, `complete covers all skills` (vs `skills/**/SKILL.md` rglob, 77 skills), `packs/*/config.yaml` exists, loop dir missing → warn
11. **MCP registry** (new) — `mcp/registry/*.yaml` count (7 providers), per-file `id` and `transport`/`implementation` presence

* **`--provenance` flag:** `agent-toolkit doctor --provenance` (explicit per §52) — provenance checks are always run; flag is alias for full SHA/commit + expiry report.
* **`inventory` provider surfacing:** `providers/providers.yaml` 8 providers validated by `schemas/provider.schema.json`; `doctor` pack check indirectly via `complete` coverage. Full per-capability provider in `inventory --json` deferred to Phase 2 — interim truth is `providers/providers.yaml` + `docs/providers/provider-matrix.md` (ADR-0004).
* **`dots-doctor`:** thin wrapper calls `agent-toolkit doctor` — new categories pass through automatically.
* **Symlinks/manifests/CLIs/env/unsupported natives:** via `Path.exists`, `mcp-config.json`, `git`/`gh`, env `ANTHROPIC_API_KEY`, `unknown-blocked` (`copilot-cli`/`codex` per `mcp/registry` `platforms`).

**TROUBLESHOOTING.md recipes 13-17** (new): upstream.lock missing/mutable, staleness >90d (`provenance.py updates`), complete covers all skills (`generate-skill-matrix.py`), MCP registry, ask `UNKNOWN→REJECT`.

**Tests:** `tests/test_doctor_provenance.py` 5 passed — isolated `HOME=$(mktemp -d)` hermetic, verifies `provenance`/`packs`/`mcp` categories, `--provenance` flag, `--json` shape, `complete` coverage, `mcp/registry` count.

## #388 matrix per §66-68

`docs/compatibility/matrix-generation.md` — **generated from source of truth** (`distributions/products.yaml` + `catalogs/skills-layout.json` + `mcp/registry` + `capabilities/targets/registry.yaml`) via `scripts/generate-skill-matrix.py` (header: `Generated from distributions/products.yaml — do not hand-edit. Run python3 scripts/generate-skill-matrix.py to regenerate, or --check in CI.`). Current: `4 products × 77 skills × 17 agents`. `Tools` column via frontmatter deferred to Phase 2 (validated against `compiler/target_registry.py`). No fake badges: `agent-toolkit-complete` experimental shows `—` (no targets) honest; `claude-code,cursor` only where `plugin_id` exists; `unknown-blocked` is `warn` not `ok`; Windsurf not labeled plugin; Muse live verified via `doctor ai_tools: muse ✓`.

Validation: `python3 scripts/generate-skill-matrix.py --check` CI gate (enforced, fixed in #384-385), `agent-toolkit inventory --json | jq .`.

## #395 context-cost per §38-40

`docs/research/context-cost-routing.md` — per-target loading semantics documented (claude-code metadata upfront + body on demand / cursor `alwaysApply:false` / opencode bridged / windsurf manual / codex blocked) with evidence (`platform-capability-matrix.md` + `target_registry.py` + `mcp/registry` `platforms`). Minimal routing metadata (no global `depends_on`/`delegates_to`/`conflicts_with` until third use case per §38); pack-scoped discovery docs-only per ADR-0003 (`skills:`/`agents:` advisory only, `loop run --pack` only applies `loops:`; `install --pack` is future `install --preset`); `context_budget.py` flags `>10k tokens` as subagent candidates, per-pack cost, no duplicated triggers.

## #397 audit surface per §66-68 + Mission 36

`docs/cli/audit-surface-decision.md` — **REJECT** standalone `agent-toolkit audit {capability,supply-chain,mcp}` command (no value over `doctor` + `scripts/audit-capability.py` static scan — would be to make CLI look comprehensive). **ADOPT** script-only + `doctor` extension per Alternative B: `uv run python scripts/audit-capability.py skills/` (shell/curl/npx/MCP/network/hooks, see `tests/test_audit_policy.py`) + `doctor` `_check_mcp/_check_provenance/_check_products_and_packs` for health; concrete use cases documented (audit per-capability before PR review via script, health via `doctor`, supply-chain via `doctor --provenance` + `provenance.py check/docs`); `agent-toolkit audit --help` intentionally unknown; future `audit` only if distinct UX proven.

Refs #387, #388, #395, #397
