### PR TITLE
docs(adr): ADR-012 Python/V coexistence (experimental binary) (#482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — ADR-012 Python/V coexistence via experimental V binary; Python remains canonical until cutover (Closes #482)
+- **Fixed** — `agent-toolkit update` honors `AGENT_TOOLKIT_OFFLINE` and maps download `OSError` to skippable errors (CI flake)
 - **Docs** — ADR-011 hybrid capability packaging (embedded baseline + external override); resolution order remains ADR-005/#547 (Closes #481)
 - **Docs** — ADR-010 CLI/core boundary: structured domain results; CLI renders human/JSON; exit-code classes (Closes #480)
 - **Docs** — ADR-009 V module architecture: `agent_toolkit_core` + `agent_toolkit_cli` (no premature server/TUI stubs) (Closes #479)

--- a/docs/adrs/ADR-012-python-v-coexistence.md
+++ b/docs/adrs/ADR-012-python-v-coexistence.md
@@ -1,0 +1,50 @@
+# ADR-012: Python / V Coexistence During Strangler Migration
+
+**Status:** Accepted  
+**Date:** 2026-08-12  
+**Deciders:** maintainers (V migration program [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456), issue [#482](https://github.com/ulises-jeremias/agent-toolkit/issues/482))
+
+## Context
+
+During the strangler migration, both Python and V implementations will exist. We must decide whether end users get a dual-engine switch, a separate experimental binary, per-command delegation, or CI-only dual builds.
+
+## Options considered
+
+| ID | Option | Summary |
+|----|--------|---------|
+| **A** | Separate experimental V preview binary | Distinct artifact/name or clearly marked pre-release; Python remains default `agent-toolkit` until cutover gate [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555) |
+| **B** | Global engine env (`AGENT_TOOLKIT_ENGINE=python\|v`) | One entrypoint switches implementation |
+| **C** | Per-command strangler | V root binary delegates unfinished commands to Python |
+| **D** | CI-only dual implementation | No runtime dual engine; channels publish one artifact at a time |
+
+## Decision
+
+Adopt **option A** as the primary coexistence strategy, with **D** for continuous integration parity:
+
+1. Publish an **experimental native V binary** (naming/tagging clearly non-canonical, e.g. experimental assets / prerelease) for early platform and parity learning ([#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562)).
+2. Keep the **canonical `agent-toolkit` command** on the Python implementation until the V-default cutover gate ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)).
+3. Run **Python↔V golden parity in CI** ([#476](https://github.com/ulises-jeremias/agent-toolkit/issues/476) / [#548](https://github.com/ulises-jeremias/agent-toolkit/issues/548)) without requiring users to set an engine env var.
+4. **Reject B and C for the default product path** — they increase packaging complexity, mixed semantics, and support burden. If a future spike proves C is necessary for a short window, it requires a new ADR amendment; it is not authorized by this decision.
+
+### Observability
+
+Experimental and stable binaries should expose engine/language, version, and commit via existing diagnostic surfaces (e.g. `doctor --json` / version JSON when added) without polluting normal human output.
+
+## Consequences
+
+- **Positive:** Clean mental model; no silent mixed engines; early binary validation without forcing users onto V.
+- **Negative:** Two artifacts during transition; docs must explain experimental vs stable.
+- **Rejected:** Global engine switch (drift/support); per-command Python exec from V (packaging and security complexity).
+
+## Validation plan
+
+- Experimental releases never overwrite stable channel assets without explicit promotion.
+- Cutover [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555) requires parity gates before renaming/replacing the canonical binary.
+- Doctor/version diagnostics report which binary ran.
+
+## References
+
+- Issues [#482](https://github.com/ulises-jeremias/agent-toolkit/issues/482), [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555), [#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562)
+- Program [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456)
+
+**Verified:** 2026-08-12


### PR DESCRIPTION
## Summary
- Add `docs/adrs/ADR-012-python-v-coexistence.md` (Accepted) for V migration issue #482.
- Records the concrete decision from the roadmap execution plan.

Fixes #482.

## Test plan
- [ ] Docs-only: Validate / Danger / MegaLinter (as applicable) green
- [ ] Skim ADR for consistency with ADR-005..008 and program #456
- [ ] CodeRabbit review completed on final HEAD

Made with [Cursor](https://cursor.com)