### PR TITLE
docs(adr): ADR-014 schema validation strategy (#546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — ADR-014 schema validation: typed validators in core + Python bridge only during parity (Closes #546)
 - **Docs** — ADR-013 YAML strategy: use `vlib/yaml` for toolkit config; no custom general YAML parser (Closes #483)
 - **Docs** — ADR-012 Python/V coexistence via experimental V binary; Python remains canonical until cutover (Closes #482)
 - **Fixed** — `agent-toolkit update` honors `AGENT_TOOLKIT_OFFLINE` and maps download `OSError` to skippable errors (CI flake)

--- a/docs/adrs/ADR-014-schema-validation.md
+++ b/docs/adrs/ADR-014-schema-validation.md
@@ -1,0 +1,45 @@
+# ADR-014: Schema Validation Strategy in V
+
+**Status:** Accepted  
+**Date:** 2026-08-12  
+**Deciders:** maintainers (V migration program [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456), issue [#546](https://github.com/ulises-jeremias/agent-toolkit/issues/546))
+
+## Context
+
+Parsing YAML/JSON successfully is not validation. Agent Toolkit relies on structured accept/reject behavior for products, targets, loops, MCP registry entries, receipts, provenance, and related manifests. Risk register [#478](https://github.com/ulises-jeremias/agent-toolkit/issues/478) flags JSON Schema gaps as Medium/High. YAML parsing is ADR-013 ([#483](https://github.com/ulises-jeremias/agent-toolkit/issues/483)); this ADR covers **validation**.
+
+## Options considered
+
+1. Mature V JSON Schema library (if quality/license acceptable).
+2. Strictly limited subset validator owned by Agent Toolkit.
+3. **Generated / hand-maintained typed validators** from known schemas and structs.
+4. External validator bridge (long-term).
+5. Keep Python validator during parity phase only, then cut over.
+
+## Decision
+
+Adopt a **phased combination of 3 + 5**:
+
+1. **Primary (V):** typed validators in `agent_toolkit_core` for first-party documents we control (products, targets, receipts, MCP registry shapes, provenance fields). Prefer decode-to-struct + explicit field/invariant checks over a general JSON Schema engine.
+2. **Parity phase:** where existing Python tests or `jsonschema` fixtures already encode accept/reject cases, keep those fixtures runnable against Python until V validators cover the same cases ([#548](https://github.com/ulises-jeremias/agent-toolkit/issues/548)).
+3. **Do not** silently weaken validation because a Python library disappears.
+4. Revisit a full JSON Schema library only if typed validators cannot express a **required** upstream schema; that requires an ADR amendment with fixtures.
+
+## Consequences
+
+- **Positive:** Validation stays in-core; no weak “parse OK” bar; clear parity fixtures.
+- **Negative:** More hand-maintained checks; must inventory current schema call sites.
+- **Rejected:** Custom general YAML/JSON-Schema engine as day-one work; permanent Python bridge after cutover.
+
+## Validation plan
+
+- Inventory Python validation call sites (compiler/installer/doctor/loops).
+- Golden accept/reject fixtures per document class.
+- Block compiler/installer parity issues on green fixture sets.
+
+## References
+
+- Issues [#546](https://github.com/ulises-jeremias/agent-toolkit/issues/546), [#483](https://github.com/ulises-jeremias/agent-toolkit/issues/483), [#478](https://github.com/ulises-jeremias/agent-toolkit/issues/478)
+- ADR-013 (YAML parse)
+
+**Verified:** 2026-08-12


### PR DESCRIPTION
## Summary
- Add `docs/adrs/ADR-014-schema-validation.md` (Accepted) for V migration issue #546.
- Recommendation: typed validators in `agent_toolkit_core`; Python/jsonschema bridge only during parity; no silent weakening.

Fixes #546.

## Acceptance criteria
- [x] Concrete recommendation recorded (typed validators + parity-phase Python bridge)
- [x] Linked to #456 / YAML ADR-013 / risk #478

## Test plan
- [ ] Docs-only: Validate / Danger green
- [ ] Skim for consistency with ADR-013 and program #456
- [ ] CodeRabbit review completed on final HEAD

Made with [Cursor](https://cursor.com)