### PR TITLE
feat(v): add read-only install receipt parser (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V read-only install receipt parser (SCHEMA + path-escape/secrets refuse) (Closes #512)
 - **Feat** — V remaining target emitters (copilot, windsurf, pi, gemini, muse, codex, agent-plugins) (Closes #552)
 - **Feat** — V `build --check` Tier-1 dry-run + plugins/ skill/agent drift detection (Closes #510)
 - **Feat** — V Tier-1 target emitters (cursor, claude-code, opencode) with provenance (Closes #509)

--- a/docs/v/receipt.md
+++ b/docs/v/receipt.md
@@ -1,0 +1,12 @@
+# V install receipt parser
+
+**Issue:** [#512](https://github.com/ulises-jeremias/agent-toolkit/issues/512)
+
+Read-only parser for installer receipts (`~/.config/agent-toolkit/receipts/<target>-<product>.json`) compatible with Python `installer/receipt.py`:
+
+- camelCase SCHEMA (`schemaVersion`, `installedAt`, `sourceDigest`, artifacts, empty `secrets`)
+- ownership `created` | `merged`
+- refuses non-empty secrets and `..` path segments (path-escape)
+- preserves `configPatches` as raw JSON for round-trip by later install/uninstall slices
+
+See also #511 (formal schema doc) and TRUST.md.

--- a/modules/agent_toolkit_core/fs.v
+++ b/modules/agent_toolkit_core/fs.v
@@ -52,6 +52,15 @@ pub fn (fs FsService) xdg_data_home() string {
 	return fs.join(fs.home(), '.local', 'share')
 }
 
+// xdg_config_home returns XDG_CONFIG_HOME or ~/.config.
+pub fn (fs FsService) xdg_config_home() string {
+	v := os.getenv('XDG_CONFIG_HOME')
+	if v.len > 0 {
+		return v
+	}
+	return fs.join(fs.home(), '.config')
+}
+
 // toolkit_cache_dir returns the Agent Toolkit cache root under XDG cache.
 pub fn (fs FsService) toolkit_cache_dir() string {
 	return fs.join(fs.xdg_cache_home(), 'agent-toolkit')
@@ -60,6 +69,16 @@ pub fn (fs FsService) toolkit_cache_dir() string {
 // toolkit_data_dir returns the Agent Toolkit data root under XDG data home.
 pub fn (fs FsService) toolkit_data_dir() string {
 	return fs.join(fs.xdg_data_home(), 'agent-toolkit', 'data')
+}
+
+// toolkit_config_dir returns ~/.config/agent-toolkit (or XDG_CONFIG_HOME).
+pub fn (fs FsService) toolkit_config_dir() string {
+	return fs.join(fs.xdg_config_home(), 'agent-toolkit')
+}
+
+// receipt_dir returns the install receipt directory.
+pub fn (fs FsService) receipt_dir() string {
+	return fs.join(fs.toolkit_config_dir(), 'receipts')
 }
 
 // ensure_dir creates a directory and parents; returns a domain error on failure.

--- a/modules/agent_toolkit_core/receipt.v
+++ b/modules/agent_toolkit_core/receipt.v
@@ -1,0 +1,191 @@
+module agent_toolkit_core
+
+import crypto.sha256
+import json
+import os
+
+// profiles_product is the receipt product id used by the profile installer.
+pub const profiles_product = 'agent-toolkit-profiles'
+
+// ArtifactEntry is one installed file recorded in an InstallReceipt.
+pub struct ArtifactEntry {
+pub:
+	path      string
+	digest    string
+	ownership string // created | merged
+}
+
+// InstallReceipt matches Python installer/receipt.py JSON (camelCase keys).
+pub struct InstallReceipt {
+pub mut:
+	schema_version      int    @[json: 'schemaVersion']
+	product             string
+	target              string
+	scope               string
+	version             string
+	installed_at        string @[json: 'installedAt']
+	source_digest       string @[json: 'sourceDigest']
+	artifacts           []ArtifactEntry
+	config_patches_json string // raw JSON array; always round-tripped, default "[]"
+	secrets             []string
+}
+
+// new_install_receipt creates a schemaVersion=1 receipt (secrets always empty).
+pub fn new_install_receipt(product string, target string, scope string, version string, source_digest string) InstallReceipt {
+	return InstallReceipt{
+		schema_version:      1
+		product:             product
+		target:              target
+		scope:               scope
+		version:             version
+		installed_at:        ''
+		source_digest:       source_digest
+		artifacts:           []ArtifactEntry{}
+		config_patches_json: '[]'
+		secrets:             []string{}
+	}
+}
+
+// receipt_filename returns <target>-<product>.json.
+pub fn receipt_filename(target string, product string) string {
+	return '${target}-${product}.json'
+}
+
+// default_receipt_dir returns ~/.config/agent-toolkit/receipts.
+pub fn default_receipt_dir() string {
+	return new_fs().receipt_dir()
+}
+
+// parse_install_receipt parses receipt JSON (read-only; no filesystem writes).
+// Refuses non-empty secrets and unknown ownership values. Validates schemaVersion >= 1.
+pub fn parse_install_receipt(text string) !InstallReceipt {
+	trimmed := text.trim_space()
+	if trimmed.len == 0 {
+		return error('empty receipt JSON')
+	}
+	mut r := json.decode(InstallReceipt, trimmed) or { return error('receipt decode failed: ${err}') }
+	if r.schema_version < 1 {
+		r.schema_version = 1
+	}
+	if r.product.len == 0 || r.target.len == 0 {
+		return error('receipt missing required product/target')
+	}
+	if r.scope.len == 0 {
+		r.scope = 'project'
+	}
+	r.config_patches_json = extract_json_array_field(trimmed, 'configPatches') or { '[]' }
+	if r.secrets.len > 0 {
+		return error('receipt must not contain secrets')
+	}
+	r.secrets = []string{}
+	for a in r.artifacts {
+		if a.path.len == 0 {
+			return error('artifact path must not be empty')
+		}
+		if a.ownership !in ['created', 'merged'] {
+			return error("artifact ownership must be 'created' or 'merged' (got '${a.ownership}')")
+		}
+		if receipt_path_escapes(a.path) {
+			return error('artifact path refused (path escape): ${a.path}')
+		}
+	}
+	return r
+}
+
+// load_install_receipt loads ~/.config/.../receipts/<target>-<product>.json (or receipt_dir).
+pub fn load_install_receipt(target string, product string, receipt_dir string) ?InstallReceipt {
+	dir := if receipt_dir.len > 0 { receipt_dir } else { default_receipt_dir() }
+	path := os.join_path(dir, receipt_filename(target, product))
+	if !os.is_file(path) {
+		return none
+	}
+	text := os.read_file(path) or { return none }
+	return parse_install_receipt(text) or { return none }
+}
+
+// list_install_receipts lists parsed receipts under receipt_dir (skip invalid).
+pub fn list_install_receipts(receipt_dir string) []InstallReceipt {
+	dir := if receipt_dir.len > 0 { receipt_dir } else { default_receipt_dir() }
+	mut out := []InstallReceipt{}
+	if !os.is_dir(dir) {
+		return out
+	}
+	entries := os.ls(dir) or { return out }
+	for e in entries {
+		if !e.ends_with('.json') {
+			continue
+		}
+		path := os.join_path(dir, e)
+		if !os.is_file(path) {
+			continue
+		}
+		text := os.read_file(path) or { continue }
+		r := parse_install_receipt(text) or { continue }
+		out << r
+	}
+	return out
+}
+
+// receipt_artifact_digest returns SHA256 hex truncated to 16 chars (Python tracking.file_digest).
+pub fn receipt_artifact_digest(path string) string {
+	if !os.is_file(path) {
+		return 'missing'
+	}
+	data := os.read_file(path) or { return 'missing' }
+	sum := sha256.hexhash(data)
+	if sum.len < 16 {
+		return sum
+	}
+	return sum[..16]
+}
+
+// receipt_path_escapes reports suspicious path forms that install/uninstall must refuse.
+// Blocks NUL, and Windows/Unix relative escapes (`..` segments). Absolute paths are allowed
+// (receipts store resolved home paths) but must not contain `..` after normalization.
+pub fn receipt_path_escapes(path string) bool {
+	if path.contains('\x00') {
+		return true
+	}
+	normalized := path.replace('\\', '/')
+	parts := normalized.split('/')
+	for p in parts {
+		if p == '..' {
+			return true
+		}
+	}
+	return false
+}
+
+fn extract_json_array_field(text string, key string) ?string {
+	needle := '"${key}"'
+	mut i := text.index(needle) or { return none }
+	i += needle.len
+	for i < text.len && text[i].is_space() {
+		i++
+	}
+	if i >= text.len || text[i] != `:` {
+		return none
+	}
+	i++
+	for i < text.len && text[i].is_space() {
+		i++
+	}
+	if i >= text.len || text[i] != `[` {
+		return none
+	}
+	start := i
+	mut depth := 0
+	for i < text.len {
+		c := text[i]
+		if c == `[` {
+			depth++
+		} else if c == `]` {
+			depth--
+			if depth == 0 {
+				return text[start..i + 1]
+			}
+		}
+		i++
+	}
+	return none
+}

--- a/modules/agent_toolkit_core/receipt_test.v
+++ b/modules/agent_toolkit_core/receipt_test.v
@@ -1,0 +1,97 @@
+module agent_toolkit_core
+
+import os
+
+fn test_parse_install_receipt_roundtrip_fields() {
+	text := '{
+  "schemaVersion": 1,
+  "product": "agent-toolkit-core",
+  "target": "cursor",
+  "scope": "project",
+  "version": "1.1.0",
+  "installedAt": "2026-08-12T00:00:00+00:00",
+  "sourceDigest": "abc123",
+  "artifacts": [
+    {"path": ".cursor/rules/assistant.mdc", "digest": "def456", "ownership": "created"}
+  ],
+  "configPatches": [{"op": "add", "path": "/toolkit", "value": true}],
+  "secrets": []
+}
+'
+	r := parse_install_receipt(text) or {
+		assert false, err.msg()
+		return
+	}
+	assert r.schema_version == 1
+	assert r.product == 'agent-toolkit-core'
+	assert r.target == 'cursor'
+	assert r.secrets.len == 0
+	assert r.artifacts.len == 1
+	assert r.artifacts[0].ownership == 'created'
+	assert r.config_patches_json.contains('"op"')
+}
+
+fn test_parse_rejects_secrets_and_bad_ownership() {
+	bad_secrets := '{"schemaVersion":1,"product":"p","target":"t","version":"1","artifacts":[],"secrets":["x"]}'
+	parse_install_receipt(bad_secrets) or {
+		assert err.msg().contains('secrets')
+		return
+	}
+	assert false, 'expected secrets rejection'
+}
+
+fn test_parse_rejects_path_escape() {
+	bad := '{"schemaVersion":1,"product":"p","target":"t","version":"1","artifacts":[{"path":"../../etc/passwd","digest":"x","ownership":"created"}],"secrets":[]}'
+	parse_install_receipt(bad) or {
+		assert err.msg().contains('path escape')
+		return
+	}
+	assert false, 'expected path escape rejection'
+}
+
+fn test_load_and_list_receipts() {
+	dir := os.join_path(os.temp_dir(), 'at-receipt-${os.getpid()}')
+	os.mkdir_all(dir) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	path := os.join_path(dir, receipt_filename('cursor', 'agent-toolkit-core'))
+	os.write_file(path, '{
+  "schemaVersion": 1,
+  "product": "agent-toolkit-core",
+  "target": "cursor",
+  "version": "1.1.0",
+  "artifacts": [{"path": "/tmp/at-ok/file.mdc", "digest": "aabb", "ownership": "merged"}],
+  "secrets": []
+}
+') or { assert false, err.msg() }
+	r := load_install_receipt('cursor', 'agent-toolkit-core', dir) or {
+		assert false, 'load failed'
+		return
+	}
+	assert r.version == '1.1.0'
+	assert load_install_receipt('missing', 'product', dir) == none
+	listed := list_install_receipts(dir)
+	assert listed.len == 1
+}
+
+fn test_new_receipt_and_digest() {
+	r := new_install_receipt(profiles_product, 'cursor', 'user-home', '1.0.0', 'src')
+	assert r.schema_version == 1
+	assert r.secrets.len == 0
+	assert receipt_filename('cursor', profiles_product) == 'cursor-agent-toolkit-profiles.json'
+	path := os.join_path(os.temp_dir(), 'at-dig-${os.getpid()}.txt')
+	os.write_file(path, 'abc') or { assert false, err.msg() }
+	defer {
+		os.rm(path) or {}
+	}
+	d := receipt_artifact_digest(path)
+	assert d.len == 16
+}
+
+fn test_receipt_dir_under_config() {
+	fs := FsService{
+		home_dir: '/tmp/at-home-receipt'
+	}
+	assert fs.receipt_dir().ends_with(os.join_path('.config', 'agent-toolkit', 'receipts')) || fs.receipt_dir().contains('agent-toolkit')
+}


### PR DESCRIPTION
## Summary
- Add V `InstallReceipt` parser (`receipt.v`) matching Python `installer/receipt.py` SCHEMA (camelCase JSON, empty secrets)
- Refuse path-escape (`..`) and non-empty secrets; load/list from XDG receipt dir
- Docs under `docs/v/receipt.md`; FsService helpers for config/receipt paths

Fixes #512

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/receipt_test.v`
- [ ] CI green (validate + V tests)

Made with [Cursor](https://cursor.com)