### PR TITLE
feat(v): add atomic install transaction service (#513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V atomic install transaction (stage/commit/rollback + receipt save) (Closes #513)
 - **Feat** — V read-only install receipt parser (SCHEMA + path-escape/secrets refuse) (Closes #512)
 - **Feat** — V remaining target emitters (copilot, windsurf, pi, gemini, muse, codex, agent-plugins) (Closes #552)
 - **Feat** — V `build --check` Tier-1 dry-run + plugins/ skill/agent drift detection (Closes #510)

--- a/docs/v/install-transaction.md
+++ b/docs/v/install-transaction.md
@@ -1,0 +1,11 @@
+# V atomic install transaction
+
+**Issue:** [#513](https://github.com/ulises-jeremias/agent-toolkit/issues/513)
+
+`InstallTransaction` stages profile install writes, commits with `FsService.write_atomic`, and rolls back created files (or restores force-overwrites) if commit/receipt save fails:
+
+- refuse path-escape at stage time
+- `--dry-run` / preserve-without-`--force` parity with Python `cli/install.py`
+- receipt save only after successful commit (`save_install_receipt`)
+
+Depends on [#512](https://github.com/ulises-jeremias/agent-toolkit/issues/512) receipt parser. Uninstall/rollback CLI is [#514](https://github.com/ulises-jeremias/agent-toolkit/issues/514).

--- a/modules/agent_toolkit_core/install_tx.v
+++ b/modules/agent_toolkit_core/install_tx.v
@@ -1,0 +1,217 @@
+module agent_toolkit_core
+
+import os
+
+// InstallTxOptions configures an install transaction (Python install dry-run/force parity).
+pub struct InstallTxOptions {
+pub:
+	dry_run      bool
+	force        bool
+	receipt_dir  string // empty → default_receipt_dir()
+	toolkit_root string
+	product      string // empty → profiles_product
+	scope        string // empty → user-home (profile installs)
+	version      string // empty → resolve_toolkit_version()
+	source_digest string
+}
+
+// StagedOp is one pending install write inside a transaction.
+struct StagedOp {
+	src       string // empty → content write
+	dest      string
+	content   string
+	ownership string // created | merged
+}
+
+// InstallTransaction stages file writes, commits atomically, and rolls back on failure.
+pub struct InstallTransaction {
+pub mut:
+	receipt InstallReceipt
+	dry_run bool
+	force   bool
+mut:
+	fs            FsService
+	receipt_dir   string
+	staged       []StagedOp
+	committed    []CommittedArtifact
+	finished     bool
+	receipt_path string
+}
+
+// CommittedArtifact records a file written during commit (for rollback).
+pub struct CommittedArtifact {
+pub:
+	path           string
+	ownership      string
+	created_by_tx  bool // true if dest did not exist before this commit
+	backup_content string // prior content when force-overwriting an existing file
+	had_backup     bool
+}
+
+// new_install_transaction starts a profiles install receipt transaction for target.
+pub fn new_install_transaction(target string, opts InstallTxOptions) InstallTransaction {
+	product := if opts.product.len > 0 { opts.product } else { profiles_product }
+	scope := if opts.scope.len > 0 { opts.scope } else { 'user-home' }
+	version := if opts.version.len > 0 { opts.version } else { resolve_toolkit_version() }
+	src := if opts.source_digest.len > 0 {
+		opts.source_digest
+	} else {
+		profiles_source_digest(opts.toolkit_root)
+	}
+	dir := if opts.receipt_dir.len > 0 { opts.receipt_dir } else { default_receipt_dir() }
+	return InstallTransaction{
+		receipt:     new_install_receipt(product, target, scope, version, src)
+		dry_run:     opts.dry_run
+		force:       opts.force
+		fs:          new_fs()
+		receipt_dir: dir
+		staged:    []StagedOp{}
+		committed: []CommittedArtifact{}
+	}
+}
+
+// stage_write queues an atomic content write to dest (ownership created).
+pub fn (mut tx InstallTransaction) stage_write(dest string, content string) ! {
+	tx.stage_write_owned(dest, content, 'created')!
+}
+
+// stage_write_owned queues a write with explicit ownership (created|merged).
+pub fn (mut tx InstallTransaction) stage_write_owned(dest string, content string, ownership string) ! {
+	if tx.finished {
+		return error('install transaction already finished')
+	}
+	if receipt_path_escapes(dest) {
+		return error('artifact path refused (path escape): ${dest}')
+	}
+	if ownership !in ['created', 'merged'] {
+		return error("artifact ownership must be 'created' or 'merged'")
+	}
+	tx.staged << StagedOp{
+		dest:      dest
+		content:   content
+		ownership: ownership
+	}
+}
+
+// stage_copy queues copying src file bytes to dest.
+pub fn (mut tx InstallTransaction) stage_copy(src string, dest string) ! {
+	if tx.finished {
+		return error('install transaction already finished')
+	}
+	if !os.is_file(src) {
+		return error('source not found: ${src}')
+	}
+	if receipt_path_escapes(dest) {
+		return error('artifact path refused (path escape): ${dest}')
+	}
+	content := os.read_file(src) or { return error('read source failed: ${src}: ${err}') }
+	tx.staged << StagedOp{
+		src:       src
+		dest:      dest
+		content:   content
+		ownership: 'created'
+	}
+}
+
+// commit applies staged writes with write_atomic, then saves the receipt.
+// On mid-commit failure, rolls back files written by this transaction and returns error.
+// dry_run skips filesystem mutation and receipt save (returns empty path).
+pub fn (mut tx InstallTransaction) commit() !string {
+	if tx.finished {
+		return error('install transaction already finished')
+	}
+	if tx.dry_run {
+		tx.finished = true
+		return ''
+	}
+	for op in tx.staged {
+		tx.apply_one(op) or {
+			tx.rollback_committed()
+			tx.finished = true
+			return error('install commit failed: ${err}')
+		}
+	}
+	if tx.receipt.artifacts.len == 0 {
+		tx.finished = true
+		return ''
+	}
+	path := save_install_receipt(mut tx.receipt, tx.receipt_dir) or {
+		tx.rollback_committed()
+		tx.finished = true
+		return error('receipt save failed: ${err}')
+	}
+	tx.receipt_path = path
+	tx.finished = true
+	return path
+}
+
+// rollback removes created artifacts from a successful commit and deletes the receipt file.
+// Prefer using automatic rollback on commit failure; this supports explicit abort after success
+// (used by uninstall/#514 and tests).
+pub fn (mut tx InstallTransaction) rollback() ! {
+	tx.rollback_committed()
+	if tx.receipt_path.len > 0 && os.is_file(tx.receipt_path) {
+		os.rm(tx.receipt_path) or { return error('failed to remove receipt: ${err}') }
+		tx.receipt_path = ''
+	}
+	tx.finished = true
+}
+
+fn (mut tx InstallTransaction) apply_one(op StagedOp) ! {
+	dest := op.dest
+	existed := os.is_file(dest)
+	if existed {
+		existing := os.read_file(dest) or { return error('read existing failed: ${dest}: ${err}') }
+		if existing == op.content {
+			// Idempotent: already up to date — do not re-record.
+			return
+		}
+		if !tx.force {
+			// Preserve user-owned file (Python install skip without --force).
+			return
+		}
+		tx.fs.write_atomic(dest, op.content)!
+		tx.committed << CommittedArtifact{
+			path:           dest
+			ownership:      op.ownership
+			created_by_tx:  false
+			backup_content: existing
+			had_backup:     true
+		}
+		tx.record_artifact(dest, op.ownership)
+		return
+	}
+	tx.fs.write_atomic(dest, op.content)!
+	tx.committed << CommittedArtifact{
+		path:          dest
+		ownership:     op.ownership
+		created_by_tx: true
+	}
+	tx.record_artifact(dest, op.ownership)
+}
+
+fn (mut tx InstallTransaction) record_artifact(path string, ownership string) {
+	tx.receipt.artifacts << ArtifactEntry{
+		path:      path
+		digest:    receipt_artifact_digest(path)
+		ownership: ownership
+	}
+}
+
+fn (mut tx InstallTransaction) rollback_committed() {
+	// Reverse order.
+	for i := tx.committed.len - 1; i >= 0; i-- {
+		a := tx.committed[i]
+		if a.created_by_tx {
+			if os.is_file(a.path) {
+				os.rm(a.path) or {}
+			}
+			continue
+		}
+		if a.had_backup {
+			tx.fs.write_atomic(a.path, a.backup_content) or {}
+		}
+	}
+	tx.committed = []CommittedArtifact{}
+	tx.receipt.artifacts = []ArtifactEntry{}
+}

--- a/modules/agent_toolkit_core/install_tx_test.v
+++ b/modules/agent_toolkit_core/install_tx_test.v
@@ -1,0 +1,216 @@
+module agent_toolkit_core
+
+import os
+
+fn test_install_tx_commit_and_receipt() {
+	base := os.join_path(os.temp_dir(), 'at-tx-${os.getpid()}')
+	dest_root := os.join_path(base, 'dst')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(dest_root) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	dest := os.join_path(dest_root, 'rules', 'a.mdc')
+	mut tx := new_install_transaction('cursor', InstallTxOptions{
+		receipt_dir:   receipt_dir
+		toolkit_root:  base
+		version:       '1.0.0'
+		source_digest: 'srcdig'
+	})
+	tx.stage_write(dest, '# hello\n') or {
+		assert false, err.msg()
+		return
+	}
+	path := tx.commit() or {
+		assert false, err.msg()
+		return
+	}
+	assert path.len > 0
+	assert os.is_file(dest)
+	assert os.read_file(dest) or { '' } == '# hello\n'
+	loaded := load_install_receipt('cursor', profiles_product, receipt_dir) or {
+		assert false, 'receipt missing'
+		return
+	}
+	assert loaded.artifacts.len == 1
+	assert loaded.artifacts[0].ownership == 'created'
+	assert loaded.version == '1.0.0'
+}
+
+fn test_install_tx_rejects_path_escape_at_stage() {
+	base := os.join_path(os.temp_dir(), 'at-tx-rb-${os.getpid()}')
+	dest_root := os.join_path(base, 'dst')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(dest_root) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	ok_path := os.join_path(dest_root, 'ok.md')
+	bad_path := os.join_path(dest_root, '..', '..', 'etc', 'passwd')
+	mut tx := new_install_transaction('cursor', InstallTxOptions{
+		receipt_dir:   receipt_dir
+		version:       '1.0.0'
+		source_digest: 'x'
+	})
+	tx.stage_write(ok_path, 'one\n') or {
+		assert false, err.msg()
+		return
+	}
+	tx.stage_write(bad_path, 'nope\n') or {
+		assert err.msg().contains('path escape')
+		path := tx.commit() or {
+			assert false, err.msg()
+			return
+		}
+		assert path.len > 0
+		assert os.is_file(ok_path)
+		return
+	}
+	assert false, 'expected stage to refuse escape'
+}
+
+fn test_install_tx_commit_failure_rolls_back_created() {
+	base := os.join_path(os.temp_dir(), 'at-tx-fail-${os.getpid()}')
+	dest_root := os.join_path(base, 'dst')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(dest_root) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	a := os.join_path(dest_root, 'a.md')
+	b := os.join_path(dest_root, 'b.md')
+	mut tx := new_install_transaction('cursor', InstallTxOptions{
+		receipt_dir:   receipt_dir
+		version:       '1.0.0'
+		source_digest: 'x'
+		force:         true
+	})
+	tx.stage_write(a, 'A\n') or {
+		assert false, err.msg()
+		return
+	}
+	tx.stage_write(b, 'B\n') or {
+		assert false, err.msg()
+		return
+	}
+	os.write_file(receipt_dir, 'not-a-dir') or {
+		assert false, err.msg()
+		return
+	}
+	tx.commit() or {
+		assert !os.is_file(a), 'a should be rolled back'
+		assert !os.is_file(b), 'b should be rolled back'
+		return
+	}
+	assert false, 'expected commit failure'
+}
+
+fn test_install_tx_dry_run_no_writes() {
+	base := os.join_path(os.temp_dir(), 'at-tx-dry-${os.getpid()}')
+	dest := os.join_path(base, 'f.md')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	mut tx := new_install_transaction('cursor', InstallTxOptions{
+		dry_run:       true
+		receipt_dir:   receipt_dir
+		version:       '1.0.0'
+		source_digest: 'x'
+	})
+	tx.stage_write(dest, 'x\n') or {
+		assert false, err.msg()
+		return
+	}
+	path := tx.commit() or {
+		assert false, err.msg()
+		return
+	}
+	assert path == ''
+	assert !os.is_file(dest)
+	assert load_install_receipt('cursor', profiles_product, receipt_dir) == none
+}
+
+fn test_install_tx_preserve_without_force_and_restore_on_rollback() {
+	base := os.join_path(os.temp_dir(), 'at-tx-force-${os.getpid()}')
+	dest := os.join_path(base, 'f.md')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(dest, 'user\n') or {
+		assert false, err.msg()
+		return
+	}
+	mut tx := new_install_transaction('cursor', InstallTxOptions{
+		receipt_dir:   receipt_dir
+		version:       '1.0.0'
+		source_digest: 'x'
+		force:         false
+	})
+	tx.stage_write(dest, 'toolkit\n') or {
+		assert false, err.msg()
+		return
+	}
+	path := tx.commit() or {
+		assert false, err.msg()
+		return
+	}
+	assert path == ''
+	assert os.read_file(dest) or { '' } == 'user\n'
+
+	mut tx2 := new_install_transaction('cursor', InstallTxOptions{
+		receipt_dir:   receipt_dir
+		version:       '1.0.0'
+		source_digest: 'x'
+		force:         true
+	})
+	tx2.stage_write(dest, 'toolkit\n') or {
+		assert false, err.msg()
+		return
+	}
+	path2 := tx2.commit() or {
+		assert false, err.msg()
+		return
+	}
+	assert path2.len > 0
+	assert os.read_file(dest) or { '' } == 'toolkit\n'
+	tx2.rollback() or {
+		assert false, err.msg()
+		return
+	}
+	assert os.read_file(dest) or { '' } == 'user\n'
+	assert load_install_receipt('cursor', profiles_product, receipt_dir) == none
+}
+
+fn test_save_install_receipt_roundtrip() {
+	dir := os.join_path(os.temp_dir(), 'at-save-${os.getpid()}')
+	os.mkdir_all(dir) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mut r := new_install_receipt('agent-toolkit-core', 'cursor', 'project', '1.1.0', 'abc')
+	r.config_patches_json = '[{"op":"add","path":"/toolkit","value":true}]'
+	r.artifacts << ArtifactEntry{
+		path:      '/tmp/at-ok/file.mdc'
+		digest:    'def456'
+		ownership: 'created'
+	}
+	path := save_install_receipt(mut r, dir) or {
+		assert false, err.msg()
+		return
+	}
+	text := os.read_file(path) or {
+		assert false, err.msg()
+		return
+	}
+	assert text.contains('"configPatches"')
+	assert text.contains('"schemaVersion"')
+	loaded := parse_install_receipt(text) or {
+		assert false, err.msg()
+		return
+	}
+	assert loaded.config_patches_json.contains('/toolkit')
+}

--- a/modules/agent_toolkit_core/receipt.v
+++ b/modules/agent_toolkit_core/receipt.v
@@ -3,6 +3,7 @@ module agent_toolkit_core
 import crypto.sha256
 import json
 import os
+import time
 
 // profiles_product is the receipt product id used by the profile installer.
 pub const profiles_product = 'agent-toolkit-profiles'
@@ -90,6 +91,80 @@ pub fn parse_install_receipt(text string) !InstallReceipt {
 		}
 	}
 	return r
+}
+
+// encode_install_receipt serializes a receipt to camelCase JSON (secrets always []).
+pub fn encode_install_receipt(r InstallReceipt) string {
+	wire := InstallReceiptWire{
+		schema_version: r.schema_version
+		product:        r.product
+		target:         r.target
+		scope:          r.scope
+		version:        r.version
+		installed_at:   r.installed_at
+		source_digest:  r.source_digest
+		artifacts:      r.artifacts
+		secrets:        []string{}
+	}
+	mut body := json.encode(wire)
+	patches := if r.config_patches_json.len > 0 { r.config_patches_json } else { '[]' }
+	// Inject configPatches before secrets (wire struct omits raw patches field).
+	needle := '"secrets"'
+	if idx := body.index(needle) {
+		body = body[..idx] + '"configPatches":' + patches + ',' + body[idx..]
+	}
+	return body
+}
+
+// save_install_receipt writes the receipt atomically under receipt_dir.
+// Sets installed_at when empty. Returns the written path.
+pub fn save_install_receipt(mut r InstallReceipt, receipt_dir string) !string {
+	if r.secrets.len > 0 {
+		return error('receipt must not contain secrets')
+	}
+	r.secrets = []string{}
+	for a in r.artifacts {
+		if receipt_path_escapes(a.path) {
+			return error('artifact path refused (path escape): ${a.path}')
+		}
+	}
+	if r.installed_at.len == 0 {
+		r.installed_at = time.utc().format_rfc3339()
+	}
+	dir := if receipt_dir.len > 0 { receipt_dir } else { default_receipt_dir() }
+	fs := new_fs()
+	fs.ensure_dir(dir)!
+	path := os.join_path(dir, receipt_filename(r.target, r.product))
+	payload := encode_install_receipt(r)
+	fs.write_atomic(path, payload + '\n')!
+	return path
+}
+
+// profiles_source_digest mirrors Python tracking.source_digest.
+pub fn profiles_source_digest(toolkit_root string) string {
+	marker := os.join_path(toolkit_root, 'profiles')
+	if os.is_dir(marker) {
+		resolved := os.real_path(marker)
+		sum := sha256.hexhash(resolved)
+		if sum.len < 12 {
+			return sum
+		}
+		return sum[..12]
+	}
+	return resolve_toolkit_version()
+}
+
+// InstallReceiptWire is encode-only (no config_patches_json field).
+struct InstallReceiptWire {
+	schema_version int            @[json: 'schemaVersion']
+	product        string
+	target         string
+	scope          string
+	version        string
+	installed_at   string         @[json: 'installedAt']
+	source_digest  string         @[json: 'sourceDigest']
+	artifacts      []ArtifactEntry
+	secrets        []string
 }
 
 // load_install_receipt loads ~/.config/.../receipts/<target>-<product>.json (or receipt_dir).


### PR DESCRIPTION
## Summary
- Add `InstallTransaction` (stage → atomic commit → rollback) with dry-run / preserve-without-force parity
- Add `save_install_receipt` / `encode_install_receipt` for SCHEMA-compatible receipt writes
- Refuse path-escape at stage time; auto-rollback created files if receipt save fails

Fixes #513

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/install_tx_test.v modules/agent_toolkit_core/receipt_test.v`
- [ ] CI green

Made with [Cursor](https://cursor.com)