### PR TITLE
feat(v): implement doctor --fix allowlisted profile repair (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `doctor --fix` allowlisted profile refresh (Closes #550)
 - **Feat** — V capability `update` (profile refresh; --check/--pin; not self-update) (Closes #516)
 - **Feat** — V `agent-toolkit diff` (compile vs plugins/ added/changed) (Closes #515)
 - **Feat** — install receipt compatibility schema (`schemas/install-receipt.schema.json`) (Closes #511)

--- a/docs/v/doctor.md
+++ b/docs/v/doctor.md
@@ -1,5 +1,15 @@
-# V `doctor` command (read-only)
+# V `doctor` command
 
-**Issue:** [#505](https://github.com/ulises-jeremias/agent-toolkit/issues/505)
+**Issues:** [#505](https://github.com/ulises-jeremias/agent-toolkit/issues/505) (read-only), [#550](https://github.com/ulises-jeremias/agent-toolkit/issues/550) (`--fix`)
 
-Read-only health report. `--json` includes `engine`, `version`, and `platform` for migration observability. `--fix` is accepted and ignored (no writes). Missing tools are warnings so the seed stays hermetic; a missing toolkit root is an error.
+Default `doctor` is **non-mutating** health report. `--json` includes `engine`, `version`, `platform`, and `fix_applied`.
+
+## `--fix` (allowlisted)
+
+When profile checks warn (missing install paths for detected tools), `--fix` runs capability `update` for those tools only:
+
+- Documents the mutation under `── Auto-fix: refreshing profiles (allowlisted) ──`
+- Sets `fix_applied=true` / `fix_action=update_profiles` in JSON
+- No silent privilege escalation; does not modify package-manager-owned CLI binaries (#489)
+
+Without `--fix`, behavior remains read-only.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -59,7 +59,8 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.matrix_result(), mode)
 	}
 	if cmd_name == 'doctor' {
-		snap := agent_toolkit_core.run_doctor_readonly()
+		opts := parse_doctor_options(argv[1..])
+		snap := agent_toolkit_core.run_doctor(opts)
 		return render(agent_toolkit_core.doctor_result(snap), mode)
 	}
 	if cmd_name == 'build' {
@@ -89,6 +90,18 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.update_result(report), mode)
 	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
+}
+
+fn parse_doctor_options(args []string) agent_toolkit_core.DoctorOptions {
+	mut fix := false
+	for a in args {
+		if a == '--fix' {
+			fix = true
+		}
+	}
+	return agent_toolkit_core.DoctorOptions{
+		fix: fix
+	}
 }
 
 fn parse_build_options(args []string) agent_toolkit_core.BuildOptions {
@@ -463,6 +476,15 @@ Refresh installed profiles from toolkit capability data (not binary self-update)
   --check        Dry-run — show what would change without writing
   --pin VERSION  Download capability data for a release before updating
   --json         Structured CommandResult JSON
+'
+	}
+	if name == 'doctor' {
+		return 'Usage: agent-toolkit doctor [--fix] [--json]
+
+Read-only health checks by default. --fix allowlists profile refresh only.
+
+  --fix   Attempt auto-repair for missing profiles (runs capability update)
+  --json  Structured CommandResult JSON
 '
 	}
 	mut c := cli.Command{

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -41,8 +41,13 @@ fn test_dispatch_doctor_json_exit_zero() {
 	assert code == 0
 }
 
-fn test_dispatch_doctor_fix_is_readonly() {
+fn test_dispatch_doctor_fix_exits_zero() {
 	code := dispatch(['agent-toolkit', 'doctor', '--fix', '--json'])
+	assert code == 0
+}
+
+fn test_dispatch_doctor_help_mentions_fix() {
+	code := dispatch(['agent-toolkit', 'doctor', '--help'])
 	assert code == 0
 }
 

--- a/modules/agent_toolkit_core/doctor.v
+++ b/modules/agent_toolkit_core/doctor.v
@@ -2,85 +2,259 @@ module agent_toolkit_core
 
 import os
 
-// DoctorSnapshot is a read-only health summary for migration observability.
+// DoctorOptions configures doctor (default read-only; --fix is opt-in).
+pub struct DoctorOptions {
+pub:
+	fix               bool
+	home_dir           string // empty → os.home_dir()
+	data_root          string // empty → resolve via update/find_toolkit_root
+	skip_data_refresh  bool
+}
+
+// DoctorCheck is one health check row.
+pub struct DoctorCheck {
+pub:
+	category string
+	name     string
+	status   string // ok | warn | err
+	detail   string
+}
+
+// DoctorSnapshot is a health summary for migration observability.
 pub struct DoctorSnapshot {
 pub:
-	engine   string
-	version  string
-	platform string
-	root     string
-	root_ok  bool
-	offline  bool
-	ok       bool
-	message  string
+	engine      string
+	version     string
+	platform    string
+	root        string
+	root_ok     bool
+	offline     bool
+	ok          bool
+	message     string
+	fix_applied bool
+	fix_action  string
+pub mut:
+	checks []DoctorCheck
 }
 
 // run_doctor_readonly performs read-only checks (no --fix).
 pub fn run_doctor_readonly() DoctorSnapshot {
+	return run_doctor(DoctorOptions{})
+}
+
+// run_doctor performs health checks; with fix=true, allowlisted repairs only (#550).
+// Allowlisted fix: refresh missing/outdated profiles via run_update (no privilege escalation).
+pub fn run_doctor(opts DoctorOptions) DoctorSnapshot {
 	ver := doctor_version()
 	offline := doctor_is_offline()
 	root := doctor_lookup_root()
 	root_ok := root.len > 0
 	platform := '${os.user_os()}/${os.uname().machine}'
-	ok := root_ok
+	home := if opts.home_dir.len > 0 { opts.home_dir } else { os.home_dir() }
+
+	mut checks := []DoctorCheck{}
+	checks << DoctorCheck{'engine', 'engine', 'ok', 'v'}
+	checks << DoctorCheck{'engine', 'version', 'ok', ver}
+	checks << DoctorCheck{'engine', 'platform', 'ok', platform}
+	if root_ok {
+		checks << DoctorCheck{'root', 'root', 'ok', root}
+	} else {
+		checks << DoctorCheck{'root', 'root', 'err', 'not found (set AGENT_TOOLKIT_ROOT)'}
+	}
+	if offline {
+		checks << DoctorCheck{'root', 'offline', 'warn', 'AGENT_TOOLKIT_OFFLINE set'}
+	}
+	checks << collect_profile_checks(home)
+
+	mut ok := true
+	for c in checks {
+		if c.status == 'err' {
+			ok = false
+		}
+	}
+
 	mut lines := []string{}
 	lines << ''
 	lines << 'agent-toolkit doctor'
 	lines << ''
 	lines << '── Engine ──'
-	lines << '  ✓  engine                          v'
-	lines << '  ✓  version                         ${ver}'
-	lines << '  ✓  platform                        ${platform}'
+	for c in checks {
+		if c.category == 'engine' {
+			lines << doctor_format_check(c)
+		}
+	}
 	lines << ''
 	lines << '── Toolkit root ──'
-	if root_ok {
-		lines << '  ✓  root                            ${root}'
-	} else {
-		lines << '  ✗  root                            not found (set AGENT_TOOLKIT_ROOT)'
+	for c in checks {
+		if c.category == 'root' {
+			lines << doctor_format_check(c)
+		}
 	}
-	if offline {
-		lines << '  ⚠  offline                         AGENT_TOOLKIT_OFFLINE set'
+	profile_checks := checks.filter(it.category == 'profiles')
+	if profile_checks.len > 0 {
+		lines << ''
+		lines << '── Profiles ──'
+		for c in profile_checks {
+			lines << doctor_format_check(c)
+		}
 	}
+
+	mut fix_applied := false
+	mut fix_action := ''
+	if opts.fix {
+		has_profile_issues := profile_checks.any(it.status != 'ok')
+		if has_profile_issues {
+			lines << ''
+			lines << '── Auto-fix: refreshing profiles (allowlisted) ──'
+			tools := tools_needing_profile_fix(home, profile_checks)
+			upd := run_update(UpdateOptions{
+				tools:             tools
+				home_dir:          home
+				data_root:         opts.data_root
+				skip_data_refresh: opts.skip_data_refresh || offline
+			})
+			fix_applied = true
+			fix_action = 'update_profiles'
+			lines << upd.message
+			if !upd.ok && upd.files_updated == 0 {
+				ok = false
+			}
+			// Re-check profiles after fix for summary honesty
+			checks = checks.filter(it.category != 'profiles')
+			checks << collect_profile_checks(home)
+		} else {
+			lines << ''
+			lines << '── Auto-fix ──'
+			lines << '  -  No profile issues to repair'
+		}
+	}
+
 	lines << ''
 	lines << '── Summary ──'
 	if ok {
-		lines << '  ✓  read-only checks passed'
+		if opts.fix {
+			lines << '  ✓  checks passed'
+		} else {
+			lines << '  ✓  read-only checks passed'
+		}
 	} else {
 		lines << '  ✗  one or more errors detected'
 	}
 	lines << ''
-	return DoctorSnapshot{
-		engine:   'v'
-		version:  ver
-		platform: platform
-		root:     root
-		root_ok:  root_ok
-		offline:  offline
-		ok:       ok
-		message:  lines.join('\n')
-	}
-}
 
-// run_doctor is an alias used by the CLI adapter.
-pub fn run_doctor() DoctorSnapshot {
-	return run_doctor_readonly()
+	return DoctorSnapshot{
+		engine:       'v'
+		version:      ver
+		platform:     platform
+		root:         root
+		root_ok:      root_ok
+		offline:      offline
+		ok:           ok
+		message:      lines.join('\n')
+		fix_applied:  fix_applied
+		fix_action:   fix_action
+		checks:       checks
+	}
 }
 
 // doctor_result maps a snapshot to CommandResult (includes engine/version/platform).
 pub fn doctor_result(snap DoctorSnapshot) CommandResult {
+	mut warn_n := 0
+	mut err_n := 0
+	for c in snap.checks {
+		if c.status == 'warn' {
+			warn_n++
+		}
+		if c.status == 'err' {
+			err_n++
+		}
+	}
 	return CommandResult{
 		command: 'doctor'
 		ok:      snap.ok
 		message: snap.message
 		data:    {
-			'engine':   snap.engine
-			'version':  snap.version
-			'platform': snap.platform
-			'root':     snap.root
-			'root_ok':  if snap.root_ok { 'true' } else { 'false' }
-			'offline':  if snap.offline { 'true' } else { 'false' }
+			'engine':       snap.engine
+			'version':      snap.version
+			'platform':     snap.platform
+			'root':         snap.root
+			'root_ok':      if snap.root_ok { 'true' } else { 'false' }
+			'offline':      if snap.offline { 'true' } else { 'false' }
+			'fix_applied':  if snap.fix_applied { 'true' } else { 'false' }
+			'fix_action':   snap.fix_action
+			'warnings':     '${warn_n}'
+			'errors':       '${err_n}'
 		}
 	}
+}
+
+fn doctor_format_check(c DoctorCheck) string {
+	icon := match c.status {
+		'ok' { '✓' }
+		'warn' { '⚠' }
+		else { '✗' }
+	}
+	return '  ${icon}  ${c.name:-30} ${c.detail}'
+}
+
+fn collect_profile_checks(home string) []DoctorCheck {
+	mut out := []DoctorCheck{}
+	if os.is_dir(os.join_path(home, '.claude')) {
+		out << profile_check('claude-code CLAUDE.md', os.join_path(home, '.claude', 'CLAUDE.md'))
+		out << profile_check('claude-code agents/', os.join_path(home, '.claude', 'agents'))
+	}
+	if os.is_dir(os.join_path(home, '.cursor')) {
+		out << profile_check('cursor rules/', os.join_path(home, '.cursor', 'rules'))
+	}
+	if os.is_dir(os.join_path(home, '.config', 'opencode')) {
+		out << profile_check('opencode agents/', os.join_path(home, '.config', 'opencode', 'agents'))
+		out << profile_check('opencode opencode.json', os.join_path(home, '.config', 'opencode',
+			'opencode.json'))
+	}
+	windsurf := windsurf_config_dir(home)
+	if os.is_dir(windsurf) || os.is_dir(os.join_path(home, '.windsurf')) {
+		out << profile_check('windsurf rules/', os.join_path(windsurf, 'rules'))
+		out << profile_check('windsurf memories/', os.join_path(windsurf, 'memories'))
+	}
+	if os.is_dir(os.join_path(home, '.pi')) {
+		out << profile_check('pi skills/', os.join_path(home, '.pi', 'agent', 'skills'))
+	}
+	return out
+}
+
+fn profile_check(name string, path string) DoctorCheck {
+	if os.exists(path) {
+		return DoctorCheck{'profiles', name, 'ok', path}
+	}
+	return DoctorCheck{'profiles', name, 'warn', 'Not installed: ${path}'}
+}
+
+fn tools_needing_profile_fix(home string, checks []DoctorCheck) []string {
+	mut tools := []string{}
+	for c in checks {
+		if c.status == 'ok' {
+			continue
+		}
+		if c.name.starts_with('claude-code') && 'claude-code' !in tools {
+			tools << 'claude-code'
+		}
+		if c.name.starts_with('cursor') && 'cursor' !in tools {
+			tools << 'cursor'
+		}
+		if c.name.starts_with('opencode') && 'opencode' !in tools {
+			tools << 'opencode'
+		}
+		if c.name.starts_with('windsurf') && 'windsurf' !in tools {
+			tools << 'windsurf'
+		}
+		if c.name.starts_with('pi') && 'pi' !in tools {
+			tools << 'pi'
+		}
+	}
+	if tools.len == 0 {
+		return detect_update_tools(home)
+	}
+	return tools
 }
 
 fn doctor_version() string {

--- a/modules/agent_toolkit_core/doctor_test.v
+++ b/modules/agent_toolkit_core/doctor_test.v
@@ -1,12 +1,71 @@
 module agent_toolkit_core
 
+import os
+
 fn test_run_doctor_readonly_has_observability_fields() {
 	snap := run_doctor_readonly()
 	assert snap.engine == 'v'
 	assert snap.version.len > 0
 	assert snap.platform.contains('/')
+	assert !snap.fix_applied
 	r := doctor_result(snap)
 	assert r.data['engine'] == 'v'
 	assert r.data['version'] == snap.version
 	assert r.data['platform'] == snap.platform
+	assert r.data['fix_applied'] == 'false'
+}
+
+fn test_doctor_fix_refreshes_missing_cursor_profile() {
+	base := os.join_path(os.temp_dir(), 'at-doc-fix-${os.getpid()}')
+	home := os.join_path(base, 'home')
+	data := os.join_path(base, 'data')
+	os.mkdir_all(os.join_path(home, '.cursor')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(data, 'profiles', 'cursor', 'rules')) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(data, 'profiles', 'cursor', 'rules', 'assistant.mdc'), 'fixed\n') or {
+		assert false, err.msg()
+		return
+	}
+	// Missing rules/ → warn; --fix should create it
+	readonly := run_doctor(DoctorOptions{
+		home_dir:          home
+		data_root:         data
+		skip_data_refresh: true
+	})
+	assert !readonly.fix_applied
+	assert readonly.checks.any(it.category == 'profiles' && it.status == 'warn')
+
+	fixed := run_doctor(DoctorOptions{
+		fix:               true
+		home_dir:          home
+		data_root:         data
+		skip_data_refresh: true
+	})
+	assert fixed.fix_applied
+	assert fixed.fix_action == 'update_profiles'
+	assert os.is_file(os.join_path(home, '.cursor', 'rules', 'assistant.mdc'))
+	assert doctor_result(fixed).data['fix_applied'] == 'true'
+}
+
+fn test_doctor_fix_noop_when_profiles_ok() {
+	base := os.join_path(os.temp_dir(), 'at-doc-ok-${os.getpid()}')
+	home := os.join_path(base, 'home')
+	os.mkdir_all(os.join_path(home, '.cursor', 'rules')) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(home, '.cursor', 'rules', 'x.mdc'), 'x\n') or {
+		assert false, err.msg()
+		return
+	}
+	snap := run_doctor(DoctorOptions{
+		fix:               true
+		home_dir:          home
+		data_root:         base
+		skip_data_refresh: true
+	})
+	assert !snap.fix_applied
+	assert snap.message.contains('No profile issues')
 }

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -282,6 +282,22 @@
         "check",
         "tools"
       ]
+    },
+    {
+      "command": "doctor-fix",
+      "args": [
+        "doctor",
+        "--fix",
+        "--json"
+      ],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": [
+        "engine",
+        "version",
+        "platform",
+        "fix_applied"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Extend `doctor` with profile checks; default remains non-mutating
- `--fix` allowlists profile refresh via `run_update` only (documented mutations; JSON `fix_applied`)
- Parity SCHEMA fixture for `doctor --fix --json`

Fixes #550

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/doctor_test.v modules/agent_toolkit_cli/dispatch_test.v`
- [ ] CI green

Made with [Cursor](https://cursor.com)