### PR TITLE
feat(v): add XDG content cache service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V content cache service (XDG hit/miss/offline; no network) (Closes #556)
 - **Feat** — V `doctor` read-only + `--json` with engine/version/platform (Closes #505)
 - **Feat** — V `inventory` lists skills/agents/products from the toolkit tree (Closes #503)
 - **Feat** — V `matrix` prints the platform capability matrix (Closes #504)

--- a/modules/agent_toolkit_core/cache.v
+++ b/modules/agent_toolkit_core/cache.v
@@ -1,0 +1,81 @@
+module agent_toolkit_core
+
+import json
+import os
+
+// CacheMeta is the metadata stored in cached_version.json.
+pub struct CacheMeta {
+pub:
+	version string
+	source  string
+	url     string
+}
+
+// ContentCache is the XDG cache service (no network; sync is #557).
+pub struct ContentCache {
+pub:
+	fs FsService
+}
+
+// new_content_cache builds a cache service using real XDG paths.
+pub fn new_content_cache() ContentCache {
+	return ContentCache{
+		fs: new_fs()
+	}
+}
+
+// dir returns the toolkit cache directory (~/.cache/agent-toolkit).
+pub fn (c ContentCache) dir() string {
+	return c.fs.toolkit_cache_dir()
+}
+
+// version_file returns the path to cached_version.json.
+pub fn (c ContentCache) version_file() string {
+	return c.fs.join(c.dir(), 'cached_version.json')
+}
+
+// read_meta loads cache metadata if present.
+pub fn (c ContentCache) read_meta() ?CacheMeta {
+	path := c.version_file()
+	if !os.is_file(path) {
+		return none
+	}
+	text := os.read_file(path) or { return none }
+	meta := json.decode(CacheMeta, text) or { return none }
+	if meta.version.len == 0 {
+		return none
+	}
+	return meta
+}
+
+// write_meta stores cache metadata atomically.
+pub fn (c ContentCache) write_meta(meta CacheMeta) ! {
+	c.fs.ensure_dir(c.dir())!
+	payload := json.encode(meta)
+	c.fs.write_atomic(c.version_file(), payload + '\n')!
+}
+
+// has_profiles reports whether the cache looks populated (profiles/).
+pub fn (c ContentCache) has_profiles() bool {
+	return os.is_dir(c.fs.join(c.dir(), 'profiles'))
+}
+
+// is_current reports whether cached version matches expected.
+pub fn (c ContentCache) is_current(expected string) bool {
+	meta := c.read_meta() or { return false }
+	return meta.version == expected && c.has_profiles()
+}
+
+// resolve_local returns the cache dir on hit, or none on miss (never downloads).
+pub fn (c ContentCache) resolve_local(expected string, offline bool) ?string {
+	if c.is_current(expected) {
+		return c.dir()
+	}
+	if offline && c.has_profiles() {
+		return c.dir()
+	}
+	if c.has_profiles() && expected.len == 0 {
+		return c.dir()
+	}
+	return none
+}

--- a/modules/agent_toolkit_core/cache_test.v
+++ b/modules/agent_toolkit_core/cache_test.v
@@ -1,0 +1,44 @@
+module agent_toolkit_core
+
+import os
+
+fn restore_env_cache(key string, old string) {
+	if old.len > 0 {
+		os.setenv(key, old, true)
+	} else {
+		os.unsetenv(key)
+	}
+}
+
+fn test_content_cache_hit_miss_offline() {
+	home := os.join_path(os.temp_dir(), 'at-cache-${os.getpid()}')
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(home) or {}
+	}
+	old_xdg := os.getenv('XDG_CACHE_HOME')
+	os.setenv('XDG_CACHE_HOME', home, true)
+	defer {
+		restore_env_cache('XDG_CACHE_HOME', old_xdg)
+	}
+	c := new_content_cache()
+	assert c.resolve_local('1.10.0', false) == none
+	os.mkdir_all(c.fs.join(c.dir(), 'profiles')) or { assert false, err.msg() }
+	c.write_meta(CacheMeta{
+		version: '1.10.0'
+		source:  'test'
+		url:     ''
+	}) or { assert false, err.msg() }
+	hit := c.resolve_local('1.10.0', false) or {
+		assert false, 'expected cache hit'
+		return
+	}
+	assert hit == c.dir()
+	assert c.is_current('1.10.0')
+	assert c.resolve_local('9.9.9', false) == none
+	offline_hit := c.resolve_local('9.9.9', true) or {
+		assert false, 'expected offline hit'
+		return
+	}
+	assert offline_hit == c.dir()
+}


### PR DESCRIPTION
## Summary
- V \`ContentCache\` for XDG \`~/.cache/agent-toolkit\` hit/miss/offline semantics.
- No network — download/sync remains #557.
- Unit fixtures cover hit, miss, and offline populated cache.

Fixes #556.

## Test plan
- [ ] \`make test\`
- [ ] Unit: \`v test modules/agent_toolkit_core/cache_test.v\`


Made with [Cursor](https://cursor.com)