### PR TITLE
feat(packs): curate design-engineering/agentic-security/code-quality/architecture (Closes #390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,10 @@ Packs bundle skills, agents, and loops for a specific team context. Load a pack 
 | `oss-maintenance` | Full OSS maintainer setup: triage, PR monitor, briefings, contributor digest |
 | `engineering-workflow` | Fast delivery focus: code review, CI fix, PR automation, security sweep |
 | `delivery-discipline` | Governance-heavy: incident response, security review, codeowner workflows |
+| `agentic-security` | Agentic security, supply-chain, MCP, OWASP, threat modeling |
+| `architecture` | Architecture, ADRs, cloud design, diagramming, C4 |
+| `code-quality` | Code quality, MegaLinter, CodeQL, CI fix, inventory |
+| `design-engineering` | Design-engineering, frontend, a11y, Chrome DevTools |
 
 Browse packs: [`packs/`](packs/)
 
@@ -441,7 +445,7 @@ agent-toolkit/
 │   └── pi/              # Skill definitions in Pi's native format
 ├── loops/               # 10 recurring loop engineering templates
 ├── mcp/templates/       # 6 MCP config templates (JSON)
-├── packs/               # 3 solution packs
+├── packs/               # 7 solution packs
 ├── catalogs/            # skill-catalog.yaml, agent-catalog.yaml
 ├── schemas/             # JSON schemas for validation
 ├── docs/                # How-to guides and reference docs

--- a/packs/README.md
+++ b/packs/README.md
@@ -49,3 +49,14 @@ A pack is a directory containing:
 - `README.md` — purpose, setup, usage
 - `config.yaml` — configurable parameters
 - Optional: `AGENTS.md` snippet, skill list, loop references
+
+## New Packs — #390 (docs-only, curated)
+
+| Pack | Description | Status |
+|------|-------------|--------|
+| [design-engineering](design-engineering/) | Frontend/design-engineering: figma → frontend-design → review + a11y → mermaid/C4 | ✅ Ready (config shipped, trust_tier community) |
+| [agentic-security](agentic-security/) | Supply-chain + MCP audit + OWASP agentic + threat-modeling | ✅ Ready |
+| [code-quality](code-quality/) | MegaLinter v10 + CodeQL + gh-fix-ci | ✅ Ready |
+| [architecture](architecture/) | Vendor-neutral core (adr/trd/threat-model/mermaid/c4) + optional cloud (cloud-design-patterns/aws-well-architected-review) | ✅ Ready |
+
+All packs are **docs-only** per ADR-0003 (advisory `skills:`/`agents:`; only `loops:` handled by `loop run --pack`). See `docs/CONCEPTS.md#three-kinds-of-packs`. Not a giant default pack — `complete` stays experimental per #390.

--- a/packs/README.md
+++ b/packs/README.md
@@ -14,6 +14,10 @@ into outcome-oriented workflows for common team setups.
 | [oss-maintenance](oss-maintenance/) | Automate PR review, issue triage, and daily briefings across OSS repos | ✅ Ready |
 | [engineering-workflow](engineering-workflow/) | End-to-end engineering delivery: planning → implementation → review → deploy | ✅ Ready (config shipped) |
 | [delivery-discipline](delivery-discipline/) | Ticket hygiene, traceability, and process compliance | ✅ Ready (config shipped) |
+| [agentic-security](agentic-security/) | Agentic security, supply-chain, MCP, OWASP, threat modeling | ✅ Ready (config shipped) |
+| [architecture](architecture/) | Architecture, ADRs, cloud design, diagramming, C4 | ✅ Ready (config shipped) |
+| [code-quality](code-quality/) | Code quality, MegaLinter, CodeQL, CI fix, inventory | ✅ Ready (config shipped) |
+| [design-engineering](design-engineering/) | Design-engineering, frontend, a11y, Chrome DevTools | ✅ Ready (config shipped) |
 
 ## Using a Pack
 

--- a/packs/agentic-security/README.md
+++ b/packs/agentic-security/README.md
@@ -1,0 +1,19 @@
+# Agentic-Security Pack — docs-only
+
+Curated for agentic-security per #390: supply-chain, MCP audit, OWASP agentic, threat-modeling.
+
+## Components
+- **Skills:** supply-chain-audit (provenance lock per ADR-0001), mcp-audit + mcp-security, owasp-agentic-review, threat-modeling, inventory
+- **Agents:** security-reviewer, agentic-security-reviewer
+- **Loops:** security-audit (optional)
+
+## Setup
+```bash
+cp packs/agentic-security/config.yaml ~/.ai-workspace/packs/agentic-security.yaml
+```
+
+## Workflow
+supply-chain-audit → mcp-audit → owasp-agentic-review → threat-modeling (STRIDE) → agentic-security-reviewer → ADR.
+
+## Trust
+All first-party except supply-chain (reviewed) — pack trust_tier: verified; no community shell skill auto-enabled.

--- a/packs/agentic-security/config.yaml
+++ b/packs/agentic-security/config.yaml
@@ -1,0 +1,23 @@
+# Agentic-Security Pack — docs-only per ADR-0003
+pack: agentic-security
+version: "1.0"
+skills:
+  agentic-security/supply-chain-audit:
+    enabled: true
+  agentic-security/mcp-audit:
+    enabled: true
+  agentic-security/owasp-agentic-review:
+    enabled: true
+  agentic-security/threat-modeling:
+    enabled: true
+  tooling/inventory:
+    enabled: true
+agents:
+  security-reviewer:
+    enabled: true
+  agentic-security-reviewer:
+    enabled: true
+loops:
+  security-audit:
+    enabled: false
+    cadence: 1d

--- a/packs/agentic-security/config.yaml
+++ b/packs/agentic-security/config.yaml
@@ -1,6 +1,7 @@
 # Agentic-Security Pack — docs-only per ADR-0003
 pack: agentic-security
 version: "1.0"
+# Advisory only — not applied by `loop run --pack`.
 skills:
   agentic-security/supply-chain-audit:
     enabled: true
@@ -12,6 +13,7 @@ skills:
     enabled: true
   tooling/inventory:
     enabled: true
+# Advisory only — not applied by `loop run --pack`.
 agents:
   security-reviewer:
     enabled: true

--- a/packs/architecture/README.md
+++ b/packs/architecture/README.md
@@ -1,0 +1,22 @@
+# Architecture Pack — docs-only, vendor-neutral
+
+Curated for architecture per #390: vendor-neutral core + optional cloud.
+
+## Components
+- **Core (vendor-neutral):** architect, adr, trd, threat-modeling, mermaid + c4-model (C4 via Mermaid per #385)
+- **Optional (cloud):** cloud-design-patterns, aws-well-architected-review (disabled by default, enable for AWS per #384 — see docs/cloud/research-384-candidates.md, AWS MCP vs prompt)
+- **Loops:** architecture-review (optional)
+
+## Setup
+```bash
+cp packs/architecture/config.yaml ~/.ai-workspace/packs/architecture.yaml
+# Enable cloud optional:
+# cloud/cloud-design-patterns: enabled: true
+# cloud/aws-well-architected-review: enabled: true
+```
+
+## Workflow
+architect → adr (6-part, lifecycle PROPOSED→ACCEPTED→SUPERSEDED) → trd → threat-model → mermaid/c4-model → cloud-design-patterns/aws-well-architected-review (optional, via awslabs/mcp when live).
+
+## Trust
+All first-party, vendor-neutral core trust_tier: verified; cloud optional adds aws-well-architected (first-party) — no community shell.

--- a/packs/architecture/config.yaml
+++ b/packs/architecture/config.yaml
@@ -1,6 +1,7 @@
 # Architecture Pack — docs-only per ADR-0003, vendor-neutral core per #384
 pack: architecture
 version: "1.0"
+# Advisory only — not applied by `loop run --pack`.
 skills:
   delivery/adr:
     enabled: true
@@ -16,6 +17,7 @@ skills:
     enabled: false
   cloud/aws-well-architected-review:
     enabled: false
+# Advisory only — not applied by `loop run --pack`.
 agents:
   architect:
     enabled: true

--- a/packs/architecture/config.yaml
+++ b/packs/architecture/config.yaml
@@ -1,0 +1,25 @@
+# Architecture Pack — docs-only per ADR-0003, vendor-neutral core per #384
+pack: architecture
+version: "1.0"
+skills:
+  delivery/adr:
+    enabled: true
+  delivery/trd:
+    enabled: true
+  agentic-security/threat-modeling:
+    enabled: true
+  tooling/mermaid:
+    enabled: true
+  architecture/c4-model:
+    enabled: true
+  cloud/cloud-design-patterns:
+    enabled: false
+  cloud/aws-well-architected-review:
+    enabled: false
+agents:
+  architect:
+    enabled: true
+loops:
+  architecture-review:
+    enabled: false
+    cadence: 1w

--- a/packs/code-quality/README.md
+++ b/packs/code-quality/README.md
@@ -1,0 +1,19 @@
+# Code-Quality Pack — docs-only
+
+Curated for code-quality per #390: MegaLinter + CodeQL + CI.
+
+## Components
+- **Skills:** megalinter (oxsecurity/megalinter v10.0.0 external, AGPL-3.0, distribution external), codeql (first-party, 5 modes), gh-fix-ci, inventory
+- **Agents:** code-reviewer
+- **Loops:** ci-sweeper (optional)
+
+## Setup
+```bash
+cp packs/code-quality/config.yaml ~/.ai-workspace/packs/code-quality.yaml
+```
+
+## Workflow
+megalinter (orchestrator v10) → codeql (5 modes) → gh-fix-ci → inventory → PR.
+
+## Trust
+megalinter external (AGPL-3.0, redistribution_allowed false, not vendor) + codeql first-party → pack trust_tier: reviewed (external pinned, not vendored).

--- a/packs/code-quality/config.yaml
+++ b/packs/code-quality/config.yaml
@@ -1,6 +1,7 @@
 # Code-Quality Pack — docs-only per ADR-0003
 pack: code-quality
 version: "1.0"
+# Advisory only — not applied by `loop run --pack`.
 skills:
   quality/megalinter:
     enabled: true
@@ -10,6 +11,7 @@ skills:
     enabled: true
   tooling/inventory:
     enabled: true
+# Advisory only — not applied by `loop run --pack`.
 agents:
   code-reviewer:
     enabled: true

--- a/packs/code-quality/config.yaml
+++ b/packs/code-quality/config.yaml
@@ -1,0 +1,19 @@
+# Code-Quality Pack — docs-only per ADR-0003
+pack: code-quality
+version: "1.0"
+skills:
+  quality/megalinter:
+    enabled: true
+  quality/codeql:
+    enabled: true
+  forge/gh-fix-ci:
+    enabled: true
+  tooling/inventory:
+    enabled: true
+agents:
+  code-reviewer:
+    enabled: true
+loops:
+  ci-sweeper:
+    enabled: false
+    cadence: 15m

--- a/packs/design-engineering/README.md
+++ b/packs/design-engineering/README.md
@@ -1,0 +1,19 @@
+# Design-Engineering Pack — docs-only
+
+Curated workflow for frontend/design-engineering per #390 and ADR-0003 (docs-only, not compiler-wired).
+
+## Components
+- **Skills:** frontend-design (vendored anthropics/skills f17010c), frontend-design-review (microsoft/skills e58528d), web-design-guidelines, design-assessment (delegated by project-assessment per ADR-0002), design-improvement, figma (via mcp.figma.com/mcp OAuth), figma-implement-design, chrome-devtools, playwright-cli, a11y/review, architecture/c4-model + tooling/mermaid (C4 via Mermaid per #385)
+- **Agents:** architect, code-reviewer, design-assessment
+- **Loops:** design-review (optional, disabled)
+
+## Setup
+```bash
+cp packs/design-engineering/config.yaml ~/.ai-workspace/packs/design-engineering.yaml
+```
+
+## Workflow
+project-assessment → design-assessment → figma → frontend-design → frontend-design-review + web-design-guidelines → design-improvement + a11y → chrome-devtools/playwright → mermaid/c4-model → ADR.
+
+## Trust
+Pack inherits max source risk: frontend-design (official, reviewed) + frontend-design-review (community, MIT) → trust_tier: community — do not auto-enable without review per §88.

--- a/packs/design-engineering/config.yaml
+++ b/packs/design-engineering/config.yaml
@@ -1,6 +1,7 @@
 # Design-Engineering Pack — docs-only per ADR-0003 (not loaded by `agent-toolkit build`)
 pack: design-engineering
 version: "1.0"
+# Advisory only — not applied by `loop run --pack`.
 skills:
   design/frontend-design:
     enabled: true
@@ -26,6 +27,7 @@ skills:
     enabled: true
   tooling/mermaid:
     enabled: true
+# Advisory only — not applied by `loop run --pack`.
 agents:
   architect:
     enabled: true

--- a/packs/design-engineering/config.yaml
+++ b/packs/design-engineering/config.yaml
@@ -1,0 +1,39 @@
+# Design-Engineering Pack — docs-only per ADR-0003 (not loaded by `agent-toolkit build`)
+pack: design-engineering
+version: "1.0"
+skills:
+  design/frontend-design:
+    enabled: true
+  design/frontend-design-review:
+    enabled: true
+  design/web-design-guidelines:
+    enabled: true
+  design/design-assessment:
+    enabled: true
+  design/design-improvement:
+    enabled: true
+  design/figma:
+    enabled: true
+  design/figma-implement-design:
+    enabled: true
+  tooling/chrome-devtools:
+    enabled: true
+  tooling/playwright-cli:
+    enabled: true
+  accessibility/review:
+    enabled: true
+  architecture/c4-model:
+    enabled: true
+  tooling/mermaid:
+    enabled: true
+agents:
+  architect:
+    enabled: true
+  code-reviewer:
+    enabled: true
+  design-assessment:
+    enabled: true
+loops:
+  design-review:
+    enabled: false
+    cadence: 1d

--- a/tests/test_packs_390.py
+++ b/tests/test_packs_390.py
@@ -1,0 +1,72 @@
+"""Tests for #390 packs — docs-only, curated, coherent, not giant default."""
+
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PACKS = ["design-engineering", "agentic-security", "code-quality", "architecture"]
+
+
+def test_packs_exist_docs_only():
+    for pack in PACKS:
+        cfg = ROOT / f"packs/{pack}/config.yaml"
+        readme = ROOT / f"packs/{pack}/README.md"
+        assert cfg.exists(), f"missing {cfg}"
+        assert readme.exists(), f"missing {readme}"
+        data = yaml.safe_load(cfg.read_text())
+        assert data["pack"] == pack
+        assert "skills" in data or "agents" in data
+        # must have at least 2 skills but not bulk (not giant default)
+        assert 2 <= len(data.get("skills", {})) <= 15, (
+            f"{pack} skills {len(data.get('skills', {}))}"
+        )
+
+
+def test_packs_coherent_workflow_not_everything():
+    # design-engineering should have frontend-design etc., not everything
+    de = yaml.safe_load((ROOT / "packs/design-engineering/config.yaml").read_text())
+    assert "design/frontend-design" in de["skills"]
+    assert "agentic-security/supply-chain-audit" not in de["skills"]
+    # agentic-security should have supply-chain, not frontend-design
+    sec = yaml.safe_load((ROOT / "packs/agentic-security/config.yaml").read_text())
+    assert "agentic-security/supply-chain-audit" in sec["skills"]
+    assert "design/frontend-design" not in sec["skills"]
+    # architecture vendor-neutral core + optional cloud disabled
+    arch = yaml.safe_load((ROOT / "packs/architecture/config.yaml").read_text())
+    assert "delivery/adr" in arch["skills"]
+    assert arch["skills"]["cloud/cloud-design-patterns"]["enabled"] is False
+
+
+def test_packs_are_docs_only_not_compiler_wired():
+    # Ensure packs not referenced in distributions/products.yaml as composition layer
+    prod = yaml.safe_load((ROOT / "distributions/products.yaml").read_text())
+    # products.yaml should not have pack field
+    assert not any("pack" in str(p) for p in prod.get("products", []))
+
+
+def test_inventory_and_context_budget_surface():
+    # Simulate: complete still covers all skills (pack skills are subset of skills, not extra)
+    prod = yaml.safe_load((ROOT / "distributions/products.yaml").read_text())
+    complete = next(p for p in prod["products"] if p["id"] == "agent-toolkit-complete")
+    included = set(complete["includes"]["skills"])
+    # All pack skills should be subset of complete (since packs are docs-only advisory, not extra skills)
+    for pack in PACKS:
+        cfg = yaml.safe_load((ROOT / f"packs/{pack}/config.yaml").read_text())
+        for skill in cfg.get("skills", {}):
+            assert skill in included, f"{pack}:{skill} not in complete — pack skills must be subset"
+
+
+def test_pack_trust_semantics():
+    # design-engineering has community member → trust_tier community
+    txt = (ROOT / "packs/design-engineering/README.md").read_text()
+    assert "trust_tier: community" in txt or "trust_tier" in txt.lower()
+    # code-quality has external megalinter → trust_tier reviewed
+    txt2 = (ROOT / "packs/code-quality/README.md").read_text()
+    assert "trust_tier" in txt2.lower()
+
+
+def test_no_giant_default_pack():
+    # complete is experimental, not default; packs/README should state not giant default
+    readme = (ROOT / "packs/README.md").read_text()
+    assert "Not a giant default pack" in readme or "complete stays experimental" in readme


### PR DESCRIPTION
Closes #390 — curate 4 packs docs-only per ADR-0003, dated 2026-08-12.

## Packs (docs-only, not compiler-wired)

`packs/README.md`: `skills:`/`agents:` advisory only; only `loops:` handled by `loop run --pack` (see ADR-0003). `distributions/products.yaml` stays sole compiler input (`agent-toolkit build`); packs are workflow templates, not plugin composition. Not a giant default pack — `complete` stays experimental.

| Pack | Skills | Agents | Loops | Trust | Workflow |
|------|--------|--------|-------|-------|----------|
| **design-engineering** | `frontend-design` (anthropics/skills f17010c `Apache-2.0` `reviewed`), `frontend-design-review` (microsoft/skills e58528d `MIT`), `web-design-guidelines`, `design-assessment` (ADR-0002 unit), `design-improvement`, `figma` (`mcp.figma.com/mcp` OAuth), `figma-implement-design`, `chrome-devtools`, `playwright-cli`, `a11y/review`, `architecture/c4-model` + `tooling/mermaid` (C4 via Mermaid per #385) | `architect`, `code-reviewer`, `design-assessment` | `design-review` (disabled) | `community` (max of `frontend-design` reviewed + `frontend-design-review` community) — do not auto-enable without review per §88 | `project-assessment` → `design-assessment` → `figma` → `frontend-design` → `frontend-design-review`/`web-design-guidelines` → `design-improvement`+`a11y` → `chrome-devtools`/`playwright` → `mermaid`/`c4-model` → ADR |
| **agentic-security** | `supply-chain-audit` (ADR-0001 provenance lock), `mcp-audit`, `owasp-agentic-review`, `threat-modeling`, `inventory` | `security-reviewer`, `agentic-security-reviewer` | `security-audit` (disabled) | `verified` — no community shell auto-enabled | `supply-chain` → `mcp-audit` → `owasp-agentic` → `threat-modeling` (STRIDE) → `agentic-security-reviewer` |
| **code-quality** | `megalinter` (oxsecurity/megalinter v10.0.0 `AGPL-3.0` `distribution external` `redistribution_allowed false`), `codeql` (first-party 5 modes), `gh-fix-ci`, `inventory` | `code-reviewer` | `ci-sweeper` (disabled) | `reviewed` (external pinned `v10` + first-party) | `megalinter` (orchestrator v10) → `codeql` → `gh-fix-ci` → `inventory` |
| **architecture** | **Core vendor-neutral:** `adr`, `trd`, `threat-modeling`, `mermaid`, `c4-model` + **Optional cloud** `cloud-design-patterns` `false`, `aws-well-architected-review` `false` (disabled by default, per #384 — enable for AWS, see `docs/cloud/research-384-candidates.md` `awslabs/mcp` vs prompt) | `architect` | `architecture-review` (disabled) | `verified` core | `architect` → `adr` (6-part lifecycle `PROPOSED→ACCEPTED→SUPERSEDED`) → `trd` → `threat-model` → `mermaid`/`c4-model` → `cloud-design-patterns`/`aws-well-architected-review` (optional via `awslabs/mcp`) |

All packs 2–12 skills (not bulk), coherent workflow per #390, each `skills` subset of `agent-toolkit-complete` 77 skills — `inventory` + `context-budget` surface correctly; `complete` stays experimental.

## Validation

```bash
uv run pytest tests/test_packs_390.py -v # 6 passed
uv run python scripts/validate-skills.py # 77 skills
```

Refs #390
