### PR TITLE
feat(v): wire agent-toolkit install to InstallTransaction (#607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `agent-toolkit install` via InstallTransaction (dry-run/force/receipts) (Closes #607)
 - **Feat** — V `plugin sync|check` gen-surfaces parity (Closes #519)
 - **Feat** — V `mcp` list/setup/health/doctor/uninstall (env names only; no secrets) (Closes #518)
 - **Feat** — V `skills` list/sync/validate command family (Closes #517)

--- a/docs/compatibility/cli-contract.yaml
+++ b/docs/compatibility/cli-contract.yaml
@@ -53,7 +53,7 @@ commands:
     stdout: human progress / optional JSON
     stderr: errors
     exit_codes: {success: 0, usage: 2}
-    flags: ["--tools", "--offline", "--json"]
+    flags: ["--tools", "--dry-run", "--force", "--offline", "--json"]
     env: ["AGENT_TOOLKIT_OFFLINE", "AGENT_TOOLKIT_INSTALL_SOURCE", "AGENT_TOOLKIT_ROOT", "AI_WORKSPACE"]
     effects: {filesystem: write-profiles-receipts, network: optional-data-fetch, processes: none}
     platform_notes: ["tool detection differs by OS"]

--- a/docs/v/cli-dispatcher.md
+++ b/docs/v/cli-dispatcher.md
@@ -3,6 +3,6 @@
 **Issue:** [#553](https://github.com/ulises-jeremias/agent-toolkit/issues/553)  
 **Spike:** [`vlib-cli-spike.md`](vlib-cli-spike.md)
 
-Single dispatch table matching `docs/CLI_SURFACES.md` consumer/advanced split, aliases (`dc`, `rollback`), help via `vlib/cli` grouping, bad-flag exit **2**, unknown command exit **1**. Business logic stays in core; commands currently return `not_implemented` until per-command ports land.
+Single dispatch table matching `docs/CLI_SURFACES.md` consumer/advanced split, aliases (`dc`, `rollback`), help via `vlib/cli` grouping, bad-flag exit **2**, unknown command exit **1**. Business logic stays in core; unfinished advanced commands return `not_implemented`. Consumer `install` is wired (#607).
 
 Build: `make build-cli` → `build/agent-toolkit-v`.

--- a/docs/v/install-transaction.md
+++ b/docs/v/install-transaction.md
@@ -8,4 +8,4 @@
 - `--dry-run` / preserve-without-`--force` parity with Python `cli/install.py`
 - receipt save only after successful commit (`save_install_receipt`)
 
-Depends on [#512](https://github.com/ulises-jeremias/agent-toolkit/issues/512) receipt parser. Uninstall/rollback CLI is [#514](https://github.com/ulises-jeremias/agent-toolkit/issues/514).
+Depends on [#512](https://github.com/ulises-jeremias/agent-toolkit/issues/512) receipt parser. Consumer CLI wiring is [#607](https://github.com/ulises-jeremias/agent-toolkit/issues/607). Uninstall/rollback CLI is [#514](https://github.com/ulises-jeremias/agent-toolkit/issues/514).

--- a/docs/v/install.md
+++ b/docs/v/install.md
@@ -1,0 +1,13 @@
+# V `agent-toolkit install`
+
+**Issue:** [#607](https://github.com/ulises-jeremias/agent-toolkit/issues/607) (EPIC 4 [#461](https://github.com/ulises-jeremias/agent-toolkit/issues/461))
+
+Wires consumer `install` through [`InstallTransaction`](install-transaction.md):
+
+- Flags: `--tools`, `--dry-run`, `--force`, `--offline` (dispatcher `--json`)
+- Auto-detect; never auto-install Copilot (per-project; non-interactive skip)
+- Prefer compiled `plugins/*/agents/*/AGENT.md` when present; skip `~/.claude/settings.json`
+- Receipts for created artifacts; existing files (including JSON configs) are preserved without `--force`
+- Honor `AGENT_TOOLKIT_OFFLINE` and `AGENT_TOOLKIT_INSTALL_SOURCE`
+
+Python remains the canonical `agent-toolkit` entry until cutover [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555).

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -68,6 +68,14 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_build(opts)
 		return render(agent_toolkit_core.build_result(report), mode)
 	}
+	if cmd_name == 'install' {
+		opts := parse_install_options(argv[1..]) or {
+			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
+			return render_error(e, mode)
+		}
+		report := agent_toolkit_core.run_install(opts)
+		return render(agent_toolkit_core.install_result(report), mode)
+	}
 	if cmd_name == 'uninstall' {
 		opts := parse_uninstall_options(argv[1..]) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
@@ -175,6 +183,65 @@ fn parse_build_options(args []string) agent_toolkit_core.BuildOptions {
 		product:     product
 		output_dir:  output_dir
 		write_files: write_files
+	}
+}
+
+fn parse_install_options(args []string) !agent_toolkit_core.InstallOptions {
+	mut dry_run := false
+	mut force := false
+	mut offline := false
+	mut tools_raw := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--dry-run' {
+			dry_run = true
+			i++
+			continue
+		}
+		if a == '--force' {
+			force = true
+			i++
+			continue
+		}
+		if a == '--offline' {
+			offline = true
+			i++
+			continue
+		}
+		if a == '--tools' {
+			if i + 1 >= args.len {
+				return error('--tools requires an argument')
+			}
+			tools_raw = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--tools=') {
+			tools_raw = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	mut tools := []string{}
+	if tools_raw.len > 0 {
+		for part in tools_raw.split(',') {
+			t := part.trim_space()
+			if t.len > 0 {
+				tools << t
+			}
+		}
+	}
+	return agent_toolkit_core.InstallOptions{
+		tools:   tools
+		dry_run: dry_run
+		force:   force
+		offline: offline
 	}
 }
 
@@ -442,6 +509,14 @@ fn allowed_flag(cmd string, a string) bool {
 	if cmd == 'doctor' && a in ['--fix', '--provenance'] {
 		return true
 	}
+	if cmd == 'install' {
+		if a in ['--dry-run', '--force', '--offline'] {
+			return true
+		}
+		if a.starts_with('--tools') {
+			return true
+		}
+	}
 	if cmd == 'uninstall' {
 		if a in ['--dry-run', '--rollback'] {
 			return true
@@ -451,7 +526,7 @@ fn allowed_flag(cmd string, a string) bool {
 		}
 	}
 	if cmd == 'update' {
-		if a in ['--check'] {
+		if a == '--check' {
 			return true
 		}
 		if a.starts_with('--tools') || a.starts_with('--pin') {
@@ -464,7 +539,7 @@ fn allowed_flag(cmd string, a string) bool {
 		}
 	}
 	if cmd == 'mcp' {
-		if a in ['--offline'] {
+		if a == '--offline' {
 			return true
 		}
 	}
@@ -474,7 +549,7 @@ fn allowed_flag(cmd string, a string) bool {
 		}
 	}
 	if cmd == 'build' {
-		if a in ['--check'] {
+		if a == '--check' {
 			return true
 		}
 		if a.starts_with('--target') || a.starts_with('--product') || a.starts_with('--output') {
@@ -578,7 +653,20 @@ Compile canonical capabilities into target artifacts (Tier-1 + remaining emitter
   --target TARGET    Target id (default: all implemented emitters)
   --product PRODUCT  Product id (default: all products)
   --output DIR       Output directory (default: <repo>/plugins)
-  --json             Structured CommandResult JSON
+	--json             Structured CommandResult JSON
+'
+	}
+	if name == 'install' {
+		return 'Usage: agent-toolkit install [--tools LIST] [--dry-run] [--force] [--offline] [--json]
+
+Install profiles for detected or selected AI tools.
+
+  --tools LIST   Comma-separated tools (default: auto-detect)
+                 Valid: claude-code, cursor, opencode, copilot, windsurf, pi, muse-code
+  --dry-run      Show what would happen without making changes
+  --force        Overwrite existing files without prompting
+  --offline      Use only bundled/cached data (skip GitHub Release refresh)
+  --json         Structured CommandResult JSON
 '
 	}
 	if name == 'uninstall' {

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -61,6 +61,17 @@ fn test_dispatch_build_help() {
 	assert code == 0
 }
 
+fn test_dispatch_install_help() {
+	code := dispatch(['agent-toolkit', 'install', '--help'])
+	assert code == 0
+}
+
+fn test_dispatch_install_dry_run_json() {
+	code := dispatch(['agent-toolkit', 'install', '--tools', 'cursor', '--dry-run', '--offline',
+		'--json'])
+	assert code == 0
+}
+
 fn test_dispatch_uninstall_help() {
 	code := dispatch(['agent-toolkit', 'uninstall', '--help'])
 	assert code == 0

--- a/modules/agent_toolkit_core/install.v
+++ b/modules/agent_toolkit_core/install.v
@@ -1,0 +1,549 @@
+module agent_toolkit_core
+
+import os
+
+// install_valid_tools lists profile tools supported by `agent-toolkit install`.
+pub const install_valid_tools = ['claude-code', 'cursor', 'opencode', 'copilot', 'windsurf', 'pi',
+	'muse-code', 'muse']
+
+const install_agent_products = ['agent-toolkit-core', 'agent-toolkit-agents', 'agent-toolkit-forge']
+const install_muse_products = ['agent-toolkit-complete', 'agent-toolkit-core']
+
+// InstallOptions configures profile install (Python cli/install.py).
+pub struct InstallOptions {
+pub:
+	tools             []string
+	dry_run           bool
+	force             bool
+	offline           bool
+	home_dir          string // empty → os.home_dir()
+	data_root         string // empty → find_toolkit_root()
+	receipt_dir       string // empty → default_receipt_dir()
+	skip_data_refresh bool
+}
+
+// InstallReport summarizes install outcomes.
+pub struct InstallReport {
+pub mut:
+	ok            bool
+	message       string
+	data_root     string
+	files_written int
+	tools_ok      int
+	skipped       int
+	dry_run       bool
+	failures      []string
+}
+
+// run_install copies toolkit profiles into AI-tool config dirs via InstallTransaction (#607).
+pub fn run_install(opts InstallOptions) InstallReport {
+	mut report := InstallReport{
+		ok:      true
+		dry_run: opts.dry_run
+	}
+	if opts.offline {
+		os.setenv('AGENT_TOOLKIT_OFFLINE', '1', true)
+	}
+	home := if opts.home_dir.len > 0 { opts.home_dir } else { os.home_dir() }
+	mut data_root := opts.data_root
+	if data_root.len == 0 {
+		tr := find_toolkit_root() or {
+			report.ok = false
+			report.message = 'toolkit root not found: ${err}'
+			return report
+		}
+		data_root = tr.path
+	}
+	report.data_root = data_root
+	receipt_dir := if opts.receipt_dir.len > 0 { opts.receipt_dir } else { default_receipt_dir() }
+
+	mut lines := []string{}
+	lines << ''
+	lines << 'agent-toolkit installer'
+	lines << 'Toolkit: ${data_root}'
+	if opts.offline {
+		lines << '  [info]  Offline mode — using bundled data only'
+	}
+	if opts.dry_run {
+		lines << ''
+		lines << '  ⚠  DRY RUN — no files will be written'
+	}
+
+	mut tools := opts.tools.clone()
+	if tools.len == 0 {
+		lines << ''
+		lines << '  [info]  Auto-detecting installed AI tools...'
+		tools = detect_install_tools(home, opts.home_dir.len == 0)
+		for t in tools {
+			lines << '  [info]    Detected: ${t}'
+		}
+		lines << '  [info]  Copilot: use --tools copilot to install per-project'
+		if tools.len == 0 {
+			report.ok = false
+			lines << '  ⚠  No AI tools detected. Install at least one supported tool and re-run,'
+			lines << '  ⚠  or specify with: --tools claude-code,cursor,opencode,copilot,windsurf,pi,muse-code'
+			report.message = lines.join('\n')
+			return report
+		}
+	}
+
+	lines << ''
+	lines << '  [info]  Tools to install: ${tools.join(', ')}'
+
+	mut installed := []string{}
+	mut skipped_tools := []string{}
+	mut failed := []string{}
+	mut files := 0
+
+	for tool in tools {
+		canonical := canonical_install_tool(tool)
+		if canonical.len == 0 {
+			lines << '  ⚠  Unknown tool: ${tool} (valid: ${install_valid_tools.join(', ')})'
+			skipped_tools << tool
+			report.skipped++
+			continue
+		}
+		if canonical == 'copilot' {
+			lines << ''
+			lines << '  [info]  Installing: GitHub Copilot'
+			lines << '  -  Non-interactive — skip per-project Copilot (run interactively in Python CLI)'
+			skipped_tools << canonical
+			report.skipped++
+			continue
+		}
+		ok, tool_files, tool_lines := install_one_tool(canonical, data_root, home, receipt_dir,
+			opts.dry_run, opts.force)
+		lines << tool_lines
+		files += tool_files
+		if ok {
+			installed << canonical
+			report.tools_ok++
+		} else {
+			failed << canonical
+			report.ok = false
+		}
+	}
+
+	lines << ''
+	lines << '----------------------------------------------------------------------'
+	lines << 'Installation summary'
+	if installed.len > 0 {
+		lines << '  ✓  Installed: ${installed.join(', ')}'
+	}
+	if skipped_tools.len > 0 {
+		lines << '  -  Skipped:   ${skipped_tools.join(', ')}'
+	}
+	if failed.len > 0 {
+		lines << '  ✗  Failed:    ${failed.join(', ')}'
+		report.failures = failed
+	}
+	lines << ''
+	lines << '  [info]  Next steps:'
+	lines << '  [info]    1. Restart your AI tool(s) to load the new profiles'
+	lines << "  [info]    2. Run 'agent-toolkit doctor' to verify the installation"
+	report.files_written = files
+	report.message = lines.join('\n')
+	if failed.len > 0 {
+		report.ok = false
+	}
+	return report
+}
+
+// install_result maps InstallReport to CommandResult.
+pub fn install_result(report InstallReport) CommandResult {
+	return CommandResult{
+		command: 'install'
+		ok:      report.ok
+		message: report.message
+		data:    {
+			'data_root':     report.data_root
+			'files_written': '${report.files_written}'
+			'tools_ok':      '${report.tools_ok}'
+			'skipped':       '${report.skipped}'
+			'dry_run':       if report.dry_run { 'true' } else { 'false' }
+			'failures':      report.failures.join(',')
+		}
+	}
+}
+
+fn canonical_install_tool(tool string) string {
+	if tool == 'muse' {
+		return 'muse-code'
+	}
+	if tool in install_valid_tools {
+		return tool
+	}
+	return ''
+}
+
+fn detect_install_tools(home string, check_path bool) []string {
+	mut out := []string{}
+	if (check_path && install_tool_on_path('claude')) || os.exists(os.join_path(home, '.claude')) {
+		out << 'claude-code'
+	}
+	if (check_path && install_tool_on_path('cursor')) || os.exists(os.join_path(home, '.cursor')) {
+		out << 'cursor'
+	}
+	if (check_path && install_tool_on_path('opencode'))
+		|| os.exists(os.join_path(home, '.config', 'opencode')) {
+		out << 'opencode'
+	}
+	if (check_path && install_tool_on_path('windsurf'))
+		|| os.exists(os.join_path(home, '.codeium', 'windsurf'))
+		|| os.exists(os.join_path(home, '.windsurf')) {
+		out << 'windsurf'
+	}
+	if (check_path && install_tool_on_path('pi')) || os.exists(os.join_path(home, '.pi')) {
+		out << 'pi'
+	}
+	if (check_path && install_tool_on_path('muse'))
+		|| os.exists(os.join_path(home, '.config', 'muse'))
+		|| os.exists(os.join_path(home, '.agents')) {
+		out << 'muse-code'
+	}
+	return out
+}
+
+fn install_tool_on_path(name string) bool {
+	os.find_abs_path_of_executable(name) or { return false }
+	return true
+}
+
+fn install_one_tool(tool string, data_root string, home string, receipt_dir string, dry_run bool, force bool) (bool, int, string) {
+	mut lines := []string{}
+	lines << ''
+	lines << '  [info]  Installing: ${tool}'
+	if !install_source_present(tool, data_root) {
+		lines << '  ⚠  Profile source not found for ${tool}'
+		return false, 0, lines.join('\n')
+	}
+	mappings := install_file_mappings(tool, data_root, home)
+	if mappings.len == 0 {
+		lines << '  ⚠  No installable files for ${tool}'
+		return false, 0, lines.join('\n')
+	}
+	if dry_run {
+		for m in mappings {
+			lines << '  [dry]   Would copy: ${os.file_name(m.src)} → ${m.dst}'
+		}
+		return true, mappings.len, lines.join('\n')
+	}
+	mut tx := new_install_transaction(tool, InstallTxOptions{
+		dry_run:      false
+		force:        force
+		receipt_dir:  receipt_dir
+		toolkit_root: data_root
+	})
+	mut planned := 0
+	for m in mappings {
+		if !os.is_file(m.src) {
+			lines << '  ⚠  Source not found, skipping: ${m.src}'
+			continue
+		}
+		kind := stage_install_mapping(mut tx, m, force) or {
+			lines << '  ✗  Failed to stage ${m.dst}: ${err}'
+			return false, 0, lines.join('\n')
+		}
+		match kind {
+			'skip_identical' {
+				lines << '  -  Already up to date: ${m.dst}'
+			}
+			'skip_preserve' {
+				lines << '  -  Preserving user-owned file (use --force to overwrite): ${m.dst}'
+			}
+			'merged' {
+				lines << '  ✓  Merged config: ${m.dst}'
+				planned++
+			}
+			else {
+				lines << '  ✓  Installed: ${m.dst}'
+				planned++
+			}
+		}
+	}
+	path := tx.commit() or {
+		lines << '  ✗  Install commit failed: ${err}'
+		return false, 0, lines.join('\n')
+	}
+	if path.len > 0 {
+		lines << '  ✓  Saved install receipt for ${tool}'
+	}
+	return true, planned, lines.join('\n')
+}
+
+fn stage_install_mapping(mut tx InstallTransaction, m FileMapping, force bool) !string {
+	if m.dst.ends_with('.json') && os.is_file(m.dst) && !force {
+		content, ownership := merge_json_install(m.src, m.dst)
+		if ownership == 'skipped' {
+			return 'skip_preserve'
+		}
+		if ownership == 'unchanged' {
+			return 'skip_identical'
+		}
+		tx.stage_write_owned(m.dst, content, 'merged')!
+		return 'merged'
+	}
+	src := os.read_file(m.src) or { return error('read source failed: ${m.src}: ${err}') }
+	if os.is_file(m.dst) {
+		existing := os.read_file(m.dst) or { return error('read dest failed: ${m.dst}: ${err}') }
+		if existing == src {
+			return 'skip_identical'
+		}
+		if !force {
+			return 'skip_preserve'
+		}
+	}
+	tx.stage_write(m.dst, src)!
+	return 'created'
+}
+
+fn merge_json_install(src_path string, dst_path string) (string, string) {
+	src_text := os.read_file(src_path) or { return '', 'skipped' }
+	dst_text := os.read_file(dst_path) or { return '', 'skipped' }
+	overlay := parse_flat_json_strings(src_text) or { return '', 'skipped' }
+	mut base := parse_flat_json_strings(dst_text) or { return '', 'skipped' }
+	mut changed := false
+	for k, v in overlay {
+		if k !in base {
+			base[k] = v
+			changed = true
+		}
+	}
+	if !changed {
+		return dst_text, 'unchanged'
+	}
+	return encode_flat_json_strings(base) + '\n', 'merged'
+}
+
+fn parse_flat_json_strings(text string) ?map[string]string {
+	s := text.trim_space()
+	if s.len < 2 || s[0] != `{` {
+		return none
+	}
+	mut out := map[string]string{}
+	mut i := 1
+	for i < s.len {
+		for i < s.len && (s[i].is_space() || s[i] == `,`) {
+			i++
+		}
+		if i >= s.len || s[i] == `}` {
+			break
+		}
+		if s[i] != `"` {
+			return none
+		}
+		i++
+		key_start := i
+		for i < s.len && s[i] != `"` {
+			i++
+		}
+		if i >= s.len {
+			return none
+		}
+		key := s[key_start..i]
+		i++
+		for i < s.len && s[i].is_space() {
+			i++
+		}
+		if i >= s.len || s[i] != `:` {
+			return none
+		}
+		i++
+		for i < s.len && s[i].is_space() {
+			i++
+		}
+		if i >= s.len || s[i] != `"` {
+			return none
+		}
+		i++
+		val_start := i
+		for i < s.len {
+			if s[i] == `\\` && i + 1 < s.len {
+				i += 2
+				continue
+			}
+			if s[i] == `"` {
+				break
+			}
+			i++
+		}
+		if i >= s.len {
+			return none
+		}
+		out[key] = s[val_start..i]
+		i++
+	}
+	return out
+}
+
+fn encode_flat_json_strings(m map[string]string) string {
+	mut keys := m.keys()
+	keys.sort()
+	mut parts := []string{}
+	for k in keys {
+		parts << '"${k}":"${m[k]}"'
+	}
+	return '{' + parts.join(',') + '}'
+}
+
+fn install_source_present(tool string, data_root string) bool {
+	match tool {
+		'claude-code' {
+			profile := os.join_path(data_root, 'profiles', 'claude-code')
+			return os.is_dir(profile) || compiled_agent_files(data_root).len > 0
+		}
+		'cursor' {
+			return os.is_dir(os.join_path(data_root, 'profiles', 'cursor', 'rules'))
+		}
+		'opencode' {
+			profile := os.join_path(data_root, 'profiles', 'opencode')
+			return os.is_dir(profile) || compiled_agent_files(data_root).len > 0
+		}
+		'windsurf' {
+			return os.is_dir(os.join_path(data_root, 'profiles', 'windsurf'))
+		}
+		'pi' {
+			return os.is_dir(os.join_path(data_root, 'profiles', 'pi', 'skills'))
+		}
+		'muse-code' {
+			if os.is_dir(os.join_path(data_root, 'skills')) {
+				return true
+			}
+			if os.is_dir(os.join_path(data_root, 'profiles', 'muse-code')) {
+				return true
+			}
+			for prod in install_muse_products {
+				if os.is_dir(os.join_path(data_root, 'plugins', prod, 'skills')) {
+					return true
+				}
+			}
+			return os.is_dir(os.join_path(data_root, 'plugins', 'muse-code', 'skills'))
+		}
+		else {
+			return false
+		}
+	}
+}
+
+fn install_file_mappings(tool string, data_root string, home string) []FileMapping {
+	mut mappings := []FileMapping{}
+	compiled := compiled_agent_files(data_root)
+	match tool {
+		'claude-code' {
+			claude_md := os.join_path(data_root, 'profiles', 'claude-code', 'CLAUDE.md')
+			if os.is_file(claude_md) {
+				mappings << FileMapping{claude_md, os.join_path(home, '.claude', 'CLAUDE.md')}
+			}
+			mappings << agent_dest_mappings(tool, data_root, compiled, os.join_path(home,
+				'.claude', 'agents'))
+		}
+		'cursor' {
+			src := os.join_path(data_root, 'profiles', 'cursor', 'rules')
+			mappings << map_tree_files(src, os.join_path(home, '.cursor', 'rules'))
+		}
+		'opencode' {
+			cfg := os.join_path(data_root, 'profiles', 'opencode', 'opencode.json')
+			if os.is_file(cfg) {
+				mappings << FileMapping{cfg, os.join_path(home, '.config', 'opencode',
+					'opencode.json')}
+			}
+			mappings << agent_dest_mappings(tool, data_root, compiled, os.join_path(home,
+				'.config', 'opencode', 'agents'))
+		}
+		'windsurf' {
+			src := os.join_path(data_root, 'profiles', 'windsurf')
+			cfg := windsurf_config_dir(home)
+			for sub in ['rules', 'memories'] {
+				mappings << map_tree_files(os.join_path(src, sub), os.join_path(cfg, sub))
+			}
+		}
+		'pi' {
+			src := os.join_path(data_root, 'profiles', 'pi', 'skills')
+			mappings << map_tree_files(src, os.join_path(home, '.pi', 'agent', 'skills'))
+		}
+		'muse-code' {
+			mappings << muse_skill_mappings(data_root, home)
+		}
+		else {}
+	}
+	return mappings
+}
+
+fn agent_dest_mappings(tool string, data_root string, compiled map[string]string, dst_dir string) []FileMapping {
+	if compiled.len > 0 {
+		mut out := []FileMapping{}
+		mut names := compiled.keys()
+		names.sort()
+		for name in names {
+			out << FileMapping{
+				src: compiled[name]
+				dst: os.join_path(dst_dir, '${name}.md')
+			}
+		}
+		return out
+	}
+	return map_tree_files(os.join_path(data_root, 'profiles', tool, 'agents'), dst_dir)
+}
+
+fn compiled_agent_files(data_root string) map[string]string {
+	mut plugins := os.join_path(data_root, 'plugins')
+	override := os.getenv('AGENT_TOOLKIT_INSTALL_SOURCE').trim_space()
+	if override.len > 0 && os.is_dir(override) {
+		plugins = override
+	}
+	if !os.is_dir(plugins) {
+		parent := os.join_path(os.dir(data_root), 'plugins')
+		if os.is_dir(parent) {
+			plugins = parent
+		}
+	}
+	mut agents := map[string]string{}
+	if !os.is_dir(plugins) {
+		return agents
+	}
+	for product_id in install_agent_products {
+		agents_dir := os.join_path(plugins, product_id, 'agents')
+		if !os.is_dir(agents_dir) {
+			continue
+		}
+		entries := os.ls(agents_dir) or { continue }
+		for e in entries {
+			agent_md := os.join_path(agents_dir, e, 'AGENT.md')
+			if os.is_file(agent_md) {
+				agents[e] = agent_md
+			}
+		}
+	}
+	return agents
+}
+
+fn muse_skill_mappings(data_root string, home string) []FileMapping {
+	mut src := ''
+	for prod in install_muse_products {
+		p := os.join_path(data_root, 'plugins', prod, 'skills')
+		if os.is_dir(p) {
+			src = p
+			break
+		}
+	}
+	if src.len == 0 {
+		p := os.join_path(data_root, 'plugins', 'muse-code', 'skills')
+		if os.is_dir(p) {
+			src = p
+		}
+	}
+	if src.len == 0 {
+		p := os.join_path(data_root, 'skills')
+		if os.is_dir(p) {
+			src = p
+		}
+	}
+	if src.len == 0 {
+		return map_tree_files(os.join_path(data_root, 'profiles', 'muse-code'), os.join_path(home,
+			'.config', 'muse'))
+	}
+	mut out := []FileMapping{}
+	out << map_tree_files(src, os.join_path(home, '.config', 'muse', 'skills'))
+	out << map_tree_files(src, os.join_path(home, '.agents', 'skills'))
+	return out
+}

--- a/modules/agent_toolkit_core/install_test.v
+++ b/modules/agent_toolkit_core/install_test.v
@@ -1,0 +1,268 @@
+module agent_toolkit_core
+
+import os
+
+fn test_install_cursor_dry_run_writes_nothing() {
+	base := os.join_path(os.temp_dir(), 'at-ins-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(os.join_path(data, 'profiles', 'cursor', 'rules')) or { assert false, err.msg() }
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	src := os.join_path(data, 'profiles', 'cursor', 'rules', 'assistant.mdc')
+	os.write_file(src, 'rule\n') or {
+		assert false, err.msg()
+		return
+	}
+	report := run_install(InstallOptions{
+		tools:       ['cursor']
+		dry_run:     true
+		home_dir:    home
+		data_root:   data
+		receipt_dir: receipt_dir
+	})
+	assert report.ok
+	assert report.dry_run
+	assert report.message.contains('DRY RUN')
+	dst := os.join_path(home, '.cursor', 'rules', 'assistant.mdc')
+	assert !os.is_file(dst)
+	assert !os.is_dir(receipt_dir) || os.ls(receipt_dir) or { []string{} }.len == 0
+}
+
+fn test_install_cursor_writes_file_and_receipt() {
+	base := os.join_path(os.temp_dir(), 'at-ins-w-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(os.join_path(data, 'profiles', 'cursor', 'rules')) or { assert false, err.msg() }
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	src := os.join_path(data, 'profiles', 'cursor', 'rules', 'assistant.mdc')
+	os.write_file(src, 'rule-v1\n') or {
+		assert false, err.msg()
+		return
+	}
+	report := run_install(InstallOptions{
+		tools:       ['cursor']
+		home_dir:    home
+		data_root:   data
+		receipt_dir: receipt_dir
+	})
+	assert report.ok, report.message
+	dst := os.join_path(home, '.cursor', 'rules', 'assistant.mdc')
+	assert os.read_file(dst) or { '' } == 'rule-v1\n'
+	loaded := load_install_receipt('cursor', profiles_product, receipt_dir) or {
+		assert false, 'receipt missing'
+		return
+	}
+	assert loaded.artifacts.len == 1
+	assert loaded.artifacts[0].ownership == 'created'
+}
+
+fn test_install_preserves_without_force() {
+	base := os.join_path(os.temp_dir(), 'at-ins-p-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(os.join_path(data, 'profiles', 'cursor', 'rules')) or { assert false, err.msg() }
+	dst := os.join_path(home, '.cursor', 'rules', 'assistant.mdc')
+	os.mkdir_all(os.dir(dst)) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(data, 'profiles', 'cursor', 'rules', 'assistant.mdc'), 'new\n') or {
+		assert false, err.msg()
+		return
+	}
+	os.write_file(dst, 'user\n') or {
+		assert false, err.msg()
+		return
+	}
+	report := run_install(InstallOptions{
+		tools:       ['cursor']
+		home_dir:    home
+		data_root:   data
+		receipt_dir: receipt_dir
+	})
+	assert report.ok, report.message
+	assert os.read_file(dst) or { '' } == 'user\n'
+	assert report.message.contains('Preserving user-owned file')
+}
+
+fn test_install_force_overwrites() {
+	base := os.join_path(os.temp_dir(), 'at-ins-f-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(os.join_path(data, 'profiles', 'cursor', 'rules')) or { assert false, err.msg() }
+	dst := os.join_path(home, '.cursor', 'rules', 'assistant.mdc')
+	os.mkdir_all(os.dir(dst)) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(data, 'profiles', 'cursor', 'rules', 'assistant.mdc'), 'new\n') or {
+		assert false, err.msg()
+		return
+	}
+	os.write_file(dst, 'user\n') or {
+		assert false, err.msg()
+		return
+	}
+	report := run_install(InstallOptions{
+		tools:       ['cursor']
+		force:       true
+		home_dir:    home
+		data_root:   data
+		receipt_dir: receipt_dir
+	})
+	assert report.ok, report.message
+	assert os.read_file(dst) or { '' } == 'new\n'
+}
+
+fn test_install_unknown_tool_skipped() {
+	base := os.join_path(os.temp_dir(), 'at-ins-u-${os.getpid()}')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	report := run_install(InstallOptions{
+		tools:       ['not-a-tool']
+		home_dir:    base
+		data_root:   base
+		receipt_dir: os.join_path(base, 'receipts')
+	})
+	assert report.ok
+	assert report.message.contains('Unknown tool')
+	assert report.skipped == 1
+}
+
+fn test_install_no_tools_detected() {
+	base := os.join_path(os.temp_dir(), 'at-ins-n-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	os.mkdir_all(os.join_path(data, 'profiles')) or { assert false, err.msg() }
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	report := run_install(InstallOptions{
+		home_dir:    home
+		data_root:   data
+		receipt_dir: os.join_path(base, 'receipts')
+	})
+	assert !report.ok
+	assert report.message.contains('No AI tools detected')
+}
+
+fn test_install_opencode_json_merge() {
+	base := os.join_path(os.temp_dir(), 'at-ins-j-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(os.join_path(data, 'profiles', 'opencode')) or { assert false, err.msg() }
+	dst := os.join_path(home, '.config', 'opencode', 'opencode.json')
+	os.mkdir_all(os.dir(dst)) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(data, 'profiles', 'opencode', 'opencode.json'),
+		'{"schema":"https://opencode.ai/config.json"}\n') or {
+		assert false, err.msg()
+		return
+	}
+	os.write_file(dst, '{"theme":"dark"}\n') or {
+		assert false, err.msg()
+		return
+	}
+	report := run_install(InstallOptions{
+		tools:       ['opencode']
+		home_dir:    home
+		data_root:   data
+		receipt_dir: receipt_dir
+	})
+	assert report.ok, report.message
+	got := os.read_file(dst) or { '' }
+	assert got.contains('theme')
+	assert got.contains('schema')
+	loaded := load_install_receipt('opencode', profiles_product, receipt_dir) or {
+		assert false, 'receipt missing'
+		return
+	}
+	assert loaded.artifacts.len == 1
+	assert loaded.artifacts[0].ownership == 'merged'
+}
+
+fn test_install_copilot_skipped_noninteractive() {
+	base := os.join_path(os.temp_dir(), 'at-ins-c-${os.getpid()}')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	report := run_install(InstallOptions{
+		tools:       ['copilot']
+		home_dir:    base
+		data_root:   base
+		receipt_dir: os.join_path(base, 'receipts')
+	})
+	assert report.ok
+	assert report.skipped == 1
+	assert report.message.contains('Copilot')
+}
+
+fn test_install_autodetect_cursor_home() {
+	base := os.join_path(os.temp_dir(), 'at-ins-d-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(os.join_path(data, 'profiles', 'cursor', 'rules')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(home, '.cursor')) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(data, 'profiles', 'cursor', 'rules', 'assistant.mdc'), 'r\n') or {
+		assert false, err.msg()
+		return
+	}
+	report := run_install(InstallOptions{
+		home_dir:    home
+		data_root:   data
+		receipt_dir: receipt_dir
+	})
+	assert report.ok, report.message
+	assert os.is_file(os.join_path(home, '.cursor', 'rules', 'assistant.mdc'))
+}
+
+fn test_install_skips_claude_settings_json() {
+	base := os.join_path(os.temp_dir(), 'at-ins-s-${os.getpid()}')
+	data := os.join_path(base, 'data')
+	home := os.join_path(base, 'home')
+	receipt_dir := os.join_path(base, 'receipts')
+	profile := os.join_path(data, 'profiles', 'claude-code')
+	os.mkdir_all(profile) or { assert false, err.msg() }
+	os.mkdir_all(home) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.write_file(os.join_path(profile, 'CLAUDE.md'), '# claude\n') or {
+		assert false, err.msg()
+		return
+	}
+	os.write_file(os.join_path(profile, 'settings.json'), '{"permissions":{}}\n') or {
+		assert false, err.msg()
+		return
+	}
+	report := run_install(InstallOptions{
+		tools:       ['claude-code']
+		home_dir:    home
+		data_root:   data
+		receipt_dir: receipt_dir
+	})
+	assert report.ok, report.message
+	assert os.is_file(os.join_path(home, '.claude', 'CLAUDE.md'))
+	assert !os.exists(os.join_path(home, '.claude', 'settings.json'))
+}

--- a/modules/agent_toolkit_core/uninstall.v
+++ b/modules/agent_toolkit_core/uninstall.v
@@ -10,6 +10,7 @@ pub const uninstall_tool_targets = {
 	'copilot':     'copilot'
 	'windsurf':    'windsurf'
 	'pi':          'pi'
+	'muse-code':   'muse-code'
 }
 
 // UninstallOptions configures receipt-based uninstall / rollback.

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -235,6 +235,51 @@
       ]
     },
     {
+      "command": "install-help",
+      "args": [
+        "install",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "install",
+        "dry-run",
+        "tools"
+      ]
+    },
+    {
+      "command": "install-dry-run",
+      "args": [
+        "install",
+        "--tools",
+        "cursor",
+        "--dry-run",
+        "--offline"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "cursor",
+        "dry"
+      ]
+    },
+    {
+      "command": "install-dry-run-json",
+      "args": [
+        "install",
+        "--tools",
+        "cursor",
+        "--dry-run",
+        "--json"
+      ],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": [
+        "command",
+        "ok",
+        "dry_run"
+      ]
+    },
+    {
       "command": "install-bad-flag",
       "args": [
         "install",


### PR DESCRIPTION
## Summary
- Wire consumer `agent-toolkit install` to `InstallTransaction` (dry-run / force / offline / `--tools`, auto-detect)
- Skip Copilot (per-project, non-interactive); never write `~/.claude/settings.json`; receipts for created artifacts
- Golden parity fixtures for install help + dry-run

Fixes #607

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/install_test.v modules/agent_toolkit_cli/dispatch_test.v`
- [x] Parity harness: install-help, install-dry-run, install-dry-run-json, install-bad-flag PASS
- [ ] CI green

Made with [Cursor](https://cursor.com)