### PR TITLE
feat(v): filesystem service (XDG, atomic write) (#499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V filesystem service (XDG paths, join, atomic write) (Closes #499)
 - **Feat** — V domain error model + CLI exit-code mapping (ADR-010 classes) (Closes #498)
 - **Docs** — vlib/cli spike matrix vs CLI contract; GO with thin exit/completion wrapper (Closes #554)
 - **Chore** — Makefile `fmt`/`fmt-check`/`vet`/`test`/`build` for V modules (Closes #497)

--- a/docs/v/filesystem-service.md
+++ b/docs/v/filesystem-service.md
@@ -1,0 +1,12 @@
+# V filesystem service
+
+**Issue:** [#499](https://github.com/ulises-jeremias/agent-toolkit/issues/499)  
+**Related:** ADR-015 resolution, env precedence `#559`
+
+`FsService` in `agent_toolkit_core` centralizes:
+
+- OS-aware `join` via `os.join_path` (Windows path semantics)
+- XDG cache/data homes + toolkit cache/data dirs
+- `ensure_dir`, `write_atomic` (temp + rename), `read_text`, `exists`
+
+Install/receipts/workspace code should call this service instead of scattering raw `os` calls.

--- a/modules/agent_toolkit_core/fs.v
+++ b/modules/agent_toolkit_core/fs.v
@@ -1,0 +1,92 @@
+module agent_toolkit_core
+
+import os
+
+// FsService centralizes filesystem helpers for install/receipts/workspace.
+pub struct FsService {
+pub:
+	// home_dir override for tests; empty uses os.home_dir().
+	home_dir string
+}
+
+// new_fs returns an FsService using the real home directory.
+pub fn new_fs() FsService {
+	return FsService{}
+}
+
+// home returns the effective home directory.
+pub fn (fs FsService) home() string {
+	if fs.home_dir.len > 0 {
+		return fs.home_dir
+	}
+	return os.home_dir()
+}
+
+// join joins path segments with the OS separator (Windows-aware via os.join_path).
+pub fn (fs FsService) join(parts ...string) string {
+	if parts.len == 0 {
+		return ''
+	}
+	mut out := parts[0]
+	for i in 1 .. parts.len {
+		out = os.join_path(out, parts[i])
+	}
+	return out
+}
+
+// xdg_cache_home returns XDG_CACHE_HOME or ~/.cache.
+pub fn (fs FsService) xdg_cache_home() string {
+	v := os.getenv('XDG_CACHE_HOME')
+	if v.len > 0 {
+		return v
+	}
+	return fs.join(fs.home(), '.cache')
+}
+
+// xdg_data_home returns XDG_DATA_HOME or ~/.local/share.
+pub fn (fs FsService) xdg_data_home() string {
+	v := os.getenv('XDG_DATA_HOME')
+	if v.len > 0 {
+		return v
+	}
+	return fs.join(fs.home(), '.local', 'share')
+}
+
+// toolkit_cache_dir returns the Agent Toolkit cache root under XDG cache.
+pub fn (fs FsService) toolkit_cache_dir() string {
+	return fs.join(fs.xdg_cache_home(), 'agent-toolkit')
+}
+
+// toolkit_data_dir returns the Agent Toolkit data root under XDG data home.
+pub fn (fs FsService) toolkit_data_dir() string {
+	return fs.join(fs.xdg_data_home(), 'agent-toolkit', 'data')
+}
+
+// ensure_dir creates a directory and parents; returns a domain error on failure.
+pub fn (fs FsService) ensure_dir(path string) ! {
+	os.mkdir_all(path) or { return error_with_code('mkdir_all failed: ${path}: ${err}', 1) }
+}
+
+// write_atomic writes data to path via a temp file + rename (best-effort atomic).
+pub fn (fs FsService) write_atomic(path string, data string) ! {
+	dir := os.dir(path)
+	if dir.len > 0 {
+		fs.ensure_dir(dir)!
+	}
+	tmp := '${path}.tmp.${os.getpid()}'
+	os.write_file(tmp, data) or { return error_with_code('write temp failed: ${tmp}: ${err}', 1) }
+	os.mv(tmp, path) or {
+		os.rm(tmp) or {}
+		return error_with_code('rename failed: ${tmp} -> ${path}: ${err}', 1)
+	}
+}
+
+// read_text reads a UTF-8 text file.
+pub fn (fs FsService) read_text(path string) !string {
+	return os.read_file(path) or { return error_with_code('read failed: ${path}: ${err}', 1) }
+}
+
+// exists reports whether path exists.
+pub fn (fs FsService) exists(path string) bool {
+	return os.exists(path)
+}

--- a/modules/agent_toolkit_core/fs_test.v
+++ b/modules/agent_toolkit_core/fs_test.v
@@ -1,0 +1,39 @@
+module agent_toolkit_core
+
+import os
+
+fn test_join_uses_os_join_path() {
+	fs := FsService{
+		home_dir: '/home/test'
+	}
+	p := fs.join(fs.home(), '.cache', 'agent-toolkit')
+	assert p.contains('agent-toolkit')
+	assert p.starts_with('/home/test') || p.starts_with('C:') // allow Windows CI later
+}
+
+fn test_xdg_cache_default() {
+	fs := FsService{
+		home_dir: '/home/test'
+	}
+	// Clear override for this process if set — save/restore
+	old := os.getenv('XDG_CACHE_HOME')
+	os.unsetenv('XDG_CACHE_HOME')
+	defer {
+		if old.len > 0 {
+			os.setenv('XDG_CACHE_HOME', old, true)
+		}
+	}
+	assert fs.xdg_cache_home() == fs.join('/home/test', '.cache')
+	assert fs.toolkit_cache_dir() == fs.join('/home/test', '.cache', 'agent-toolkit')
+}
+
+fn test_write_atomic_roundtrip() {
+	fs := new_fs()
+	dir := os.join_path(os.temp_dir(), 'at-fs-test-${os.getpid()}')
+	path := os.join_path(dir, 'receipt.json')
+	fs.write_atomic(path, '{"ok":true}')!
+	assert fs.exists(path)
+	text := fs.read_text(path)!
+	assert text == '{"ok":true}'
+	os.rmdir_all(dir) or {}
+}


### PR DESCRIPTION
## Summary
- Add `FsService` in `agent_toolkit_core` with XDG helpers, path join, atomic write/read.
- Document in `docs/v/filesystem-service.md`.
- Unit tests for XDG defaults and atomic roundtrip.

Fixes #499.

## Test plan
- [ ] `make test` includes `fs_test.v`
- [ ] Python CI green
- [ ] No server/TUI stubs

Made with [Cursor](https://cursor.com)