### PR TITLE
feat(v): resolve version from VERSION file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `version` / `--version` resolves from VERSION file (fallback synced via bump-version) (Closes #502)
 - **Feat** — V toolkit root resolution per ADR-015 (env override → XDG → embedded → checkout → CWD; offline never downloads) (Closes #506)
 - **Test** — Python↔V golden CLI parity harness + CI seed job (Closes #548)
 - **Feat** — experimental V CLI dispatcher + `make build-cli` (`build/agent-toolkit-v`) (Closes #553)

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -3,9 +3,6 @@ module agent_toolkit_cli
 import agent_toolkit_core
 import cli
 
-// experimental_version is the V binary version string (keep in sync with Python / VERSION).
-pub const experimental_version = '1.10.0'
-
 // run is the library entry used by cmd/agent-toolkit.
 pub fn run(args []string) int {
 	return dispatch(args)
@@ -24,7 +21,8 @@ pub fn dispatch(args []string) int {
 		return 0
 	}
 	if argv[0] in ['-V', '--version', 'version'] {
-		return render(agent_toolkit_core.version_result(experimental_version), mode)
+		ver := agent_toolkit_core.resolve_toolkit_version()
+		return render(agent_toolkit_core.version_result(ver), mode)
 	}
 	// Bad flags before a command (argparse parity → exit 2)
 	if argv[0].starts_with('-')
@@ -100,7 +98,7 @@ fn grouped_help() string {
 	mut root := cli.Command{
 		name:        'agent-toolkit'
 		description: 'Composable AI agent toolkit CLI (V experimental)\n\nSee docs/CLI_SURFACES.md for consumer vs advanced commands.'
-		version:     experimental_version
+		version:     agent_toolkit_core.resolve_toolkit_version()
 		commands:    help_commands()
 	}
 	root.setup()

--- a/modules/agent_toolkit_core/version.v
+++ b/modules/agent_toolkit_core/version.v
@@ -1,0 +1,51 @@
+module agent_toolkit_core
+
+import os
+
+// embedded_version is the compile-time fallback; keep in sync with root VERSION
+// and packages/.../__init__.py via scripts/bump-version.py.
+pub const embedded_version = '1.10.0'
+
+// resolve_toolkit_version returns the toolkit version string.
+// Prefers a VERSION file under env roots / CWD checkout, else embedded_version.
+pub fn resolve_toolkit_version() string {
+	for env in ['AGENT_TOOLKIT_ROOT', 'AI_WORKSPACE'] {
+		val := os.getenv(env).trim_space()
+		if val.len == 0 {
+			continue
+		}
+		if v := read_version_file(os.join_path(val, 'VERSION')) {
+			return v
+		}
+	}
+	cwd := os.getwd()
+	mut cur := cwd
+	for {
+		ver_path := os.join_path(cur, 'VERSION')
+		if v := read_version_file(ver_path) {
+			if os.is_dir(os.join_path(cur, 'skills'))
+				|| os.is_dir(os.join_path(cur, 'loops'))
+				|| os.is_dir(os.join_path(cur, 'profiles')) {
+				return v
+			}
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	return embedded_version
+}
+
+fn read_version_file(path string) ?string {
+	if !os.is_file(path) {
+		return none
+	}
+	text := os.read_file(path) or { return none }
+	v := text.trim_space()
+	if v.len == 0 {
+		return none
+	}
+	return v
+}

--- a/modules/agent_toolkit_core/version_test.v
+++ b/modules/agent_toolkit_core/version_test.v
@@ -1,0 +1,36 @@
+module agent_toolkit_core
+
+import os
+
+fn restore_env_ver(key string, old string) {
+	if old.len > 0 {
+		os.setenv(key, old, true)
+	} else {
+		os.unsetenv(key)
+	}
+}
+
+fn test_embedded_version_semver_shape() {
+	parts := embedded_version.split('.')
+	assert parts.len >= 3
+}
+
+fn test_resolve_reads_version_file_via_env() {
+	dir := os.join_path(os.temp_dir(), 'at-ver-${os.getpid()}')
+	os.mkdir_all(os.join_path(dir, 'skills')) or { assert false, err.msg() }
+	os.write_file(os.join_path(dir, 'VERSION'), '9.9.9\n') or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	old := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', dir, true)
+	defer {
+		restore_env_ver('AGENT_TOOLKIT_ROOT', old)
+	}
+	assert resolve_toolkit_version() == '9.9.9'
+}
+
+fn test_resolve_returns_nonempty() {
+	v := resolve_toolkit_version()
+	assert v.len > 0
+}

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -52,6 +52,13 @@ def main():
         '__version__ = "{version}"',
         version,
     )
+    # V embedded_version fallback (parity with VERSION / __init__.py)
+    changed += bump_file(
+        "modules/agent_toolkit_core/version.v",
+        r"pub const embedded_version = '.*'",
+        "pub const embedded_version = '{version}'",
+        version,
+    )
     # package.json
     pkg = ROOT / "package.json"
     if pkg.exists():

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -3,8 +3,14 @@
     {
       "command": "version",
       "args": ["version"],
-      "class": "NORMALIZED_EXACT",
-      "stdout_prefix": "agent-toolkit "
+      "class": "EXACT",
+      "expect_exit": 0
+    },
+    {
+      "command": "version-flag",
+      "args": ["--version"],
+      "class": "EXACT",
+      "expect_exit": 0
     },
     {
       "command": "help",


### PR DESCRIPTION
## Summary
- V \`version\` / \`--version\` resolves from \`VERSION\` (env root / checkout), not a dispatch-only constant.
- \`embedded_version\` fallback stays synced via \`scripts/bump-version.py\`.
- Parity fixtures upgraded to EXACT stdout match vs Python.

Fixes #502.

## Test plan
- [ ] \`make test\`
- [ ] \`make build-cli && ./build/agent-toolkit-v version\` matches \`agent-toolkit version\`
- [ ] \`PARITY_V_BIN=./build/agent-toolkit-v python3 tests/parity/run_harness.py\`


Made with [Cursor](https://cursor.com)