### PR TITLE
feat(v): implement read-only doctor with --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `doctor` read-only + `--json` with engine/version/platform (Closes #505)
 - **Feat** — V `inventory` lists skills/agents/products from the toolkit tree (Closes #503)
 - **Feat** — V `matrix` prints the platform capability matrix (Closes #504)
 - **Feat** — V `version` / `--version` resolves from VERSION file (fallback synced via bump-version) (Closes #502)

--- a/docs/v/doctor.md
+++ b/docs/v/doctor.md
@@ -1,0 +1,5 @@
+# V `doctor` command (read-only)
+
+**Issue:** [#505](https://github.com/ulises-jeremias/agent-toolkit/issues/505)
+
+Read-only health report. `--json` includes `engine`, `version`, and `platform` for migration observability. `--fix` is accepted and ignored (no writes). Missing tools are warnings so the seed stays hermetic; a missing toolkit root is an error.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -39,7 +39,7 @@ pub fn dispatch(args []string) int {
 	}
 	// Remaining tokens may include unknown flags → exit 2
 	for a in argv[1..] {
-		if a.starts_with('-') && a !in ['-h', '--help', '--json', '--quiet'] {
+		if a.starts_with('-') && !allowed_flag(cmd_name, a) {
 			e := agent_toolkit_core.err_usage_flags('flag.unknown', 'unknown flag: ${a}')
 			return render_error(e, mode)
 		}
@@ -58,7 +58,21 @@ pub fn dispatch(args []string) int {
 	if cmd_name == 'matrix' {
 		return render(agent_toolkit_core.matrix_result(), mode)
 	}
+	if cmd_name == 'doctor' {
+		snap := agent_toolkit_core.run_doctor_readonly()
+		return render(agent_toolkit_core.doctor_result(snap), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
+}
+
+fn allowed_flag(cmd string, a string) bool {
+	if a in ['-h', '--help', '--json', '--quiet'] {
+		return true
+	}
+	if cmd == 'doctor' && a in ['--fix', '--provenance'] {
+		return true
+	}
+	return false
 }
 
 fn resolve_alias(name string) string {

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -36,6 +36,16 @@ fn test_dispatch_inventory_exit_zero() {
 	assert code == 0
 }
 
+fn test_dispatch_doctor_json_exit_zero() {
+	code := dispatch(['agent-toolkit', 'doctor', '--json'])
+	assert code == 0
+}
+
+fn test_dispatch_doctor_fix_is_readonly() {
+	code := dispatch(['agent-toolkit', 'doctor', '--fix', '--json'])
+	assert code == 0
+}
+
 fn test_grouped_help_mentions_consumer_and_advanced() {
 	h := grouped_help()
 	assert h.contains('Consumer') || h.to_lower().contains('install')

--- a/modules/agent_toolkit_core/doctor.v
+++ b/modules/agent_toolkit_core/doctor.v
@@ -1,0 +1,152 @@
+module agent_toolkit_core
+
+import os
+
+// DoctorSnapshot is a read-only health summary for migration observability.
+pub struct DoctorSnapshot {
+pub:
+	engine   string
+	version  string
+	platform string
+	root     string
+	root_ok  bool
+	offline  bool
+	ok       bool
+	message  string
+}
+
+// run_doctor_readonly performs read-only checks (no --fix).
+pub fn run_doctor_readonly() DoctorSnapshot {
+	ver := doctor_version()
+	offline := doctor_is_offline()
+	root := doctor_lookup_root()
+	root_ok := root.len > 0
+	platform := '${os.user_os()}/${os.uname().machine}'
+	ok := root_ok
+	mut lines := []string{}
+	lines << ''
+	lines << 'agent-toolkit doctor'
+	lines << ''
+	lines << '── Engine ──'
+	lines << '  ✓  engine                          v'
+	lines << '  ✓  version                         ${ver}'
+	lines << '  ✓  platform                        ${platform}'
+	lines << ''
+	lines << '── Toolkit root ──'
+	if root_ok {
+		lines << '  ✓  root                            ${root}'
+	} else {
+		lines << '  ✗  root                            not found (set AGENT_TOOLKIT_ROOT)'
+	}
+	if offline {
+		lines << '  ⚠  offline                         AGENT_TOOLKIT_OFFLINE set'
+	}
+	lines << ''
+	lines << '── Summary ──'
+	if ok {
+		lines << '  ✓  read-only checks passed'
+	} else {
+		lines << '  ✗  one or more errors detected'
+	}
+	lines << ''
+	return DoctorSnapshot{
+		engine:   'v'
+		version:  ver
+		platform: platform
+		root:     root
+		root_ok:  root_ok
+		offline:  offline
+		ok:       ok
+		message:  lines.join('\n')
+	}
+}
+
+// run_doctor is an alias used by the CLI adapter.
+pub fn run_doctor() DoctorSnapshot {
+	return run_doctor_readonly()
+}
+
+// doctor_result maps a snapshot to CommandResult (includes engine/version/platform).
+pub fn doctor_result(snap DoctorSnapshot) CommandResult {
+	return CommandResult{
+		command: 'doctor'
+		ok:      snap.ok
+		message: snap.message
+		data:    {
+			'engine':   snap.engine
+			'version':  snap.version
+			'platform': snap.platform
+			'root':     snap.root
+			'root_ok':  if snap.root_ok { 'true' } else { 'false' }
+			'offline':  if snap.offline { 'true' } else { 'false' }
+		}
+	}
+}
+
+fn doctor_version() string {
+	for env in ['AGENT_TOOLKIT_ROOT', 'AI_WORKSPACE'] {
+		val := os.getenv(env).trim_space()
+		if val.len == 0 {
+			continue
+		}
+		vf := os.join_path(val, 'VERSION')
+		if os.is_file(vf) {
+			text := os.read_file(vf) or { continue }
+			v := text.trim_space()
+			if v.len > 0 {
+				return v
+			}
+		}
+	}
+	mut cur := os.getwd()
+	for {
+		vf := os.join_path(cur, 'VERSION')
+		if os.is_file(vf)
+			&& (os.is_dir(os.join_path(cur, 'skills')) || os.is_dir(os.join_path(cur, 'loops'))) {
+			text := os.read_file(vf) or { '' }
+			v := text.trim_space()
+			if v.len > 0 {
+				return v
+			}
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	return '1.10.0'
+}
+
+fn doctor_is_offline() bool {
+	v := os.getenv('AGENT_TOOLKIT_OFFLINE').trim_space().to_lower()
+	return v in ['1', 'true', 'yes']
+}
+
+fn doctor_lookup_root() string {
+	for env in ['AGENT_TOOLKIT_ROOT', 'AI_WORKSPACE'] {
+		val := os.getenv(env).trim_space()
+		if val.len == 0 {
+			continue
+		}
+		if os.is_dir(os.join_path(val, 'skills')) || os.is_dir(os.join_path(val, 'profiles')) {
+			return val
+		}
+	}
+	mut cur := os.getwd()
+	for {
+		if os.is_dir(os.join_path(cur, 'skills')) && os.is_dir(os.join_path(cur, 'loops')) {
+			return cur
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	cwd := os.getwd()
+	if os.is_dir(os.join_path(cwd, 'skills')) || os.is_dir(os.join_path(cwd, 'loops')) {
+		return cwd
+	}
+	return ''
+}

--- a/modules/agent_toolkit_core/doctor_test.v
+++ b/modules/agent_toolkit_core/doctor_test.v
@@ -1,0 +1,12 @@
+module agent_toolkit_core
+
+fn test_run_doctor_readonly_has_observability_fields() {
+	snap := run_doctor_readonly()
+	assert snap.engine == 'v'
+	assert snap.version.len > 0
+	assert snap.platform.contains('/')
+	r := doctor_result(snap)
+	assert r.data['engine'] == 'v'
+	assert r.data['version'] == snap.version
+	assert r.data['platform'] == snap.platform
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -42,8 +42,8 @@
       "command": "doctor",
       "args": ["doctor", "--json"],
       "class": "SCHEMA",
-      "expect_v_exit": 1,
-      "required_keys": ["command", "data"]
+      "expect_v_exit": 0,
+      "required_keys": ["engine", "version", "platform"]
     },
     {
       "command": "install-bad-flag",


### PR DESCRIPTION
## Summary
- V \`doctor\` read-only health report with \`engine\` / \`version\` / \`platform\` in JSON.
- \`--fix\` / \`--provenance\` accepted and ignored (no writes).
- SCHEMA parity fixture updated for observability keys.

Fixes #505.

## Test plan
- [ ] \`make test\`
- [ ] \`make build-cli && ./build/agent-toolkit-v doctor --json\`
- [ ] \`PARITY_V_BIN=./build/agent-toolkit-v python3 tests/parity/run_harness.py\`


Made with [Cursor](https://cursor.com)