### PR TITLE
feat(v): add GitHub release data sync client (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V content sync/download client (GitHub release data; offline never networks; staging validation) (Closes #557)
 - **Feat** — V content cache service (XDG hit/miss/offline; no network) (Closes #556)
 - **Feat** — V `doctor` read-only + `--json` with engine/version/platform (Closes #505)
 - **Feat** — V `inventory` lists skills/agents/products from the toolkit tree (Closes #503)

--- a/docs/v/sync.md
+++ b/docs/v/sync.md
@@ -1,0 +1,5 @@
+# V content sync / download client
+
+**Issue:** [#557](https://github.com/ulises-jeremias/agent-toolkit/issues/557)
+
+Downloads capability trees from GitHub Release tarballs into XDG data (`$XDG_DATA_HOME/agent-toolkit/data`). Uses `NetworkClient` (#558). Offline (`AGENT_TOOLKIT_OFFLINE` or `ensure_data(..., offline: true)`) never hits the network. Staging is validated before replace so a corrupt/partial download does not activate the cache.

--- a/modules/agent_toolkit_core/sync.v
+++ b/modules/agent_toolkit_core/sync.v
@@ -1,0 +1,175 @@
+module agent_toolkit_core
+
+import os
+
+const data_subdirs = ['skills', 'agents', 'loops', 'profiles', 'mcp', 'catalogs']
+const github_repo = 'ulises-jeremias/agent-toolkit'
+const version_marker = '.version'
+
+// DataSync downloads capability trees from GitHub Releases into XDG data.
+pub struct DataSync {
+pub:
+	net NetworkClient
+	fs  FsService
+}
+
+// new_data_sync builds a sync client; auto_offline honors AGENT_TOOLKIT_OFFLINE.
+pub fn new_data_sync() DataSync {
+	return DataSync{
+		net: new_network_client(true)
+		fs:  new_fs()
+	}
+}
+
+// data_dir is XDG data home / agent-toolkit / data (same as Python data_sync).
+pub fn (s DataSync) data_dir() string {
+	return s.fs.toolkit_data_dir()
+}
+
+// is_valid_data_root reports profiles/ plus skills/ or loops/.
+pub fn is_valid_data_root(path string) bool {
+	if path.len == 0 || !os.is_dir(path) {
+		return false
+	}
+	if !os.is_dir(os.join_path(path, 'profiles')) {
+		return false
+	}
+	return os.is_dir(os.join_path(path, 'skills')) || os.is_dir(os.join_path(path, 'loops'))
+}
+
+// cached_data_version reads the .version marker in the data dir.
+pub fn (s DataSync) cached_data_version() string {
+	vf := s.fs.join(s.data_dir(), version_marker)
+	if !os.is_file(vf) {
+		return ''
+	}
+	text := os.read_file(vf) or { return '' }
+	return text.trim_space()
+}
+
+// ensure_data returns a valid data root. Offline never hits the network.
+pub fn (s DataSync) ensure_data(version string, offline bool, force bool) !string {
+	dest := s.data_dir()
+	pin := strip_v_prefix(version)
+	if !force && is_valid_data_root(dest) {
+		cv := strip_v_prefix(s.cached_data_version())
+		if cv.len == 0 || cv == pin || pin.len == 0 {
+			return dest
+		}
+	}
+	if offline || s.net.offline {
+		if is_valid_data_root(dest) {
+			return dest
+		}
+		return error('network offline: capability data cache missing (set AGENT_TOOLKIT_ROOT)')
+	}
+	return s.download_data(version)
+}
+
+// download_data fetches a release tarball into a staging dir, then promotes only if valid.
+pub fn (s DataSync) download_data(version string) !string {
+	if s.net.offline {
+		return error('network offline: AGENT_TOOLKIT_OFFLINE prevents download')
+	}
+	tag := release_tag(version)
+	url := 'https://github.com/${github_repo}/archive/refs/tags/${tag}.tar.gz'
+	tmp := s.fs.join(os.temp_dir(), 'agent-toolkit-data-${os.getpid()}')
+	os.mkdir_all(tmp) or { return error('staging mkdir failed: ${err}') }
+	defer {
+		os.rmdir_all(tmp) or {}
+	}
+	tarball := s.fs.join(tmp, 'source.tar.gz')
+	s.net.download(url, tarball) or {
+		return error('download failed (cache not activated): ${err}')
+	}
+	extract_dir := s.fs.join(tmp, 'extract')
+	os.mkdir_all(extract_dir) or { return error('extract mkdir failed: ${err}') }
+	extract_tarball(tarball, extract_dir)!
+	src := first_dir(extract_dir) or { return error('no top-level directory in release tarball') }
+	if !is_valid_data_root(src) {
+		return error('release tarball does not contain capability data (cache not activated)')
+	}
+	return s.promote_staging(src, strip_v_prefix(tag))
+}
+
+// promote_staging copies DATA_SUBDIRS from a validated tree into the data dir.
+// Dest is replaced only after the source validates — partial/corrupt trees never activate.
+pub fn (s DataSync) promote_staging(src string, version string) !string {
+	if !is_valid_data_root(src) {
+		return error('staging tree is not a valid data root (cache not activated)')
+	}
+	dest := s.data_dir()
+	staging := '${dest}.staging.${os.getpid()}'
+	os.mkdir_all(staging) or { return error('staging dest mkdir failed: ${err}') }
+	for name in data_subdirs {
+		from := os.join_path(src, name)
+		if !os.is_dir(from) {
+			continue
+		}
+		to := os.join_path(staging, name)
+		os.cp_all(from, to, true) or {
+			os.rmdir_all(staging) or {}
+			return error('copy ${name} failed (cache not activated): ${err}')
+		}
+	}
+	if !is_valid_data_root(staging) {
+		os.rmdir_all(staging) or {}
+		return error('copied tree failed validation (cache not activated)')
+	}
+	ver := strip_v_prefix(version)
+	os.write_file(os.join_path(staging, version_marker), ver + '\n') or {
+		os.rmdir_all(staging) or {}
+		return error('write .version failed (cache not activated): ${err}')
+	}
+	if os.exists(dest) {
+		os.rmdir_all(dest) or {
+			os.rmdir_all(staging) or {}
+			return error('replace dest failed (cache not activated): ${err}')
+		}
+	}
+	os.mv(staging, dest) or {
+		os.rmdir_all(staging) or {}
+		return error('activate dest failed: ${err}')
+	}
+	return dest
+}
+
+fn release_tag(version string) string {
+	v := version.trim_space()
+	if v.len == 0 {
+		return 'v${embedded_version}'
+	}
+	if v.starts_with('v') {
+		return v
+	}
+	return 'v${v}'
+}
+
+fn strip_v_prefix(version string) string {
+	v := version.trim_space()
+	if v.starts_with('v') {
+		return v[1..]
+	}
+	return v
+}
+
+fn first_dir(path string) ?string {
+	entries := os.ls(path) or { return none }
+	for e in entries {
+		p := os.join_path(path, e)
+		if os.is_dir(p) {
+			return p
+		}
+	}
+	return none
+}
+
+fn extract_tarball(tarball string, dest string) ! {
+	ps := new_process_service()
+	res := ps.run(
+		argv: ['tar', '-xzf', tarball, '-C', dest]
+	)!
+	if res.exit_code != 0 {
+		return error('tar extract failed: ${res.stderr}')
+	}
+}

--- a/modules/agent_toolkit_core/sync_test.v
+++ b/modules/agent_toolkit_core/sync_test.v
@@ -1,0 +1,107 @@
+module agent_toolkit_core
+
+import os
+
+fn restore_env_sync(key string, old string) {
+	if old.len > 0 {
+		os.setenv(key, old, true)
+	} else {
+		os.unsetenv(key)
+	}
+}
+
+fn test_ensure_data_offline_never_hits_network() {
+	home := os.join_path(os.temp_dir(), 'at-sync-off-${os.getpid()}')
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(home) or {}
+	}
+	old := os.getenv('XDG_DATA_HOME')
+	os.setenv('XDG_DATA_HOME', home, true)
+	defer {
+		restore_env_sync('XDG_DATA_HOME', old)
+	}
+	s := DataSync{
+		net: NetworkClient{
+			offline: true
+		}
+		fs:  new_fs()
+	}
+	s.ensure_data('1.10.0', true, false) or {
+		assert err.msg().contains('offline')
+		assert !is_valid_data_root(s.data_dir())
+		return
+	}
+	assert false, 'expected offline miss error'
+}
+
+fn test_promote_staging_rejects_invalid_tree() {
+	home := os.join_path(os.temp_dir(), 'at-sync-bad-${os.getpid()}')
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(home) or {}
+	}
+	old := os.getenv('XDG_DATA_HOME')
+	os.setenv('XDG_DATA_HOME', home, true)
+	defer {
+		restore_env_sync('XDG_DATA_HOME', old)
+	}
+	src := os.join_path(home, 'src')
+	os.mkdir_all(src) or { assert false, err.msg() }
+	s := new_data_sync()
+	s.promote_staging(src, '1.10.0') or {
+		assert err.msg().contains('not a valid data root')
+		assert !os.exists(s.data_dir())
+		return
+	}
+	assert false, 'expected invalid staging error'
+}
+
+fn test_promote_staging_activates_valid_tree() {
+	home := os.join_path(os.temp_dir(), 'at-sync-ok-${os.getpid()}')
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(home) or {}
+	}
+	old := os.getenv('XDG_DATA_HOME')
+	os.setenv('XDG_DATA_HOME', home, true)
+	defer {
+		restore_env_sync('XDG_DATA_HOME', old)
+	}
+	src := os.join_path(home, 'src')
+	os.mkdir_all(os.join_path(src, 'profiles')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(src, 'skills')) or { assert false, err.msg() }
+	os.write_file(os.join_path(src, 'skills', 'marker.txt'), 'ok') or { assert false, err.msg() }
+	s := DataSync{
+		net: NetworkClient{
+			offline: true
+		}
+		fs:  new_fs()
+	}
+	dest := s.promote_staging(src, 'v1.10.0') or {
+		assert false, err.msg()
+		return
+	}
+	assert is_valid_data_root(dest)
+	assert s.cached_data_version() == '1.10.0'
+	assert os.is_file(os.join_path(dest, 'skills', 'marker.txt'))
+	got := s.ensure_data('1.10.0', true, false) or {
+		assert false, err.msg()
+		return
+	}
+	assert got == dest
+}
+
+fn test_download_data_offline_does_not_activate() {
+	s := DataSync{
+		net: NetworkClient{
+			offline: true
+		}
+		fs:  new_fs()
+	}
+	s.download_data('1.10.0') or {
+		assert err.msg().contains('offline')
+		return
+	}
+	assert false, 'expected offline download error'
+}


### PR DESCRIPTION
## Summary
- V `DataSync` downloads GitHub Release tarballs into XDG data (`$XDG_DATA_HOME/agent-toolkit/data`).
- Uses `NetworkClient` (#558). Offline never hits the network.
- Staging is validated before replace so a corrupt/partial download does not activate the cache.

Fixes #557.

## Test plan
- [ ] `make test`
- [ ] Unit: offline miss, invalid staging rejected, valid staging activates `.version`


Made with [Cursor](https://cursor.com)