### PR TITLE
feat(v): emit provenance JSON compatible with Python metadata (#508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V provenance emission compatible with Python `.provenance.json` schema (Closes #508)
 - **Feat** — V capability loader + product selection from `distributions/products.yaml` (Closes #507)
 - **Docs** — ADR-016 versioning during Python→V migration: major at cutover, not experimental binary (Closes #495)
 - **Feat** — V content sync/download client (GitHub release data; offline never networks; staging validation) (Closes #557)

--- a/docs/v/provenance.md
+++ b/docs/v/provenance.md
@@ -1,0 +1,5 @@
+# V provenance emission
+
+**Issue:** [#508](https://github.com/ulises-jeremias/agent-toolkit/issues/508)
+
+Emits `.provenance.json` sidecars compatible with Python `compiler/provenance.py`: `generatorVersion`, `product`, `target`, and artifact `path` / `sourceFile` / `sourceDigest` / `generatedDigest` (SHA256 truncated to 12 hex chars). `verify_generated_digests` reports drift without stripping provenance.

--- a/modules/agent_toolkit_core/provenance.v
+++ b/modules/agent_toolkit_core/provenance.v
@@ -1,0 +1,78 @@
+module agent_toolkit_core
+
+import crypto.sha256
+import json
+import os
+
+// ArtifactRecord is one generated file in a .provenance.json sidecar.
+pub struct ArtifactRecord {
+pub:
+	path             string
+	source_file      string @[json: 'sourceFile']
+	source_digest    string @[json: 'sourceDigest']
+	generated_digest string @[json: 'generatedDigest']
+}
+
+// ProvenanceManifest matches Python compiler/provenance.py JSON (camelCase keys).
+pub struct ProvenanceManifest {
+pub:
+	generator_version string @[json: 'generatorVersion']
+	product           string
+	target            string
+	artifacts         []ArtifactRecord
+}
+
+// file_digest returns SHA256 hex truncated to 12 chars, or "missing".
+pub fn file_digest(path string) string {
+	if !os.is_file(path) {
+		return 'missing'
+	}
+	data := os.read_file(path) or { return 'missing' }
+	sum := sha256.hexhash(data)
+	if sum.len < 12 {
+		return sum
+	}
+	return sum[..12]
+}
+
+// write_provenance writes .provenance.json under out_dir. Returns the path.
+pub fn write_provenance(out_dir string, product_id string, target_id string, artifacts []ArtifactRecord) !string {
+	os.mkdir_all(out_dir) or { return error('mkdir provenance dir failed: ${err}') }
+	manifest := ProvenanceManifest{
+		generator_version: resolve_toolkit_version()
+		product:           product_id
+		target:            target_id
+		artifacts:         artifacts
+	}
+	path := os.join_path(out_dir, '.provenance.json')
+	payload := json.encode(manifest)
+	os.write_file(path, payload + '\n') or { return error('write provenance failed: ${err}') }
+	return path
+}
+
+// load_provenance reads a .provenance.json sidecar.
+pub fn load_provenance(path string) ?ProvenanceManifest {
+	if !os.is_file(path) {
+		return none
+	}
+	text := os.read_file(path) or { return none }
+	m := json.decode(ProvenanceManifest, text) or { return none }
+	if m.product.len == 0 && m.target.len == 0 && m.artifacts.len == 0 {
+		return none
+	}
+	return m
+}
+
+// verify_generated_digests compares recorded generatedDigest values to files under plugins_dir.
+pub fn verify_generated_digests(plugins_dir string, provenance_path string) []string {
+	manifest := load_provenance(provenance_path) or { return []string{} }
+	mut errors := []string{}
+	for rec in manifest.artifacts {
+		artifact_path := os.join_path(plugins_dir, rec.path)
+		current := file_digest(artifact_path)
+		if current != rec.generated_digest {
+			errors << 'provenance digest drift: ${rec.path} (expected ${rec.generated_digest}, got ${current})'
+		}
+	}
+	return errors
+}

--- a/modules/agent_toolkit_core/provenance_test.v
+++ b/modules/agent_toolkit_core/provenance_test.v
@@ -1,0 +1,62 @@
+module agent_toolkit_core
+
+import os
+
+fn test_file_digest_missing_and_roundtrip() {
+	assert file_digest('/nonexistent/at-prov-missing') == 'missing'
+	path := os.join_path(os.temp_dir(), 'at-prov-${os.getpid()}.txt')
+	os.write_file(path, 'abc') or { assert false, err.msg() }
+	defer {
+		os.rm(path) or {}
+	}
+	d := file_digest(path)
+	assert d.len == 12
+	assert d == 'ba7816bf8f01'
+}
+
+fn test_write_load_verify_provenance() {
+	dir := os.join_path(os.temp_dir(), 'at-prov-dir-${os.getpid()}')
+	os.mkdir_all(dir) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	art := os.join_path(dir, 'plugin.json')
+	os.write_file(art, '{"ok":true}') or { assert false, err.msg() }
+	rec := ArtifactRecord{
+		path:             'plugin.json'
+		source_file:      'skills/core/assistant/SKILL.md'
+		source_digest:    file_digest(art)
+		generated_digest: file_digest(art)
+	}
+	p := write_provenance(dir, 'agent-toolkit-core', 'cursor', [rec]) or {
+		assert false, err.msg()
+		return
+	}
+	assert os.file_name(p) == '.provenance.json'
+	raw := os.read_file(p) or {
+		assert false, err.msg()
+		return
+	}
+	assert raw.contains('"generatorVersion"')
+	assert raw.contains('"sourceFile"')
+	assert raw.contains('"sourceDigest"')
+	assert raw.contains('"generatedDigest"')
+	m := load_provenance(p) or {
+		assert false, 'load failed'
+		return
+	}
+	assert m.product == 'agent-toolkit-core'
+	assert m.target == 'cursor'
+	assert m.generator_version.len > 0
+	assert m.artifacts.len == 1
+	assert m.artifacts[0].source_file == 'skills/core/assistant/SKILL.md'
+	assert verify_generated_digests(dir, p).len == 0
+	os.write_file(art, '{"ok":false}') or { assert false, err.msg() }
+	drift := verify_generated_digests(dir, p)
+	assert drift.len == 1
+	assert drift[0].contains('plugin.json')
+}
+
+fn test_load_provenance_missing() {
+	assert load_provenance('/nonexistent/.provenance.json') == none
+}


### PR DESCRIPTION
## Summary
- V `write_provenance` / `load_provenance` / `verify_generated_digests` matching Python `compiler/provenance.py`.
- Sidecar keys: `generatorVersion`, `sourceFile`, `sourceDigest`, `generatedDigest` (SHA256 truncated to 12 hex chars).
- Drift detection does not strip provenance.

Fixes #508.

## Test plan
- [ ] `make test`
- [ ] Roundtrip write/load + digest drift after mutation


Made with [Cursor](https://cursor.com)