### PR TITLE
feat(v): domain error model and exit-code mapping (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V domain error model + CLI exit-code mapping (ADR-010 classes) (Closes #498)
 - **Docs** — vlib/cli spike matrix vs CLI contract; GO with thin exit/completion wrapper (Closes #554)
 - **Chore** — Makefile `fmt`/`fmt-check`/`vet`/`test`/`build` for V modules (Closes #497)
 - **Chore** — pin V compiler via `.v-version` (0.5.2) + upgrade policy (Closes #496)

--- a/docs/v/error-model.md
+++ b/docs/v/error-model.md
@@ -1,0 +1,14 @@
+# V domain error model and exit codes
+
+**Issue:** [#498](https://github.com/ulises-jeremias/agent-toolkit/issues/498)  
+**ADR:** [ADR-010](../adrs/ADR-010-cli-core-boundary.md)
+
+Core returns `DomainError` with `ErrorClass` (`user`/`config`/`env`/`external`/`network`/`internal`/`usage_flags`). CLI maps via `map_exit`:
+
+| Class | Exit |
+|-------|------|
+| ok | 0 |
+| usage_flags | 2 |
+| all others | 1 |
+
+Core must not print; CLI renders and exits.

--- a/modules/agent_toolkit_cli/exit_map.v
+++ b/modules/agent_toolkit_cli/exit_map.v
@@ -1,0 +1,13 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+
+// map_exit returns the process exit code for a domain error (ADR-010).
+pub fn map_exit(err agent_toolkit_core.DomainError) int {
+	return err.exit_code()
+}
+
+// map_exit_class returns the process exit code for an error class.
+pub fn map_exit_class(class agent_toolkit_core.ErrorClass) int {
+	return class.exit_code()
+}

--- a/modules/agent_toolkit_cli/exit_map_test.v
+++ b/modules/agent_toolkit_cli/exit_map_test.v
@@ -1,0 +1,17 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+
+fn test_map_exit_usage_flags() {
+	e := agent_toolkit_core.err_usage_flags('flag', 'bad flag')
+	assert map_exit(e) == 2
+}
+
+fn test_map_exit_user() {
+	e := agent_toolkit_core.err_user('validate', 'bad input')
+	assert map_exit(e) == 1
+}
+
+fn test_map_exit_ok_class() {
+	assert map_exit_class(.ok) == 0
+}

--- a/modules/agent_toolkit_core/errors.v
+++ b/modules/agent_toolkit_core/errors.v
@@ -1,0 +1,103 @@
+module agent_toolkit_core
+
+// ErrorClass is the ADR-010 domain error taxonomy.
+pub enum ErrorClass {
+	ok
+	user
+	config
+	env
+	external
+	network
+	internal
+	usage_flags
+}
+
+// DomainError is a structured error returned by core (no printing).
+pub struct DomainError {
+pub:
+	class   ErrorClass
+	code    string
+	message string
+}
+
+// msg returns the human-readable message.
+pub fn (e DomainError) msg() string {
+	return e.message
+}
+
+// exit_code maps a domain error class to a CLI process exit code (ADR-010).
+pub fn (c ErrorClass) exit_code() int {
+	return match c {
+		.ok { 0 }
+		.usage_flags { 2 }
+		.user, .config, .env, .external, .network, .internal { 1 }
+	}
+}
+
+// exit_code maps this domain error to a CLI exit code.
+pub fn (e DomainError) exit_code() int {
+	return e.class.exit_code()
+}
+
+// err_user constructs a USER-class domain error.
+pub fn err_user(code string, message string) DomainError {
+	return DomainError{
+		class:   .user
+		code:    code
+		message: message
+	}
+}
+
+// err_config constructs a CONFIG-class domain error.
+pub fn err_config(code string, message string) DomainError {
+	return DomainError{
+		class:   .config
+		code:    code
+		message: message
+	}
+}
+
+// err_env constructs an ENV-class domain error.
+pub fn err_env(code string, message string) DomainError {
+	return DomainError{
+		class:   .env
+		code:    code
+		message: message
+	}
+}
+
+// err_external constructs an EXTERNAL-class domain error.
+pub fn err_external(code string, message string) DomainError {
+	return DomainError{
+		class:   .external
+		code:    code
+		message: message
+	}
+}
+
+// err_network constructs a NETWORK-class domain error.
+pub fn err_network(code string, message string) DomainError {
+	return DomainError{
+		class:   .network
+		code:    code
+		message: message
+	}
+}
+
+// err_internal constructs an INTERNAL-class domain error.
+pub fn err_internal(code string, message string) DomainError {
+	return DomainError{
+		class:   .internal
+		code:    code
+		message: message
+	}
+}
+
+// err_usage_flags constructs a USAGE_FLAGS-class domain error (CLI parse).
+pub fn err_usage_flags(code string, message string) DomainError {
+	return DomainError{
+		class:   .usage_flags
+		code:    code
+		message: message
+	}
+}

--- a/modules/agent_toolkit_core/errors_test.v
+++ b/modules/agent_toolkit_core/errors_test.v
@@ -1,0 +1,32 @@
+module agent_toolkit_core
+
+fn test_exit_code_ok_is_zero() {
+	assert ErrorClass.ok.exit_code() == 0
+}
+
+fn test_exit_code_usage_flags_is_two() {
+	assert ErrorClass.usage_flags.exit_code() == 2
+	e := err_usage_flags('parse', 'unknown flag')
+	assert e.exit_code() == 2
+}
+
+fn test_exit_code_other_classes_are_one() {
+	classes := [
+		ErrorClass.user,
+		ErrorClass.config,
+		ErrorClass.env,
+		ErrorClass.external,
+		ErrorClass.network,
+		ErrorClass.internal,
+	]
+	for c in classes {
+		assert c.exit_code() == 1
+	}
+}
+
+fn test_err_constructors_set_class_and_message() {
+	e := err_env('offline', 'AGENT_TOOLKIT_OFFLINE set')
+	assert e.class == .env
+	assert e.code == 'offline'
+	assert e.msg() == 'AGENT_TOOLKIT_OFFLINE set'
+}


### PR DESCRIPTION
## Summary
- Add `agent_toolkit_core` `ErrorClass` / `DomainError` + constructors.
- Add CLI `map_exit` / `map_exit_class` (0 / 1 / 2 per ADR-010).
- Document in `docs/v/error-model.md`.

Fixes #498.

## Test plan
- [ ] `make test` (includes `errors_test.v`, `exit_map_test.v`)
- [ ] Python CI unchanged/green
- [ ] No println of business results in core

Made with [Cursor](https://cursor.com)