### PR TITLE
fix(ci): remove extra blank line at EOF in providers.yaml

### DIFF
--- a/providers/providers.yaml
+++ b/providers/providers.yaml
@@ -966,4 +966,3 @@ providers:
     security:
       source_trust: 'official + community (distinct)'
       runtime_privilege: 'read-write vs admin — separate'
-


### PR DESCRIPTION
MegaLinter on 0061df0 failed with

```
providers/providers.yaml:969:1 error too many blank lines (1 > 0) (empty-lines)
```

File ended with `\n\n` producing an empty last line. Trim to a single trailing newline so YAML_YAMLLINT (the only non-warning error in the 0061df0 MegaLinter run) passes.

All other MegaLinter findings on 0061df0 were warnings (line-length, truthy, comments) covered by DISABLE_ERRORS_LINTERS or warning-only handling.

Follows up #453 which fixed PYTHON_RUFF/v10 and Validate Required CI gate.