### PR TITLE
feat(v): implement agent-toolkit diff vs plugins (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `agent-toolkit diff` (compile vs plugins/ added/changed) (Closes #515)
 - **Feat** — install receipt compatibility schema (`schemas/install-receipt.schema.json`) (Closes #511)
 - **Feat** — V uninstall/rollback from install receipts (created-only; dry-run) (Closes #514)
 - **Feat** — V atomic install transaction (stage/commit/rollback + receipt save) (Closes #513)

--- a/docs/v/diff.md
+++ b/docs/v/diff.md
@@ -1,0 +1,11 @@
+# V `agent-toolkit diff`
+
+**Issue:** [#515](https://github.com/ulises-jeremias/agent-toolkit/issues/515)
+
+Compiles selected products/targets into a temp tree and compares file digests against `plugins/` (Python `cli/diff.py` parity):
+
+- Default targets: Tier-1 (`cursor`, `claude-code`, `opencode`)
+- Reports `+` added / `~` changed; exit non-zero when any changes
+- Flags: `--target`, `--product`, `--json`
+
+Related: `build --check` (#510) for plugin drift gates.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -75,6 +75,11 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_uninstall(opts)
 		return render(agent_toolkit_core.uninstall_result(report), mode)
 	}
+	if cmd_name == 'diff' {
+		opts := parse_diff_options(argv[1..])
+		report := agent_toolkit_core.run_diff(opts)
+		return render(agent_toolkit_core.diff_result(report), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
@@ -185,6 +190,44 @@ fn parse_uninstall_options(args []string) !agent_toolkit_core.UninstallOptions {
 	}
 }
 
+fn parse_diff_options(args []string) agent_toolkit_core.DiffOptions {
+	mut target := ''
+	mut product := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--target' && i + 1 < args.len {
+			target = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--target=') {
+			target = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--product' && i + 1 < args.len {
+			product = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--product=') {
+			product = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	return agent_toolkit_core.DiffOptions{
+		target:  target
+		product: product
+	}
+}
+
 fn allowed_flag(cmd string, a string) bool {
 	if a in ['-h', '--help', '--json', '--quiet'] {
 		return true
@@ -197,6 +240,11 @@ fn allowed_flag(cmd string, a string) bool {
 			return true
 		}
 		if a.starts_with('--tools') {
+			return true
+		}
+	}
+	if cmd == 'diff' {
+		if a.starts_with('--target') || a.starts_with('--product') {
 			return true
 		}
 	}
@@ -318,6 +366,16 @@ Alias: rollback
   --dry-run      Show what would be removed without deleting
   --rollback     Alias for uninstall (removes toolkit-owned files)
   --json         Structured CommandResult JSON
+'
+	}
+	if name == 'diff' {
+		return 'Usage: agent-toolkit diff [--target TARGET] [--product PRODUCT] [--json]
+
+Show what would change between freshly compiled output and plugins/.
+
+  --target TARGET    Target platform (default: Tier-1 cursor/claude-code/opencode)
+  --product PRODUCT  Product ID to diff (default: all products)
+  --json             Structured CommandResult JSON
 '
 	}
 	mut c := cli.Command{

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -61,6 +61,11 @@ fn test_dispatch_uninstall_help() {
 	assert code == 0
 }
 
+fn test_dispatch_diff_help() {
+	code := dispatch(['agent-toolkit', 'diff', '--help'])
+	assert code == 0
+}
+
 fn test_dispatch_rollback_alias_allowed() {
 	// No receipts in default dir may exit non-zero; alias must be known (not unknown command).
 	code := dispatch(['agent-toolkit', 'rollback', '--dry-run', '--json'])

--- a/modules/agent_toolkit_core/diff.v
+++ b/modules/agent_toolkit_core/diff.v
@@ -1,0 +1,236 @@
+module agent_toolkit_core
+
+import crypto.sha256
+import os
+
+// DiffOptions configures `agent-toolkit diff` (Python cli/diff.py parity).
+pub struct DiffOptions {
+pub:
+	target     string // empty = Tier-1 defaults
+	product    string // empty = all products
+	plugins_dir string // empty = <repo>/plugins
+}
+
+// DiffChangeSet is added/changed/removed relative paths for one product×target.
+pub struct DiffChangeSet {
+pub mut:
+	added   []string
+	changed []string
+	removed []string
+}
+
+// DiffEntry is one product→target comparison result.
+pub struct DiffEntry {
+pub mut:
+	target     string
+	product    string
+	changes    DiffChangeSet
+	no_changes bool
+	error      string
+}
+
+// DiffReport aggregates diff entries (exit non-zero when any changes / errors).
+pub struct DiffReport {
+pub mut:
+	ok      bool
+	entries []DiffEntry
+	message string
+}
+
+// run_diff compiles into a temp tree and compares against committed plugins/.
+pub fn run_diff(opts DiffOptions) DiffReport {
+	mut report := DiffReport{
+		ok: true
+	}
+	repo := find_repo_root() or {
+		report.ok = false
+		report.message = 'repo root not found: ${err}'
+		return report
+	}
+	graph := load_graph(repo)
+	if !graph.is_valid() {
+		report.ok = false
+		report.message = 'canonical graph load failed (${graph.errors.len} error(s))'
+		return report
+	}
+	mut products := []LoadedProduct{}
+	if opts.product.len > 0 {
+		p := graph.select_product(opts.product) or {
+			report.ok = false
+			report.message = "product '${opts.product}' not found"
+			return report
+		}
+		products << p
+	} else {
+		for _, p in graph.products {
+			products << p
+		}
+	}
+	mut targets := []string{}
+	if opts.target.len > 0 {
+		if !is_tier1_target(opts.target) && !is_known_emit_target(opts.target) {
+			report.ok = false
+			report.message = "unknown target '${opts.target}'"
+			return report
+		}
+		// Diff focuses on Tier-1 like Python defaults; allow explicit known targets.
+		targets << normalize_emit_target(opts.target)
+	} else {
+		targets = tier1_targets()
+	}
+	plugins_root := if opts.plugins_dir.len > 0 {
+		opts.plugins_dir
+	} else {
+		os.join_path(repo, 'plugins')
+	}
+	work_root := os.join_path(os.temp_dir(), 'agent-toolkit-diff-${os.getpid()}')
+	os.mkdir_all(work_root) or {
+		report.ok = false
+		report.message = 'temp output mkdir failed: ${err}'
+		return report
+	}
+	defer {
+		os.rmdir_all(work_root) or {}
+	}
+
+	mut lines := []string{}
+	lines << 'agent-toolkit diff'
+	lines << 'Plugins: ${plugins_root}'
+	lines << 'Targets: ${targets.join(', ')}  Products: ${products.len}'
+	lines << ''
+
+	for t in targets {
+		for p in products {
+			mut entry := DiffEntry{
+				target:  t
+				product: p.id
+			}
+			r := compile_target(t, graph, p, work_root, repo)
+			if !r.is_valid() {
+				entry.error = r.errors.join('; ')
+				report.ok = false
+				report.entries << entry
+				lines << '  ✗  ${p.id} → ${t}: compile failed (${entry.error})'
+				continue
+			}
+			entry.changes = diff_product_trees(os.join_path(work_root, p.id), os.join_path(plugins_root,
+				p.id))
+			entry.no_changes = entry.changes.added.len == 0 && entry.changes.changed.len == 0
+				&& entry.changes.removed.len == 0
+			report.entries << entry
+			header := '~ ${p.id} → ${t}'
+			if entry.no_changes {
+				lines << '  ✓  ${header}: no changes'
+			} else {
+				report.ok = false
+				lines << ''
+				lines << '  ${header}:'
+				for f in entry.changes.added {
+					lines << '    + ${f}'
+				}
+				for f in entry.changes.changed {
+					lines << '    ~ ${f}'
+				}
+				for f in entry.changes.removed {
+					lines << '    - ${f}'
+				}
+			}
+		}
+	}
+	lines << ''
+	report.message = lines.join('\n')
+	return report
+}
+
+// diff_result maps DiffReport to CommandResult.
+pub fn diff_result(report DiffReport) CommandResult {
+	mut changed := 0
+	for e in report.entries {
+		if !e.no_changes || e.error.len > 0 {
+			changed++
+		}
+	}
+	return CommandResult{
+		command: 'diff'
+		ok:      report.ok
+		message: report.message
+		data:    {
+			'entries':  '${report.entries.len}'
+			'changed':  '${changed}'
+			'ok':       if report.ok { 'true' } else { 'false' }
+		}
+	}
+}
+
+fn diff_product_trees(built_dir string, current_dir string) DiffChangeSet {
+	mut changes := DiffChangeSet{}
+	built := list_rel_files(built_dir)
+	mut built_set := map[string]bool{}
+	for rel in built {
+		built_set[rel] = true
+		b_path := os.join_path(built_dir, rel)
+		c_path := os.join_path(current_dir, rel)
+		if !os.is_file(c_path) {
+			changes.added << rel
+			continue
+		}
+		if diff_file_digest(b_path) != diff_file_digest(c_path) {
+			changes.changed << rel
+		}
+	}
+	if os.is_dir(current_dir) {
+		for rel in list_rel_files(current_dir) {
+			if rel.ends_with('.provenance.json') {
+				continue
+			}
+			if rel in built_set {
+				continue
+			}
+			// Python currently does not populate removed (pass); keep empty for parity.
+			_ = rel
+		}
+	}
+	changes.added.sort()
+	changes.changed.sort()
+	changes.removed.sort()
+	return changes
+}
+
+fn list_rel_files(root string) []string {
+	mut out := []string{}
+	if !os.is_dir(root) {
+		return out
+	}
+	collect_rel_files(root, root, mut out)
+	out.sort()
+	return out
+}
+
+fn collect_rel_files(base string, dir string, mut out []string) {
+	entries := os.ls(dir) or { return }
+	for e in entries {
+		path := os.join_path(dir, e)
+		if os.is_dir(path) {
+			collect_rel_files(base, path, mut out)
+			continue
+		}
+		if !os.is_file(path) {
+			continue
+		}
+		rel := relative_to(path, base) or { continue }
+		norm := rel.replace('\\', '/')
+		if norm.ends_with('.provenance.json') {
+			continue
+		}
+		out << norm
+	}
+}
+
+fn diff_file_digest(path string) string {
+	data := os.read_file(path) or { return 'missing' }
+	sum := sha256.hexhash(data)
+	if sum.len < 12 {
+		return sum
+	}
+	return sum[..12]
+}

--- a/modules/agent_toolkit_core/diff_test.v
+++ b/modules/agent_toolkit_core/diff_test.v
@@ -1,0 +1,55 @@
+module agent_toolkit_core
+
+import os
+
+fn test_diff_file_digest_stable() {
+	path := os.join_path(os.temp_dir(), 'at-diff-dig-${os.getpid()}.txt')
+	os.write_file(path, 'abc') or {
+		assert false, err.msg()
+		return
+	}
+	defer {
+		os.rm(path) or {}
+	}
+	d := diff_file_digest(path)
+	assert d.len == 12
+	assert d == diff_file_digest(path)
+}
+
+fn test_diff_product_trees_added_and_changed() {
+	base := os.join_path(os.temp_dir(), 'at-diff-${os.getpid()}')
+	built := os.join_path(base, 'built')
+	current := os.join_path(base, 'current')
+	os.mkdir_all(os.join_path(built, 'skills', 'a')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(current, 'skills', 'a')) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(built, 'skills', 'a', 'SKILL.md'), 'new\n') or {
+		assert false, err.msg()
+		return
+	}
+	os.write_file(os.join_path(current, 'skills', 'a', 'SKILL.md'), 'old\n') or {
+		assert false, err.msg()
+		return
+	}
+	os.write_file(os.join_path(built, 'skills', 'b', 'SKILL.md'), 'only-built\n') or {
+		// parent missing
+		os.mkdir_all(os.join_path(built, 'skills', 'b')) or {}
+		os.write_file(os.join_path(built, 'skills', 'b', 'SKILL.md'), 'only-built\n') or {
+			assert false, err.msg()
+			return
+		}
+	}
+	changes := diff_product_trees(built, current)
+	assert 'skills/a/SKILL.md' in changes.changed
+	assert 'skills/b/SKILL.md' in changes.added
+}
+
+fn test_run_diff_unknown_product() {
+	report := run_diff(DiffOptions{
+		product: 'not-a-real-product-xyz'
+	})
+	assert !report.ok
+	assert report.message.len > 0
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -256,6 +256,19 @@
         "dry-run",
         "tools"
       ]
+    },
+    {
+      "command": "diff-help",
+      "args": [
+        "diff",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "diff",
+        "target",
+        "product"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `run_diff` / `diff_result` comparing freshly compiled output to `plugins/`
- Wire `diff` CLI with `--target` / `--product` / `--json` (Tier-1 defaults)
- Parity help fixture + docs

Fixes #515

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/diff_test.v modules/agent_toolkit_cli/dispatch_test.v`
- [ ] CI green

Made with [Cursor](https://cursor.com)