### PR TITLE
feat(v): complete remaining target emitters (copilot, windsurf, pi, gemini, muse, codex, agent-plugins) (#552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V Copilot emitters (`copilot-cli`, `copilot-repository`) as first #552 remaining-target slice
 - **Feat** — V `build --check` Tier-1 dry-run + plugins/ skill/agent drift detection (Closes #510)
 - **Feat** — V Tier-1 target emitters (cursor, claude-code, opencode) with provenance (Closes #509)
 - **Feat** — V provenance emission compatible with Python `.provenance.json` schema (Closes #508)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Feat** — V Copilot emitters (`copilot-cli`, `copilot-repository`) as first #552 remaining-target slice
+- **Feat** — V remaining target emitters (copilot, windsurf, pi, gemini, muse, codex, agent-plugins) (Closes #552)
 - **Feat** — V `build --check` Tier-1 dry-run + plugins/ skill/agent drift detection (Closes #510)
 - **Feat** — V Tier-1 target emitters (cursor, claude-code, opencode) with provenance (Closes #509)
 - **Feat** — V provenance emission compatible with Python `.provenance.json` schema (Closes #508)

--- a/docs/v/emitters-copilot.md
+++ b/docs/v/emitters-copilot.md
@@ -1,5 +1,5 @@
-# V Copilot emitters (remaining targets)
+# V Copilot emitters
 
-**Issue:** [#552](https://github.com/ulises-jeremias/agent-toolkit/issues/552) (partial)
+**Issue:** [#552](https://github.com/ulises-jeremias/agent-toolkit/issues/552)
 
-Adds `copilot-cli` (root `plugin.json` + `skills/` + `agents/*.agent.md`) and `copilot-repository` (`.github/copilot-instructions.md` + skills/agents). Wired into `compile_target` / `build --check`. Remaining families (windsurf, pi, gemini, muse, codex, …) still open under #552.
+See [`emitters-remaining.md`](emitters-remaining.md) for the full remaining-target set. Copilot surfaces: `copilot-cli` and `copilot-repository`.

--- a/docs/v/emitters-copilot.md
+++ b/docs/v/emitters-copilot.md
@@ -1,0 +1,5 @@
+# V Copilot emitters (remaining targets)
+
+**Issue:** [#552](https://github.com/ulises-jeremias/agent-toolkit/issues/552) (partial)
+
+Adds `copilot-cli` (root `plugin.json` + `skills/` + `agents/*.agent.md`) and `copilot-repository` (`.github/copilot-instructions.md` + skills/agents). Wired into `compile_target` / `build --check`. Remaining families (windsurf, pi, gemini, muse, codex, …) still open under #552.

--- a/docs/v/emitters-remaining.md
+++ b/docs/v/emitters-remaining.md
@@ -1,0 +1,18 @@
+# V remaining target emitters
+
+**Issue:** [#552](https://github.com/ulises-jeremias/agent-toolkit/issues/552)
+
+Completes non-Tier-1 compiler families in V:
+
+| Target | Surface |
+|--------|---------|
+| `copilot-cli` / `copilot` | root `plugin.json`, `skills/`, `agents/*.agent.md` |
+| `copilot-repository` | `.github/copilot-instructions.md`, skills/agents |
+| `windsurf` | `AGENTS.md`, `rules/*.mdc`, `skills/` |
+| `pi` | `pi-package.json`, skills/agents |
+| `gemini-cli` / `gemini` | `gemini-extension.json`, `commands.toml`, skills, `context/` |
+| `muse-code` / `muse` | `skills/`, `agents/` |
+| `codex` | `.codex-plugin/plugin.json` (experimental), skills/agents |
+| `agent-plugins` | Agent Plugins 1.0 root `plugin.json` (+ skills); MCP registry deferred |
+
+Hooks/MCP registries remain reported in `unsupported` where Python also deferred them. Wired into `compile_target` / `build --check`.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -232,10 +232,10 @@ fn subcommand_help(name string) string {
 	if name == 'build' {
 		return 'Usage: agent-toolkit build [--check] [--target TARGET] [--product PRODUCT] [--output DIR] [--json]
 
-Compile canonical capabilities into Tier-1 target artifacts (cursor, claude-code, opencode).
+Compile canonical capabilities into target artifacts (Tier-1 + remaining emitters).
 
   --check            Dry-run + compare emitted skills/agents to plugins/ (exit 1 on drift)
-  --target TARGET    Tier-1 target id (default: all Tier-1)
+  --target TARGET    Target id (default: all implemented emitters)
   --product PRODUCT  Product id (default: all products)
   --output DIR       Output directory (default: <repo>/plugins)
   --json             Structured CommandResult JSON

--- a/modules/agent_toolkit_core/build.v
+++ b/modules/agent_toolkit_core/build.v
@@ -60,14 +60,14 @@ pub fn run_build(opts BuildOptions) BuildReport {
 
 	mut targets := []string{}
 	if opts.target.len > 0 {
-		if !is_tier1_target(opts.target) {
+		if !is_known_emit_target(opts.target) {
 			report.ok = false
-			report.message = "unknown Tier-1 target '${opts.target}' (available: ${tier1_targets().join(', ')})"
+			report.message = "unknown emit target '${opts.target}' (available: ${all_emit_targets().join(', ')})"
 			return report
 		}
 		targets << opts.target
 	} else {
-		targets = tier1_targets()
+		targets = all_emit_targets()
 	}
 
 	output_root := if opts.output_dir.len > 0 {
@@ -99,7 +99,7 @@ pub fn run_build(opts BuildOptions) BuildReport {
 
 	for t in targets {
 		for p in products {
-			r := compile_tier1(t, graph, p, work_root, repo)
+			r := compile_target(t, graph, p, work_root, repo)
 			report.results << r
 			lines << r.report()
 			lines << ''

--- a/modules/agent_toolkit_core/build.v
+++ b/modules/agent_toolkit_core/build.v
@@ -65,7 +65,7 @@ pub fn run_build(opts BuildOptions) BuildReport {
 			report.message = "unknown emit target '${opts.target}' (available: ${all_emit_targets().join(', ')})"
 			return report
 		}
-		targets << opts.target
+		targets << normalize_emit_target(opts.target)
 	} else {
 		targets = all_emit_targets()
 	}

--- a/modules/agent_toolkit_core/build_test.v
+++ b/modules/agent_toolkit_core/build_test.v
@@ -105,5 +105,5 @@ fn test_run_build_unknown_target() {
 		target: 'not-a-target'
 	})
 	assert !report.ok
-	assert report.message.contains('unknown Tier-1 target'), report.message
+	assert report.message.contains('unknown emit target'), report.message
 }

--- a/modules/agent_toolkit_core/emitters_copilot.v
+++ b/modules/agent_toolkit_core/emitters_copilot.v
@@ -1,0 +1,147 @@
+module agent_toolkit_core
+
+import os
+
+// remaining_targets lists non-Tier-1 emitters under #552 (partial).
+pub fn remaining_targets() []string {
+	return ['copilot-cli', 'copilot-repository']
+}
+
+// all_emit_targets returns Tier-1 + implemented remaining emitters.
+pub fn all_emit_targets() []string {
+	mut out := tier1_targets()
+	out << remaining_targets()
+	return out
+}
+
+// is_known_emit_target reports whether target_id has a V emitter.
+pub fn is_known_emit_target(target_id string) bool {
+	return is_tier1_target(target_id) || target_id in remaining_targets()
+}
+
+// compile_target dispatches Tier-1 and remaining emitters.
+pub fn compile_target(target_id string, graph CanonicalGraph, product LoadedProduct, output_root string, repo_root string) CompilationResult {
+	if is_tier1_target(target_id) {
+		return compile_tier1(target_id, graph, product, output_root, repo_root)
+	}
+	mut result := CompilationResult{
+		target:  target_id
+		product: product.id
+	}
+	if output_root.len == 0 {
+		result.errors << 'output root is empty'
+		return result
+	}
+	out_dir := os.join_path(output_root, product.id)
+	os.mkdir_all(out_dir) or {
+		result.errors << 'cannot create output dir: ${err}'
+		return result
+	}
+	mut records := []ArtifactRecord{}
+	match target_id {
+		'copilot-cli' {
+			emit_copilot_cli(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		'copilot-repository' {
+			emit_copilot_repository(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		else {
+			result.errors << "unknown emit target '${target_id}'"
+		}
+	}
+	_ = repo_root
+	if result.is_valid() && records.len > 0 {
+		prov := write_provenance(out_dir, product.id, target_id, records) or {
+			result.warnings << 'provenance write skipped: ${err}'
+			return result
+		}
+		result.artifacts << prov
+		result.emitted << 'provenance'
+	}
+	return result
+}
+
+fn emit_copilot_cli(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	manifest_path := os.join_path(out_dir, 'plugin.json')
+	ver := resolve_toolkit_version()
+	body := '{\n' + '  "name": "${json_escape(product.id)}",\n' +
+		'  "version": "${json_escape(ver)}",\n' +
+		'  "description": "${json_escape(product.description)}",\n' +
+		'  "author": {\n' + '    "name": "ulises-jeremias",\n' +
+		'    "url": "https://github.com/ulises-jeremias/agent-toolkit"\n' + '  },\n' +
+		'  "repository": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
+		'  "license": "MIT",\n' + '  "skills": "skills/",\n' + '  "agents": "agents/"\n}\n'
+	write_text_artifact(manifest_path, body, 'generated', output_root, mut result, mut records)
+	if result.errors.len > 0 {
+		return
+	}
+	result.emitted << 'plugin-manifest'
+	emit_skills_under(mut result, mut records, graph, product, os.join_path(out_dir, 'skills'),
+		output_root)
+	emit_copilot_agents_flat(mut result, mut records, graph, product, os.join_path(out_dir, 'agents'),
+		output_root)
+	result.unsupported << 'hooks (cross-platform Bash+PowerShell handlers required — pending #16)'
+	result.unsupported << 'mcp (unknown-blocked: not confirmed in official Copilot CLI docs)'
+}
+
+fn emit_copilot_repository(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	emit_copilot_instructions(mut result, mut records, graph, product, out_dir, output_root)
+	emit_skills_under(mut result, mut records, graph, product, os.join_path(out_dir, '.github',
+		'skills'), output_root)
+	emit_copilot_agents_flat(mut result, mut records, graph, product, os.join_path(out_dir, '.github',
+		'agents'), output_root)
+	result.unsupported << 'hooks (unknown-blocked for repository surface)'
+	result.unsupported << 'mcp (unknown-blocked for repository surface)'
+}
+
+fn emit_copilot_instructions(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	mut lines := []string{}
+	name := if product.name.len > 0 { product.name } else { product.id }
+	lines << '# ${name}'
+	lines << ''
+	lines << product.description
+	lines << ''
+	lines << '## Available skills'
+	lines << ''
+	for skill_id in product.included_skills {
+		skill := graph.skills[skill_id] or { continue }
+		lines << '- **${skill.name}**: ${skill.id}'
+	}
+	lines << ''
+	lines << '## Available agents'
+	lines << ''
+	for agent_id in product.included_agents {
+		agent := graph.agents[agent_id] or { continue }
+		lines << '- **${agent.name}**: ${agent.id}'
+	}
+	content := lines.join('\n') + '\n'
+	path := os.join_path(out_dir, '.github', 'copilot-instructions.md')
+	write_text_artifact(path, content, 'generated', output_root, mut result, mut records)
+	result.emitted << 'copilot-instructions.md'
+}
+
+fn emit_copilot_agents_flat(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, agents_dir string, output_root string) {
+	for agent_id in product.included_agents {
+		agent := graph.agents[agent_id] or {
+			result.warnings << "Agent '${agent_id}' not found — skipping"
+			result.omitted << 'agent:${agent_id}'
+			continue
+		}
+		if !os.is_file(agent.source_path) {
+			result.warnings << 'Agent source missing: ${agent.source_path}'
+			result.omitted << 'agent:${agent_id}'
+			continue
+		}
+		os.mkdir_all(agents_dir) or {
+			result.errors << 'mkdir agents dir failed: ${err}'
+			return
+		}
+		content := os.read_file(agent.source_path) or {
+			result.errors << 'read agent failed: ${err}'
+			return
+		}
+		dst := os.join_path(agents_dir, '${agent.name}.agent.md')
+		write_text_artifact(dst, content, agent.source_path, output_root, mut result, mut records)
+		result.emitted << 'agent:${agent_id}'
+	}
+}

--- a/modules/agent_toolkit_core/emitters_copilot.v
+++ b/modules/agent_toolkit_core/emitters_copilot.v
@@ -2,30 +2,41 @@ module agent_toolkit_core
 
 import os
 
-// remaining_targets lists non-Tier-1 emitters under #552 (partial).
+// remaining_targets lists non-Tier-1 emitters (#552).
 pub fn remaining_targets() []string {
-	return ['copilot-cli', 'copilot-repository']
+	return [
+		'copilot-cli',
+		'copilot-repository',
+		'windsurf',
+		'pi',
+		'gemini-cli',
+		'muse-code',
+		'codex',
+		'agent-plugins',
+	]
 }
 
-// all_emit_targets returns Tier-1 + implemented remaining emitters.
+// all_emit_targets returns Tier-1 + remaining emitters.
 pub fn all_emit_targets() []string {
 	mut out := tier1_targets()
 	out << remaining_targets()
 	return out
 }
 
-// is_known_emit_target reports whether target_id has a V emitter.
+// is_known_emit_target reports whether target_id has a V emitter (incl. aliases).
 pub fn is_known_emit_target(target_id string) bool {
-	return is_tier1_target(target_id) || target_id in remaining_targets()
+	id := normalize_emit_target(target_id)
+	return is_tier1_target(id) || id in remaining_targets()
 }
 
 // compile_target dispatches Tier-1 and remaining emitters.
 pub fn compile_target(target_id string, graph CanonicalGraph, product LoadedProduct, output_root string, repo_root string) CompilationResult {
-	if is_tier1_target(target_id) {
-		return compile_tier1(target_id, graph, product, output_root, repo_root)
+	id := normalize_emit_target(target_id)
+	if is_tier1_target(id) {
+		return compile_tier1(id, graph, product, output_root, repo_root)
 	}
 	mut result := CompilationResult{
-		target:  target_id
+		target:  id
 		product: product.id
 	}
 	if output_root.len == 0 {
@@ -38,12 +49,30 @@ pub fn compile_target(target_id string, graph CanonicalGraph, product LoadedProd
 		return result
 	}
 	mut records := []ArtifactRecord{}
-	match target_id {
+	match id {
 		'copilot-cli' {
 			emit_copilot_cli(mut result, mut records, graph, product, out_dir, output_root)
 		}
 		'copilot-repository' {
 			emit_copilot_repository(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		'windsurf' {
+			emit_windsurf(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		'pi' {
+			emit_pi(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		'gemini-cli' {
+			emit_gemini_cli(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		'muse-code' {
+			emit_muse_code(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		'codex' {
+			emit_codex(mut result, mut records, graph, product, out_dir, output_root)
+		}
+		'agent-plugins' {
+			emit_agent_plugins(mut result, mut records, graph, product, out_dir, output_root)
 		}
 		else {
 			result.errors << "unknown emit target '${target_id}'"
@@ -51,7 +80,7 @@ pub fn compile_target(target_id string, graph CanonicalGraph, product LoadedProd
 	}
 	_ = repo_root
 	if result.is_valid() && records.len > 0 {
-		prov := write_provenance(out_dir, product.id, target_id, records) or {
+		prov := write_provenance(out_dir, product.id, id, records) or {
 			result.warnings << 'provenance write skipped: ${err}'
 			return result
 		}

--- a/modules/agent_toolkit_core/emitters_copilot_test.v
+++ b/modules/agent_toolkit_core/emitters_copilot_test.v
@@ -1,0 +1,47 @@
+module agent_toolkit_core
+
+import os
+
+fn test_remaining_targets_include_copilot() {
+	ids := remaining_targets()
+	assert 'copilot-cli' in ids
+	assert 'copilot-repository' in ids
+	assert is_known_emit_target('copilot-cli')
+	assert !is_known_emit_target('muse-code')
+}
+
+fn test_compile_copilot_cli_and_repo() {
+	root := os.join_path(os.temp_dir(), 'at-copilot-${os.getpid()}')
+	os.mkdir_all(os.join_path(root, 'skills', 'core', 'assistant')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'agents', 'code-reviewer')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'distributions')) or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'skills', 'core', 'assistant', 'SKILL.md'), 'skill\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'agents', 'code-reviewer', 'AGENT.md'), 'agent\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'distributions', 'products.yaml'),
+		'products:\n  - id: demo\n    name: Demo\n    description: Demo product\n    includes:\n      skills:\n        - core/assistant\n      agents:\n        - code-reviewer\n') or {
+		assert false, err.msg()
+	}
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	g := load_graph(root)
+	product := g.select_product('demo') or {
+		assert false, 'missing'
+		return
+	}
+	out := os.join_path(root, 'out')
+	cli := compile_target('copilot-cli', g, product, out, root)
+	assert cli.is_valid(), cli.errors.str()
+	assert os.is_file(os.join_path(out, 'demo', 'plugin.json'))
+	assert os.is_file(os.join_path(out, 'demo', 'skills', 'assistant', 'SKILL.md'))
+	assert os.is_file(os.join_path(out, 'demo', 'agents', 'code-reviewer.agent.md'))
+	repo := compile_target('copilot-repository', g, product, out, root)
+	assert repo.is_valid(), repo.errors.str()
+	assert os.is_file(os.join_path(out, 'demo', '.github', 'copilot-instructions.md'))
+	assert os.is_file(os.join_path(out, 'demo', '.github', 'skills', 'assistant', 'SKILL.md'))
+	assert os.is_file(os.join_path(out, 'demo', '.github', 'agents', 'code-reviewer.agent.md'))
+}

--- a/modules/agent_toolkit_core/emitters_copilot_test.v
+++ b/modules/agent_toolkit_core/emitters_copilot_test.v
@@ -7,7 +7,7 @@ fn test_remaining_targets_include_copilot() {
 	assert 'copilot-cli' in ids
 	assert 'copilot-repository' in ids
 	assert is_known_emit_target('copilot-cli')
-	assert !is_known_emit_target('muse-code')
+	assert is_known_emit_target('muse-code')
 }
 
 fn test_compile_copilot_cli_and_repo() {

--- a/modules/agent_toolkit_core/emitters_remaining.v
+++ b/modules/agent_toolkit_core/emitters_remaining.v
@@ -1,0 +1,264 @@
+module agent_toolkit_core
+
+import os
+
+// normalize_emit_target maps Python CLI aliases to canonical emitter ids.
+pub fn normalize_emit_target(target_id string) string {
+	return match target_id {
+		'gemini', 'gemini-cli' { 'gemini-cli' }
+		'muse', 'muse-code' { 'muse-code' }
+		'copilot', 'copilot-cli' { 'copilot-cli' }
+		else { target_id }
+	}
+}
+
+fn emit_windsurf(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	emit_windsurf_agents_md(mut result, mut records, graph, product, out_dir, output_root)
+	emit_skills_under(mut result, mut records, graph, product, os.join_path(out_dir, 'skills'),
+		output_root)
+	for agent_id in product.included_agents {
+		agent := graph.agents[agent_id] or {
+			result.warnings << "Agent '${agent_id}' not found — skipping"
+			result.omitted << 'agent:${agent_id}'
+			continue
+		}
+		if !os.is_file(agent.source_path) {
+			result.warnings << 'Agent source missing: ${agent.source_path}'
+			result.omitted << 'agent:${agent_id}'
+			continue
+		}
+		body := os.read_file(agent.source_path) or {
+			result.errors << 'read agent failed: ${err}'
+			return
+		}
+		header := '---\ndescription: ${json_escape(agent.name)}\nalwaysApply: true\n---\n\n'
+		path := os.join_path(out_dir, 'rules', '${agent.name}.mdc')
+		write_text_artifact(path, header + body, agent.source_path, output_root, mut result, mut records)
+		result.emitted << 'rule:${agent_id}'
+	}
+	result.unsupported << 'hooks — no official Windsurf extension format for lifecycle hooks'
+	result.unsupported << 'mcp — no official Windsurf MCP configuration format'
+	result.unsupported << 'memories — intentionally NOT generated; personal per-user state (ADR-002)'
+	result.unsupported << 'plugin-manifest — Windsurf has no marketplace; no manifest format to target'
+}
+
+fn emit_windsurf_agents_md(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	mut lines := []string{}
+	name := if product.name.len > 0 { product.name } else { product.id }
+	lines << '# ${name}'
+	lines << ''
+	lines << product.description
+	lines << ''
+	if product.included_skills.len > 0 {
+		lines << '## Available Skills'
+		lines << ''
+		for skill_id in product.included_skills {
+			skill := graph.skills[skill_id] or { continue }
+			lines << '- **${skill.name}**: ${skill.id}'
+		}
+		lines << ''
+	}
+	if product.included_agents.len > 0 {
+		lines << '## Available Agents'
+		lines << ''
+		for agent_id in product.included_agents {
+			agent := graph.agents[agent_id] or { continue }
+			lines << '- **${agent.name}**: ${agent.id}'
+		}
+		lines << ''
+	}
+	lines << '## Scope'
+	lines << ''
+	lines << 'These instructions are project-scoped. Rules in `rules/` provide always-on behavioral constraints. Skills in `skills/` are on-demand procedures invoked explicitly.'
+	lines << ''
+	write_text_artifact(os.join_path(out_dir, 'AGENTS.md'), lines.join('\n'), 'generated',
+		output_root, mut result, mut records)
+	result.emitted << 'AGENTS.md'
+}
+
+fn emit_pi(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	emit_pi_package_json(mut result, mut records, graph, product, out_dir, output_root)
+	emit_skills_under(mut result, mut records, graph, product, os.join_path(out_dir, 'skills'),
+		output_root)
+	emit_agents_under(mut result, mut records, graph, product, os.join_path(out_dir, 'agents'),
+		output_root)
+	result.unsupported << 'lifecycle hooks — requires TypeScript ExtensionAPI (packages/pi-package/)'
+	result.unsupported << 'custom tools — requires TypeScript ExtensionAPI with tool registration'
+	result.unsupported << 'MCP server config — no static format; requires TypeScript runtime'
+	result.unsupported << 'session state — runtime only; not expressible in static assets'
+	result.unsupported << 'plugin marketplace install — Pi uses npm/pi.dev registry, not a marketplace'
+}
+
+fn emit_pi_package_json(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	ver := resolve_toolkit_version()
+	mut skill_paths := []string{}
+	for skill_id in product.included_skills {
+		skill := graph.skills[skill_id] or { continue }
+		skill_paths << '"skills/${skill.name}/SKILL.md"'
+	}
+	mut agent_paths := []string{}
+	for agent_id in product.included_agents {
+		agent := graph.agents[agent_id] or { continue }
+		agent_paths << '"agents/${agent.name}/AGENT.md"'
+	}
+	kw := product.id.replace('agent-toolkit-', '')
+	body := '{\n' + '  "name": "@agent-toolkit/${json_escape(product.id)}",\n' +
+		'  "version": "${json_escape(ver)}",\n' +
+		'  "description": "${json_escape(product.description)}",\n' +
+		'  "license": "MIT",\n' + '  "repository": {\n' + '    "type": "git",\n' +
+		'    "url": "https://github.com/ulises-jeremias/agent-toolkit"\n' + '  },\n' +
+		'  "keywords": [\n' + '    "agent-toolkit",\n' + '    "pi",\n' + '    "skills",\n' +
+		'    "agents",\n' + '    "${json_escape(kw)}"\n' + '  ],\n' + '  "pi": {\n' +
+		'    "skills": [\n      ${skill_paths.join(',\n      ')}\n    ],\n' +
+		'    "agents": [\n      ${agent_paths.join(',\n      ')}\n    ]\n' + '  }\n}\n'
+	write_text_artifact(os.join_path(out_dir, 'pi-package.json'), body, 'generated', output_root, mut
+		result, mut records)
+	result.emitted << 'pi-package-json'
+}
+
+fn emit_gemini_cli(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	ver := resolve_toolkit_version()
+	manifest := '{\n' + '  "name": "${json_escape(product.id)}",\n' +
+		'  "version": "${json_escape(ver)}",\n' +
+		'  "description": "${json_escape(product.description)}",\n' +
+		'  "author": "ulises-jeremias",\n' +
+		'  "repository": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
+		'  "license": "MIT",\n' + '  "geminiCliVersion": ">=0.1.0",\n' +
+		'  "contextFiles": [],\n' + '  "commands": "\${extensionPath}/commands.toml"\n}\n'
+	write_text_artifact(os.join_path(out_dir, 'gemini-extension.json'), manifest, 'generated',
+		output_root, mut result, mut records)
+	result.emitted << 'extension-manifest'
+
+	mut toml_lines := []string{}
+	for skill_id in product.included_skills {
+		skill := graph.skills[skill_id] or {
+			result.warnings << "Skill '${skill_id}' not found — skipping"
+			result.omitted << 'skill:${skill_id}'
+			continue
+		}
+		if !os.is_file(skill.source_path) {
+			result.warnings << 'Skill source missing: ${skill.source_path}'
+			result.omitted << 'skill:${skill_id}'
+			continue
+		}
+		dst_dir := os.join_path(out_dir, 'skills', skill.name)
+		os.mkdir_all(dst_dir) or {
+			result.errors << 'mkdir skill dir failed: ${err}'
+			return
+		}
+		content := os.read_file(skill.source_path) or {
+			result.errors << 'read skill failed: ${err}'
+			return
+		}
+		write_text_artifact(os.join_path(dst_dir, 'SKILL.md'), content, skill.source_path, output_root, mut
+			result, mut records)
+		copy_skill_references(skill, dst_dir, output_root, mut result, mut records)
+		rel := 'skills/${skill.name}/SKILL.md'
+		safe_name := skill.name.replace('-', '_').replace(' ', '_')
+		desc := skill.id.replace('"', "'")
+		toml_lines << '[[commands]]'
+		toml_lines << 'name = "${safe_name}"'
+		toml_lines << 'description = "${desc}"'
+		toml_lines << 'prompt = """'
+		toml_lines << 'Follow the `${skill.name}` skill instructions for {{args}}.'
+		toml_lines << ''
+		toml_lines << '@{${rel}}'
+		toml_lines << '"""'
+		toml_lines << ''
+		result.emitted << 'skill:${skill_id}'
+	}
+	if toml_lines.len > 0 {
+		write_text_artifact(os.join_path(out_dir, 'commands.toml'), toml_lines.join('\n') + '\n',
+			'generated', output_root, mut result, mut records)
+		result.emitted << 'commands.toml'
+	}
+	for agent_id in product.included_agents {
+		agent := graph.agents[agent_id] or {
+			result.warnings << "Agent '${agent_id}' not found — skipping"
+			result.omitted << 'agent:${agent_id}'
+			continue
+		}
+		if !os.is_file(agent.source_path) {
+			result.warnings << 'Agent source missing: ${agent.source_path}'
+			result.omitted << 'agent:${agent_id}'
+			continue
+		}
+		content := os.read_file(agent.source_path) or {
+			result.errors << 'read agent failed: ${err}'
+			return
+		}
+		path := os.join_path(out_dir, 'context', '${agent.name}.md')
+		write_text_artifact(path, content, agent.source_path, output_root, mut result, mut records)
+		result.emitted << 'agent:${agent_id}'
+	}
+	result.unsupported << 'hooks (hooks/hooks.json — pending canonical hook model #16)'
+	result.unsupported << 'mcp (mcpServers — pending MCP registry #15; field reserved in manifest)'
+	result.unsupported << 'excludeTools (tool restrictions — pending agent model with abstract tools)'
+}
+
+fn emit_muse_code(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	emit_skills_under(mut result, mut records, graph, product, os.join_path(out_dir, 'skills'),
+		output_root)
+	emit_agents_under(mut result, mut records, graph, product, os.join_path(out_dir, 'agents'),
+		output_root)
+	result.unsupported << 'plugin-marketplace — Muse Code has no marketplace; install via muse skills install / .agents/skills'
+}
+
+fn emit_codex(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	ver := resolve_toolkit_version()
+	kw := product.id.replace('agent-toolkit-', '')
+	body := '{\n' + '  "name": "${json_escape(product.id)}",\n' +
+		'  "version": "${json_escape(ver)}",\n' +
+		'  "description": "${json_escape(product.description)}",\n' +
+		'  "maturity": "experimental",\n' + '  "author": {\n' +
+		'    "name": "ulises-jeremias",\n' + '    "email": "ulisescf.24@gmail.com"\n' +
+		'  },\n' + '  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
+		'  "repository": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
+		'  "license": "MIT",\n' + '  "keywords": [\n' + '    "agent-toolkit",\n' +
+		'    "${json_escape(kw)}",\n' + '    "codex",\n' + '    "skills",\n' +
+		'    "agents"\n' + '  ]\n}\n'
+	write_text_artifact(os.join_path(out_dir, '.codex-plugin', 'plugin.json'), body, 'generated',
+		output_root, mut result, mut records)
+	result.emitted << 'plugin-manifest'
+	emit_skills_under(mut result, mut records, graph, product, os.join_path(out_dir, 'skills'),
+		output_root)
+	emit_agents_under(mut result, mut records, graph, product, os.join_path(out_dir, 'agents'),
+		output_root)
+	result.unsupported << 'hooks — unknown-blocked: lifecycle hooks not confirmed in official Codex plugin docs'
+	result.unsupported << 'mcp — unknown-blocked: MCP integration not confirmed in official Codex plugin docs'
+	result.warnings << "Codex plugin API is experimental (maturity='experimental'). Do NOT submit to Codex marketplace without explicit OpenAI authorization."
+}
+
+fn emit_agent_plugins(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+	ver := resolve_toolkit_version()
+	mut keywords := ['agent-toolkit', product.id.replace('agent-toolkit-', '')]
+	if product.id == 'agent-toolkit-core' {
+		keywords = ['agent-toolkit', 'core', 'skills', 'agents']
+	} else if product.id == 'agent-toolkit-complete' {
+		keywords = ['agent-toolkit', 'complete', 'skills', 'agents', 'mcp']
+	}
+	mut kw_json := []string{}
+	for k in keywords {
+		kw_json << '"${json_escape(k)}"'
+	}
+	body := '{\n' +
+		'  "\$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",\n' +
+		'  "name": "${json_escape(product.id)}",\n' + '  "version": "${json_escape(ver)}",\n' +
+		'  "description": "${json_escape(product.description)}",\n' + '  "author": {\n' +
+		'    "name": "ulises-jeremias",\n' +
+		'    "url": "https://github.com/ulises-jeremias/agent-toolkit"\n' + '  },\n' +
+		'  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
+		'  "repository": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
+		'  "license": "MIT",\n' + '  "keywords": [\n    ${kw_json.join(',\n    ')}\n  ]\n}\n'
+	write_text_artifact(os.join_path(out_dir, 'plugin.json'), body, 'generated', output_root, mut
+		result, mut records)
+	result.emitted << 'plugin-manifest'
+	emit_skills_under(mut result, mut records, graph, product, os.join_path(out_dir, 'skills'),
+		output_root)
+	if product.included_agents.len > 0 || product.included_hooks.len > 0 {
+		result.unsupported << 'agents/hooks are not portable in Agent Plugins 1.0 — emitted via com.anthropic.claude-code/ extension (ignored by portable clients)'
+	}
+	if product.included_mcp.len > 0 {
+		result.unsupported << 'mcp.json (registry emit not yet ported to V remaining emitters)'
+	}
+}

--- a/modules/agent_toolkit_core/emitters_remaining_test.v
+++ b/modules/agent_toolkit_core/emitters_remaining_test.v
@@ -1,0 +1,73 @@
+module agent_toolkit_core
+
+import os
+
+fn test_remaining_targets_cover_issue_552() {
+	ids := remaining_targets()
+	for need in ['copilot-cli', 'copilot-repository', 'windsurf', 'pi', 'gemini-cli', 'muse-code',
+		'codex', 'agent-plugins'] {
+		assert need in ids, need
+	}
+	assert normalize_emit_target('gemini') == 'gemini-cli'
+	assert normalize_emit_target('muse') == 'muse-code'
+	assert normalize_emit_target('copilot') == 'copilot-cli'
+	assert is_known_emit_target('gemini')
+	assert is_known_emit_target('muse')
+}
+
+fn test_compile_remaining_families_temp() {
+	root := os.join_path(os.temp_dir(), 'at-remain-${os.getpid()}')
+	os.mkdir_all(os.join_path(root, 'skills', 'core', 'assistant')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'agents', 'code-reviewer')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'distributions')) or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'skills', 'core', 'assistant', 'SKILL.md'), 'skill\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'agents', 'code-reviewer', 'AGENT.md'), 'agent\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'distributions', 'products.yaml'),
+		'products:\n  - id: demo\n    name: Demo\n    description: Demo product\n    includes:\n      skills:\n        - core/assistant\n      agents:\n        - code-reviewer\n') or {
+		assert false, err.msg()
+	}
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	g := load_graph(root)
+	product := g.select_product('demo') or {
+		assert false, 'missing'
+		return
+	}
+	out := os.join_path(root, 'out')
+
+	ws := compile_target('windsurf', g, product, out, root)
+	assert ws.is_valid(), ws.errors.str()
+	assert os.is_file(os.join_path(out, 'demo', 'AGENTS.md'))
+	assert os.is_file(os.join_path(out, 'demo', 'rules', 'code-reviewer.mdc'))
+
+	pi := compile_target('pi', g, product, out, root)
+	assert pi.is_valid(), pi.errors.str()
+	assert os.is_file(os.join_path(out, 'demo', 'pi-package.json'))
+
+	gem := compile_target('gemini', g, product, out, root)
+	assert gem.is_valid(), gem.errors.str()
+	assert os.is_file(os.join_path(out, 'demo', 'gemini-extension.json'))
+	assert os.is_file(os.join_path(out, 'demo', 'commands.toml'))
+
+	muse := compile_target('muse', g, product, out, root)
+	assert muse.is_valid(), muse.errors.str()
+	assert os.is_file(os.join_path(out, 'demo', 'skills', 'assistant', 'SKILL.md'))
+
+	codex := compile_target('codex', g, product, out, root)
+	assert codex.is_valid(), codex.errors.str()
+	assert os.is_file(os.join_path(out, 'demo', '.codex-plugin', 'plugin.json'))
+	assert codex.warnings.len >= 1
+
+	ap := compile_target('agent-plugins', g, product, out, root)
+	assert ap.is_valid(), ap.errors.str()
+	raw := os.read_file(os.join_path(out, 'demo', 'plugin.json')) or {
+		assert false, err.msg()
+		return
+	}
+	assert raw.contains('agent-plugins.org/schemas')
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -53,6 +53,55 @@
       "required_keys": ["command", "mode", "ok"]
     },
     {
+      "command": "build-check-copilot-cli",
+      "args": ["build", "--check", "--target", "copilot-cli", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
+      "command": "build-check-windsurf",
+      "args": ["build", "--check", "--target", "windsurf", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
+      "command": "build-check-pi",
+      "args": ["build", "--check", "--target", "pi", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
+      "command": "build-check-gemini",
+      "args": ["build", "--check", "--target", "gemini-cli", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
+      "command": "build-check-muse",
+      "args": ["build", "--check", "--target", "muse-code", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
+      "command": "build-check-codex",
+      "args": ["build", "--check", "--target", "codex", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
+      "command": "build-check-agent-plugins",
+      "args": ["build", "--check", "--target", "agent-plugins", "--product", "agent-toolkit-core", "--json"],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": ["command", "mode", "ok"]
+    },
+    {
       "command": "install-bad-flag",
       "args": ["install", "--not-a-real-flag"],
       "class": "EXACT",


### PR DESCRIPTION
## Summary
- Completes #552 remaining target families in V: `copilot-cli`, `copilot-repository`, `windsurf`, `pi`, `gemini-cli`, `muse-code`, `codex`, `agent-plugins`
- Aliases: `gemini`→`gemini-cli`, `muse`→`muse-code`, `copilot`→`copilot-cli`
- Golden parity SCHEMA fixtures for `build --check` per remaining family
- Hooks/MCP registries remain explicit `unsupported` where Python also deferred

## Test plan
- [x] `v test` emitters_remaining + emitters_copilot + build_test
- [x] `build --check` exit 0 (all targets)
- [ ] Required CI green
- [ ] Squash-merge when threads clear

Fixes #552