### PR TITLE
feat(v): implement capability update for installed profiles (#516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V capability `update` (profile refresh; --check/--pin; not self-update) (Closes #516)
 - **Feat** — V `agent-toolkit diff` (compile vs plugins/ added/changed) (Closes #515)
 - **Feat** — install receipt compatibility schema (`schemas/install-receipt.schema.json`) (Closes #511)
 - **Feat** — V uninstall/rollback from install receipts (created-only; dry-run) (Closes #514)

--- a/docs/v/update.md
+++ b/docs/v/update.md
@@ -1,0 +1,12 @@
+# V capability `update`
+
+**Issue:** [#516](https://github.com/ulises-jeremias/agent-toolkit/issues/516)
+
+Refreshes installed AI-tool **profiles** from toolkit capability data (not executable self-update):
+
+- Tools: `claude-code`, `cursor`, `opencode`, `windsurf`, `pi`
+- `--check` dry-run (exit non-zero when changes pending)
+- `--pin VERSION` / auto data refresh via `DataSync.ensure_data`
+- Atomic writes via `FsService.write_atomic`
+
+See also ADR package-manager ownership (#489) — this command updates content, not the CLI binary.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -80,6 +80,14 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_diff(opts)
 		return render(agent_toolkit_core.diff_result(report), mode)
 	}
+	if cmd_name == 'update' {
+		opts := parse_update_options(argv[1..]) or {
+			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
+			return render_error(e, mode)
+		}
+		report := agent_toolkit_core.run_update(opts)
+		return render(agent_toolkit_core.update_result(report), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
@@ -228,6 +236,66 @@ fn parse_diff_options(args []string) agent_toolkit_core.DiffOptions {
 	}
 }
 
+fn parse_update_options(args []string) !agent_toolkit_core.UpdateOptions {
+	mut check_only := false
+	mut tools_raw := ''
+	mut pin := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--check' {
+			check_only = true
+			i++
+			continue
+		}
+		if a == '--tools' {
+			if i + 1 >= args.len {
+				return error('--tools requires an argument')
+			}
+			tools_raw = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--tools=') {
+			tools_raw = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--pin' {
+			if i + 1 >= args.len {
+				return error('--pin requires an argument')
+			}
+			pin = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--pin=') {
+			pin = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	mut tools := []string{}
+	if tools_raw.len > 0 {
+		for part in tools_raw.split(',') {
+			t := part.trim_space()
+			if t.len > 0 {
+				tools << t
+			}
+		}
+	}
+	return agent_toolkit_core.UpdateOptions{
+		tools:      tools
+		check_only: check_only
+		pin:        pin
+	}
+}
+
 fn allowed_flag(cmd string, a string) bool {
 	if a in ['-h', '--help', '--json', '--quiet'] {
 		return true
@@ -240,6 +308,14 @@ fn allowed_flag(cmd string, a string) bool {
 			return true
 		}
 		if a.starts_with('--tools') {
+			return true
+		}
+	}
+	if cmd == 'update' {
+		if a in ['--check'] {
+			return true
+		}
+		if a.starts_with('--tools') || a.starts_with('--pin') {
 			return true
 		}
 	}
@@ -376,6 +452,17 @@ Show what would change between freshly compiled output and plugins/.
   --target TARGET    Target platform (default: Tier-1 cursor/claude-code/opencode)
   --product PRODUCT  Product ID to diff (default: all products)
   --json             Structured CommandResult JSON
+'
+	}
+	if name == 'update' {
+		return 'Usage: agent-toolkit update [--tools LIST] [--check] [--pin VERSION] [--json]
+
+Refresh installed profiles from toolkit capability data (not binary self-update).
+
+  --tools LIST   Comma-separated tools (default: auto-detect installed)
+  --check        Dry-run — show what would change without writing
+  --pin VERSION  Download capability data for a release before updating
+  --json         Structured CommandResult JSON
 '
 	}
 	mut c := cli.Command{

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -66,6 +66,11 @@ fn test_dispatch_diff_help() {
 	assert code == 0
 }
 
+fn test_dispatch_update_help() {
+	code := dispatch(['agent-toolkit', 'update', '--help'])
+	assert code == 0
+}
+
 fn test_dispatch_rollback_alias_allowed() {
 	// No receipts in default dir may exit non-zero; alias must be known (not unknown command).
 	code := dispatch(['agent-toolkit', 'rollback', '--dry-run', '--json'])

--- a/modules/agent_toolkit_core/update.v
+++ b/modules/agent_toolkit_core/update.v
@@ -1,0 +1,307 @@
+module agent_toolkit_core
+
+import crypto.sha256
+import os
+
+// update_valid_tools lists profile tools supported by `agent-toolkit update`.
+pub const update_valid_tools = ['claude-code', 'cursor', 'opencode', 'windsurf', 'pi']
+
+// UpdateOptions configures capability profile update (not binary self-update).
+pub struct UpdateOptions {
+pub:
+	tools             []string
+	check_only        bool
+	pin               string // empty → ensure current toolkit version when refreshing
+	home_dir          string // empty → os.home_dir()
+	data_root         string // empty → find_toolkit_root()
+	skip_data_refresh bool   // tests / offline callers that already resolved data
+}
+
+// UpdateReport summarizes profile refresh outcomes.
+pub struct UpdateReport {
+pub mut:
+	ok             bool
+	message        string
+	data_root      string
+	files_updated  int
+	tools_planned  int
+	warnings       []string
+}
+
+// run_update refreshes installed AI-tool profiles from toolkit capability data (#516).
+pub fn run_update(opts UpdateOptions) UpdateReport {
+	mut report := UpdateReport{
+		ok: true
+	}
+	mut lines := []string{}
+	lines << 'agent-toolkit update'
+
+	home := if opts.home_dir.len > 0 { opts.home_dir } else { os.home_dir() }
+	mut data_root := opts.data_root
+	if data_root.len == 0 {
+		if !opts.skip_data_refresh {
+			ver := if opts.pin.len > 0 { opts.pin } else { resolve_toolkit_version() }
+			sync := new_data_sync()
+			offline := is_offline()
+			refreshed := sync.ensure_data(ver, offline, opts.pin.len > 0) or {
+				report.warnings << 'data refresh skipped: ${err}'
+				lines << '  ⚠  Data refresh skipped: ${err}'
+				''
+			}
+			if refreshed.len > 0 {
+				data_root = refreshed
+			}
+		}
+		if data_root.len == 0 {
+			tr := find_toolkit_root() or {
+				report.ok = false
+				report.message = 'toolkit root not found: ${err}'
+				return report
+			}
+			data_root = tr.path
+		}
+	}
+	report.data_root = data_root
+	lines << '  Data: ${data_root}'
+	if opts.check_only {
+		lines << '  [check] Dry run — no files will be written'
+	}
+
+	mut tools := opts.tools.clone()
+	if tools.len == 0 {
+		tools = detect_update_tools(home)
+		if tools.len == 0 {
+			report.ok = false
+			report.message = lines.join('\n') + '\n  ⚠  No installed tools detected. Use --tools to specify targets.'
+			return report
+		}
+		lines << '  Tools: ${tools.join(', ')}'
+	}
+
+	mut total := 0
+	mut any_errors := false
+	for tool in tools {
+		if tool !in update_valid_tools {
+			lines << '  ⚠  Unknown tool: ${tool}'
+			report.warnings << 'unknown tool: ${tool}'
+			any_errors = true
+			continue
+		}
+		plan := plan_tool_update(tool, data_root, home) or {
+			lines << '  ⚠  No profile data for: ${tool}'
+			continue
+		}
+		report.tools_planned++
+		pending := plan.changed.len + plan.added.len
+		if pending == 0 {
+			lines << '  ✓ ${tool}: up to date (${plan.up_to_date.len} files)'
+			continue
+		}
+		lines << '  → ${tool}: ${plan.changed.len} changed, ${plan.added.len} new'
+		n, apply_lines := apply_tool_update(plan, data_root, home, opts.check_only)
+		total += n
+		for l in apply_lines {
+			lines << l
+		}
+	}
+
+	lines << ''
+	if opts.check_only {
+		lines << '  ${total} file(s) would be updated'
+		report.ok = total == 0 && !any_errors
+	} else if total > 0 {
+		lines << '  Updated ${total} file(s)'
+		report.ok = !any_errors
+	} else {
+		lines << '  All profiles up to date'
+		report.ok = !any_errors
+	}
+	report.files_updated = total
+	report.message = lines.join('\n')
+	return report
+}
+
+// update_result maps UpdateReport to CommandResult.
+pub fn update_result(report UpdateReport) CommandResult {
+	return CommandResult{
+		command: 'update'
+		ok:      report.ok
+		message: report.message
+		data:    {
+			'data_root':     report.data_root
+			'files_updated': '${report.files_updated}'
+			'tools_planned': '${report.tools_planned}'
+			'check':         if report.message.contains('[check]') { 'true' } else { 'false' }
+		}
+	}
+}
+
+struct FileMapping {
+	src string
+	dst string
+}
+
+struct ToolUpdatePlan {
+mut:
+	tool       string
+	changed    []string
+	added      []string
+	up_to_date []string
+	mappings   []FileMapping
+}
+
+fn detect_update_tools(home string) []string {
+	mut out := []string{}
+	if os.exists(os.join_path(home, '.claude')) || os.exists('/usr/bin/claude') {
+		out << 'claude-code'
+	}
+	if os.exists(os.join_path(home, '.cursor')) {
+		out << 'cursor'
+	}
+	if os.exists(os.join_path(home, '.config', 'opencode')) {
+		out << 'opencode'
+	}
+	if os.exists(os.join_path(home, '.codeium', 'windsurf')) || os.exists(os.join_path(home, '.windsurf')) {
+		out << 'windsurf'
+	}
+	if os.exists(os.join_path(home, '.pi')) {
+		out << 'pi'
+	}
+	return out
+}
+
+fn windsurf_config_dir(home string) string {
+	codeium := os.join_path(home, '.codeium', 'windsurf')
+	if os.is_dir(codeium) {
+		return codeium
+	}
+	legacy := os.join_path(home, '.windsurf')
+	if os.is_dir(legacy) {
+		return legacy
+	}
+	return codeium
+}
+
+fn mappings_for_tool(tool string, data_root string, home string) []FileMapping {
+	mut mappings := []FileMapping{}
+	match tool {
+		'claude-code' {
+			src := os.join_path(data_root, 'profiles', 'claude-code')
+			claude_md := os.join_path(src, 'CLAUDE.md')
+			if os.is_file(claude_md) {
+				mappings << FileMapping{claude_md, os.join_path(home, '.claude', 'CLAUDE.md')}
+			}
+			agents := os.join_path(src, 'agents')
+			mappings << map_tree_files(agents, os.join_path(home, '.claude', 'agents'))
+		}
+		'cursor' {
+			src := os.join_path(data_root, 'profiles', 'cursor', 'rules')
+			mappings << map_tree_files(src, os.join_path(home, '.cursor', 'rules'))
+		}
+		'opencode' {
+			src := os.join_path(data_root, 'profiles', 'opencode')
+			cfg := os.join_path(src, 'opencode.json')
+			if os.is_file(cfg) {
+				mappings << FileMapping{cfg, os.join_path(home, '.config', 'opencode', 'opencode.json')}
+			}
+			agents := os.join_path(src, 'agents')
+			mappings << map_tree_files(agents, os.join_path(home, '.config', 'opencode', 'agents'))
+		}
+		'windsurf' {
+			src := os.join_path(data_root, 'profiles', 'windsurf')
+			cfg := windsurf_config_dir(home)
+			for sub in ['rules', 'memories'] {
+				mappings << map_tree_files(os.join_path(src, sub), os.join_path(cfg, sub))
+			}
+		}
+		'pi' {
+			src := os.join_path(data_root, 'profiles', 'pi', 'skills')
+			mappings << map_tree_files(src, os.join_path(home, '.pi', 'agent', 'skills'))
+		}
+		else {}
+	}
+	return mappings
+}
+
+fn map_tree_files(src_dir string, dst_dir string) []FileMapping {
+	mut out := []FileMapping{}
+	if !os.is_dir(src_dir) {
+		return out
+	}
+	for rel in list_rel_files(src_dir) {
+		out << FileMapping{
+			src: os.join_path(src_dir, rel)
+			dst: os.join_path(dst_dir, rel)
+		}
+	}
+	return out
+}
+
+fn plan_tool_update(tool string, data_root string, home string) ?ToolUpdatePlan {
+	mappings := mappings_for_tool(tool, data_root, home)
+	if mappings.len == 0 {
+		return none
+	}
+	mut plan := ToolUpdatePlan{
+		tool:     tool
+		mappings: mappings
+	}
+	for m in mappings {
+		if !os.is_file(m.src) {
+			continue
+		}
+		src_hash := update_file_hash(m.src)
+		if os.is_file(m.dst) {
+			if update_file_hash(m.dst) == src_hash {
+				plan.up_to_date << m.dst
+			} else {
+				plan.changed << m.dst
+			}
+		} else {
+			plan.added << m.dst
+		}
+	}
+	return plan
+}
+
+fn apply_tool_update(plan ToolUpdatePlan, data_root string, home string, check_only bool) (int, []string) {
+	mut lines := []string{}
+	mut updated := 0
+	mut targets := map[string]bool{}
+	for p in plan.changed {
+		targets[p] = true
+	}
+	for p in plan.added {
+		targets[p] = true
+	}
+	fs := new_fs()
+	for m in plan.mappings {
+		if m.dst !in targets {
+			continue
+		}
+		rel := relative_to(m.dst, home) or { m.dst }
+		display := if rel.starts_with('/') || rel.contains(':') { rel } else { '~/${rel.replace('\\', '/')}' }
+		if check_only {
+			lines << '  ~ would update: ${display}'
+			updated++
+			continue
+		}
+		content := os.read_file(m.src) or {
+			lines << '  ✗  failed to read ${m.src}: ${err}'
+			continue
+		}
+		fs.write_atomic(m.dst, content) or {
+			lines << '  ✗  failed to write ${m.dst}: ${err}'
+			continue
+		}
+		lines << '  ✓ updated: ${display}'
+		updated++
+	}
+	_ = data_root
+	return updated, lines
+}
+
+fn update_file_hash(path string) string {
+	data := os.read_file(path) or { return '' }
+	return sha256.hexhash(data)
+}

--- a/modules/agent_toolkit_core/update_test.v
+++ b/modules/agent_toolkit_core/update_test.v
@@ -1,0 +1,71 @@
+module agent_toolkit_core
+
+import os
+
+fn test_plan_and_apply_cursor_update_check_and_write() {
+	base := os.join_path(os.temp_dir(), 'at-upd-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	os.mkdir_all(os.join_path(data, 'profiles', 'cursor', 'rules')) or { assert false, err.msg() }
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	src := os.join_path(data, 'profiles', 'cursor', 'rules', 'assistant.mdc')
+	os.write_file(src, 'v2\n') or {
+		assert false, err.msg()
+		return
+	}
+	dst := os.join_path(home, '.cursor', 'rules', 'assistant.mdc')
+	os.mkdir_all(os.dir(dst)) or {}
+	os.write_file(dst, 'v1\n') or {
+		assert false, err.msg()
+		return
+	}
+
+	check_report := run_update(UpdateOptions{
+		tools:             ['cursor']
+		check_only:        true
+		home_dir:          home
+		data_root:         data
+		skip_data_refresh: true
+	})
+	assert check_report.files_updated == 1
+	assert os.read_file(dst) or { '' } == 'v1\n'
+	assert !check_report.ok // pending changes → non-zero like Python --check
+
+	write_report := run_update(UpdateOptions{
+		tools:             ['cursor']
+		home_dir:          home
+		data_root:         data
+		skip_data_refresh: true
+	})
+	assert write_report.files_updated == 1
+	assert os.read_file(dst) or { '' } == 'v2\n'
+	assert write_report.ok
+
+	again := run_update(UpdateOptions{
+		tools:             ['cursor']
+		home_dir:          home
+		data_root:         data
+		skip_data_refresh: true
+	})
+	assert again.files_updated == 0
+	assert again.ok
+}
+
+fn test_update_unknown_tool() {
+	base := os.join_path(os.temp_dir(), 'at-upd-unk-${os.getpid()}')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	report := run_update(UpdateOptions{
+		tools:             ['not-a-tool']
+		home_dir:          base
+		data_root:         base
+		skip_data_refresh: true
+	})
+	assert !report.ok
+	assert report.message.contains('Unknown tool')
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -269,6 +269,19 @@
         "target",
         "product"
       ]
+    },
+    {
+      "command": "update-help",
+      "args": [
+        "update",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "update",
+        "check",
+        "tools"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `run_update` to refresh profiles (cursor/claude-code/opencode/windsurf/pi) from capability data
- Support `--check`, `--tools`, `--pin` (DataSync); atomic writes
- Wire CLI + parity help fixture

Fixes #516

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/update_test.v modules/agent_toolkit_cli/dispatch_test.v`
- [ ] CI green

Made with [Cursor](https://cursor.com)