### PR TITLE
feat(v): implement read-only matrix command (#504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `matrix` prints the platform capability matrix (Closes #504)
 - **Feat** — V `version` / `--version` resolves from VERSION file (fallback synced via bump-version) (Closes #502)
 - **Feat** — V toolkit root resolution per ADR-015 (env override → XDG → embedded → checkout → CWD; offline never downloads) (Closes #506)
 - **Test** — Python↔V golden CLI parity harness + CI seed job (Closes #548)

--- a/docs/v/matrix.md
+++ b/docs/v/matrix.md
@@ -1,0 +1,5 @@
+# V `matrix` command
+
+**Issue:** [#504](https://github.com/ulises-jeremias/agent-toolkit/issues/504)
+
+Read-only print of `docs/research/platform-capability-matrix.md` from the toolkit root (env / checkout walk-up). Missing file prints the same fallback as Python and still exits 0.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -48,6 +48,9 @@ pub fn dispatch(args []string) int {
 			return 0
 		}
 	}
+	if cmd_name == 'matrix' {
+		return render(agent_toolkit_core.matrix_result(), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -26,6 +26,11 @@ fn test_dispatch_dc_alias_not_unknown() {
 	assert code == 1
 }
 
+fn test_dispatch_matrix_exit_zero() {
+	code := dispatch(['agent-toolkit', 'matrix'])
+	assert code == 0
+}
+
 fn test_grouped_help_mentions_consumer_and_advanced() {
 	h := grouped_help()
 	assert h.contains('Consumer') || h.to_lower().contains('install')

--- a/modules/agent_toolkit_core/matrix.v
+++ b/modules/agent_toolkit_core/matrix.v
@@ -1,0 +1,87 @@
+module agent_toolkit_core
+
+import os
+
+const matrix_rel = 'docs/research/platform-capability-matrix.md'
+
+// matrix_result prints the platform capability matrix from the toolkit tree.
+pub fn matrix_result() CommandResult {
+	root := lookup_matrix_root()
+	if root.len == 0 {
+		msg := 'Matrix not found. Run the research pipeline first.\nExpected at: ${matrix_rel}'
+		return CommandResult{
+			command: 'matrix'
+			ok:      true
+			message: msg
+			data:    {
+				'found': 'false'
+				'path':  matrix_rel
+			}
+		}
+	}
+	return matrix_result_at(root)
+}
+
+// matrix_result_at is the injectable variant for tests.
+pub fn matrix_result_at(root string) CommandResult {
+	path := os.join_path(root, 'docs', 'research', 'platform-capability-matrix.md')
+	if os.is_file(path) {
+		text := os.read_file(path) or {
+			return CommandResult{
+				command: 'matrix'
+				ok:      true
+				message: 'Matrix not found. Run the research pipeline first.\nExpected at: ${path}'
+				data:    {
+					'found': 'false'
+					'path':  path
+				}
+			}
+		}
+		return CommandResult{
+			command: 'matrix'
+			ok:      true
+			message: text
+			data:    {
+				'found': 'true'
+				'path':  path
+			}
+		}
+	}
+	return CommandResult{
+		command: 'matrix'
+		ok:      true
+		message: 'Matrix not found. Run the research pipeline first.\nExpected at: ${path}'
+		data:    {
+			'found': 'false'
+			'path':  path
+		}
+	}
+}
+
+fn lookup_matrix_root() string {
+	for env in ['AGENT_TOOLKIT_ROOT', 'AI_WORKSPACE'] {
+		val := os.getenv(env).trim_space()
+		if val.len == 0 {
+			continue
+		}
+		if os.is_dir(os.join_path(val, 'skills')) || os.is_dir(os.join_path(val, 'docs')) {
+			return val
+		}
+	}
+	mut cur := os.getwd()
+	for {
+		if os.is_dir(os.join_path(cur, 'skills')) && os.is_dir(os.join_path(cur, 'loops')) {
+			return cur
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	cwd := os.getwd()
+	if os.is_dir(os.join_path(cwd, 'docs')) {
+		return cwd
+	}
+	return ''
+}

--- a/modules/agent_toolkit_core/matrix_test.v
+++ b/modules/agent_toolkit_core/matrix_test.v
@@ -1,0 +1,30 @@
+module agent_toolkit_core
+
+import os
+
+fn test_matrix_result_at_found() {
+	root := os.join_path(os.temp_dir(), 'at-matrix-${os.getpid()}')
+	dir := os.join_path(root, 'docs', 'research')
+	os.mkdir_all(dir) or { assert false, err.msg() }
+	path := os.join_path(dir, 'platform-capability-matrix.md')
+	os.write_file(path, '# Capability Matrix\nClaude Code\n') or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	r := matrix_result_at(root)
+	assert r.ok
+	assert r.data['found'] == 'true'
+	assert r.message.contains('Capability Matrix')
+}
+
+fn test_matrix_result_at_missing() {
+	root := os.join_path(os.temp_dir(), 'at-matrix-miss-${os.getpid()}')
+	os.mkdir_all(root) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	r := matrix_result_at(root)
+	assert r.ok
+	assert r.data['found'] == 'false'
+	assert r.message.contains('Matrix not found')
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -2,6 +2,7 @@
   "fixtures": [
     {
       "command": "version",
+<<<<<<< HEAD
       "args": ["version"],
       "class": "EXACT",
       "expect_exit": 0
@@ -11,30 +12,71 @@
       "args": ["--version"],
       "class": "EXACT",
       "expect_exit": 0
+=======
+      "args": [
+        "version"
+      ],
+      "class": "NORMALIZED_EXACT",
+      "stdout_prefix": "agent-toolkit "
+>>>>>>> 29a9fc2 (feat(v): implement read-only matrix command)
     },
     {
       "command": "help",
-      "args": ["--help"],
+      "args": [
+        "--help"
+      ],
       "class": "SEMANTIC",
-      "must_contain": ["install", "doctor", "inventory"]
+      "must_contain": [
+        "install",
+        "doctor",
+        "inventory"
+      ]
     },
     {
       "command": "inventory",
-      "args": ["inventory", "--json"],
+      "args": [
+        "inventory",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 1,
-      "required_keys": ["command", "data"]
+      "required_keys": [
+        "command",
+        "data"
+      ]
+    },
+    {
+      "command": "matrix",
+      "args": [
+        "matrix",
+        "--json"
+      ],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": [
+        "command",
+        "found"
+      ]
     },
     {
       "command": "doctor",
-      "args": ["doctor", "--json"],
+      "args": [
+        "doctor",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 1,
-      "required_keys": ["command", "data"]
+      "required_keys": [
+        "command",
+        "data"
+      ]
     },
     {
       "command": "install-bad-flag",
-      "args": ["install", "--not-a-real-flag"],
+      "args": [
+        "install",
+        "--not-a-real-flag"
+      ],
       "class": "EXACT",
       "expect_exit": 2,
       "compare": "exit_only"


### PR DESCRIPTION
## Summary
- V `matrix` prints `docs/research/platform-capability-matrix.md` from env/checkout root.
- Missing file uses the same fallback message as Python and still exits 0.
- Parity SCHEMA fixture for `matrix --json` (`found` key).

Fixes #504.

## Test plan
- [ ] `make test`
- [ ] `make build-cli && ./build/agent-toolkit-v matrix | head`
- [ ] `python3 tests/parity/run_harness.py --v-bin build/agent-toolkit-v`


Made with [Cursor](https://cursor.com)