### PR TITLE
feat(v): CLI dispatcher with CLI_SURFACES contract (#553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — experimental V CLI dispatcher + `make build-cli` (`build/agent-toolkit-v`) (Closes #553)
 - **Feat** — V structured CommandResult + CLI human/JSON/quiet renderers (Closes #501)
 - **Feat** — V shared HTTP/network client (offline short-circuit, TLS, checksum hook) (Closes #558)
 - **Feat** — V process service (no-shell spawn, cwd/env/timeout/capture) (Closes #500)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export VMODULES := $(ROOT)/modules
 V_MODULES := agent_toolkit_core agent_toolkit_cli
 V ?= v
 
-.PHONY: help ensure-v fmt fmt-check vet test build
+.PHONY: help ensure-v fmt fmt-check vet test build build-cli
 
 help:
 	@echo "V targets (pin: $$(cat $(ROOT)/.v-version 2>/dev/null || echo 'pending #496'))"
@@ -17,6 +17,7 @@ help:
 	@echo "  make vet         Vet V modules"
 	@echo "  make test        Run V unit tests"
 	@echo "  make build       Typecheck/compile smoke for each module"
+	@echo "  make build-cli   Build experimental V binary to build/agent-toolkit-v"
 
 ensure-v:
 	@command -v $(V) >/dev/null || (echo "v not found; install V matching .v-version" >&2; exit 1)
@@ -61,3 +62,8 @@ build: ensure-v
 	  $(V) -o "$$tmp/out" "$$tmp/main.v"; \
 	  rm -rf "$$tmp"; \
 	done
+
+# Experimental V CLI binary (ADR-012 / #553).
+build-cli: ensure-v
+	@mkdir -p $(ROOT)/build
+	$(V) -o $(ROOT)/build/agent-toolkit-v $(ROOT)/cmd/agent-toolkit

--- a/cmd/agent-toolkit/main.v
+++ b/cmd/agent-toolkit/main.v
@@ -1,0 +1,9 @@
+module main
+
+import agent_toolkit_cli
+import os
+
+fn main() {
+	code := agent_toolkit_cli.run(os.args)
+	exit(code)
+}

--- a/docs/v/cli-dispatcher.md
+++ b/docs/v/cli-dispatcher.md
@@ -1,0 +1,8 @@
+# V CLI shell / dispatcher
+
+**Issue:** [#553](https://github.com/ulises-jeremias/agent-toolkit/issues/553)  
+**Spike:** [`vlib-cli-spike.md`](vlib-cli-spike.md)
+
+Single dispatch table matching `docs/CLI_SURFACES.md` consumer/advanced split, aliases (`dc`, `rollback`), help via `vlib/cli` grouping, bad-flag exit **2**, unknown command exit **1**. Business logic stays in core; commands currently return `not_implemented` until per-command ports land.
+
+Build: `make build-cli` → `build/agent-toolkit-v`.

--- a/modules/agent_toolkit_cli/agent_toolkit_cli.v
+++ b/modules/agent_toolkit_cli/agent_toolkit_cli.v
@@ -2,7 +2,7 @@ module agent_toolkit_cli
 
 import agent_toolkit_core
 
-// run is a smoke entry for the thin CLI adapter (no argv parsing yet).
-pub fn run() string {
+// ping_core exposes a tiny smoke dependency on core (used in unit tests).
+pub fn ping_core() string {
 	return agent_toolkit_core.ping()
 }

--- a/modules/agent_toolkit_cli/agent_toolkit_cli_test.v
+++ b/modules/agent_toolkit_cli/agent_toolkit_cli_test.v
@@ -1,5 +1,5 @@
 module agent_toolkit_cli
 
-fn test_run() {
-	assert run() == 'ok'
+fn test_ping_core() {
+	assert ping_core() == 'ok'
 }

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -1,0 +1,147 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+import cli
+
+// experimental_version is the V binary version string (keep in sync with Python / VERSION).
+pub const experimental_version = '1.10.0'
+
+// run is the library entry used by cmd/agent-toolkit.
+pub fn run(args []string) int {
+	return dispatch(args)
+}
+
+// dispatch implements the root command contract (CLI_SURFACES consumer/advanced split).
+pub fn dispatch(args []string) int {
+	// Drop program name
+	mut argv := []string{}
+	if args.len > 1 {
+		argv = args[1..].clone()
+	}
+	mode := mode_from_argv(argv)
+	if argv.len == 0 || argv[0] in ['-h', '--help', 'help'] {
+		print(grouped_help())
+		return 0
+	}
+	if argv[0] in ['-V', '--version', 'version'] {
+		return render(agent_toolkit_core.version_result(experimental_version), mode)
+	}
+	// Bad flags before a command (argparse parity → exit 2)
+	if argv[0].starts_with('-')
+		&& argv[0] !in ['-h', '--help', '-V', '--version', '--json', '--quiet'] {
+		e := agent_toolkit_core.err_usage_flags('flag.unknown', 'unknown flag: ${argv[0]}')
+		return render_error(e, mode)
+	}
+	cmd_name := resolve_alias(argv[0])
+	if !is_known_command(cmd_name) {
+		eprintln('Unknown command: ${argv[0]}')
+		eprintln("Run 'agent-toolkit help' for usage.")
+		eprintln('See docs/CLI_SURFACES.md for consumer vs advanced commands.')
+		return 1
+	}
+	// Remaining tokens may include unknown flags → exit 2
+	for a in argv[1..] {
+		if a.starts_with('-') && a !in ['-h', '--help', '--json', '--quiet'] {
+			e := agent_toolkit_core.err_usage_flags('flag.unknown', 'unknown flag: ${a}')
+			return render_error(e, mode)
+		}
+		if a in ['-h', '--help'] {
+			print(subcommand_help(cmd_name))
+			return 0
+		}
+	}
+	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
+}
+
+fn resolve_alias(name string) string {
+	return match name {
+		'dc' { 'devcompanion' }
+		'rollback' { 'uninstall' }
+		else { name }
+	}
+}
+
+fn is_known_command(name string) bool {
+	for c in consumer_commands() {
+		if c == name {
+			return true
+		}
+	}
+	for c in advanced_commands() {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+fn consumer_commands() []string {
+	return ['install', 'update', 'uninstall', 'doctor', 'diff', 'skills', 'mcp', 'plugin']
+}
+
+fn advanced_commands() []string {
+	return ['loop', 'workspace', 'memory', 'project', 'devcompanion', 'insights', 'build',
+		'inventory', 'matrix', 'release', 'swarm']
+}
+
+fn mode_from_argv(argv []string) agent_toolkit_core.RenderMode {
+	for a in argv {
+		if a == '--json' {
+			return .json
+		}
+		if a == '--quiet' {
+			return .quiet
+		}
+	}
+	return .human
+}
+
+fn grouped_help() string {
+	mut root := cli.Command{
+		name:        'agent-toolkit'
+		description: 'Composable AI agent toolkit CLI (V experimental)\n\nSee docs/CLI_SURFACES.md for consumer vs advanced commands.'
+		version:     experimental_version
+		commands:    help_commands()
+	}
+	root.setup()
+	return root.help_message()
+}
+
+fn help_commands() []cli.Command {
+	mut cmds := []cli.Command{}
+	cmds << cli.Command{
+		name:        'version'
+		description: 'Print agent-toolkit version'
+	}
+	for name in consumer_commands() {
+		cmds << cli.Command{
+			name:        name
+			description: '${name} (consumer)'
+			group:       'Consumer'
+		}
+	}
+	for name in advanced_commands() {
+		mut c := cli.Command{
+			name:        name
+			description: '${name} (advanced)'
+			group:       'Advanced'
+		}
+		if name == 'devcompanion' {
+			c.alias = 'dc'
+		}
+		if name == 'uninstall' {
+			c.description = 'uninstall / rollback (consumer alias rollback)'
+		}
+		cmds << c
+	}
+	return cmds
+}
+
+fn subcommand_help(name string) string {
+	mut c := cli.Command{
+		name:        name
+		description: '${name} — not yet implemented in V experimental binary'
+	}
+	c.setup()
+	return c.help_message()
+}

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -1,0 +1,33 @@
+module agent_toolkit_cli
+
+fn test_dispatch_version_exit_zero() {
+	code := dispatch(['agent-toolkit', 'version'])
+	assert code == 0
+}
+
+fn test_dispatch_help_exit_zero() {
+	code := dispatch(['agent-toolkit', '--help'])
+	assert code == 0
+}
+
+fn test_dispatch_unknown_command_exit_one() {
+	code := dispatch(['agent-toolkit', 'not-a-real-command'])
+	assert code == 1
+}
+
+fn test_dispatch_unknown_flag_exit_two() {
+	code := dispatch(['agent-toolkit', '--bogus-flag'])
+	assert code == 2
+}
+
+fn test_dispatch_dc_alias_not_unknown() {
+	code := dispatch(['agent-toolkit', 'dc'])
+	// not implemented → user exit 1, but known command
+	assert code == 1
+}
+
+fn test_grouped_help_mentions_consumer_and_advanced() {
+	h := grouped_help()
+	assert h.contains('Consumer') || h.to_lower().contains('install')
+	assert h.contains('Advanced') || h.to_lower().contains('inventory')
+}


### PR DESCRIPTION
## Summary
- Single root dispatch table (consumer/advanced) matching `CLI_SURFACES.md`.
- Aliases: `dc` → devcompanion, `rollback` → uninstall.
- Help via `vlib/cli` grouped commands; bad flags → exit 2; unknown command → exit 1.
- `make build-cli` produces `build/agent-toolkit-v`.
- Commands stub to `not_implemented` (no business logic in dispatcher).

Fixes #553.

## Test plan
- [ ] `make test`
- [ ] `make build-cli && ./build/agent-toolkit-v version`
- [ ] `./build/agent-toolkit-v --not-a-real-flag` → exit 2
- [ ] `./build/agent-toolkit-v nosuch` → exit 1

Made with [Cursor](https://cursor.com)