### PR TITLE
feat(v): implement plugin sync and check (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `plugin sync|check` gen-surfaces parity (Closes #519)
 - **Feat** — V `mcp` list/setup/health/doctor/uninstall (env names only; no secrets) (Closes #518)
 - **Feat** — V `skills` list/sync/validate command family (Closes #517)
 - **Feat** — V `doctor --fix` allowlisted profile refresh (Closes #550)

--- a/docs/v/plugin.md
+++ b/docs/v/plugin.md
@@ -1,0 +1,10 @@
+# V `plugin sync|check`
+
+**Issue:** [#519](https://github.com/ulises-jeremias/agent-toolkit/issues/519) (EPIC 4b [#551](https://github.com/ulises-jeremias/agent-toolkit/issues/551))
+
+Gen-surfaces copy/compare for `agent-toolkit-core` / `agents` / `forge` plugin bundles (Python `cli/plugin.py`):
+
+- `check` — exit non-zero on drift; also verifies `.provenance.json` digests when present
+- `sync` — copy canonical agents/skills into `plugins/<product>/`
+
+**Boundary vs `build --check`:** plugin sync/check is a **directory copy** of source trees. `build --check` compiles emitters and compares generated artifacts.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -102,6 +102,11 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_mcp(opts)
 		return render(agent_toolkit_core.mcp_result(report), mode)
 	}
+	if cmd_name == 'plugin' {
+		opts := parse_plugin_options(argv[1..])
+		report := agent_toolkit_core.run_plugin(opts)
+		return render(agent_toolkit_core.plugin_result(report), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
@@ -412,6 +417,24 @@ fn parse_mcp_options(args []string) agent_toolkit_core.McpOptions {
 	}
 }
 
+fn parse_plugin_options(args []string) agent_toolkit_core.PluginOptions {
+	mut sub := ''
+	for a in args {
+		if a in ['--json', '--quiet'] {
+			continue
+		}
+		if a.starts_with('-') {
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+		}
+	}
+	return agent_toolkit_core.PluginOptions{
+		subcommand: sub
+	}
+}
+
 fn allowed_flag(cmd string, a string) bool {
 	if a in ['-h', '--help', '--json', '--quiet'] {
 		return true
@@ -605,6 +628,9 @@ Read-only health checks by default. --fix allowlists profile refresh only.
 	}
 	if name == 'mcp' {
 		return agent_toolkit_core.mcp_help_text()
+	}
+	if name == 'plugin' {
+		return agent_toolkit_core.plugin_help_text()
 	}
 	mut c := cli.Command{
 		name:        name

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -86,6 +86,11 @@ fn test_dispatch_mcp_help() {
 	assert code == 0
 }
 
+fn test_dispatch_plugin_help() {
+	code := dispatch(['agent-toolkit', 'plugin', '--help'])
+	assert code == 0
+}
+
 fn test_dispatch_rollback_alias_allowed() {
 	// No receipts in default dir may exit non-zero; alias must be known (not unknown command).
 	code := dispatch(['agent-toolkit', 'rollback', '--dry-run', '--json'])

--- a/modules/agent_toolkit_core/plugin.v
+++ b/modules/agent_toolkit_core/plugin.v
@@ -1,0 +1,233 @@
+module agent_toolkit_core
+
+import os
+
+// PluginOptions configures `plugin sync|check` (#519).
+pub struct PluginOptions {
+pub:
+	subcommand   string // sync | check
+	toolkit_root string
+}
+
+// PluginReport summarizes surface sync/check vs gen-surfaces mapping.
+pub struct PluginReport {
+pub mut:
+	ok      bool
+	message string
+	drift   int
+}
+
+// run_plugin syncs or checks canonical agents/skills into plugin bundles.
+// Distinct from `build --check` (compiler drift): this is gen-surfaces copy/compare.
+pub fn run_plugin(opts PluginOptions) PluginReport {
+	sub := opts.subcommand
+	if sub.len == 0 || sub in ['help', '-h', '--help'] {
+		return PluginReport{
+			ok:      true
+			message: plugin_help_text()
+		}
+	}
+	root := if opts.toolkit_root.len > 0 { opts.toolkit_root } else { lookup_checkout_root() }
+	if root.len == 0 {
+		return PluginReport{
+			ok:      false
+			message: 'Cannot locate toolkit directory'
+		}
+	}
+	if sub !in ['sync', 'check'] {
+		return PluginReport{
+			ok:      false
+			message: 'Unknown subcommand: ${sub}\n  Valid subcommands: sync, check'
+		}
+	}
+	return run_plugin_surfaces(root, sub == 'check')
+}
+
+pub fn plugin_result(report PluginReport) CommandResult {
+	return CommandResult{
+		command: 'plugin'
+		ok:      report.ok
+		message: report.message
+		data:    {
+			'drift': '${report.drift}'
+			'mode':  if report.message.contains('checking') { 'check' } else { 'sync' }
+		}
+	}
+}
+
+pub fn plugin_help_text() string {
+	return 'Usage: agent-toolkit plugin <subcommand>
+
+Subcommands:
+    sync     Sync canonical agents/skills into plugin bundles
+    check    Verify plugin bundles are in sync (exit 1 if drift)
+
+This is gen-surfaces copy/compare (core/agents/forge). Compiler emit drift is `build --check`.
+'
+}
+
+fn run_plugin_surfaces(root string, check bool) PluginReport {
+	plugins_dir := os.join_path(root, 'plugins')
+	surfaces := build_plugin_surfaces(root)
+	mode := if check { 'checking' } else { 'syncing' }
+	icon := if check { '🔍' } else { '🔄' }
+	mut lines := []string{}
+	lines << ''
+	lines << '${icon} plugin bundles (${mode})...'
+	lines << ''
+	mut drift := 0
+	mut names := surfaces.keys()
+	names.sort()
+	for plugin_name in names {
+		pairs := surfaces[plugin_name]
+		plugin_dir := os.join_path(plugins_dir, plugin_name)
+		if !os.is_dir(plugin_dir) {
+			lines << '  ⚠  Plugin dir missing: ${plugin_name}'
+			continue
+		}
+		lines << '── ${plugin_name} ──'
+		for pair in pairs {
+			src := os.join_path(root, pair[0])
+			dst := os.join_path(plugin_dir, pair[1])
+			ok, msg := sync_or_check_surface(src, dst, root, check)
+			if msg.len > 0 {
+				lines << msg
+			}
+			if !ok {
+				drift++
+			}
+		}
+		if check {
+			prov := os.join_path(plugin_dir, '.provenance.json')
+			if os.is_file(prov) {
+				for msg in verify_generated_digests(plugins_dir, prov) {
+					lines << '  ✗  ${msg}'
+					drift++
+				}
+			}
+		}
+		lines << ''
+	}
+	if drift > 0 {
+		lines << '  ✗  Plugin surfaces are out of sync'
+		if check {
+			lines << '     Run: agent-toolkit plugin sync'
+		}
+	} else {
+		lines << '  ✓  All plugin surfaces are in sync!'
+	}
+	return PluginReport{
+		ok:      drift == 0
+		message: lines.join('\n')
+		drift:   drift
+	}
+}
+
+fn build_plugin_surfaces(root string) map[string][][]string {
+	mut surfaces := map[string][][]string{}
+	surfaces['agent-toolkit-core'] = [
+		['agents/code-reviewer', 'agents/code-reviewer'],
+		['skills/core/assistant', 'skills/assistant'],
+		['skills/core/dev-companion', 'skills/dev-companion'],
+		['skills/core/output-handshake', 'skills/output-handshake'],
+		['skills/core/pr-fallback', 'skills/pr-fallback'],
+		['skills/core/workspace-knowledge-sync', 'skills/workspace-knowledge-sync'],
+		['skills/core/onboarding', 'skills/onboarding'],
+	]
+	mut agents := [][]string{}
+	agents_dir := os.join_path(root, 'agents')
+	if os.is_dir(agents_dir) {
+		entries := os.ls(agents_dir) or { []string{} }
+		mut names := entries.clone()
+		names.sort()
+		for d in names {
+			if os.is_dir(os.join_path(agents_dir, d)) {
+				agents << ['agents/${d}', 'agents/${d}']
+			}
+		}
+	}
+	surfaces['agent-toolkit-agents'] = agents
+	mut forge := [][]string{}
+	forge_dir := os.join_path(root, 'skills', 'forge')
+	if os.is_dir(forge_dir) {
+		entries := os.ls(forge_dir) or { []string{} }
+		mut names := entries.clone()
+		names.sort()
+		for d in names {
+			if os.is_dir(os.join_path(forge_dir, d)) {
+				forge << ['skills/forge/${d}', 'skills/${d}']
+			}
+		}
+	}
+	surfaces['agent-toolkit-forge'] = forge
+	return surfaces
+}
+
+fn sync_or_check_surface(src string, dst string, root string, check bool) (bool, string) {
+	if !os.exists(src) {
+		return true, ''
+	}
+	if dirs_in_sync(src, dst) {
+		return true, ''
+	}
+	src_rel := relative_to(src, root) or { src }
+	dst_rel := relative_to(dst, root) or { dst }
+	if check {
+		return false, '  ✗  DRIFT: ${src_rel} → ${dst_rel}'
+	}
+	copy_tree(src, dst) or {
+		return false, '  ✗  Failed to sync ${src} → ${dst}: ${err}'
+	}
+	return true, '  ✓  synced: ${src_rel} → ${dst_rel}'
+}
+
+fn dirs_in_sync(src string, dst string) bool {
+	if !os.exists(dst) {
+		return false
+	}
+	src_files := plugin_list_rel_files(src)
+	dst_files := plugin_list_rel_files(dst)
+	if src_files.len != dst_files.len {
+		return false
+	}
+	mut dset := map[string]bool{}
+	for f in dst_files {
+		dset[f] = true
+	}
+	for f in src_files {
+		if f !in dset {
+			return false
+		}
+		if file_digest(os.join_path(src, f)) != file_digest(os.join_path(dst, f)) {
+			return false
+		}
+	}
+	for f in dst_files {
+		if f !in src_files {
+			return false
+		}
+	}
+	return true
+}
+
+fn plugin_list_rel_files(root string) []string {
+	mut out := []string{}
+	collect_rel_files(root, root, mut out)
+	// include provenance files for surface dirs (collect_rel_files skips them)
+	out.sort()
+	return out
+}
+
+fn copy_tree(src string, dst string) ! {
+	if os.exists(dst) {
+		os.rmdir_all(dst) or { return error('rmtree failed: ${err}') }
+	}
+	files := plugin_list_rel_files(src)
+	fs := new_fs()
+	for rel in files {
+		from := os.join_path(src, rel)
+		to := os.join_path(dst, rel)
+		data := os.read_file(from) or { return error('read ${from}: ${err}') }
+		fs.write_atomic(to, data)!
+	}
+}

--- a/modules/agent_toolkit_core/plugin_test.v
+++ b/modules/agent_toolkit_core/plugin_test.v
@@ -1,0 +1,48 @@
+module agent_toolkit_core
+
+import os
+
+fn test_plugin_check_drift_then_sync() {
+	base := os.join_path(os.temp_dir(), 'at-plugin-${os.getpid()}')
+	src_skill := os.join_path(base, 'skills', 'core', 'assistant')
+	dst_skill := os.join_path(base, 'plugins', 'agent-toolkit-core', 'skills', 'assistant')
+	os.mkdir_all(src_skill) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(base, 'plugins', 'agent-toolkit-core')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(base, 'plugins', 'agent-toolkit-agents')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(base, 'plugins', 'agent-toolkit-forge')) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(src_skill, 'SKILL.md'), '---\nname: assistant\ndescription: x\n---\n') or {
+		assert false, err.msg()
+		return
+	}
+	check := run_plugin(PluginOptions{
+		subcommand:   'check'
+		toolkit_root: base
+	})
+	assert !check.ok
+	assert check.drift > 0
+	assert check.message.contains('DRIFT')
+
+	sync := run_plugin(PluginOptions{
+		subcommand:   'sync'
+		toolkit_root: base
+	})
+	assert sync.ok
+	assert os.is_file(os.join_path(dst_skill, 'SKILL.md'))
+
+	again := run_plugin(PluginOptions{
+		subcommand:   'check'
+		toolkit_root: base
+	})
+	assert again.ok
+	assert again.drift == 0
+}
+
+fn test_plugin_unknown_subcommand() {
+	r := run_plugin(PluginOptions{
+		subcommand: 'explode'
+	})
+	assert !r.ok
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -324,6 +324,18 @@
         "setup",
         "uninstall"
       ]
+    },
+    {
+      "command": "plugin-help",
+      "args": [
+        "plugin",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "sync",
+        "check"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add V `plugin sync|check` matching Python `cli/plugin.py` gen-surfaces mapping
- `check` exits non-zero on drift; optional `.provenance.json` digest verify
- Documented boundary vs `build --check`

Fixes #519

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/plugin_test.v modules/agent_toolkit_cli/dispatch_test.v`
- [ ] CI green

Made with [Cursor](https://cursor.com)