### PR TITLE
feat(v): shared HTTP/network download abstraction (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V shared HTTP/network client (offline short-circuit, TLS, checksum hook) (Closes #558)
 - **Feat** — V process service (no-shell spawn, cwd/env/timeout/capture) (Closes #500)
 - **Feat** — V filesystem service (XDG paths, join, atomic write) (Closes #499)
 - **Feat** — V domain error model + CLI exit-code mapping (ADR-010 classes) (Closes #498)

--- a/docs/v/network-service.md
+++ b/docs/v/network-service.md
@@ -1,0 +1,5 @@
+# V HTTP/network download abstraction
+
+**Issue:** [#558](https://github.com/ulises-jeremias/agent-toolkit/issues/558)
+
+`NetworkClient` provides GET/download with User-Agent, timeouts, TLS validate, redirect policy, offline short-circuit (`AGENT_TOOLKIT_OFFLINE`), and SHA-256 verification hooks. All V core network calls should go through this module.

--- a/modules/agent_toolkit_core/network.v
+++ b/modules/agent_toolkit_core/network.v
@@ -1,0 +1,76 @@
+module agent_toolkit_core
+
+import net.http
+import os
+import time
+import crypto.sha256
+
+// NetworkClient is the shared HTTP/download abstraction for V core.
+pub struct NetworkClient {
+pub:
+	user_agent     string        = 'agent-toolkit'
+	timeout        time.Duration = 30 * time.second
+	allow_redirect bool          = true
+	offline        bool
+}
+
+// new_network_client builds a client; offline is read from AGENT_TOOLKIT_OFFLINE when auto_offline is true.
+pub fn new_network_client(auto_offline bool) NetworkClient {
+	mut offline := false
+	if auto_offline {
+		v := os.getenv('AGENT_TOOLKIT_OFFLINE').to_lower()
+		offline = v in ['1', 'true', 'yes']
+	}
+	return NetworkClient{
+		offline: offline
+	}
+}
+
+// HttpResponse is a narrowed response for core callers.
+pub struct HttpResponse {
+pub:
+	status_code int
+	body        string
+}
+
+// get performs an HTTP GET with toolkit defaults (TLS validate on).
+pub fn (c NetworkClient) get(url string) !HttpResponse {
+	if c.offline {
+		return error('network offline: AGENT_TOOLKIT_OFFLINE prevents HTTP')
+	}
+	resp := http.fetch(
+		method:         .get
+		url:            url
+		user_agent:     c.user_agent
+		read_timeout:   i64(c.timeout)
+		write_timeout:  i64(c.timeout)
+		allow_redirect: c.allow_redirect
+		validate:       true
+	) or { return error('http get failed: ${err}') }
+	return HttpResponse{
+		status_code: resp.status_code
+		body:        resp.body
+	}
+}
+
+// download writes url contents to dest_path via atomic write.
+pub fn (c NetworkClient) download(url string, dest_path string) ! {
+	if c.offline {
+		return error('network offline: AGENT_TOOLKIT_OFFLINE prevents download')
+	}
+	resp := c.get(url)!
+	if resp.status_code < 200 || resp.status_code >= 300 {
+		return error('download failed: HTTP ${resp.status_code} for ${url}')
+	}
+	fs := new_fs()
+	fs.write_atomic(dest_path, resp.body)!
+}
+
+// verify_sha256 checks file contents against an expected hex digest (checksum hook).
+pub fn (c NetworkClient) verify_sha256(path string, expected_hex string) ! {
+	data := os.read_file(path) or { return error('checksum read failed: ${err}') }
+	sum := sha256.hexhash(data)
+	if sum.to_lower() != expected_hex.to_lower() {
+		return error('checksum mismatch for ${path}: got ${sum}, want ${expected_hex}')
+	}
+}

--- a/modules/agent_toolkit_core/network_test.v
+++ b/modules/agent_toolkit_core/network_test.v
@@ -1,0 +1,54 @@
+module agent_toolkit_core
+
+import os
+
+fn test_offline_short_circuits_get() {
+	c := NetworkClient{
+		offline: true
+	}
+	c.get('https://example.com') or {
+		assert err.msg().contains('offline')
+		return
+	}
+	assert false, 'expected offline error'
+}
+
+fn test_offline_short_circuits_download() {
+	c := NetworkClient{
+		offline: true
+	}
+	c.download('https://example.com/x', os.join_path(os.temp_dir(), 'at-net-x')) or {
+		assert err.msg().contains('offline')
+		return
+	}
+	assert false, 'expected offline error'
+}
+
+fn test_auto_offline_from_env() {
+	old := os.getenv('AGENT_TOOLKIT_OFFLINE')
+	os.setenv('AGENT_TOOLKIT_OFFLINE', '1', true)
+	defer {
+		if old.len > 0 {
+			os.setenv('AGENT_TOOLKIT_OFFLINE', old, true)
+		} else {
+			os.unsetenv('AGENT_TOOLKIT_OFFLINE')
+		}
+	}
+	c := new_network_client(true)
+	assert c.offline == true
+}
+
+fn test_verify_sha256_roundtrip() {
+	c := new_network_client(false)
+	path := os.join_path(os.temp_dir(), 'at-net-sha-${os.getpid()}.txt')
+	os.write_file(path, 'abc') or { assert false, err.msg() }
+	defer {
+		os.rm(path) or {}
+	}
+	// sha256("abc")
+	expected := 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+	c.verify_sha256(path, expected) or {
+		assert false, err.msg()
+		return
+	}
+}


### PR DESCRIPTION
## Summary
- Add `NetworkClient` with GET/download, User-Agent, timeouts, TLS validate, redirects.
- Offline short-circuit via `AGENT_TOOLKIT_OFFLINE`.
- SHA-256 verification hook for downloads.

Fixes #558.

## Test plan
- [ ] `make test` (offline + checksum tests; no live network required)
- [ ] Confirm downloads use atomic write via `FsService`

Made with [Cursor](https://cursor.com)