### PR TITLE
docs(adr): ADR-015 runtime resolution amends ADR-005 (#547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — ADR-015 runtime resolution (amends ADR-005 for V binary hybrid packaging) (Closes #547)
 - **Docs** — ADR-014 schema validation: typed validators in core + Python bridge only during parity (Closes #546)
 - **Docs** — ADR-013 YAML strategy: use `vlib/yaml` for toolkit config; no custom general YAML parser (Closes #483)
 - **Docs** — ADR-012 Python/V coexistence via experimental V binary; Python remains canonical until cutover (Closes #482)

--- a/docs/adrs/ADR-005-data-packaging.md
+++ b/docs/adrs/ADR-005-data-packaging.md
@@ -4,6 +4,8 @@
 **Date:** 2026-08-06  
 **Deciders:** maintainers (Wave 3 #266, parent #263)
 
+> **Amendment (V binary-first):** For the V product and dual-run V path, runtime resolution order is defined by [ADR-015](ADR-015-runtime-resolution.md) ([#547](https://github.com/ulises-jeremias/agent-toolkit/issues/547)). This ADR remains the historical Python wheel-era record; where they differ, ADR-015 wins for V.
+
 ## Context
 
 Toolkit data can come from multiple places: editable repo checkout (`skills/`, `profiles/`, `loops/` at repo root), wheel-bundled `agent_toolkit/data/` (populated by `scripts/prepare-package-data.sh` before `uv build`), XDG cache (`~/.cache/agent-toolkit` or `~/.local/share/agent-toolkit/data`), or a GitHub Release tarball download. The resolution logic lives in `packages/agent-toolkit-cli/src/agent_toolkit/_paths.py` / `data_cache.py` / `data_sync.py` and is tribal knowledge for Homebrew/AUR packagers (#257/#258).

--- a/docs/adrs/ADR-015-runtime-resolution.md
+++ b/docs/adrs/ADR-015-runtime-resolution.md
@@ -1,0 +1,52 @@
+# ADR-015: Runtime Resource Resolution Order (Amends ADR-005)
+
+**Status:** Accepted  
+**Date:** 2026-08-12  
+**Deciders:** maintainers (V migration program [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456), issue [#547](https://github.com/ulises-jeremias/agent-toolkit/issues/547))
+
+## Context
+
+ADR-005 defines Python resolution: env override → wheel/bundled data → XDG cache (optional download) → editable walk-up → CWD. ADR-011 ([#481](https://github.com/ulises-jeremias/agent-toolkit/issues/481)) chooses **hybrid packaging** (embedded baseline + external override). Runtime lookup must be updated for the V binary without leaving two conflicting Accepted orders.
+
+## Relationship to ADR-005
+
+**This ADR formally amends ADR-005** for the V binary-first product. ADR-005 remains the historical record of the Python wheel era. Where they differ, **this ADR wins for V** (and for Python during dual-run only where explicitly mirrored). Packaging layout remains ADR-011.
+
+## Decision — V resolution order
+
+Highest priority first:
+
+1. **Explicit override** — `--data-dir` (when added) or `AGENT_TOOLKIT_ROOT` / `AI_WORKSPACE` if the path contains a valid data root (`skills/` or `profiles/` / packaged data markers as today).
+2. **Installed shared / external data** — package-manager share dir or XDG data home populated by install/sync (override layer from hybrid packaging).
+3. **Embedded baseline** — resources shipped with the native binary (ADR-011 baseline).
+4. **Development repository checkout** — walk-up from process CWD / source tree when running from a git checkout (editable/dev mode).
+5. **CWD fallback** — only if it looks like a toolkit root (same safety as ADR-005).
+
+### Offline
+
+`AGENT_TOOLKIT_OFFLINE=1|true|yes` **must not** download. Missing external data falls back to embedded baseline; if baseline is also missing, fail with a clear `ENV` error (ADR-010 taxonomy).
+
+### Channel parity
+
+GitHub binary, PyPI wrapper, Homebrew, AUR, Docker, and source builds must document how they populate (2) and (3) so users do not see accidental behavioral differences.
+
+## Consequences
+
+- **Positive:** Single authoritative V order; ADR-005 not left contradictory; hybrid packaging usable.
+- **Negative:** Implementers must port `_paths.py` carefully; tests per channel.
+- **Supersession note:** Python wheel path (importlib.resources) maps to **embedded baseline** conceptually under V; do not keep a second published “ADR-005 order” for V docs.
+
+## Validation plan
+
+- Fixtures for each tier winning over lower tiers.
+- Offline never hits network ([#557](https://github.com/ulises-jeremias/agent-toolkit/issues/557)).
+- Doctor reports which root was selected.
+
+## References
+
+- `docs/adrs/ADR-005-data-packaging.md`
+- ADR-011 / [#481](https://github.com/ulises-jeremias/agent-toolkit/issues/481)
+- Issue [#547](https://github.com/ulises-jeremias/agent-toolkit/issues/547)
+- `packages/.../_paths.py`
+
+**Verified:** 2026-08-12


### PR DESCRIPTION
## Summary
- Add `docs/adrs/ADR-015-runtime-resolution.md` with V resolution order for hybrid packaging.
- Amend ADR-005 with an explicit pointer: ADR-015 wins for V; ADR-005 remains Python wheel-era history.

Fixes #547.

## Acceptance criteria
- [x] No second conflicting Accepted order without amendment
- [x] Offline + channel parity called out
- [x] Distinct from packaging layout (ADR-011 / #481)

## Test plan
- [ ] Docs-only CI green
- [ ] Confirm ADR-005 amendment note is visible and non-contradictory
- [ ] CodeRabbit on final HEAD

Made with [Cursor](https://cursor.com)