### PR TITLE
chore(v): Makefile fmt/vet/test/build for V modules (#497)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ loops/*/STATE.md
 
 # Git worktrees
 .worktrees/
+modules/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Chore** — Makefile `fmt`/`fmt-check`/`vet`/`test`/`build` for V modules (Closes #497)
 - **Chore** — pin V compiler via `.v-version` (0.5.2) + upgrade policy (Closes #496)
 - **Docs** — configuration/env precedence contract (`flags > env > config > defaults`) + `AGENT_TOOLKIT_*` inventory (Closes #559)
 - **Docs** — machine-readable CLI contract manifest (`docs/compatibility/cli-contract.yaml`) (Closes #549)

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build: ensure-v
 	@for m in $(V_MODULES); do \
 	  echo "==> build $$m"; \
 	  tmp=$$(mktemp -d); \
-	  printf 'module main\nimport %s\nfn main() {}\n' "$$m" > "$$tmp/main.v"; \
+	  printf 'module main\nimport %s as _\nfn main() {}\n' "$$m" > "$$tmp/main.v"; \
 	  $(V) -o "$$tmp/out" "$$tmp/main.v"; \
 	  rm -rf "$$tmp"; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+# V foundation targets for modules/ (ADR-009). Python tooling remains uv/pytest.
+# Pattern adapted from Create-Vlang-App (VMODULES + fmt/vet/test/build).
+# Do NOT require VPM for normal binary installs.
+
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+export VMODULES := $(ROOT)/modules
+
+V_MODULES := agent_toolkit_core agent_toolkit_cli
+V ?= v
+
+.PHONY: help ensure-v fmt fmt-check vet test build
+
+help:
+	@echo "V targets (pin: $$(cat $(ROOT)/.v-version 2>/dev/null || echo 'pending #496'))"
+	@echo "  make fmt         Format V modules"
+	@echo "  make fmt-check   Verify formatting"
+	@echo "  make vet         Vet V modules"
+	@echo "  make test        Run V unit tests"
+	@echo "  make build       Typecheck/compile smoke for each module"
+
+ensure-v:
+	@command -v $(V) >/dev/null || (echo "v not found; install V matching .v-version" >&2; exit 1)
+	@if [ -f $(ROOT)/.v-version ]; then \
+	  pinned=$$(tr -d '[:space:]' < $(ROOT)/.v-version); \
+	  have=$$($(V) version | awk '{print $$2}'); \
+	  if [ "$$have" != "$$pinned" ]; then \
+	    echo "warning: v version $$have != pinned $$pinned (see docs/v/upgrade-policy.md)" >&2; \
+	  fi; \
+	fi
+
+fmt: ensure-v
+	@for m in $(V_MODULES); do \
+	  echo "==> fmt $$m"; \
+	  $(V) fmt -w $(ROOT)/modules/$$m; \
+	done
+
+fmt-check: ensure-v
+	@for m in $(V_MODULES); do \
+	  echo "==> fmt-check $$m"; \
+	  $(V) fmt -verify $(ROOT)/modules/$$m; \
+	done
+
+vet: ensure-v
+	@for m in $(V_MODULES); do \
+	  echo "==> vet $$m"; \
+	  $(V) vet $(ROOT)/modules/$$m; \
+	done
+
+test: ensure-v
+	@for m in $(V_MODULES); do \
+	  echo "==> test $$m"; \
+	  $(V) test $(ROOT)/modules/$$m; \
+	done
+
+# Compile each module via `v -o` using a temporary main that imports it.
+build: ensure-v
+	@for m in $(V_MODULES); do \
+	  echo "==> build $$m"; \
+	  tmp=$$(mktemp -d); \
+	  printf 'module main\nimport %s\nfn main() {}\n' "$$m" > "$$tmp/main.v"; \
+	  $(V) -o "$$tmp/out" "$$tmp/main.v"; \
+	  rm -rf "$$tmp"; \
+	done

--- a/modules/.cache/README.md
+++ b/modules/.cache/README.md
@@ -1,4 +1,0 @@
-This folder contains cached build artifacts from the V build system.
-You can safely delete it, if it is getting too large.
-It will be recreated the next time you compile something with V.
-You can change its location with the VCACHE environment variable.

--- a/modules/.cache/README.md
+++ b/modules/.cache/README.md
@@ -1,0 +1,4 @@
+This folder contains cached build artifacts from the V build system.
+You can safely delete it, if it is getting too large.
+It will be recreated the next time you compile something with V.
+You can change its location with the VCACHE environment variable.

--- a/modules/agent_toolkit_cli/agent_toolkit_cli.v
+++ b/modules/agent_toolkit_cli/agent_toolkit_cli.v
@@ -1,0 +1,8 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+
+// run is a smoke entry for the thin CLI adapter (no argv parsing yet).
+pub fn run() string {
+	return agent_toolkit_core.ping()
+}

--- a/modules/agent_toolkit_cli/agent_toolkit_cli_test.v
+++ b/modules/agent_toolkit_cli/agent_toolkit_cli_test.v
@@ -1,0 +1,5 @@
+module agent_toolkit_cli
+
+fn test_run() {
+	assert run() == 'ok'
+}

--- a/modules/agent_toolkit_cli/v.mod
+++ b/modules/agent_toolkit_cli/v.mod
@@ -1,0 +1,7 @@
+Module {
+	name: 'agent_toolkit_cli'
+	description: 'Agent Toolkit CLI adapter (V migration)'
+	version: '0.0.0'
+	license: 'MIT'
+	dependencies: []
+}

--- a/modules/agent_toolkit_core/agent_toolkit_core.v
+++ b/modules/agent_toolkit_core/agent_toolkit_core.v
@@ -1,0 +1,6 @@
+module agent_toolkit_core
+
+// ping is a smoke-test entry used by foundation Makefile targets.
+pub fn ping() string {
+	return 'ok'
+}

--- a/modules/agent_toolkit_core/agent_toolkit_core_test.v
+++ b/modules/agent_toolkit_core/agent_toolkit_core_test.v
@@ -1,0 +1,5 @@
+module agent_toolkit_core
+
+fn test_ping() {
+	assert ping() == 'ok'
+}

--- a/modules/agent_toolkit_core/v.mod
+++ b/modules/agent_toolkit_core/v.mod
@@ -1,0 +1,7 @@
+Module {
+	name: 'agent_toolkit_core'
+	description: 'Agent Toolkit domain core (V migration)'
+	version: '0.0.0'
+	license: 'MIT'
+	dependencies: []
+}


### PR DESCRIPTION
## Summary
- Add root `Makefile` with `fmt`, `fmt-check`, `vet`, `test`, `build` for V modules (CVA-style `VMODULES`, no VPM-primary).
- Scaffold `modules/agent_toolkit_core` + `modules/agent_toolkit_cli` per ADR-009 (smoke only; no server/TUI stubs).

Fixes #497.

## Test plan
- [ ] `make fmt-check vet test build` locally with V matching `.v-version` (or warn if pin PR not merged yet)
- [ ] Python CI still green (no Python behavior change)
- [ ] Confirm no `agent_toolkit_server` / `agent_toolkit_tui` directories

Made with [Cursor](https://cursor.com)