### PR TITLE
feat(v): publish install receipt compatibility schema (#511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — install receipt compatibility schema (`schemas/install-receipt.schema.json`) (Closes #511)
 - **Feat** — V uninstall/rollback from install receipts (created-only; dry-run) (Closes #514)
 - **Feat** — V atomic install transaction (stage/commit/rollback + receipt save) (Closes #513)
 - **Feat** — V read-only install receipt parser (SCHEMA + path-escape/secrets refuse) (Closes #512)

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -44,16 +44,21 @@ install or conflicting older profile.
 
 ## Installation receipts
 
-The installer receipt module (`agent_toolkit.installer.receipt`) defines a
-JSON schema for recording what was installed:
+The installer receipt module (`agent_toolkit.installer.receipt` / V
+`agent_toolkit_core`) records what was installed. The **compatibility schema**
+is published at [`schemas/install-receipt.schema.json`](../schemas/install-receipt.schema.json)
+(issue [#511](https://github.com/ulises-jeremias/agent-toolkit/issues/511)):
 
 - **Location:** `~/.config/agent-toolkit/receipts/<target>-<product>.json`
-- **Fields:** product, target, version, file paths, content digests
+- **schemaVersion:** `1` only
+- **Fields:** product, target, scope, version, installedAt, sourceDigest, artifacts, configPatches, secrets
 - **Secrets:** always empty (`secrets: []`)
+- **Ownership:** `created` (uninstall removes) or `merged` (preserved)
+- **Safety:** artifact paths must not contain `..` segments
 
 Receipts are written by `agent-toolkit install` / `update` and consumed by
 `agent-toolkit uninstall` / rollback. Lifecycle tests cover create, save, load,
-and uninstall-by-receipt.
+and uninstall-by-receipt; schema tests live in `tests/test_install_receipt_schema.py`.
 
 Example shape (illustrative):
 
@@ -64,8 +69,9 @@ Example shape (illustrative):
   "target": "cursor",
   "version": "1.2.0",
   "artifacts": [
-    { "path": "~/.cursor/rules/code-reviewer.mdc", "digest": "sha256:…", "ownership": "created" }
+    { "path": "/home/user/.cursor/rules/code-reviewer.mdc", "digest": "deadbeefcafebabe", "ownership": "created" }
   ],
+  "configPatches": [],
   "secrets": []
 }
 ```

--- a/docs/v/receipt-schema.md
+++ b/docs/v/receipt-schema.md
@@ -1,0 +1,11 @@
+# Install receipt compatibility schema
+
+**Issue:** [#511](https://github.com/ulises-jeremias/agent-toolkit/issues/511)
+
+Formal JSON Schema for installer receipts:
+
+- File: [`schemas/install-receipt.schema.json`](../../schemas/install-receipt.schema.json)
+- Contract: `schemaVersion` **1**, camelCase keys, `secrets: []`, ownership `created|merged`, no `..` in artifact paths
+- Verified by: Python `tests/test_install_receipt_schema.py` + V `parse_install_receipt` / `save_install_receipt` (#512/#513)
+
+See [TRUST.md](../TRUST.md) (Installation receipts) and ADR-014 (typed V validators + published schema for cross-language parity).

--- a/modules/agent_toolkit_core/receipt.v
+++ b/modules/agent_toolkit_core/receipt.v
@@ -8,6 +8,9 @@ import time
 // profiles_product is the receipt product id used by the profile installer.
 pub const profiles_product = 'agent-toolkit-profiles'
 
+// receipt_schema_version is the only supported InstallReceipt schemaVersion (#511).
+pub const receipt_schema_version = 1
+
 // ArtifactEntry is one installed file recorded in an InstallReceipt.
 pub struct ArtifactEntry {
 pub:
@@ -34,7 +37,7 @@ pub mut:
 // new_install_receipt creates a schemaVersion=1 receipt (secrets always empty).
 pub fn new_install_receipt(product string, target string, scope string, version string, source_digest string) InstallReceipt {
 	return InstallReceipt{
-		schema_version:      1
+		schema_version:      receipt_schema_version
 		product:             product
 		target:              target
 		scope:               scope
@@ -66,7 +69,10 @@ pub fn parse_install_receipt(text string) !InstallReceipt {
 	}
 	mut r := json.decode(InstallReceipt, trimmed) or { return error('receipt decode failed: ${err}') }
 	if r.schema_version < 1 {
-		r.schema_version = 1
+		r.schema_version = receipt_schema_version
+	}
+	if r.schema_version != receipt_schema_version {
+		return error('unsupported receipt schemaVersion ${r.schema_version} (expected ${receipt_schema_version})')
 	}
 	if r.product.len == 0 || r.target.len == 0 {
 		return error('receipt missing required product/target')

--- a/modules/agent_toolkit_core/receipt_test.v
+++ b/modules/agent_toolkit_core/receipt_test.v
@@ -40,6 +40,15 @@ fn test_parse_rejects_secrets_and_bad_ownership() {
 	assert false, 'expected secrets rejection'
 }
 
+fn test_parse_rejects_unsupported_schema_version() {
+	bad := '{"schemaVersion":2,"product":"p","target":"t","version":"1","artifacts":[],"secrets":[]}'
+	parse_install_receipt(bad) or {
+		assert err.msg().contains('schemaVersion')
+		return
+	}
+	assert false, 'expected schemaVersion rejection'
+}
+
 fn test_parse_rejects_path_escape() {
 	bad := '{"schemaVersion":1,"product":"p","target":"t","version":"1","artifacts":[{"path":"../../etc/passwd","digest":"x","ownership":"created"}],"secrets":[]}'
 	parse_install_receipt(bad) or {

--- a/schemas/install-receipt.schema.json
+++ b/schemas/install-receipt.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/install-receipt.schema.json",
+  "title": "Agent Toolkit Install Receipt",
+  "description": "Compatibility schema for installer receipts written under ~/.config/agent-toolkit/receipts/<target>-<product>.json. Matches Python agent_toolkit.installer.receipt and V agent_toolkit_core receipt.v (schemaVersion 1). Secrets MUST be empty. Artifact paths MUST NOT contain '..' segments (path-escape refuse). See docs/TRUST.md and docs/v/receipt-schema.md.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "product",
+    "target",
+    "version",
+    "artifacts",
+    "secrets"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Receipt format version. Only 1 is supported."
+    },
+    "product": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Product id (e.g. agent-toolkit-profiles, agent-toolkit-core)."
+    },
+    "target": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Install target id (cursor, claude-code, opencode, …)."
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Install scope (project | user-home).",
+      "default": "project"
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Toolkit version recorded at install time."
+    },
+    "installedAt": {
+      "type": "string",
+      "description": "ISO-8601 / RFC3339 timestamp when the receipt was written."
+    },
+    "sourceDigest": {
+      "type": "string",
+      "description": "Short digest of install source (profiles tree or version fallback)."
+    },
+    "artifacts": {
+      "type": "array",
+      "description": "Installed files with digests and ownership.",
+      "items": {
+        "$ref": "#/$defs/artifactEntry"
+      }
+    },
+    "configPatches": {
+      "type": "array",
+      "description": "Optional JSON-merge / patch records applied to tool configs.",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "secrets": {
+      "type": "array",
+      "description": "Always empty — receipts must never store secrets.",
+      "maxItems": 0,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "artifactEntry": {
+      "type": "object",
+      "required": ["path", "digest", "ownership"],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute or resolved install path. Must not contain '..' path segments.",
+          "not": {
+            "pattern": "(^|[/\\\\])\\.\\.([/\\\\]|$)"
+          }
+        },
+        "digest": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Content digest (SHA256 hex truncated to 16 chars in current installers)."
+        },
+        "ownership": {
+          "type": "string",
+          "enum": ["created", "merged"],
+          "description": "created = toolkit-owned (uninstall removes); merged = user-preserved."
+        }
+      }
+    }
+  }
+}

--- a/tests/test_install_receipt_schema.py
+++ b/tests/test_install_receipt_schema.py
@@ -1,0 +1,94 @@
+"""Validate install receipts against schemas/install-receipt.schema.json (#511)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+from jsonschema import Draft202012Validator, ValidationError, validate  # noqa: E402
+
+from agent_toolkit.installer.receipt import ArtifactEntry, InstallReceipt  # noqa: E402
+
+REPO_ROOT = Path(__file__).parent.parent
+SCHEMA_PATH = REPO_ROOT / "schemas" / "install-receipt.schema.json"
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _sample_receipt() -> dict[str, Any]:
+    r = InstallReceipt.create(
+        "agent-toolkit-profiles",
+        "cursor",
+        "user-home",
+        "1.10.0",
+        "abc123def456",
+    )
+    r.artifacts.append(
+        ArtifactEntry("/tmp/at-ok/.cursor/rules/assistant.mdc", "deadbeefcafebabe", "created")
+    )
+    r.config_patches = [{"op": "add", "path": "/toolkit", "value": True}]
+    return r.to_dict()
+
+
+def test_install_receipt_schema_file_exists():
+    assert SCHEMA_PATH.is_file()
+
+
+def test_python_receipt_to_dict_validates():
+    schema = _load_schema()
+    data = _sample_receipt()
+    validate(instance=data, schema=schema)
+
+
+def test_schema_rejects_nonempty_secrets():
+    schema = _load_schema()
+    data = _sample_receipt()
+    data["secrets"] = ["leak"]
+    with pytest.raises(ValidationError, match=r"secrets|maxItems"):
+        validate(instance=data, schema=schema)
+
+
+def test_schema_rejects_path_escape():
+    schema = _load_schema()
+    data = _sample_receipt()
+    data["artifacts"][0]["path"] = "../../etc/passwd"
+    with pytest.raises(ValidationError):
+        validate(instance=data, schema=schema)
+
+
+def test_schema_rejects_bad_ownership():
+    schema = _load_schema()
+    data = _sample_receipt()
+    data["artifacts"][0]["ownership"] = "owned"
+    with pytest.raises(ValidationError, match="ownership|created|merged"):
+        validate(instance=data, schema=schema)
+
+
+def test_schema_rejects_wrong_schema_version():
+    schema = _load_schema()
+    data = _sample_receipt()
+    data["schemaVersion"] = 2
+    with pytest.raises(ValidationError):
+        validate(instance=data, schema=schema)
+
+
+def test_schema_rejects_missing_required():
+    schema = _load_schema()
+    data = _sample_receipt()
+    broken = copy.deepcopy(data)
+    del broken["product"]
+    with pytest.raises(ValidationError, match="product"):
+        validate(instance=broken, schema=schema)
+
+
+def test_draft202012_validator_compiles():
+    schema = _load_schema()
+    Draft202012Validator.check_schema(schema)


### PR DESCRIPTION
## Summary
- Add `schemas/install-receipt.schema.json` (schemaVersion 1, empty secrets, created|merged, no `..` paths)
- Python jsonschema tests + V `receipt_schema_version` enforcement in parser
- Document in TRUST.md and `docs/v/receipt-schema.md`

Fixes #511

## Test plan
- [x] `uv run pytest tests/test_install_receipt_schema.py -q`
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/receipt_test.v`
- [ ] CI green

Made with [Cursor](https://cursor.com)