### PR TITLE
feat(loop): AI-assisted attribution on outbound gh comments

### DIFF
--- a/docs/LOOPS.md
+++ b/docs/LOOPS.md
@@ -39,6 +39,12 @@ deny:               # Explicit list of forbidden actions
   - approve
   - force-push
 
+# Optional. Default ON: hard gate prepends AI disclosure to comments/reviews.
+# attribution: false
+# attribution:
+#   enabled: true
+#   template: "> 🤖 AI-assisted message posted as `@{login}` by [agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit){loop_suffix}."
+
 exit_conditions:
   - goal_met
   - budget_exhausted
@@ -55,6 +61,30 @@ request: |
   The prompt template executed by the loop runner.
   This is the full instruction set for the AI.
 ```
+
+---
+
+## Comment attribution (default ON)
+
+When a loop posts a GitHub comment or review body via `gh`, `loop-gh-gate` prepends a disclosure if it is missing:
+
+```markdown
+> 🤖 AI-assisted message posted as `@your-login` by [agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit) (`loop-name`).
+```
+
+- **Default:** enabled for every loop run (no config required).
+- **Login:** resolved from the authenticated `gh` token (`gh api user`).
+- **Idempotent:** bodies that already start with `> 🤖 AI-assisted` are left unchanged.
+- **Disable per loop:**
+
+```yaml
+attribution: false
+# or
+attribution:
+  enabled: false
+```
+
+Supported injection surfaces (v1): `--body` / `-b`, `--body-file`, and `-f`/`-F body=` on comment/review commands classified as `comment` by the hard gate.
 
 ---
 
@@ -311,4 +341,5 @@ request: string (multiline)     # The prompt template executed by the loop runne
 # Optional fields
 resumable: boolean               # Default: false
 verifier: string | null          # Agent name to verify output (e.g. code-reviewer)
+attribution: boolean | object    # Default: true; false disables AI comment disclosure
 ```

--- a/packages/agent-toolkit-cli/CHANGELOG.md
+++ b/packages/agent-toolkit-cli/CHANGELOG.md
@@ -194,6 +194,14 @@ The canonical compiler pipeline now generates native artifacts for 9 AI coding t
 
 ### Added
 
+- **Loop comment attribution (default ON):** `loop-gh-gate` prepends
+  `> 🤖 AI-assisted message posted as @{login} by [agent-toolkit](...) (`loop`)`
+  to outbound `gh` comment/review bodies (`--body`, `--body-file`, `-f body=`).
+  Opt out per loop with `attribution: false` or `attribution.enabled: false` in
+  LOOP.md / `loop.yaml`. Login is resolved from the authenticated `gh` token.
+
+### Added (historical backlog)
+
 - Initial toolkit release with 53+ skills across 9 domains (core, delivery, design, forge, integrations, data, tooling, ops, loops)
 - Agent personas for all major AI coding tools: architect, planner, code-reviewer, security-reviewer, performance-optimizer, tdd-guide, refactor-cleaner, docs-lookup
 - Profiles for Claude Code, Cursor, OpenCode, GitHub Copilot, Windsurf, and Pi Coding Agent

--- a/packages/agent-toolkit-cli/CHANGELOG.md
+++ b/packages/agent-toolkit-cli/CHANGELOG.md
@@ -192,6 +192,11 @@ The canonical compiler pipeline now generates native artifacts for 9 AI coding t
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex/OpenCode/Pi manifest validators no longer treat semver `1.10.0` as a
+  private `10.x` hostname (false positive after the v1.10.0 bump).
+
 ### Added
 
 - **Loop comment attribution (default ON):** `loop-gh-gate` prepends

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -12,6 +13,40 @@ from agent_toolkit.compiler.provenance import ArtifactRecord, file_digest, write
 
 class PathEscapeError(ValueError):
     """Raised when a path resolves outside its containment root."""
+
+
+# Private LAN markers for public plugin/package manifests.
+# Use IP regexes (not bare "10.") so semver like 1.10.0 does not false-positive.
+_PRIVATE_IPV4_10 = re.compile(r"\b10\.\d{1,3}\.\d{1,3}\.\d{1,3}\b")
+_PRIVATE_IPV4_192 = re.compile(r"\b192\.168\.\d{1,3}\.\d{1,3}\b")
+_PRIVATE_IPV4_172 = re.compile(r"\b172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}\b")
+_LOCAL_HOSTNAME = re.compile(r"(?:https?://[^\s\"']*|\b)[a-z0-9-]+\.local\b", re.I)
+
+
+def private_network_leak_errors(text: str, *, context: str) -> list[str]:
+    """Return error messages when *text* embeds private hostnames/IPs."""
+    errors: list[str] = []
+    if _PRIVATE_IPV4_10.search(text):
+        errors.append(
+            f"Possible private hostname '10.x' in {context} — "
+            "public distributions must never contain machine-specific URLs"
+        )
+    if _PRIVATE_IPV4_192.search(text):
+        errors.append(
+            f"Possible private hostname '192.168.x' in {context} — "
+            "public distributions must never contain machine-specific URLs"
+        )
+    if _PRIVATE_IPV4_172.search(text):
+        errors.append(
+            f"Possible private hostname '172.16-31.x' in {context} — "
+            "public distributions must never contain machine-specific URLs"
+        )
+    if _LOCAL_HOSTNAME.search(text):
+        errors.append(
+            f"Possible private hostname '.local' in {context} — "
+            "public distributions must never contain machine-specific URLs"
+        )
+    return errors
 
 
 class TargetAdapter(ABC):

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/codex.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/codex.py
@@ -45,7 +45,7 @@ from agent_toolkit.compiler.model import (
     Product,
     Skill,
 )
-from agent_toolkit.compiler.targets.base import TargetAdapter
+from agent_toolkit.compiler.targets.base import TargetAdapter, private_network_leak_errors
 
 # Settings that must never appear in a publicly distributed Codex plugin.
 # These bypass safety mechanisms and are forbidden in any marketplace submission.
@@ -55,8 +55,6 @@ _FORBIDDEN_CODEX_SETTINGS = {
     "disablePermissionPrompts",
     "allowUnsafeCode",
 }
-
-_PRIVATE_HOSTNAME_PATTERNS = (".local", "192.168.", "10.", "172.16.")
 
 
 class CodexAdapter(TargetAdapter):
@@ -196,12 +194,7 @@ class CodexAdapter(TargetAdapter):
                     "in any Codex marketplace submission"
                 )
         text = json.dumps(data)
