### PR TITLE
feat(v): implement read-only inventory command (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `inventory` lists skills/agents/products from the toolkit tree (Closes #503)
 - **Feat** — V `matrix` prints the platform capability matrix (Closes #504)
 - **Feat** — V `version` / `--version` resolves from VERSION file (fallback synced via bump-version) (Closes #502)
 - **Feat** — V toolkit root resolution per ADR-015 (env override → XDG → embedded → checkout → CWD; offline never downloads) (Closes #506)

--- a/docs/v/inventory.md
+++ b/docs/v/inventory.md
@@ -1,0 +1,5 @@
+# V `inventory` command
+
+**Issue:** [#503](https://github.com/ulises-jeremias/agent-toolkit/issues/503)
+
+Read-only listing of `skills/**/SKILL.md`, `agents/*`, and `distributions/products.yaml`. Human output matches the Python header/counts contract; `--json` emits `CommandResult` with `skills_count` / `agents_count` / `products_count`. Does not use the compiler loader ([#507](https://github.com/ulises-jeremias/agent-toolkit/issues/507)).

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -48,6 +48,13 @@ pub fn dispatch(args []string) int {
 			return 0
 		}
 	}
+	if cmd_name == 'inventory' {
+		snap := agent_toolkit_core.load_inventory() or {
+			e := agent_toolkit_core.err_env('root.missing', err.msg())
+			return render_error(e, mode)
+		}
+		return render(agent_toolkit_core.inventory_result(snap), mode)
+	}
 	if cmd_name == 'matrix' {
 		return render(agent_toolkit_core.matrix_result(), mode)
 	}

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -31,6 +31,11 @@ fn test_dispatch_matrix_exit_zero() {
 	assert code == 0
 }
 
+fn test_dispatch_inventory_exit_zero() {
+	code := dispatch(['agent-toolkit', 'inventory'])
+	assert code == 0
+}
+
 fn test_grouped_help_mentions_consumer_and_advanced() {
 	h := grouped_help()
 	assert h.contains('Consumer') || h.to_lower().contains('install')

--- a/modules/agent_toolkit_core/inventory.v
+++ b/modules/agent_toolkit_core/inventory.v
@@ -1,0 +1,207 @@
+module agent_toolkit_core
+
+import os
+import yaml
+
+struct ProductEntry {
+	id   string
+	name string
+}
+
+struct ProductsFile {
+	products []ProductEntry
+}
+
+// InventorySnapshot is the domain model for `agent-toolkit inventory`.
+pub struct InventorySnapshot {
+pub:
+	root          string
+	skill_count   int
+	agent_count   int
+	product_count int
+	domain_count  int
+	message       string
+}
+
+// load_inventory lists skills/, agents/, and distributions/products.yaml.
+// Catalog YAML is not decoded (vlib/yaml rejects folded descriptions); tree walk is the source.
+pub fn load_inventory() !InventorySnapshot {
+	root := lookup_checkout_root()
+	if root.len == 0 {
+		return error('Cannot locate agent-toolkit root (set AGENT_TOOLKIT_ROOT)')
+	}
+	return load_inventory_at(root)
+}
+
+// load_inventory_at is the injectable variant for tests.
+pub fn load_inventory_at(root string) !InventorySnapshot {
+	skill_files := collect_named(os.join_path(root, 'skills'), 'SKILL.md')
+	mut domains := map[string]int{}
+	skills_root := os.join_path(root, 'skills')
+	for p in skill_files {
+		rel := rel_under(skills_root, p)
+		domain := first_path_component(rel)
+		if domain.len > 0 {
+			domains[domain] = domains[domain] + 1
+		}
+	}
+	agent_dirs := list_agent_dirs(os.join_path(root, 'agents'))
+	products := load_products(os.join_path(root, 'distributions', 'products.yaml'))
+
+	mut lines := []string{}
+	lines << ''
+	lines << '═══ agent-toolkit Inventory ═══'
+	lines << ''
+	lines << 'Skills: ${skill_files.len} across ${domains.len} domains'
+	lines << ''
+	mut domain_names := domains.keys()
+	domain_names.sort()
+	for d in domain_names {
+		lines << '  ${d}/ (${domains[d]})'
+		for p in skill_files {
+			rel := rel_under(skills_root, p)
+			if first_path_component(rel) != d {
+				continue
+			}
+			name := os.file_name(os.dir(p))
+			lines << '    ✓  ${name}'
+		}
+	}
+	lines << ''
+	lines << 'Agents: ${agent_dirs.len}'
+	mut agents := agent_dirs.clone()
+	agents.sort()
+	for a in agents {
+		lines << '  ✓  ${a}'
+	}
+	lines << ''
+	lines << 'Products: ${products.len}'
+	for p in products {
+		lines << '  ✓  ${p.id}'
+	}
+	lines << ''
+
+	return InventorySnapshot{
+		root:          root
+		skill_count:   skill_files.len
+		agent_count:   agent_dirs.len
+		product_count: products.len
+		domain_count:  domains.len
+		message:       lines.join('\n')
+	}
+}
+
+// inventory_result maps a snapshot to CommandResult.
+pub fn inventory_result(snap InventorySnapshot) CommandResult {
+	return CommandResult{
+		command: 'inventory'
+		ok:      true
+		message: snap.message
+		data:    {
+			'root':           snap.root
+			'skills_count':   '${snap.skill_count}'
+			'agents_count':   '${snap.agent_count}'
+			'products_count': '${snap.product_count}'
+			'domains_count':  '${snap.domain_count}'
+		}
+	}
+}
+
+// lookup_checkout_root finds a toolkit checkout via env then CWD walk-up.
+pub fn lookup_checkout_root() string {
+	for env in ['AGENT_TOOLKIT_ROOT', 'AI_WORKSPACE'] {
+		val := os.getenv(env).trim_space()
+		if val.len == 0 {
+			continue
+		}
+		if os.is_dir(os.join_path(val, 'skills')) || os.is_dir(os.join_path(val, 'profiles')) {
+			return val
+		}
+	}
+	mut cur := os.getwd()
+	for {
+		if os.is_dir(os.join_path(cur, 'skills')) && os.is_dir(os.join_path(cur, 'loops')) {
+			return cur
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	cwd := os.getwd()
+	if os.is_dir(os.join_path(cwd, 'skills')) || os.is_dir(os.join_path(cwd, 'loops')) {
+		return cwd
+	}
+	return ''
+}
+
+fn collect_named(dir string, name string) []string {
+	mut out := []string{}
+	if !os.is_dir(dir) {
+		return out
+	}
+	entries := os.ls(dir) or { return out }
+	for e in entries {
+		if e.starts_with('.') {
+			continue
+		}
+		p := os.join_path(dir, e)
+		if os.is_dir(p) {
+			out << collect_named(p, name)
+		} else if e == name {
+			out << p
+		}
+	}
+	return out
+}
+
+fn list_agent_dirs(dir string) []string {
+	mut out := []string{}
+	if !os.is_dir(dir) {
+		return out
+	}
+	entries := os.ls(dir) or { return out }
+	for e in entries {
+		if e.starts_with('.') {
+			continue
+		}
+		p := os.join_path(dir, e)
+		if os.is_dir(p) {
+			out << e
+		}
+	}
+	return out
+}
+
+fn rel_under(root string, path string) string {
+	if path.len <= root.len {
+		return ''
+	}
+	mut rel := path[root.len..]
+	if rel.starts_with('/') || rel.starts_with('\\') {
+		rel = rel[1..]
+	}
+	return rel
+}
+
+fn first_path_component(rel string) string {
+	mut i := 0
+	for i < rel.len {
+		c := rel[i]
+		if c == `/` || c == `\\` {
+			return rel[..i]
+		}
+		i++
+	}
+	return rel
+}
+
+fn load_products(path string) []ProductEntry {
+	if !os.is_file(path) {
+		return []
+	}
+	text := os.read_file(path) or { return [] }
+	doc := yaml.decode[ProductsFile](text) or { return [] }
+	return doc.products
+}

--- a/modules/agent_toolkit_core/inventory_test.v
+++ b/modules/agent_toolkit_core/inventory_test.v
@@ -1,0 +1,61 @@
+module agent_toolkit_core
+
+import os
+
+fn test_load_inventory_at_temp_tree() {
+	root := os.join_path(os.temp_dir(), 'at-inv-${os.getpid()}')
+	os.mkdir_all(os.join_path(root, 'skills', 'core', 'assistant')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'skills', 'forge', 'github-cli-workflow')) or {
+		assert false, err.msg()
+	}
+	os.mkdir_all(os.join_path(root, 'agents', 'code-reviewer')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'distributions')) or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'skills', 'core', 'assistant', 'SKILL.md'), '# x\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'skills', 'forge', 'github-cli-workflow', 'SKILL.md'), '# x\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'distributions', 'products.yaml'),
+		'products:\n  - id: agent-toolkit-core\n    name: Core\n') or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	snap := load_inventory_at(root) or {
+		assert false, err.msg()
+		return
+	}
+	assert snap.skill_count == 2
+	assert snap.agent_count == 1
+	assert snap.product_count == 1
+	assert snap.domain_count == 2
+	assert snap.message.contains('Skills: 2 across 2 domains')
+	assert snap.message.contains('Agents: 1')
+	assert snap.message.contains('agent-toolkit-core')
+	r := inventory_result(snap)
+	assert r.ok
+	assert r.data['skills_count'] == '2'
+	assert r.data['products_count'] == '1'
+}
+
+fn test_lookup_checkout_root_env() {
+	dir := os.join_path(os.temp_dir(), 'at-inv-env-${os.getpid()}')
+	os.mkdir_all(os.join_path(dir, 'skills')) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	old := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', dir, true)
+	defer {
+		restore_env_inv('AGENT_TOOLKIT_ROOT', old)
+	}
+	assert lookup_checkout_root() == dir
+}
+
+fn restore_env_inv(key string, old string) {
+	if old.len > 0 {
+		os.setenv(key, old, true)
+	} else {
+		os.unsetenv(key)
+	}
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -2,77 +2,52 @@
   "fixtures": [
     {
       "command": "version",
-      "args": [
-        "version"
-      ],
+      "args": ["version"],
       "class": "EXACT",
       "expect_exit": 0
     },
     {
       "command": "version-flag",
-      "args": [
-        "--version"
-      ],
+      "args": ["--version"],
       "class": "EXACT",
       "expect_exit": 0
     },
     {
       "command": "help",
-      "args": [
-        "--help"
-      ],
+      "args": ["--help"],
       "class": "SEMANTIC",
-      "must_contain": [
-        "install",
-        "doctor",
-        "inventory"
-      ]
+      "must_contain": ["install", "doctor", "inventory"]
     },
     {
       "command": "inventory",
-      "args": [
-        "inventory",
-        "--json"
-      ],
+      "args": ["inventory", "--json"],
       "class": "SCHEMA",
-      "expect_v_exit": 1,
-      "required_keys": [
-        "command",
-        "data"
-      ]
+      "expect_v_exit": 0,
+      "required_keys": ["command", "skills_count", "agents_count", "products_count"]
+    },
+    {
+      "command": "inventory-human",
+      "args": ["inventory"],
+      "class": "SEMANTIC",
+      "must_contain": ["Skills:", "Agents:", "Products:"]
     },
     {
       "command": "matrix",
-      "args": [
-        "matrix",
-        "--json"
-      ],
+      "args": ["matrix", "--json"],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": [
-        "command",
-        "found"
-      ]
+      "required_keys": ["command", "found"]
     },
     {
       "command": "doctor",
-      "args": [
-        "doctor",
-        "--json"
-      ],
+      "args": ["doctor", "--json"],
       "class": "SCHEMA",
       "expect_v_exit": 1,
-      "required_keys": [
-        "command",
-        "data"
-      ]
+      "required_keys": ["command", "data"]
     },
     {
       "command": "install-bad-flag",
-      "args": [
-        "install",
-        "--not-a-real-flag"
-      ],
+      "args": ["install", "--not-a-real-flag"],
       "class": "EXACT",
       "expect_exit": 2,
       "compare": "exit_only"


### PR DESCRIPTION
## Summary
- V `inventory` lists `skills/**/SKILL.md`, `agents/*`, and `distributions/products.yaml`.
- `--json` emits `CommandResult` with `skills_count` / `agents_count` / `products_count`.
- Parity fixtures: SCHEMA for `--json` (exit 0) and SEMANTIC for human output.

Fixes #503.

## Test plan
- [ ] `make test`
- [ ] `make build-cli && ./build/agent-toolkit-v inventory`
- [ ] `python3 tests/parity/run_harness.py --v-bin build/agent-toolkit-v`


Made with [Cursor](https://cursor.com)