### PR TITLE
fix(workspace): validate nested packs and warn on unknown profile keys (Fixes #338)

### DIFF
--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/workspace.py
@@ -1374,7 +1374,7 @@ def _validate_packs(ws: Path) -> list[str]:
     packs_dir = ws / "packs"
     if not packs_dir.is_dir():
         return errors
-    for path in sorted(packs_dir.glob("*.yaml")):
+    for path in sorted(packs_dir.rglob("*.yaml")):
         try:
             data = _parse_yaml_file(path)
         except Exception as exc:
@@ -1457,6 +1457,10 @@ def _validate_profiles(ws: Path) -> list[str]:
                 for idx, s in enumerate(skills):
                     if not isinstance(s, str) or not s.strip():
                         errors.append(f"{path.name}: skills[{idx}] must be a non-empty string")
+            print(
+                f"  {_yellow('⚠')}  {path.name}: profile key 'skills' is schema-supported but currently not applied by the toolkit loader.",
+                file=sys.stderr,
+            )
         loops = data.get("loops")
         if loops is not None:
             if not isinstance(loops, list):
@@ -1465,6 +1469,15 @@ def _validate_profiles(ws: Path) -> list[str]:
                 for idx, ln in enumerate(loops):
                     if not isinstance(ln, str) or not ln.strip():
                         errors.append(f"{path.name}: loops[{idx}] must be a non-empty string")
+            print(
+                f"  {_yellow('⚠')}  {path.name}: profile key 'loops' is schema-supported but currently not applied by the toolkit loader.",
+                file=sys.stderr,
+            )
+
+        allowed_keys = {"name", "description", "pack", "persona", "skills", "loops"}
+        for k in data.keys():
+            if k not in allowed_keys:
+                errors.append(f"{path.name}: unknown profile key '{k}'")
     return errors
 
 
@@ -1523,6 +1536,9 @@ def cmd_validate(args: list[str]) -> int:
             case "--help" | "-h":
                 print("Usage: agent-toolkit workspace validate [surface] [--workspace PATH]")
                 print("Surfaces: all, packs, loops, personas, profiles, knowledge, jobs")
+                print(
+                    "Note: profile validation may warn about schema-supported keys that the Toolkit does not currently apply."
+                )
                 return 0
             case arg if not arg.startswith("-"):
                 surface = arg

--- a/tests/test_workspace_commands.py
+++ b/tests/test_workspace_commands.py
@@ -111,6 +111,13 @@ def test_validate_packs_missing_field(workspace: Path) -> None:
     assert ws.cmd_validate(["packs"]) == 1
 
 
+def test_validate_packs_nested(workspace: Path) -> None:
+    nested = workspace / "packs" / "nested"
+    nested.mkdir()
+    (nested / "bad.yaml").write_text("name: bad_nested\n", encoding="utf-8")
+    assert ws.cmd_validate(["packs"]) == 1
+
+
 def test_validate_knowledge_missing_dir(workspace: Path) -> None:
     import shutil
 
@@ -214,6 +221,26 @@ def test_validate_profile_bad_skills(workspace: Path) -> None:
 def test_validate_profile_bad_loops(workspace: Path) -> None:
     (workspace / "profiles" / "bad-loops.yaml").write_text(
         "name: bad-loops\ndescription: Bad loops field\nloops: not-a-list\n",
+        encoding="utf-8",
+    )
+    assert ws.cmd_validate(["profiles"]) == 1
+
+
+def test_validate_profile_unused_keys(workspace: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (workspace / "profiles" / "unused-keys.yaml").write_text(
+        "name: unused\ndescription: ok\nskills:\n  - some-skill\nloops:\n  - some-loop\n",
+        encoding="utf-8",
+    )
+    assert ws.cmd_validate(["profiles"]) == 0
+    err = capsys.readouterr().err
+    assert "schema-supported but currently not applied" in err
+    assert "skills" in err
+    assert "loops" in err
+
+
+def test_validate_profile_unknown_keys(workspace: Path) -> None:
+    (workspace / "profiles" / "unknown-key.yaml").write_text(
+        "name: unknown\ndescription: ok\ninvalid_key: true\n",
         encoding="utf-8",
     )
     assert ws.cmd_validate(["profiles"]) == 1


### PR DESCRIPTION
Fixes #338 — preserve contributor work from #436 (Rahul-pamula) with ruff format fix.

## Original contribution
- `_validate_packs` now uses `rglob("*.yaml")` for nested packs (aligns with `workspace load`)
- `_validate_profiles` warns on `skills`/`loops` (schema-supported but not applied) vs error on genuinely unknown keys
- Tests: `test_validate_packs_nested`, `test_validate_profile_unused_keys`, `test_validate_profile_unknown_keys` (30 tests pass)

## Fix
- `ruff format` only — no logic change, preserves attribution (Co-authored-by: Rahul-pamula)

## Validation
```bash
uv run ruff check .
uv run pytest tests/test_workspace_commands.py -q  # 30 passed
```

Closes #338
Supersedes #436 (will be closed as duplicate after merge)

Co-authored-by: Rahul-pamula <rahulpamula123@gmail.com>
