### PR TITLE
feat(v): implement build --check with Tier-1 plugin drift detection (#510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `build --check` Tier-1 dry-run + plugins/ skill/agent drift detection (Closes #510)
 - **Feat** — V Tier-1 target emitters (cursor, claude-code, opencode) with provenance (Closes #509)
 - **Feat** — V provenance emission compatible with Python `.provenance.json` schema (Closes #508)
 - **Feat** — V capability loader + product selection from `distributions/products.yaml` (Closes #507)

--- a/docs/v/build-check.md
+++ b/docs/v/build-check.md
@@ -1,0 +1,5 @@
+# V build --check
+
+**Issue:** [#510](https://github.com/ulises-jeremias/agent-toolkit/issues/510)
+
+`agent-toolkit build --check` dry-runs Tier-1 emitters into a temp dir. Compile errors fail the check. For gen-surfaces products (`agent-toolkit-core`, `agent-toolkit-agents`, `agent-toolkit-forge`), also compares Cursor/Claude Code `skills/` + `agents/` digests against committed `plugins/` (ADR-003 dual-run). OpenCode is compile-validated only. Supports `--target`, `--product`, `--output`, and `--json`.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -62,7 +62,68 @@ pub fn dispatch(args []string) int {
 		snap := agent_toolkit_core.run_doctor_readonly()
 		return render(agent_toolkit_core.doctor_result(snap), mode)
 	}
+	if cmd_name == 'build' {
+		opts := parse_build_options(argv[1..])
+		report := agent_toolkit_core.run_build(opts)
+		return render(agent_toolkit_core.build_result(report), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
+}
+
+fn parse_build_options(args []string) agent_toolkit_core.BuildOptions {
+	mut check := false
+	mut write_files := true
+	mut target := ''
+	mut product := ''
+	mut output_dir := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a == '--check' {
+			check = true
+			write_files = false
+			i++
+			continue
+		}
+		if a == '--target' && i + 1 < args.len {
+			target = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--target=') {
+			target = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--product' && i + 1 < args.len {
+			product = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--product=') {
+			product = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--output' && i + 1 < args.len {
+			output_dir = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--output=') {
+			output_dir = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	return agent_toolkit_core.BuildOptions{
+		check:       check
+		target:      target
+		product:     product
+		output_dir:  output_dir
+		write_files: write_files
+	}
 }
 
 fn allowed_flag(cmd string, a string) bool {
@@ -71,6 +132,14 @@ fn allowed_flag(cmd string, a string) bool {
 	}
 	if cmd == 'doctor' && a in ['--fix', '--provenance'] {
 		return true
+	}
+	if cmd == 'build' {
+		if a in ['--check'] {
+			return true
+		}
+		if a.starts_with('--target') || a.starts_with('--product') || a.starts_with('--output') {
+			return true
+		}
 	}
 	return false
 }
@@ -160,6 +229,18 @@ fn help_commands() []cli.Command {
 }
 
 fn subcommand_help(name string) string {
+	if name == 'build' {
+		return 'Usage: agent-toolkit build [--check] [--target TARGET] [--product PRODUCT] [--output DIR] [--json]
+
+Compile canonical capabilities into Tier-1 target artifacts (cursor, claude-code, opencode).
+
+  --check            Dry-run + compare emitted skills/agents to plugins/ (exit 1 on drift)
+  --target TARGET    Tier-1 target id (default: all Tier-1)
+  --product PRODUCT  Product id (default: all products)
+  --output DIR       Output directory (default: <repo>/plugins)
+  --json             Structured CommandResult JSON
+'
+	}
 	mut c := cli.Command{
 		name:        name
 		description: '${name} — not yet implemented in V experimental binary'

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -46,6 +46,16 @@ fn test_dispatch_doctor_fix_is_readonly() {
 	assert code == 0
 }
 
+fn test_dispatch_build_check_unknown_target_fails() {
+	code := dispatch(['agent-toolkit', 'build', '--check', '--target', 'not-a-target', '--json'])
+	assert code != 0
+}
+
+fn test_dispatch_build_help() {
+	code := dispatch(['agent-toolkit', 'build', '--help'])
+	assert code == 0
+}
+
 fn test_grouped_help_mentions_consumer_and_advanced() {
 	h := grouped_help()
 	assert h.contains('Consumer') || h.to_lower().contains('install')

--- a/modules/agent_toolkit_core/build.v
+++ b/modules/agent_toolkit_core/build.v
@@ -1,0 +1,223 @@
+module agent_toolkit_core
+
+import os
+
+// BuildReport aggregates Tier-1 compile / drift-check results for `build --check`.
+pub struct BuildReport {
+pub mut:
+	ok           bool
+	mode         string // check | build
+	repo_root    string
+	output_root  string
+	results      []CompilationResult
+	drift        []string
+	message      string
+}
+
+// BuildOptions configures agent-toolkit build / build --check.
+pub struct BuildOptions {
+pub:
+	check       bool
+	target      string // empty = all Tier-1
+	product     string // empty = all products
+	output_dir  string // empty = <repo>/plugins
+	write_files bool   // false for --check (temp only)
+}
+
+// run_build executes Tier-1 compile (write) or dry-run + drift check.
+pub fn run_build(opts BuildOptions) BuildReport {
+	mut report := BuildReport{
+		ok:   true
+		mode: if opts.check { 'check' } else { 'build' }
+	}
+	repo := find_repo_root() or {
+		report.ok = false
+		report.message = 'repo root not found: ${err}'
+		return report
+	}
+	report.repo_root = repo
+	graph := load_graph(repo)
+	if !graph.is_valid() {
+		report.ok = false
+		report.message = 'canonical graph load failed (${graph.errors.len} error(s))'
+		report.drift << graph.errors
+		return report
+	}
+
+	mut products := []LoadedProduct{}
+	if opts.product.len > 0 {
+		p := graph.select_product(opts.product) or {
+			report.ok = false
+			report.message = "product '${opts.product}' not found"
+			return report
+		}
+		products << p
+	} else {
+		for _, p in graph.products {
+			products << p
+		}
+	}
+
+	mut targets := []string{}
+	if opts.target.len > 0 {
+		if !is_tier1_target(opts.target) {
+			report.ok = false
+			report.message = "unknown Tier-1 target '${opts.target}' (available: ${tier1_targets().join(', ')})"
+			return report
+		}
+		targets << opts.target
+	} else {
+		targets = tier1_targets()
+	}
+
+	output_root := if opts.output_dir.len > 0 {
+		opts.output_dir
+	} else {
+		os.join_path(repo, 'plugins')
+	}
+	report.output_root = output_root
+
+	write := opts.write_files && !opts.check
+	mut work_root := output_root
+	if !write {
+		work_root = os.join_path(os.temp_dir(), 'agent-toolkit-check-${os.getpid()}')
+		os.mkdir_all(work_root) or {
+			report.ok = false
+			report.message = 'temp output mkdir failed: ${err}'
+			return report
+		}
+		defer {
+			os.rmdir_all(work_root) or {}
+		}
+	}
+
+	mut lines := []string{}
+	lines << ''
+	lines << 'Mode: ${report.mode}  Output: ${output_root}'
+	lines << 'Targets: ${targets.join(', ')}  Products: ${products.len}'
+	lines << ''
+
+	for t in targets {
+		for p in products {
+			r := compile_tier1(t, graph, p, work_root, repo)
+			report.results << r
+			lines << r.report()
+			lines << ''
+			if !r.is_valid() {
+				report.ok = false
+			}
+			if opts.check {
+				if should_check_plugin_drift(p.id) {
+					drift := detect_plugin_drift(work_root, output_root, p.id, t)
+					report.drift << drift
+					for d in drift {
+						lines << '  DRIFT: ${d}'
+						report.ok = false
+					}
+				}
+			}
+		}
+	}
+
+	if opts.check && report.ok {
+		lines << '✅ build --check: Tier-1 compile + plugin drift OK'
+	} else if opts.check && !report.ok {
+		lines << '❌ build --check failed (compile errors and/or plugin drift)'
+	} else if report.ok {
+		lines << '✅ build complete'
+	} else {
+		lines << '❌ build failed'
+	}
+	report.message = lines.join('\n')
+	return report
+}
+
+// detect_plugin_drift compares freshly emitted Tier-1 artifacts to committed plugins/.
+fn detect_plugin_drift(work_root string, plugins_root string, product_id string, target_id string) []string {
+	mut drift := []string{}
+	plugin_product := os.join_path(plugins_root, product_id)
+	if !os.is_dir(plugin_product) {
+		return drift
+	}
+	work_product := os.join_path(work_root, product_id)
+	pairs := drift_path_pairs(target_id, work_product, plugin_product)
+	for pair in pairs {
+		if !os.is_file(pair[0]) {
+			continue
+		}
+		if !os.is_file(pair[1]) {
+			drift << '${product_id}/${target_id}: missing in plugins: ${os.file_name(os.dir(pair[1]))}/${os.file_name(pair[1])}'
+			continue
+		}
+		if file_digest(pair[0]) != file_digest(pair[1]) {
+			rel := relative_to(pair[1], plugins_root) or { pair[1] }
+			drift << 'content digest mismatch: ${rel.replace('\\', '/')}'
+		}
+	}
+	return drift
+}
+
+// should_check_plugin_drift limits digest compare to gen-surfaces SURFACES products (ADR-003 dual-run).
+fn should_check_plugin_drift(product_id string) bool {
+	return product_id in ['agent-toolkit-core', 'agent-toolkit-agents', 'agent-toolkit-forge']
+}
+
+fn drift_path_pairs(target_id string, work_product string, plugin_product string) [][]string {
+	mut pairs := [][]string{}
+	match target_id {
+		'cursor', 'claude-code' {
+			// Shared plugin surface (ADR-003 / gen-surfaces parity).
+			pairs << skill_agent_pairs(os.join_path(work_product, 'skills'), os.join_path(plugin_product,
+				'skills'), 'SKILL.md')
+			pairs << skill_agent_pairs(os.join_path(work_product, 'agents'), os.join_path(plugin_product,
+				'agents'), 'AGENT.md')
+		}
+		'opencode' {
+			// Compile-validate only: committed `.opencode/` trees are often stale vs skills/
+			// until `build` regenerates them. Drift for OpenCode lands with write-mode rebuild.
+		}
+		else {}
+	}
+	return pairs
+}
+
+fn skill_agent_pairs(work_dir string, plugin_dir string, filename string) [][]string {
+	mut pairs := [][]string{}
+	if !os.is_dir(work_dir) {
+		return pairs
+	}
+	entries := os.ls(work_dir) or { return pairs }
+	for e in entries {
+		w := os.join_path(work_dir, e, filename)
+		p := os.join_path(plugin_dir, e, filename)
+		if os.is_file(w) {
+			pairs << [w, p]
+		}
+	}
+	return pairs
+}
+
+// build_result maps a BuildReport to CommandResult.
+pub fn build_result(report BuildReport) CommandResult {
+	mut data := map[string]string{}
+	data['mode'] = report.mode
+	data['ok'] = if report.ok { 'true' } else { 'false' }
+	data['repo_root'] = report.repo_root
+	data['output_root'] = report.output_root
+	data['results'] = '${report.results.len}'
+	data['drift_count'] = '${report.drift.len}'
+	if report.drift.len > 0 {
+		data['drift'] = report.drift.join('|')
+	}
+	mut emitted := []string{}
+	for r in report.results {
+		emitted << '${r.target}/${r.product}:${r.emitted.len}'
+	}
+	data['emitted_summary'] = emitted.join(',')
+	return CommandResult{
+		command: 'build'
+		ok:      report.ok
+		message: report.message
+		data:    data
+	}
+}

--- a/modules/agent_toolkit_core/build_test.v
+++ b/modules/agent_toolkit_core/build_test.v
@@ -1,0 +1,109 @@
+module agent_toolkit_core
+
+import os
+
+fn test_run_build_check_temp_repo() {
+	root := os.join_path(os.temp_dir(), 'at-build-${os.getpid()}')
+	os.mkdir_all(os.join_path(root, 'skills', 'core', 'assistant')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'agents', 'code-reviewer')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'distributions')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'loops')) or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'skills', 'core', 'assistant', 'SKILL.md'), 'skill\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'agents', 'code-reviewer', 'AGENT.md'), 'agent\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'distributions', 'products.yaml'),
+		'products:\n  - id: agent-toolkit-core\n    includes:\n      skills:\n        - core/assistant\n      agents:\n        - code-reviewer\n') or {
+		assert false, err.msg()
+	}
+	// Seed matching plugins/ so drift check is clean for cursor surface.
+	os.mkdir_all(os.join_path(root, 'plugins', 'agent-toolkit-core', 'skills', 'assistant')) or {
+		assert false, err.msg()
+	}
+	os.mkdir_all(os.join_path(root, 'plugins', 'agent-toolkit-core', 'agents', 'code-reviewer')) or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'plugins', 'agent-toolkit-core', 'skills', 'assistant', 'SKILL.md'),
+		'skill\n') or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'plugins', 'agent-toolkit-core', 'agents', 'code-reviewer',
+		'AGENT.md'), 'agent\n') or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.setenv('AGENT_TOOLKIT_ROOT', root, true)
+	defer {
+		os.unsetenv('AGENT_TOOLKIT_ROOT')
+	}
+	report := run_build(BuildOptions{
+		check:       true
+		target:      'cursor'
+		product:     'agent-toolkit-core'
+		write_files: false
+	})
+	assert report.ok, report.message
+	assert report.mode == 'check'
+	assert report.results.len == 1
+	assert report.drift.len == 0
+	cr := build_result(report)
+	assert cr.ok
+	assert cr.command == 'build'
+	assert cr.data['mode'] == 'check'
+}
+
+fn test_run_build_check_detects_drift() {
+	root := os.join_path(os.temp_dir(), 'at-build-drift-${os.getpid()}')
+	os.mkdir_all(os.join_path(root, 'skills', 'core', 'assistant')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'distributions')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'loops')) or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'skills', 'core', 'assistant', 'SKILL.md'), 'canonical\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'distributions', 'products.yaml'),
+		'products:\n  - id: agent-toolkit-core\n    includes:\n      skills:\n        - core/assistant\n      agents: []\n') or {
+		assert false, err.msg()
+	}
+	os.mkdir_all(os.join_path(root, 'plugins', 'agent-toolkit-core', 'skills', 'assistant')) or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'plugins', 'agent-toolkit-core', 'skills', 'assistant', 'SKILL.md'),
+		'stale\n') or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.setenv('AGENT_TOOLKIT_ROOT', root, true)
+	defer {
+		os.unsetenv('AGENT_TOOLKIT_ROOT')
+	}
+	report := run_build(BuildOptions{
+		check:   true
+		target:  'cursor'
+		product: 'agent-toolkit-core'
+	})
+	assert !report.ok
+	assert report.drift.len >= 1
+}
+
+fn test_run_build_unknown_target() {
+	root := os.join_path(os.temp_dir(), 'at-build-unk-${os.getpid()}')
+	os.mkdir_all(os.join_path(root, 'skills')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'loops')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'distributions')) or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'distributions', 'products.yaml'), 'products: []\n') or {
+		assert false, err.msg()
+	}
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.setenv('AGENT_TOOLKIT_ROOT', root, true)
+	defer {
+		os.unsetenv('AGENT_TOOLKIT_ROOT')
+	}
+	report := run_build(BuildOptions{
+		check:  true
+		target: 'not-a-target'
+	})
+	assert !report.ok
+	assert report.message.contains('unknown Tier-1 target'), report.message
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -46,6 +46,13 @@
       "required_keys": ["engine", "version", "platform"]
     },
     {
+      "command": "build-check",
+      "args": ["build", "--check", "--target", "cursor", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
       "command": "install-bad-flag",
       "args": ["install", "--not-a-real-flag"],
       "class": "EXACT",


### PR DESCRIPTION
## Summary
- Wire `agent-toolkit build --check` (Tier-1 dry-run compile + drift vs `plugins/` for core/agents/forge)
- Flags: `--target`, `--product`, `--output`, `--json`
- Parity seed fixture for `build --check --json`
- Docs: `docs/v/build-check.md`

Depends on #509 / #594 (already on main).

## Test plan
- [x] `v test modules/agent_toolkit_core/build_test.v`
- [x] `./build/agent-toolkit-v build --check` exit 0 on checkout
- [ ] Required CI green
- [ ] Squash-merge when threads clear

Fixes #510

Made with [Cursor](https://cursor.com)