-        for pattern in _PRIVATE_HOSTNAME_PATTERNS:
-            if pattern in text:
-                errors.append(
-                    f"Possible private hostname '{pattern}' in plugin.json — "
-                    "public distributions must never contain machine-specific URLs"
-                )
+        errors.extend(private_network_leak_errors(text, context="plugin.json"))
         return errors
 
     # ── skills ────────────────────────────────────────────────────────────────

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/opencode.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/opencode.py
@@ -42,7 +42,7 @@ from agent_toolkit.compiler.model import (
     Product,
     Skill,
 )
-from agent_toolkit.compiler.targets.base import TargetAdapter
+from agent_toolkit.compiler.targets.base import TargetAdapter, private_network_leak_errors
 
 # opencode.json safe defaults — NO private providers, NO hardcoded models.
 # Users customize their own ~/.config/opencode/opencode.json.
@@ -132,12 +132,7 @@ class OpenCodeAdapter(TargetAdapter):
                 )
         # Check for private hostnames in the whole JSON blob
         text = json.dumps(data)
-        for pattern in (".local", "192.168.", "10.", "172.16."):
-            if pattern in text:
-                errors.append(
-                    f"Possible private hostname '{pattern}' in opencode.json — "
-                    "public distributions must never contain machine-specific URLs"
-                )
+        errors.extend(private_network_leak_errors(text, context="opencode.json"))
         return errors
 
     # ── skills ────────────────────────────────────────────────────────────────

--- a/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py
@@ -45,15 +45,13 @@ from agent_toolkit.compiler.model import (
     Product,
     Skill,
 )
-from agent_toolkit.compiler.targets.base import TargetAdapter
+from agent_toolkit.compiler.targets.base import TargetAdapter, private_network_leak_errors
 
 # Fields that must never appear in a publicly distributed pi-package.json.
 # Private LAN URLs committed to public packages are a DEFECT-002 class bug.
 _FORBIDDEN_PI_FIELDS = {
     "private",  # marks private packages — companion packs should be public
 }
-
-_PRIVATE_HOSTNAME_PATTERNS = (".local", "192.168.", "10.", "172.16.")
 
 
 class PiAdapter(TargetAdapter):
@@ -200,12 +198,7 @@ class PiAdapter(TargetAdapter):
                     "companion packs should be publishable (not private)"
                 )
         text = json.dumps(data)
-        for pattern in _PRIVATE_HOSTNAME_PATTERNS:
-            if pattern in text:
-                errors.append(
-                    f"Possible private hostname '{pattern}' in pi-package.json — "
-                    "public distributions must never contain machine-specific URLs"
-                )
+        errors.extend(private_network_leak_errors(text, context="pi-package.json"))
         return errors
 
     # ── skills ────────────────────────────────────────────────────────────────

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/gh_gate.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/gh_gate.py
@@ -11,7 +11,7 @@ mutating GitHub CLI commands and enforces LOOP.md allowlist / deny / tier
 rules. Merge and close additionally require a verifier receipt under the
 active run directory.
 
-Environment (set by bin/loop):
+Environment (set by agent-toolkit loop / install_gh_shim):
   LOOP_GATE_REAL_GH       Absolute path to the real `gh` binary
   LOOP_GATE_RUN_DIR       Active run artifacts directory
   LOOP_GATE_TIER          L1 | L2 | L3
@@ -20,6 +20,11 @@ Environment (set by bin/loop):
   LOOP_GATE_VERIFIER      Verifier skill/agent name (optional)
   LOOP_GATE_RECEIPT_SECRET  If set, verifier receipts must carry a matching HMAC
   LOOP_GATE_DISABLED      If "1", pass through without checks (tests only)
+  LOOP_GATE_ATTRIBUTION   "1" (default) or "0" to disable comment attribution
+  LOOP_GATE_LOOP_NAME     Loop name for attribution footer (optional)
+  LOOP_GATE_GITHUB_LOGIN  Authenticated GitHub login (optional; resolved at install)
+  LOOP_GATE_ATTRIBUTION_TEMPLATE  Optional custom prefix template with
+                                  {login} and {loop} placeholders
 
 Usage (normally via shim):
   loop-gh-gate -- pr merge 123 --repo owner/repo --squash
@@ -62,11 +67,31 @@ RECEIPT_REQUIRED = frozenset({"merge", "close"})
 # Max age for a verifier receipt (seconds).
 RECEIPT_MAX_AGE_SEC = 3600
 
+# Outbound prose posted via gh that should carry AI attribution (default ON).
+ATTRIBUTION_ACTIONS = frozenset({"comment"})
+
+ATTRIBUTION_MARKER = "> 🤖 AI-assisted"
+
+DEFAULT_ATTRIBUTION_TEMPLATE = (
+    "> 🤖 AI-assisted message posted as `@{login}` by "
+    "[agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit)"
+    "{loop_suffix}."
+)
+
+AGENT_TOOLKIT_REPO_URL = "https://github.com/ulises-jeremias/agent-toolkit"
+
 
 def _split_csv(value: str | None) -> list[str]:
     if not value:
         return []
     return [p.strip() for p in value.split(",") if p.strip()]
+
+
+def _env_flag_enabled(name: str, *, default: bool = True) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
 
 
 def gate_config_from_env() -> dict[str, Any]:
@@ -81,6 +106,10 @@ def gate_config_from_env() -> dict[str, Any]:
         "verifier": os.environ.get("LOOP_GATE_VERIFIER") or "",
         "receipt_secret": os.environ.get("LOOP_GATE_RECEIPT_SECRET") or "",
         "disabled": os.environ.get("LOOP_GATE_DISABLED") == "1",
+        "attribution_enabled": _env_flag_enabled("LOOP_GATE_ATTRIBUTION", default=True),
+        "loop_name": os.environ.get("LOOP_GATE_LOOP_NAME") or "",
+        "github_login": os.environ.get("LOOP_GATE_GITHUB_LOGIN") or "",
+        "attribution_template": os.environ.get("LOOP_GATE_ATTRIBUTION_TEMPLATE") or "",
     }
 
 
