### PR TITLE
feat(v): uninstall/rollback from install receipts (#514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V uninstall/rollback from install receipts (created-only; dry-run) (Closes #514)
 - **Feat** — V atomic install transaction (stage/commit/rollback + receipt save) (Closes #513)
 - **Feat** — V read-only install receipt parser (SCHEMA + path-escape/secrets refuse) (Closes #512)
 - **Feat** — V remaining target emitters (copilot, windsurf, pi, gemini, muse, codex, agent-plugins) (Closes #552)

--- a/docs/v/uninstall.md
+++ b/docs/v/uninstall.md
@@ -1,0 +1,12 @@
+# V uninstall / rollback from receipts
+
+**Issue:** [#514](https://github.com/ulises-jeremias/agent-toolkit/issues/514)
+
+Receipt-based uninstall matching Python `cli/uninstall.py`:
+
+- remove only `ownership=created` artifacts; skip `merged`
+- refuse path-escape; `--dry-run` lists without deleting
+- delete `<target>-agent-toolkit-profiles.json` after success
+- CLI: `uninstall` / alias `rollback`; flags `--tools`, `--dry-run`, `--rollback`
+
+Depends on [#512](https://github.com/ulises-jeremias/agent-toolkit/issues/512) / [#513](https://github.com/ulises-jeremias/agent-toolkit/issues/513).

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -67,6 +67,14 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_build(opts)
 		return render(agent_toolkit_core.build_result(report), mode)
 	}
+	if cmd_name == 'uninstall' {
+		opts := parse_uninstall_options(argv[1..]) or {
+			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
+			return render_error(e, mode)
+		}
+		report := agent_toolkit_core.run_uninstall(opts)
+		return render(agent_toolkit_core.uninstall_result(report), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
@@ -126,12 +134,71 @@ fn parse_build_options(args []string) agent_toolkit_core.BuildOptions {
 	}
 }
 
+fn parse_uninstall_options(args []string) !agent_toolkit_core.UninstallOptions {
+	mut dry_run := false
+	mut tools_raw := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--dry-run' {
+			dry_run = true
+			i++
+			continue
+		}
+		if a == '--rollback' {
+			// Alias semantics: uninstall with side effects (not dry-run).
+			dry_run = false
+			i++
+			continue
+		}
+		if a == '--tools' {
+			if i + 1 >= args.len {
+				return error('--tools requires an argument')
+			}
+			tools_raw = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--tools=') {
+			tools_raw = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	mut tools := []string{}
+	if tools_raw.len > 0 {
+		for part in tools_raw.split(',') {
+			t := part.trim_space()
+			if t.len > 0 {
+				tools << t
+			}
+		}
+	}
+	return agent_toolkit_core.UninstallOptions{
+		tools:   tools
+		dry_run: dry_run
+	}
+}
+
 fn allowed_flag(cmd string, a string) bool {
 	if a in ['-h', '--help', '--json', '--quiet'] {
 		return true
 	}
 	if cmd == 'doctor' && a in ['--fix', '--provenance'] {
 		return true
+	}
+	if cmd == 'uninstall' {
+		if a in ['--dry-run', '--rollback'] {
+			return true
+		}
+		if a.starts_with('--tools') {
+			return true
+		}
 	}
 	if cmd == 'build' {
 		if a in ['--check'] {
@@ -239,6 +306,18 @@ Compile canonical capabilities into target artifacts (Tier-1 + remaining emitter
   --product PRODUCT  Product id (default: all products)
   --output DIR       Output directory (default: <repo>/plugins)
   --json             Structured CommandResult JSON
+'
+	}
+	if name == 'uninstall' {
+		return 'Usage: agent-toolkit uninstall [--tools LIST] [--dry-run] [--rollback] [--json]
+
+Remove agent-toolkit profile files recorded in install receipts.
+Alias: rollback
+
+  --tools LIST   Comma-separated tools (default: all with receipts)
+  --dry-run      Show what would be removed without deleting
+  --rollback     Alias for uninstall (removes toolkit-owned files)
+  --json         Structured CommandResult JSON
 '
 	}
 	mut c := cli.Command{

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -56,6 +56,17 @@ fn test_dispatch_build_help() {
 	assert code == 0
 }
 
+fn test_dispatch_uninstall_help() {
+	code := dispatch(['agent-toolkit', 'uninstall', '--help'])
+	assert code == 0
+}
+
+fn test_dispatch_rollback_alias_allowed() {
+	// No receipts in default dir may exit non-zero; alias must be known (not unknown command).
+	code := dispatch(['agent-toolkit', 'rollback', '--dry-run', '--json'])
+	assert code != 2
+}
+
 fn test_grouped_help_mentions_consumer_and_advanced() {
 	h := grouped_help()
 	assert h.contains('Consumer') || h.to_lower().contains('install')

--- a/modules/agent_toolkit_core/uninstall.v
+++ b/modules/agent_toolkit_core/uninstall.v
@@ -1,0 +1,164 @@
+module agent_toolkit_core
+
+import os
+
+// uninstall_tool_targets maps CLI tool names to receipt target ids (Python uninstall.py).
+pub const uninstall_tool_targets = {
+	'claude-code': 'claude-code'
+	'cursor':      'cursor'
+	'opencode':    'opencode'
+	'copilot':     'copilot'
+	'windsurf':    'windsurf'
+	'pi':          'pi'
+}
+
+// UninstallOptions configures receipt-based uninstall / rollback.
+pub struct UninstallOptions {
+pub:
+	tools       []string
+	dry_run     bool
+	receipt_dir string // empty → default_receipt_dir()
+}
+
+// UninstallReport summarizes uninstall outcomes.
+pub struct UninstallReport {
+pub mut:
+	ok              bool
+	message         string
+	tools_processed int
+	files_removed   int
+	skipped         int
+	failures        []string
+}
+
+// run_uninstall removes toolkit-owned (`created`) artifacts from install receipts.
+// Skips `merged` ownership. Deletes the receipt file when not dry_run.
+pub fn run_uninstall(opts UninstallOptions) UninstallReport {
+	dir := if opts.receipt_dir.len > 0 { opts.receipt_dir } else { default_receipt_dir() }
+	mut tools := opts.tools.clone()
+	if tools.len == 0 {
+		tools = discover_uninstall_tools(dir)
+	}
+	mut report := UninstallReport{
+		ok: true
+	}
+	if tools.len == 0 {
+		report.ok = false
+		report.message = 'No install receipts found. Nothing to uninstall.'
+		return report
+	}
+	mut lines := []string{}
+	lines << 'agent-toolkit uninstall'
+	if opts.dry_run {
+		lines << '  [info]  DRY RUN — no files will be deleted'
+	}
+	for tool in tools {
+		target := uninstall_tool_targets[tool] or {
+			report.ok = false
+			report.failures << tool
+			lines << '  ✗  Unknown tool: ${tool}'
+			continue
+		}
+		tool_ok, tool_lines, removed, skipped := uninstall_one_tool(tool, target, dir, opts.dry_run)
+		lines << tool_lines
+		report.tools_processed++
+		report.files_removed += removed
+		report.skipped += skipped
+		if !tool_ok {
+			report.ok = false
+			report.failures << tool
+		}
+	}
+	report.message = lines.join('\n')
+	return report
+}
+
+// discover_uninstall_tools finds tools with profiles receipts under receipt_dir.
+pub fn discover_uninstall_tools(receipt_dir string) []string {
+	dir := if receipt_dir.len > 0 { receipt_dir } else { default_receipt_dir() }
+	mut found := []string{}
+	if !os.is_dir(dir) {
+		return found
+	}
+	suffix := '-${profiles_product}.json'
+	entries := os.ls(dir) or { return found }
+	for e in entries.sorted() {
+		if !e.ends_with(suffix) {
+			continue
+		}
+		target := e[..e.len - suffix.len]
+		for tool, receipt_target in uninstall_tool_targets {
+			if receipt_target == target && tool !in found {
+				found << tool
+			}
+		}
+	}
+	found.sort()
+	return found
+}
+
+fn uninstall_one_tool(tool string, target string, receipt_dir string, dry_run bool) (bool, string, int, int) {
+	mut lines := []string{}
+	receipt := load_install_receipt(target, profiles_product, receipt_dir) or {
+		lines << '  -  No receipt for ${tool} — nothing to uninstall'
+		return true, lines.join('\n'), 0, 0
+	}
+	lines << '  [info]  Uninstalling ${tool} (${receipt.artifacts.len} artifact(s) from receipt)'
+	mut removed := 0
+	mut skipped := 0
+	for entry in receipt.artifacts {
+		if entry.ownership != 'created' {
+			lines << '  -  Skipping non-owned file (${entry.ownership}): ${entry.path}'
+			skipped++
+			continue
+		}
+		if receipt_path_escapes(entry.path) {
+			lines << '  ✗  Refused path escape: ${entry.path}'
+			return false, lines.join('\n'), removed, skipped
+		}
+		if !os.exists(entry.path) {
+			lines << '  -  Already absent: ${entry.path}'
+			skipped++
+			continue
+		}
+		if dry_run {
+			lines << '  [dry]   Would remove: ${entry.path}'
+			removed++
+			continue
+		}
+		os.rm(entry.path) or {
+			lines << '  ✗  Failed to remove ${entry.path}: ${err}'
+			return false, lines.join('\n'), removed, skipped
+		}
+		lines << '  ✓  Removed: ${entry.path}'
+		removed++
+	}
+	if !dry_run {
+		receipt_path := os.join_path(receipt_dir, receipt_filename(target, profiles_product))
+		if os.is_file(receipt_path) {
+			os.rm(receipt_path) or {
+				lines << '  ✗  Failed to remove receipt: ${err}'
+				return false, lines.join('\n'), removed, skipped
+			}
+			lines << '  ✓  Removed receipt: ${receipt_path}'
+		}
+	}
+	lines << '  [info]  ${tool}: processed ${removed} owned file(s)'
+	return true, lines.join('\n'), removed, skipped
+}
+
+// uninstall_result maps a report to CommandResult.
+pub fn uninstall_result(report UninstallReport) CommandResult {
+	return CommandResult{
+		command: 'uninstall'
+		ok:      report.ok
+		message: report.message
+		data:    {
+			'tools_processed': '${report.tools_processed}'
+			'files_removed':   '${report.files_removed}'
+			'skipped':         '${report.skipped}'
+			'failures':        report.failures.join(',')
+			'dry_run':         if report.message.contains('DRY RUN') { 'true' } else { 'false' }
+		}
+	}
+}

--- a/modules/agent_toolkit_core/uninstall_test.v
+++ b/modules/agent_toolkit_core/uninstall_test.v
@@ -1,0 +1,102 @@
+module agent_toolkit_core
+
+import os
+
+fn test_uninstall_removes_created_keeps_merged() {
+	base := os.join_path(os.temp_dir(), 'at-un-${os.getpid()}')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(receipt_dir) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	created := os.join_path(base, 'created.md')
+	merged := os.join_path(base, 'merged.md')
+	os.write_file(created, 'c\n') or { assert false, err.msg() }
+	os.write_file(merged, 'm\n') or { assert false, err.msg() }
+	mut r := new_install_receipt(profiles_product, 'cursor', 'user-home', '1.0.0', 'x')
+	r.artifacts << ArtifactEntry{
+		path:      created
+		digest:    'aa'
+		ownership: 'created'
+	}
+	r.artifacts << ArtifactEntry{
+		path:      merged
+		digest:    'bb'
+		ownership: 'merged'
+	}
+	save_install_receipt(mut r, receipt_dir) or {
+		assert false, err.msg()
+		return
+	}
+	report := run_uninstall(UninstallOptions{
+		tools:       ['cursor']
+		receipt_dir: receipt_dir
+	})
+	assert report.ok
+	assert !os.is_file(created)
+	assert os.is_file(merged)
+	assert load_install_receipt('cursor', profiles_product, receipt_dir) == none
+}
+
+fn test_uninstall_dry_run_preserves_files() {
+	base := os.join_path(os.temp_dir(), 'at-un-dry-${os.getpid()}')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(receipt_dir) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	created := os.join_path(base, 'created.md')
+	os.write_file(created, 'c\n') or { assert false, err.msg() }
+	mut r := new_install_receipt(profiles_product, 'cursor', 'user-home', '1.0.0', 'x')
+	r.artifacts << ArtifactEntry{
+		path:      created
+		digest:    'aa'
+		ownership: 'created'
+	}
+	save_install_receipt(mut r, receipt_dir) or {
+		assert false, err.msg()
+		return
+	}
+	report := run_uninstall(UninstallOptions{
+		tools:       ['cursor']
+		dry_run:     true
+		receipt_dir: receipt_dir
+	})
+	assert report.ok
+	assert os.is_file(created)
+	assert load_install_receipt('cursor', profiles_product, receipt_dir) != none
+	assert report.message.contains('DRY RUN')
+}
+
+fn test_uninstall_no_receipts() {
+	base := os.join_path(os.temp_dir(), 'at-un-empty-${os.getpid()}')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	report := run_uninstall(UninstallOptions{
+		receipt_dir: base
+	})
+	assert !report.ok
+	assert report.message.contains('No install receipts')
+}
+
+fn test_discover_uninstall_tools() {
+	base := os.join_path(os.temp_dir(), 'at-un-disc-${os.getpid()}')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	mut r := new_install_receipt(profiles_product, 'opencode', 'user-home', '1.0.0', 'x')
+	r.artifacts << ArtifactEntry{
+		path:      '/tmp/at-ok/x'
+		digest:    'aa'
+		ownership: 'created'
+	}
+	save_install_receipt(mut r, base) or {
+		assert false, err.msg()
+		return
+	}
+	tools := discover_uninstall_tools(base)
+	assert tools == ['opencode']
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -2,111 +2,260 @@
   "fixtures": [
     {
       "command": "version",
-      "args": ["version"],
+      "args": [
+        "version"
+      ],
       "class": "EXACT",
       "expect_exit": 0
     },
     {
       "command": "version-flag",
-      "args": ["--version"],
+      "args": [
+        "--version"
+      ],
       "class": "EXACT",
       "expect_exit": 0
     },
     {
       "command": "help",
-      "args": ["--help"],
+      "args": [
+        "--help"
+      ],
       "class": "SEMANTIC",
-      "must_contain": ["install", "doctor", "inventory"]
+      "must_contain": [
+        "install",
+        "doctor",
+        "inventory"
+      ]
     },
     {
       "command": "inventory",
-      "args": ["inventory", "--json"],
+      "args": [
+        "inventory",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "skills_count", "agents_count", "products_count"]
+      "required_keys": [
+        "command",
+        "skills_count",
+        "agents_count",
+        "products_count"
+      ]
     },
     {
       "command": "inventory-human",
-      "args": ["inventory"],
+      "args": [
+        "inventory"
+      ],
       "class": "SEMANTIC",
-      "must_contain": ["Skills:", "Agents:", "Products:"]
+      "must_contain": [
+        "Skills:",
+        "Agents:",
+        "Products:"
+      ]
     },
     {
       "command": "matrix",
-      "args": ["matrix", "--json"],
+      "args": [
+        "matrix",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "found"]
+      "required_keys": [
+        "command",
+        "found"
+      ]
     },
     {
       "command": "doctor",
-      "args": ["doctor", "--json"],
+      "args": [
+        "doctor",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["engine", "version", "platform"]
+      "required_keys": [
+        "engine",
+        "version",
+        "platform"
+      ]
     },
     {
       "command": "build-check",
-      "args": ["build", "--check", "--target", "cursor", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "cursor",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "build-check-copilot-cli",
-      "args": ["build", "--check", "--target", "copilot-cli", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "copilot-cli",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "build-check-windsurf",
-      "args": ["build", "--check", "--target", "windsurf", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "windsurf",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "build-check-pi",
-      "args": ["build", "--check", "--target", "pi", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "pi",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "build-check-gemini",
-      "args": ["build", "--check", "--target", "gemini-cli", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "gemini-cli",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "build-check-muse",
-      "args": ["build", "--check", "--target", "muse-code", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "muse-code",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "build-check-codex",
-      "args": ["build", "--check", "--target", "codex", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "codex",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "build-check-agent-plugins",
-      "args": ["build", "--check", "--target", "agent-plugins", "--product", "agent-toolkit-core", "--json"],
+      "args": [
+        "build",
+        "--check",
+        "--target",
+        "agent-plugins",
+        "--product",
+        "agent-toolkit-core",
+        "--json"
+      ],
       "class": "SCHEMA",
       "expect_v_exit": 0,
-      "required_keys": ["command", "mode", "ok"]
+      "required_keys": [
+        "command",
+        "mode",
+        "ok"
+      ]
     },
     {
       "command": "install-bad-flag",
-      "args": ["install", "--not-a-real-flag"],
+      "args": [
+        "install",
+        "--not-a-real-flag"
+      ],
       "class": "EXACT",
       "expect_exit": 2,
       "compare": "exit_only"
+    },
+    {
+      "command": "uninstall-help",
+      "args": [
+        "uninstall",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "uninstall",
+        "dry-run",
+        "tools"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `run_uninstall` / receipt discovery matching Python `cli/uninstall.py` (created-only, skip merged, path-escape refuse)
- Wire `uninstall` + `rollback` alias with `--tools` / `--dry-run` / `--rollback`
- Parity seed fixture for uninstall help

Fixes #514

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/uninstall_test.v modules/agent_toolkit_cli/dispatch_test.v`
- [ ] CI green

Made with [Cursor](https://cursor.com)