### PR TITLE
fix(ci): make MegaLinter and required main gate green

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: MegaLinter
-        uses: oxsecurity/megalinter@v9
+        uses: oxsecurity/megalinter@v10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -687,3 +687,53 @@ jobs:
 
       - name: Dry-run install via uvx
         run: uvx agent-toolkit-cli install --dry-run --tools cursor,opencode
+
+  # ── Aggregate required gate — single stable context for branch protection (#243) ──
+  required-ci:
+    name: Required CI
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - test-package
+      - smoke-test-skills
+      - validate-skills
+      - validate-manifests
+      - validate-agent-plugins
+      - validate-upstream
+      - check-skill-matrix
+      - validate-loops
+      - validate-products
+      - secret-scan
+      - yaml-lint
+      - ruff
+      - coverage
+      - build-package
+      - integration-tests
+      - test-uvx
+    steps:
+      - name: Check required jobs
+        run: |
+          # Fail if any required dependency failed or was cancelled
+          failed="false"
+          # Use GitHub's needs context to check each job result
+          if [[ "${{ needs.test-package.result }}" != "success" && "${{ needs.test-package.result }}" != "skipped" ]]; then echo "test-package failed: ${{ needs.test-package.result }}"; failed="true"; fi
+          if [[ "${{ needs.smoke-test-skills.result }}" != "success" && "${{ needs.smoke-test-skills.result }}" != "skipped" ]]; then echo "smoke-test-skills failed: ${{ needs.smoke-test-skills.result }}"; failed="true"; fi
+          if [[ "${{ needs.validate-skills.result }}" != "success" ]]; then echo "validate-skills failed: ${{ needs.validate-skills.result }}"; failed="true"; fi
+          if [[ "${{ needs.validate-manifests.result }}" != "success" ]]; then echo "validate-manifests failed: ${{ needs.validate-manifests.result }}"; failed="true"; fi
+          if [[ "${{ needs.validate-agent-plugins.result }}" != "success" ]]; then echo "validate-agent-plugins failed: ${{ needs.validate-agent-plugins.result }}"; failed="true"; fi
+          if [[ "${{ needs.validate-upstream.result }}" != "success" ]]; then echo "validate-upstream failed: ${{ needs.validate-upstream.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-skill-matrix.result }}" != "success" ]]; then echo "check-skill-matrix failed: ${{ needs.check-skill-matrix.result }}"; failed="true"; fi
+          if [[ "${{ needs.validate-loops.result }}" != "success" ]]; then echo "validate-loops failed: ${{ needs.validate-loops.result }}"; failed="true"; fi
+          if [[ "${{ needs.validate-products.result }}" != "success" ]]; then echo "validate-products failed: ${{ needs.validate-products.result }}"; failed="true"; fi
+          if [[ "${{ needs.secret-scan.result }}" != "success" ]]; then echo "secret-scan failed: ${{ needs.secret-scan.result }}"; failed="true"; fi
+          if [[ "${{ needs.yaml-lint.result }}" != "success" ]]; then echo "yaml-lint failed: ${{ needs.yaml-lint.result }}"; failed="true"; fi
+          if [[ "${{ needs.ruff.result }}" != "success" ]]; then echo "ruff failed: ${{ needs.ruff.result }}"; failed="true"; fi
+          if [[ "${{ needs.coverage.result }}" != "success" ]]; then echo "coverage failed: ${{ needs.coverage.result }}"; failed="true"; fi
+          if [[ "${{ needs.build-package.result }}" != "success" ]]; then echo "build-package failed: ${{ needs.build-package.result }}"; failed="true"; fi
+          if [[ "${{ needs.integration-tests.result }}" != "success" ]]; then echo "integration-tests failed: ${{ needs.integration-tests.result }}"; failed="true"; fi
+          if [[ "${{ needs.test-uvx.result }}" != "success" ]]; then echo "test-uvx failed: ${{ needs.test-uvx.result }}"; failed="true"; fi
+          if [[ "$failed" == "true" ]]; then
+            echo "::error::Required CI failed"
+            exit 1
+          fi
+          echo "All required jobs passed"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,21 +1,24 @@
-# MegaLinter configuration
+# MegaLinter configuration — keep in sync with .github/workflows/mega-linter.yml
+# Python stack: Ruff is canonical (lint + format + imports). Pylint/Flake8/Black/isort are intentionally not enabled.
 ENABLE_LINTERS:
   - YAML_YAMLLINT
   - JSON_JSONLINT
   - MARKDOWN_MARKDOWNLINT
   - BASH_SHELLCHECK
-  - PYTHON_PYLINT
+  - PYTHON_RUFF
   - REPOSITORY_SECRETLINT
+  - REPOSITORY_CHECKOV
 
-# Disable errors on these (warnings only)
+# Warnings only — never fail the build but surface in report
 DISABLE_ERRORS_LINTERS:
   - MARKDOWN_MARKDOWNLINT
-  - PYTHON_PYLINT
+  - PYTHON_RUFF
+  - REPOSITORY_CHECKOV
 
 # Only lint changed files on PR, all files on main
 VALIDATE_ALL_CODEBASE: false
 
-FILTER_REGEX_EXCLUDE: '(\.git|node_modules|\.venv|skills/.*/data/.*\.csv|profiles/claude-code/settings\.json)'
+FILTER_REGEX_EXCLUDE: '(\.git|node_modules|\.venv|megalinter-reports|skills/.*/data/.*\.csv|profiles/claude-code/settings\.json|packaging)'
 
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yaml
 YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml


### PR DESCRIPTION
## Summary
Make MegaLinter and required main gate green (closeout #2-6, #12-15).

## Root cause
- `.mega-linter.yml` listed `PYTHON_PYLINT` while workflow `mega-linter.yml` enabled `PYTHON_RUFF` (Ruff is canonical) — config drift, duplicate Python stacks.
- Workflow pinned `oxsecurity/megalinter@v9` while governed capability `quality/megalinter` is `v10.0.0` (15e5b45) — version drift.
- `validate.yml` had 19 matrix jobs but no stable aggregate `required-ci` context, so branch protection could not require a single stable gate (issue #243).

## Fix
- `.mega-linter.yml`: `PYTHON_PYLINT` → `PYTHON_RUFF`, `ENABLE_LINTERS`/`DISABLE_ERRORS_LINTERS`/`FILTER_REGEX_EXCLUDE` now exactly matches `mega-linter.yml` env (single Python stack: Ruff canonical, Pylint/Flake8 intentionally not enabled).
- `.github/workflows/mega-linter.yml`: `oxsecurity/megalinter@v9` → `@v10` (aligns with `quality/megalinter` v10.0.0)
- `.github/workflows/validate.yml`: add `required-ci` aggregate job (`if: always()`, needs 16 required jobs, excludes `mypy`/`markdown-lint` warn-only) — single stable context `Required CI` for branch protection (#243).

## Validation
```bash
uv run ruff check .  # pass
uv run python scripts/validate-skills.py  # 77 OK
```

## Issues
Closes main MegaLinter red; enables branch protection with `Required CI`.
