### PR TITLE
feat(v): structured results + CLI renderers (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V structured CommandResult + CLI human/JSON/quiet renderers (Closes #501)
 - **Feat** — V shared HTTP/network client (offline short-circuit, TLS, checksum hook) (Closes #558)
 - **Feat** — V process service (no-shell spawn, cwd/env/timeout/capture) (Closes #500)
 - **Feat** — V filesystem service (XDG paths, join, atomic write) (Closes #499)

--- a/docs/v/result-render.md
+++ b/docs/v/result-render.md
@@ -1,0 +1,6 @@
+# Structured results + CLI renderers
+
+**Issue:** [#501](https://github.com/ulises-jeremias/agent-toolkit/issues/501)  
+**ADR:** [ADR-010](../adrs/ADR-010-cli-core-boundary.md)
+
+Core returns `CommandResult`. CLI `render` / `render_error` support human / JSON / quiet without domain printing.

--- a/modules/agent_toolkit_cli/render.v
+++ b/modules/agent_toolkit_cli/render.v
@@ -1,0 +1,50 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+import json2
+
+// render writes a CommandResult to stdout according to mode; returns exit code.
+pub fn render(result agent_toolkit_core.CommandResult, mode agent_toolkit_core.RenderMode) int {
+	match mode {
+		.quiet {
+			if result.ok {
+				return 0
+			}
+			return agent_toolkit_core.err_user('command.failed', result.message).exit_code()
+		}
+		.json {
+			println(json2.encode(result, escape_unicode: true))
+			if result.ok {
+				return 0
+			}
+			return agent_toolkit_core.err_user('command.failed', result.message).exit_code()
+		}
+		.human {
+			println(result.message)
+			if result.ok {
+				return 0
+			}
+			return agent_toolkit_core.err_user('command.failed', result.message).exit_code()
+		}
+	}
+}
+
+// render_error prints a domain error and returns its exit code.
+pub fn render_error(err agent_toolkit_core.DomainError, mode agent_toolkit_core.RenderMode) int {
+	match mode {
+		.quiet {}
+		.json {
+			payload := {
+				'ok':      'false'
+				'code':    err.code
+				'class':   err.class.str()
+				'message': err.message
+			}
+			println(json2.encode(payload, escape_unicode: true))
+		}
+		.human {
+			eprintln(err.message)
+		}
+	}
+	return err.exit_code()
+}

--- a/modules/agent_toolkit_cli/render_test.v
+++ b/modules/agent_toolkit_cli/render_test.v
@@ -1,0 +1,20 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+
+fn test_render_human_ok_exit_zero() {
+	r := agent_toolkit_core.version_result('1.0.0')
+	code := render(r, .human)
+	assert code == 0
+}
+
+fn test_render_not_implemented_nonzero() {
+	r := agent_toolkit_core.not_implemented_result('doctor')
+	code := render(r, .json)
+	assert code == 1
+}
+
+fn test_render_error_usage_flags() {
+	e := agent_toolkit_core.err_usage_flags('parse', 'unknown flag')
+	assert render_error(e, .quiet) == 2
+}

--- a/modules/agent_toolkit_core/result.v
+++ b/modules/agent_toolkit_core/result.v
@@ -1,0 +1,42 @@
+module agent_toolkit_core
+
+// RenderMode selects CLI presentation for a domain result.
+pub enum RenderMode {
+	human
+	json
+	quiet
+}
+
+// CommandResult is a structured domain success payload (no printing).
+pub struct CommandResult {
+pub:
+	command string
+	ok      bool
+	message string
+	data    map[string]string
+}
+
+// version_result returns the toolkit version as a domain result.
+pub fn version_result(version string) CommandResult {
+	return CommandResult{
+		command: 'version'
+		ok:      true
+		message: 'agent-toolkit ${version}'
+		data:    {
+			'version': version
+		}
+	}
+}
+
+// not_implemented_result marks a command as not yet ported to V.
+pub fn not_implemented_result(command string) CommandResult {
+	return CommandResult{
+		command: command
+		ok:      false
+		message: 'command not implemented in V experimental binary: ${command}'
+		data:    {
+			'status':  'not_implemented'
+			'command': command
+		}
+	}
+}

--- a/modules/agent_toolkit_core/result_test.v
+++ b/modules/agent_toolkit_core/result_test.v
@@ -1,0 +1,14 @@
+module agent_toolkit_core
+
+fn test_version_result_shape() {
+	r := version_result('1.10.0')
+	assert r.ok
+	assert r.message == 'agent-toolkit 1.10.0'
+	assert r.data['version'] == '1.10.0'
+}
+
+fn test_not_implemented_result() {
+	r := not_implemented_result('inventory')
+	assert r.ok == false
+	assert r.data['status'] == 'not_implemented'
+}


### PR DESCRIPTION
## Summary
- Add core `CommandResult` + helpers (`version_result`, `not_implemented_result`).
- Add CLI `render` / `render_error` for human / JSON / quiet (ADR-010).

Fixes #501.

## Test plan
- [ ] `make test`
- [ ] Core has no println of business results

Made with [Cursor](https://cursor.com)