@@ -521,6 +550,211 @@ def check_command(
     return True, reason, action, meta
 
 
+def body_already_attributed(body: str) -> bool:
+    """Return True when the body already starts with the AI-assisted marker."""
+    return body.lstrip().startswith(ATTRIBUTION_MARKER)
+
+
+def format_attribution_prefix(
+    *,
+    login: str = "",
+    loop_name: str = "",
+    template: str = "",
+) -> str:
+    """Build the markdown attribution blockquote line(s)."""
+    login_s = (login or "unknown").lstrip("@")
+    loop_s = (loop_name or "").strip()
+    loop_suffix = f" (`{loop_s}`)" if loop_s else ""
+    raw = (template or "").strip() or DEFAULT_ATTRIBUTION_TEMPLATE
+    try:
+        text = raw.format(
+            login=login_s,
+            loop=loop_s or "loop",
+            loop_suffix=loop_suffix,
+            url=AGENT_TOOLKIT_REPO_URL,
+        )
+    except (KeyError, ValueError, IndexError):
+        text = DEFAULT_ATTRIBUTION_TEMPLATE.format(
+            login=login_s,
+            loop_suffix=loop_suffix,
+        )
+    text = text.rstrip()
+    if not text.startswith(">"):
+        text = f"> {text}"
+    return text
+
+
+def apply_attribution_to_body(body: str, prefix: str) -> str:
+    """Prepend attribution when missing. Idempotent."""
+    if body_already_attributed(body):
+        return body
+    prefix = prefix.rstrip()
+    if not body:
+        return f"{prefix}\n"
+    return f"{prefix}\n\n{body.lstrip()}"
+
+
+def resolve_github_login(real_gh: str | None = None) -> str:
+    """Resolve the authenticated GitHub login via `gh api user`."""
+    cached = os.environ.get("LOOP_GATE_GITHUB_LOGIN") or ""
+    if cached:
+        return cached
+    real = real_gh or shutil_which_gh() or os.environ.get("LOOP_GATE_REAL_GH") or ""
+    if not real:
+        return ""
+    try:
+        result = subprocess.run(
+            [real, "api", "user", "-q", ".login"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return (result.stdout or "").strip()
+
+
+def _rewrite_flag_value(
+    argv: list[str],
+    *,
+    flags: tuple[str, ...],
+    new_value: str,
+) -> tuple[list[str], bool]:
+    """Replace the value for any of the given CLI flags. Returns (argv, changed)."""
+    out = list(argv)
+    changed = False
+    i = 0
+    while i < len(out):
+        a = out[i]
+        for flag in flags:
+            if a == flag and i + 1 < len(out):
+                out[i + 1] = new_value
+                changed = True
+                i += 2
+                break
+            if a.startswith(f"{flag}="):
+                out[i] = f"{flag}={new_value}"
+                changed = True
+                i += 1
+                break
+        else:
+            i += 1
+    return out, changed
+
+
+def _rewrite_field_body(argv: list[str], new_body: str) -> tuple[list[str], bool]:
+    """Rewrite `-f body=` / `-F body=` / `--raw-field body=` style args."""
+    out = list(argv)
+    changed = False
+    field_flags = ("-f", "-F", "--field", "--raw-field")
+    i = 0
+    while i < len(out):
+        a = out[i]
+        if a in field_flags and i + 1 < len(out) and out[i + 1].startswith("body="):
+            out[i + 1] = f"body={new_body}"
+            changed = True
+            i += 2
+            continue
+        for flag in field_flags:
+            prefix = f"{flag}body="
+            # gh allows -fbody=value without space
+            if a.startswith(prefix) or a.startswith(f"{flag} body="):
+                out[i] = f"{flag}body={new_body}" if not a.startswith(f"{flag} ") else a
+                if a.startswith(prefix):
+                    out[i] = f"{prefix}{new_body}"
+                    changed = True
+            elif a.startswith("-f") and a[2:].startswith("body="):
+                out[i] = f"-fbody={new_body}"
+                changed = True
+            elif a.startswith("-F") and a[2:].startswith("body="):
+                out[i] = f"-Fbody={new_body}"
+                changed = True
+        i += 1
+    return out, changed
+
+
+def inject_attribution_argv(
+    argv: list[str],
+    *,
+    prefix: str,
+    run_dir: Path | None = None,
+) -> tuple[list[str], bool]:
+    """Rewrite gh argv so comment/review bodies include attribution.
+
+    Supports ``--body`` / ``-b``, ``--body-file``, and ``-f/-F body=``.
+    Returns (new_argv, injected).
+    """
+    # --body / -b
+    body_flags = ("--body", "-b")
+    for i, a in enumerate(argv):
+        for flag in body_flags:
+            if a == flag and i + 1 < len(argv):
+                new_body = apply_attribution_to_body(argv[i + 1], prefix)
+                if new_body == argv[i + 1]:
+                    return list(argv), False
+                out, _ = _rewrite_flag_value(argv, flags=body_flags, new_value=new_body)
+                return out, True
+            if a.startswith(f"{flag}="):
+                raw = a.split("=", 1)[1]
+                new_body = apply_attribution_to_body(raw, prefix)
+                if new_body == raw:
+                    return list(argv), False
+                out, _ = _rewrite_flag_value(argv, flags=body_flags, new_value=new_body)
+                return out, True
+
+    # --body-file
+    for i, a in enumerate(argv):
+        path_s: str | None = None
+        flag_eq = False
+        if a in ("--body-file",) and i + 1 < len(argv):
+            path_s = argv[i + 1]
+        elif a.startswith("--body-file="):
+            path_s = a.split("=", 1)[1]
+            flag_eq = True
+        if path_s is None:
+            continue
+        try:
+            original = Path(path_s).read_text(encoding="utf-8")
+        except OSError:
+            return list(argv), False
+        new_body = apply_attribution_to_body(original, prefix)
+        if new_body == original:
+            return list(argv), False
+        dest_dir = (run_dir / ".gate") if run_dir else Path(path_s).parent
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"attributed-body-{hashlib.sha256(new_body.encode()).hexdigest()[:10]}.md"
+        dest.write_text(new_body, encoding="utf-8")
+        if flag_eq:
+            out = list(argv)
+            out[i] = f"--body-file={dest}"
+            return out, True
+        out, _ = _rewrite_flag_value(argv, flags=("--body-file",), new_value=str(dest))
+        return out, True
+
+    # -f / -F body=
+    for i, a in enumerate(argv):
+        field_flags = ("-f", "-F", "--field", "--raw-field")
+        if a in field_flags and i + 1 < len(argv) and argv[i + 1].startswith("body="):
+            raw = argv[i + 1].split("=", 1)[1]
+            new_body = apply_attribution_to_body(raw, prefix)
+            if new_body == raw:
+                return list(argv), False
+            return _rewrite_field_body(argv, new_body)
+        for flag in ("-f", "-F"):
+            prefix_f = f"{flag}body="
+            if a.startswith(prefix_f):
+                raw = a[len(prefix_f) :]
+                new_body = apply_attribution_to_body(raw, prefix)
+                if new_body == raw:
+                    return list(argv), False
+                return _rewrite_field_body(argv, new_body)
+
+    return list(argv), False
+
+
 def install_gh_shim(
     run_dir: Path,
     *,
@@ -530,6 +764,10 @@ def install_gh_shim(
     verifier: str = "",
     gate_script: Path | None = None,
     real_gh: str | None = None,
+    attribution_enabled: bool = True,
+    loop_name: str = "",
+    github_login: str = "",
+    attribution_template: str = "",
 ) -> dict[str, str]:
     """Create a PATH-first `gh` shim and return env vars for the runner."""
     real = real_gh or shutil_which_gh()
@@ -550,6 +788,8 @@ def install_gh_shim(
     )
     shim.chmod(0o755)
 
+    login = github_login or resolve_github_login(real)
+
     env = os.environ.copy()
     env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', '')}"
     env["LOOP_GATE_REAL_GH"] = real
@@ -558,6 +798,13 @@ def install_gh_shim(
     env["LOOP_GATE_ALLOWLIST"] = ",".join(allowlist)
     env["LOOP_GATE_DENY"] = ",".join(deny)
     env["LOOP_GATE_VERIFIER"] = verifier
+    env["LOOP_GATE_ATTRIBUTION"] = "1" if attribution_enabled else "0"
+    if loop_name:
+        env["LOOP_GATE_LOOP_NAME"] = loop_name
+    if login:
+        env["LOOP_GATE_GITHUB_LOGIN"] = login
+    if attribution_template:
+        env["LOOP_GATE_ATTRIBUTION_TEMPLATE"] = attribution_template
     # Preserve receipt secret from the parent environment when present.
     if os.environ.get("LOOP_GATE_RECEIPT_SECRET"):
         env["LOOP_GATE_RECEIPT_SECRET"] = os.environ["LOOP_GATE_RECEIPT_SECRET"]
@@ -628,6 +875,25 @@ def main(argv: list[str] | None = None) -> int:
         print("[loop-gh-gate] real gh not found (LOOP_GATE_REAL_GH unset)", file=sys.stderr)
         return 127
 
+    attribution_injected = False
+    if (
+        action in ATTRIBUTION_ACTIONS
+        and cfg.get("attribution_enabled", True)
+        and not cfg.get("disabled")
+    ):
+        login = str(cfg.get("github_login") or "") or resolve_github_login(str(real))
+        prefix = format_attribution_prefix(
+            login=login,
+            loop_name=str(cfg.get("loop_name") or ""),
+            template=str(cfg.get("attribution_template") or ""),
+        )
+        run_dir = cfg.get("run_dir")
+        gh_args, attribution_injected = inject_attribution_argv(
+            gh_args,
+            prefix=prefix,
+            run_dir=Path(run_dir) if run_dir else None,
+        )
+
     if action:
         # Audit allowed mutations.
         run_dir = cfg.get("run_dir")
@@ -643,6 +909,7 @@ def main(argv: list[str] | None = None) -> int:
                             "reason": reason,
                             "argv": redact_argv(gh_args),
                             "meta": {k: v for k, v in meta.items() if k != "raw"},
+                            "attribution_injected": attribution_injected,
                         }
                     )
                     + "\n"

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/loop-gh-gate
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/loop-gh-gate
@@ -11,7 +11,7 @@ mutating GitHub CLI commands and enforces LOOP.md allowlist / deny / tier
 rules. Merge and close additionally require a verifier receipt under the
 active run directory.
 
-Environment (set by bin/loop):
+Environment (set by agent-toolkit loop / install_gh_shim):
   LOOP_GATE_REAL_GH       Absolute path to the real `gh` binary
   LOOP_GATE_RUN_DIR       Active run artifacts directory
   LOOP_GATE_TIER          L1 | L2 | L3
@@ -20,12 +20,18 @@ Environment (set by bin/loop):
   LOOP_GATE_VERIFIER      Verifier skill/agent name (optional)
   LOOP_GATE_RECEIPT_SECRET  If set, verifier receipts must carry a matching HMAC
   LOOP_GATE_DISABLED      If "1", pass through without checks (tests only)
+  LOOP_GATE_ATTRIBUTION   "1" (default) or "0" to disable comment attribution
+  LOOP_GATE_LOOP_NAME     Loop name for attribution footer (optional)
+  LOOP_GATE_GITHUB_LOGIN  Authenticated GitHub login (optional; resolved at install)
+  LOOP_GATE_ATTRIBUTION_TEMPLATE  Optional custom prefix template with
+                                  {login} and {loop} placeholders
 
 Usage (normally via shim):
   loop-gh-gate -- pr merge 123 --repo owner/repo --squash
   loop-gh-gate --classify pr merge 123 --repo owner/repo
   loop-gh-gate --check-receipt merge --repo owner/repo --number 123
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -39,26 +45,40 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 # Actions that mutate GitHub state and must be gated.
-MUTATING_ACTIONS = frozenset({
-    "merge",
-    "close",
-    "comment",
-    "label",
-    "assign",
-    "approve",
-    "push",
-    "commit",
-    "force-push",
-    "delete",
-})
+MUTATING_ACTIONS = frozenset(
+    {
+        "merge",
+        "close",
+        "comment",
+        "label",
+        "assign",
+        "approve",
+        "push",
+        "commit",
+        "force-push",
+        "delete",
+    }
+)
 
 # Merge/close always need a verifier receipt at L2+ (and are denied at L1).
 RECEIPT_REQUIRED = frozenset({"merge", "close"})
 
 # Max age for a verifier receipt (seconds).
 RECEIPT_MAX_AGE_SEC = 3600
+
+# Outbound prose posted via gh that should carry AI attribution (default ON).
+ATTRIBUTION_ACTIONS = frozenset({"comment"})
+
+ATTRIBUTION_MARKER = "> 🤖 AI-assisted"
+
+DEFAULT_ATTRIBUTION_TEMPLATE = (
+    "> 🤖 AI-assisted message posted as `@{login}` by "
+    "[agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit)"
+    "{loop_suffix}."
+)
+
+AGENT_TOOLKIT_REPO_URL = "https://github.com/ulises-jeremias/agent-toolkit"
 
 
 def _split_csv(value: str | None) -> list[str]:
@@ -67,23 +87,48 @@ def _split_csv(value: str | None) -> list[str]:
     return [p.strip() for p in value.split(",") if p.strip()]
 
 
+def _env_flag_enabled(name: str, *, default: bool = True) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
 def gate_config_from_env() -> dict[str, Any]:
     return {
         "real_gh": os.environ.get("LOOP_GATE_REAL_GH", ""),
-        "run_dir": Path(os.environ["LOOP_GATE_RUN_DIR"]) if os.environ.get("LOOP_GATE_RUN_DIR") else None,
+        "run_dir": Path(os.environ["LOOP_GATE_RUN_DIR"])
+        if os.environ.get("LOOP_GATE_RUN_DIR")
+        else None,
         "tier": (os.environ.get("LOOP_GATE_TIER") or "L1").upper(),
         "allowlist": _split_csv(os.environ.get("LOOP_GATE_ALLOWLIST")),
         "deny": _split_csv(os.environ.get("LOOP_GATE_DENY")),
         "verifier": os.environ.get("LOOP_GATE_VERIFIER") or "",
         "receipt_secret": os.environ.get("LOOP_GATE_RECEIPT_SECRET") or "",
         "disabled": os.environ.get("LOOP_GATE_DISABLED") == "1",
+        "attribution_enabled": _env_flag_enabled("LOOP_GATE_ATTRIBUTION", default=True),
+        "loop_name": os.environ.get("LOOP_GATE_LOOP_NAME") or "",
+        "github_login": os.environ.get("LOOP_GATE_GITHUB_LOGIN") or "",
+        "attribution_template": os.environ.get("LOOP_GATE_ATTRIBUTION_TEMPLATE") or "",
     }
 
 
-_SENSITIVE_FLAGS = frozenset({
-    "-H", "--header", "-b", "--body", "--body-file", "-F", "-f",
-    "--raw-field", "--field", "--input", "-i", "--jq",
-})
+_SENSITIVE_FLAGS = frozenset(
+    {
+        "-H",
+        "--header",
+        "-b",
+        "--body",
+        "--body-file",
+        "-F",
+        "-f",
+        "--raw-field",
+        "--field",
+        "--input",
+        "-i",
+        "--jq",
+    }
+)
 
 
 def redact_argv(argv: list[str]) -> list[str]:
@@ -295,7 +340,15 @@ def tier_forbids(tier: str, action: str) -> str | None:
     t = tier.upper()
     if t.startswith("L1") or t == "1":
         return f"L1 report-only forbids '{action}'"
-    if (t.startswith("L2") or t == "2") and action in ("merge", "close", "approve", "push", "commit", "force-push", "delete"):
+    if (t.startswith("L2") or t == "2") and action in (
+        "merge",
+        "close",
+        "approve",
+        "push",
+        "commit",
+        "force-push",
+        "delete",
+    ):
         return f"L2 assisted forbids '{action}' (allow comment/label/assign only)"
     return None
 
@@ -435,7 +488,7 @@ def require_receipt(
     if action not in RECEIPT_REQUIRED:
         return True, "receipt not required"
     if repo is None or number is None:
-        return False, f"merge/close require --repo and PR/issue number for receipt binding"
+        return False, "merge/close require --repo and PR/issue number for receipt binding"
     receipt = find_verifier_receipt(
         run_dir,
         action,
@@ -497,6 +550,211 @@ def check_command(
     return True, reason, action, meta
 
 
+def body_already_attributed(body: str) -> bool:
+    """Return True when the body already starts with the AI-assisted marker."""
+    return body.lstrip().startswith(ATTRIBUTION_MARKER)
+
+
+def format_attribution_prefix(
+    *,
+    login: str = "",
+    loop_name: str = "",
+    template: str = "",
+) -> str:
+    """Build the markdown attribution blockquote line(s)."""
+    login_s = (login or "unknown").lstrip("@")
+    loop_s = (loop_name or "").strip()
+    loop_suffix = f" (`{loop_s}`)" if loop_s else ""
+    raw = (template or "").strip() or DEFAULT_ATTRIBUTION_TEMPLATE
+    try:
+        text = raw.format(
+            login=login_s,
+            loop=loop_s or "loop",
+            loop_suffix=loop_suffix,
+            url=AGENT_TOOLKIT_REPO_URL,
+        )
+    except (KeyError, ValueError, IndexError):
+        text = DEFAULT_ATTRIBUTION_TEMPLATE.format(
+            login=login_s,
+            loop_suffix=loop_suffix,
+        )
+    text = text.rstrip()
+    if not text.startswith(">"):
+        text = f"> {text}"
+    return text
+
+
+def apply_attribution_to_body(body: str, prefix: str) -> str:
+    """Prepend attribution when missing. Idempotent."""
+    if body_already_attributed(body):
+        return body
+    prefix = prefix.rstrip()
+    if not body:
+        return f"{prefix}\n"
+    return f"{prefix}\n\n{body.lstrip()}"
+
+
+def resolve_github_login(real_gh: str | None = None) -> str:
+    """Resolve the authenticated GitHub login via `gh api user`."""
+    cached = os.environ.get("LOOP_GATE_GITHUB_LOGIN") or ""
+    if cached:
+        return cached
+    real = real_gh or shutil_which_gh() or os.environ.get("LOOP_GATE_REAL_GH") or ""
+    if not real:
+        return ""
+    try:
+        result = subprocess.run(
+            [real, "api", "user", "-q", ".login"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return (result.stdout or "").strip()
+
+
+def _rewrite_flag_value(
+    argv: list[str],
+    *,
+    flags: tuple[str, ...],
+    new_value: str,
+) -> tuple[list[str], bool]:
+    """Replace the value for any of the given CLI flags. Returns (argv, changed)."""
+    out = list(argv)
+    changed = False
+    i = 0
+    while i < len(out):
+        a = out[i]
+        for flag in flags:
+            if a == flag and i + 1 < len(out):
+                out[i + 1] = new_value
+                changed = True
+                i += 2
+                break
+            if a.startswith(f"{flag}="):
+                out[i] = f"{flag}={new_value}"
+                changed = True
+                i += 1
+                break
+        else:
+            i += 1
+    return out, changed
+
+
+def _rewrite_field_body(argv: list[str], new_body: str) -> tuple[list[str], bool]:
+    """Rewrite `-f body=` / `-F body=` / `--raw-field body=` style args."""
+    out = list(argv)
+    changed = False
+    field_flags = ("-f", "-F", "--field", "--raw-field")
+    i = 0
+    while i < len(out):
+        a = out[i]
+        if a in field_flags and i + 1 < len(out) and out[i + 1].startswith("body="):
+            out[i + 1] = f"body={new_body}"
+            changed = True
+            i += 2
+            continue
+        for flag in field_flags:
+            prefix = f"{flag}body="
+            # gh allows -fbody=value without space
+            if a.startswith(prefix) or a.startswith(f"{flag} body="):
+                out[i] = f"{flag}body={new_body}" if not a.startswith(f"{flag} ") else a
+                if a.startswith(prefix):
+                    out[i] = f"{prefix}{new_body}"
+                    changed = True
+            elif a.startswith("-f") and a[2:].startswith("body="):
+                out[i] = f"-fbody={new_body}"
+                changed = True
+            elif a.startswith("-F") and a[2:].startswith("body="):
+                out[i] = f"-Fbody={new_body}"
+                changed = True
+        i += 1
+    return out, changed
+
+
+def inject_attribution_argv(
+    argv: list[str],
+    *,
+    prefix: str,
+    run_dir: Path | None = None,
+) -> tuple[list[str], bool]:
+    """Rewrite gh argv so comment/review bodies include attribution.
+
+    Supports ``--body`` / ``-b``, ``--body-file``, and ``-f/-F body=``.
+    Returns (new_argv, injected).
+    """
+    # --body / -b
+    body_flags = ("--body", "-b")
+    for i, a in enumerate(argv):
+        for flag in body_flags:
+            if a == flag and i + 1 < len(argv):
+                new_body = apply_attribution_to_body(argv[i + 1], prefix)
+                if new_body == argv[i + 1]:
+                    return list(argv), False
+                out, _ = _rewrite_flag_value(argv, flags=body_flags, new_value=new_body)
+                return out, True
+            if a.startswith(f"{flag}="):
+                raw = a.split("=", 1)[1]
+                new_body = apply_attribution_to_body(raw, prefix)
+                if new_body == raw:
+                    return list(argv), False
+                out, _ = _rewrite_flag_value(argv, flags=body_flags, new_value=new_body)
+                return out, True
+
+    # --body-file
+    for i, a in enumerate(argv):
+        path_s: str | None = None
+        flag_eq = False
+        if a in ("--body-file",) and i + 1 < len(argv):
+            path_s = argv[i + 1]
+        elif a.startswith("--body-file="):
+            path_s = a.split("=", 1)[1]
+            flag_eq = True
+        if path_s is None:
+            continue
+        try:
+            original = Path(path_s).read_text(encoding="utf-8")
+        except OSError:
+            return list(argv), False
+        new_body = apply_attribution_to_body(original, prefix)
+        if new_body == original:
+            return list(argv), False
+        dest_dir = (run_dir / ".gate") if run_dir else Path(path_s).parent
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"attributed-body-{hashlib.sha256(new_body.encode()).hexdigest()[:10]}.md"
+        dest.write_text(new_body, encoding="utf-8")
+        if flag_eq:
+            out = list(argv)
+            out[i] = f"--body-file={dest}"
+            return out, True
+        out, _ = _rewrite_flag_value(argv, flags=("--body-file",), new_value=str(dest))
+        return out, True
+
+    # -f / -F body=
+    for i, a in enumerate(argv):
+        field_flags = ("-f", "-F", "--field", "--raw-field")
+        if a in field_flags and i + 1 < len(argv) and argv[i + 1].startswith("body="):
+            raw = argv[i + 1].split("=", 1)[1]
+            new_body = apply_attribution_to_body(raw, prefix)
+            if new_body == raw:
+                return list(argv), False
+            return _rewrite_field_body(argv, new_body)
+        for flag in ("-f", "-F"):
+            prefix_f = f"{flag}body="
+            if a.startswith(prefix_f):
+                raw = a[len(prefix_f) :]
+                new_body = apply_attribution_to_body(raw, prefix)
+                if new_body == raw:
+                    return list(argv), False
+                return _rewrite_field_body(argv, new_body)
+
+    return list(argv), False
+
+
 def install_gh_shim(
     run_dir: Path,
     *,
@@ -506,6 +764,10 @@ def install_gh_shim(
     verifier: str = "",
     gate_script: Path | None = None,
     real_gh: str | None = None,
+    attribution_enabled: bool = True,
+    loop_name: str = "",
+    github_login: str = "",
+    attribution_template: str = "",
 ) -> dict[str, str]:
     """Create a PATH-first `gh` shim and return env vars for the runner."""
     real = real_gh or shutil_which_gh()
@@ -526,6 +788,8 @@ def install_gh_shim(
     )
     shim.chmod(0o755)
 
+    login = github_login or resolve_github_login(real)
+
     env = os.environ.copy()
     env["PATH"] = f"{shim_dir}{os.pathsep}{env.get('PATH', '')}"
     env["LOOP_GATE_REAL_GH"] = real
@@ -534,6 +798,13 @@ def install_gh_shim(
     env["LOOP_GATE_ALLOWLIST"] = ",".join(allowlist)
     env["LOOP_GATE_DENY"] = ",".join(deny)
     env["LOOP_GATE_VERIFIER"] = verifier
+    env["LOOP_GATE_ATTRIBUTION"] = "1" if attribution_enabled else "0"
+    if loop_name:
+        env["LOOP_GATE_LOOP_NAME"] = loop_name
+    if login:
+        env["LOOP_GATE_GITHUB_LOGIN"] = login
+    if attribution_template:
+        env["LOOP_GATE_ATTRIBUTION_TEMPLATE"] = attribution_template
     # Preserve receipt secret from the parent environment when present.
     if os.environ.get("LOOP_GATE_RECEIPT_SECRET"):
         env["LOOP_GATE_RECEIPT_SECRET"] = os.environ["LOOP_GATE_RECEIPT_SECRET"]
@@ -543,6 +814,7 @@ def install_gh_shim(
 
 def shutil_which_gh() -> str | None:
     import shutil
+
     # Prefer a real gh that is NOT our shim (avoid recursion if already gated).
     path = os.environ.get("PATH", "")
     for directory in path.split(os.pathsep):
@@ -603,20 +875,45 @@ def main(argv: list[str] | None = None) -> int:
         print("[loop-gh-gate] real gh not found (LOOP_GATE_REAL_GH unset)", file=sys.stderr)
         return 127
 
+    attribution_injected = False
+    if (
+        action in ATTRIBUTION_ACTIONS
+        and cfg.get("attribution_enabled", True)
+        and not cfg.get("disabled")
+    ):
+        login = str(cfg.get("github_login") or "") or resolve_github_login(str(real))
+        prefix = format_attribution_prefix(
+            login=login,
+            loop_name=str(cfg.get("loop_name") or ""),
+            template=str(cfg.get("attribution_template") or ""),
+        )
+        run_dir = cfg.get("run_dir")
+        gh_args, attribution_injected = inject_attribution_argv(
+            gh_args,
+            prefix=prefix,
+            run_dir=Path(run_dir) if run_dir else None,
+        )
+
     if action:
         # Audit allowed mutations.
         run_dir = cfg.get("run_dir")
         if run_dir:
             audit = Path(run_dir) / "gate-allow.jsonl"
             with audit.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps({
-                    "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "kind": "allowed",
-                    "action": action,
-                    "reason": reason,
-                    "argv": redact_argv(gh_args),
-                    "meta": {k: v for k, v in meta.items() if k != "raw"},
-                }) + "\n")
+                fh.write(
+                    json.dumps(
+                        {
+                            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "kind": "allowed",
+                            "action": action,
+                            "reason": reason,
+                            "argv": redact_argv(gh_args),
+                            "meta": {k: v for k, v in meta.items() if k != "raw"},
+                            "attribution_injected": attribution_injected,
+                        }
+                    )
+                    + "\n"
+                )
 
     result = subprocess.run([real, *gh_args])
     return int(result.returncode)

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
@@ -610,6 +610,37 @@ def _as_str_list(value: Any) -> list[str]:
     return []
 
 
+def _parse_attribution_config(meta: dict[str, Any]) -> dict[str, Any]:
+    """Parse LOOP.md / loop.yaml ``attribution`` field.
+
+    Default: enabled. Accepts ``false``, ``true``, or a mapping with
+    ``enabled`` / ``template``.
+    """
+    raw = meta.get("attribution", True)
+    if raw is False or raw is None:
+        return {"enabled": False, "template": ""}
+    if raw is True:
+        return {"enabled": True, "template": ""}
+    if isinstance(raw, (int, float)):
+        return {"enabled": bool(raw), "template": ""}
+    if isinstance(raw, str):
+        low = raw.strip().lower()
+        if low in {"0", "false", "no", "off", "disabled"}:
+            return {"enabled": False, "template": ""}
+        if low in {"1", "true", "yes", "on", "enabled"}:
+            return {"enabled": True, "template": ""}
+        return {"enabled": True, "template": raw}
+    if isinstance(raw, dict):
+        enabled_raw = raw.get("enabled", True)
+        if isinstance(enabled_raw, str):
+            enabled = enabled_raw.strip().lower() not in {"0", "false", "no", "off"}
+        else:
+            enabled = bool(enabled_raw)
+        template = str(raw.get("template") or "")
+        return {"enabled": enabled, "template": template}
+    return {"enabled": True, "template": ""}
+
+
 def _load_request_body(loop_dir: Path, meta: dict[str, Any], loop_name: str) -> str:
     """Prefer request.md; fall back to LOOP.md goal / generic execute line."""
     request_md = loop_dir / "request.md"
@@ -677,6 +708,23 @@ def _autonomy_contract(meta: dict[str, Any], loop_dir: Path) -> str:
         "- When `LOOP_GATE_RECEIPT_SECRET` is set, receipts must include "
         "`sig` (HMAC-SHA256 hex of the canonical JSON payload).",
         "- Receipts require exact repo + number + verifier match and expire after 1 hour.",
+    ]
+
+    attr = _parse_attribution_config(meta)
+    if attr["enabled"]:
+        lines += [
+            "- Comment/review attribution (default ON): outbound `gh` comment/review "
+            "bodies are prefixed with `> 🤖 AI-assisted …` by the hard gate if missing. "
+            "Do not invent a different disclaimer; the gate injects the canonical one. "
+            "Set `attribution: false` (or `attribution.enabled: false`) in LOOP.md to disable.",
+        ]
+    else:
+        lines += [
+            "- Comment/review attribution: DISABLED for this loop "
+            "(`attribution.enabled: false`).",
+        ]
+
+    lines += [
         "",
         "Before finishing:",
         f"1. Update `{loop_dir / 'STATE.md'}` frontmatter `pending:` and `escalations:` "
@@ -740,17 +788,34 @@ def _runner_env(run_dir: Path, meta: dict[str, Any]) -> dict[str, str]:
         allow = _as_str_list(meta.get("allowlist"))
         deny = _as_str_list(meta.get("deny"))
         verifier = str(meta.get("verifier") or "")
-        env = mod["install_gh_shim"](
-            run_dir,
-            tier=tier,
-            allowlist=allow,
-            deny=deny,
-            verifier=verifier,
-            gate_script=gate_path,
-        )
+        attr = _parse_attribution_config(meta)
+        loop_name = str(meta.get("name") or run_dir.parent.parent.name)
+        # Prefer keyword args when the gate supports attribution; fall back for
+        # older copied loop-gh-gate binaries that only accept the classic kwargs.
+        install_kwargs: dict[str, Any] = {
+            "tier": tier,
+            "allowlist": allow,
+            "deny": deny,
+            "verifier": verifier,
+            "gate_script": gate_path,
+            "attribution_enabled": bool(attr["enabled"]),
+            "loop_name": loop_name,
+            "attribution_template": str(attr.get("template") or ""),
+        }
+        try:
+            env = mod["install_gh_shim"](run_dir, **install_kwargs)
+        except TypeError:
+            for key in (
+                "attribution_enabled",
+                "loop_name",
+                "attribution_template",
+            ):
+                install_kwargs.pop(key, None)
+            env = mod["install_gh_shim"](run_dir, **install_kwargs)
+        attr_label = "on" if attr["enabled"] else "off"
         log(
             f"Hard gate active: gh shim → allow=[{', '.join(allow) or '∅'}] "
-            f"deny=[{', '.join(deny) or '∅'}]"
+            f"deny=[{', '.join(deny) or '∅'}] attribution={attr_label}"
         )
         return env
     except Exception as exc:  # noqa: BLE001

--- a/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/loop/runner.py
@@ -720,8 +720,7 @@ def _autonomy_contract(meta: dict[str, Any], loop_dir: Path) -> str:
         ]
     else:
         lines += [
-            "- Comment/review attribution: DISABLED for this loop "
-            "(`attribution.enabled: false`).",
+            "- Comment/review attribution: DISABLED for this loop (`attribution.enabled: false`).",
         ]
 
     lines += [

--- a/schemas/loop.schema.json
+++ b/schemas/loop.schema.json
@@ -114,6 +114,31 @@
       "description": "Whether the loop writes STATE.md checkpoints so it can resume from the last processed item after interruption",
       "default": false
     },
+    "attribution": {
+      "description": "AI disclosure for outbound gh comments/reviews. Default ON; hard gate prepends a `> 🤖 AI-assisted …` blockquote when missing. Set false to disable.",
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "true (default) enables attribution; false disables it for this loop"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether the hard gate injects attribution into comment/review bodies",
+              "default": true
+            },
+            "template": {
+              "type": "string",
+              "description": "Optional custom prefix template. Placeholders: {login}, {loop}, {loop_suffix}, {url}"
+            }
+          }
+        }
+      ],
+      "default": true
+    },
     "request": {
       "type": "string",
       "description": "The full prompt/instructions passed to the agent at each run. Should be self-contained and include all steps."

--- a/tests/compiler/test_codex_adapter.py
+++ b/tests/compiler/test_codex_adapter.py
@@ -290,6 +290,30 @@ def test_validate_detects_private_hostname():
     assert len(errors) > 0, "Should detect private .local hostname"
 
 
+def test_validate_accepts_semver_with_ten_minor():
+    """Regression: version 1.10.0 must not trip the private 10.x IP check."""
+    errors = CodexAdapter.validate_plugin_json(
+        {
+            "name": "agent-toolkit-core",
+            "version": "1.10.0",
+            "description": "Agent Toolkit for Codex",
+            "maturity": "experimental",
+            "license": "MIT",
+        }
+    )
+    assert errors == [], f"Semver 1.10.0 wrongly rejected: {errors}"
+
+
+def test_validate_detects_private_10_dot_ip():
+    errors = CodexAdapter.validate_plugin_json(
+        {
+            "name": "test",
+            "server": "http://10.0.0.5:8080",
+        }
+    )
+    assert len(errors) > 0, "Should detect private 10.x.x.x IP"
+
+
 def test_validate_accepts_safe_manifest():
     errors = CodexAdapter.validate_plugin_json(
         {

--- a/tests/test_loop_attribution.py
+++ b/tests/test_loop_attribution.py
@@ -1,0 +1,100 @@
+"""AI-assisted comment attribution for loop-gh-gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_toolkit.loop import gh_gate
+from agent_toolkit.loop.runner import _parse_attribution_config
+
+
+def test_format_attribution_prefix_includes_login_and_loop() -> None:
+    text = gh_gate.format_attribution_prefix(login="ulises-jeremias", loop_name="oss-triage")
+    assert text.startswith("> 🤖 AI-assisted")
+    assert "`@ulises-jeremias`" in text
+    assert "(`oss-triage`)" in text
+    assert "https://github.com/ulises-jeremias/agent-toolkit" in text
+
+
+def test_apply_attribution_is_idempotent() -> None:
+    prefix = gh_gate.format_attribution_prefix(login="me", loop_name="x")
+    once = gh_gate.apply_attribution_to_body("Hello world", prefix)
+    twice = gh_gate.apply_attribution_to_body(once, prefix)
+    assert once == twice
+    assert once.startswith("> 🤖 AI-assisted")
+    assert "Hello world" in once
+
+
+def test_inject_attribution_rewrites_body_flag() -> None:
+    prefix = gh_gate.format_attribution_prefix(login="me", loop_name="oss-triage")
+    argv = ["issue", "comment", "12", "--repo", "o/r", "--body", "Thanks"]
+    out, injected = gh_gate.inject_attribution_argv(argv, prefix=prefix)
+    assert injected is True
+    assert out[out.index("--body") + 1].startswith("> 🤖 AI-assisted")
+    assert "Thanks" in out[out.index("--body") + 1]
+
+
+def test_inject_attribution_rewrites_body_file(tmp_path: Path) -> None:
+    prefix = gh_gate.format_attribution_prefix(login="me", loop_name="oss-triage")
+    body_file = tmp_path / "body.md"
+    body_file.write_text("Please rebase.\n", encoding="utf-8")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    argv = ["pr", "comment", "3", "--body-file", str(body_file)]
+    out, injected = gh_gate.inject_attribution_argv(argv, prefix=prefix, run_dir=run_dir)
+    assert injected is True
+    new_path = Path(out[out.index("--body-file") + 1])
+    assert new_path.exists()
+    text = new_path.read_text(encoding="utf-8")
+    assert text.startswith("> 🤖 AI-assisted")
+    assert "Please rebase." in text
+
+
+def test_inject_attribution_rewrites_field_body() -> None:
+    prefix = gh_gate.format_attribution_prefix(login="me", loop_name="oss-triage")
+    argv = ["api", "-X", "POST", "repos/o/r/issues/1/comments", "-f", "body=hi"]
+    out, injected = gh_gate.inject_attribution_argv(argv, prefix=prefix)
+    assert injected is True
+    assert any(a.startswith("body=") and "> 🤖 AI-assisted" in a for a in out)
+
+
+def test_parse_attribution_config_defaults_and_opt_out() -> None:
+    assert _parse_attribution_config({}) == {"enabled": True, "template": ""}
+    assert _parse_attribution_config({"attribution": False})["enabled"] is False
+    assert _parse_attribution_config({"attribution": {"enabled": False}})["enabled"] is False
+    cfg = _parse_attribution_config(
+        {"attribution": {"enabled": True, "template": "> custom `{login}`"}}
+    )
+    assert cfg["enabled"] is True
+    assert "custom" in cfg["template"]
+
+
+def test_install_gh_shim_sets_attribution_env(tmp_path: Path, monkeypatch) -> None:
+    fake_gh = tmp_path / "real-gh"
+    fake_gh.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_gh.chmod(0o755)
+    monkeypatch.setattr(gh_gate, "resolve_github_login", lambda _real=None: "tester")
+    env = gh_gate.install_gh_shim(
+        tmp_path / "run",
+        tier="L2",
+        allowlist=["comment"],
+        deny=["merge"],
+        real_gh=str(fake_gh),
+        attribution_enabled=True,
+        loop_name="oss-triage",
+        github_login="tester",
+    )
+    assert env["LOOP_GATE_ATTRIBUTION"] == "1"
+    assert env["LOOP_GATE_LOOP_NAME"] == "oss-triage"
+    assert env["LOOP_GATE_GITHUB_LOGIN"] == "tester"
+
+    env_off = gh_gate.install_gh_shim(
+        tmp_path / "run2",
+        tier="L2",
+        allowlist=["comment"],
+        deny=[],
+        real_gh=str(fake_gh),
+        attribution_enabled=False,
+        loop_name="oss-triage",
+    )
+    assert env_off["LOOP_GATE_ATTRIBUTION"] == "0"


### PR DESCRIPTION
## Summary
- Hard gate (`loop-gh-gate`) prepends a `> 🤖 AI-assisted message posted as @{login} by [agent-toolkit](...) (`loop`)` disclosure to outbound comment/review bodies by default.
- Login is resolved from the authenticated `gh` token; injection covers `--body`/`-b`, `--body-file`, and `-f`/`-F body=`.
- Opt out per loop with `attribution: false` or `attribution.enabled: false` (schema + docs + autonomy contract updated).

## Test plan
- [x] `uv run pytest tests/test_loop_attribution.py tests/test_loop_tier_gate.py tests/test_loop_wave4_units.py`
- [x] Broader `pytest -k 'schema or loop'` green
- [ ] Manual: run an L2 loop that comments and confirm the blockquote appears once
- [ ] Manual: set `attribution: false` and confirm the gate does not inject