### PR TITLE
docs(adr): add ADR-017 package-manager ownership for update (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — ADR-017 package-manager ownership: `update` is capability-only; never overwrite brew/AUR/npm/uv binaries (Closes #489)
 - **Feat** — V `plugin sync|check` gen-surfaces parity (Closes #519)
 - **Feat** — V `mcp` list/setup/health/doctor/uninstall (env names only; no secrets) (Closes #518)
 - **Feat** — V `skills` list/sync/validate command family (Closes #517)

--- a/docs/adrs/ADR-017-update-ownership.md
+++ b/docs/adrs/ADR-017-update-ownership.md
@@ -1,0 +1,56 @@
+# ADR-017: Package-Manager Ownership vs `update` / Self-Update
+
+**Status:** Accepted  
+**Date:** 2026-08-13  
+**Deciders:** maintainers (V migration program [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456), issue [#489](https://github.com/ulises-jeremias/agent-toolkit/issues/489))
+
+## Context
+
+`agent-toolkit update` refreshes **installed profiles / capability data**. The CLI **executable** is also distributed via Homebrew, AUR, npm, PyPI/`uv tool`, and GitHub Release binaries.
+
+Silently replacing `argv[0]` would fight package managers (Homebrew cellar, pacman-owned files, npm prefix, uv tool venvs) and break signature/attestation expectations ([#474](https://github.com/ulises-jeremias/agent-toolkit/issues/474)).
+
+EPIC 4 ([#461](https://github.com/ulises-jeremias/agent-toolkit/issues/461)) already ports capability `update` ([#516](https://github.com/ulises-jeremias/agent-toolkit/issues/516)). This ADR freezes ownership rules before any self-update feature exists.
+
+## Options considered
+
+| ID | Option | Summary |
+|----|--------|---------|
+| **A** | Capability-only `update` | `update` never writes the executable. Package managers own binary upgrades. |
+| **B** | Detect ownership; self-update only unmanaged installs | GitHub-release / copied binaries may self-replace; brew/AUR/npm/uv/pipx are refused. |
+| **C** | Always self-update (`update` replaces the binary) | One command upgrades code + profiles. |
+| **D** | Separate `upgrade` subcommand for the binary | Keep `update` for profiles; add `upgrade` later with ownership checks. |
+
+## Decision
+
+Adopt **A** now, and reserve **D** (with **B**'s ownership checks) as the only allowed future binary-upgrade path.
+
+1. **`agent-toolkit update` is capability update only.** It may refresh toolkit data and profile files. It must not overwrite the running executable, adjacent binaries, or package-manager metadata.
+2. **Package managers own the binary.** Homebrew, AUR/pacman, npm, PyPI wheels / `uv tool` / pipx, and Docker images upgrade via those channels. This repo documents contracts (`distribution/` when present); it does not ship foreign PKGBUILD/Formula in this ADR.
+3. **No silent self-update.** A future binary upgrade command (not `update`) requires a new implementation issue. It MUST refuse to replace files owned by a package manager. Detection heuristics (non-exhaustive): Homebrew prefix/Cellar; `pacman -Qo`; npm global prefix / `node_modules`; uv tool / pipx home; read-only `/usr` without write intent.
+4. **Standalone GitHub Release binaries** are the only class that *may* later opt into self-replace, and only after SHA256/attestation checks ([#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530)) and the threat model ([#563](https://github.com/ulises-jeremias/agent-toolkit/issues/563)).
+
+### Rejected
+
+- **C** — mixes content and executable; breaks managed installs.
+- **B as the default `update` behavior** — too easy to surprise users who ran `update` expecting profiles.
+
+## Consequences
+
+- **Positive:** Matches shipped Python/V `update` (#516); clear support story; supply-chain upgrades stay in signed package channels.
+- **Negative:** Standalone-binary users must re-download releases until a dedicated `upgrade` exists.
+- **Follow-on:** Homebrew (#490/#538), AUR (#491/#539), PyPI (#486/#535), npm (#487/#536) integration ADRs/contracts must not teach `agent-toolkit update` as the binary upgrade path.
+
+## Validation plan
+
+- V/Python `update` tests never assert writes to `os.executable()` / `sys.argv[0]`.
+- Docs (`docs/v/update.md`, install/uninstall) state capability vs binary ownership.
+- Any future `upgrade` issue must cite this ADR and include ownership-refusal tests.
+
+## References
+
+- Issues [#489](https://github.com/ulises-jeremias/agent-toolkit/issues/489), [#516](https://github.com/ulises-jeremias/agent-toolkit/issues/516)
+- [ADR-012](ADR-012-python-v-coexistence.md) coexistence / cutover
+- [ADR-016](ADR-016-versioning-migration.md) versioning (channels track one SemVer)
+
+**Verified:** 2026-08-13

--- a/docs/v/update.md
+++ b/docs/v/update.md
@@ -9,4 +9,4 @@ Refreshes installed AI-tool **profiles** from toolkit capability data (not execu
 - `--pin VERSION` / auto data refresh via `DataSync.ensure_data`
 - Atomic writes via `FsService.write_atomic`
 
-See also ADR package-manager ownership (#489) — this command updates content, not the CLI binary.
+See [ADR-017](../adrs/ADR-017-update-ownership.md) — this command updates content, not the CLI binary. Package managers own executable upgrades.


### PR DESCRIPTION
## Summary
- Accept ADR-017: `agent-toolkit update` is capability-only and must never overwrite brew/AUR/npm/uv-managed binaries
- Future binary upgrades (if any) are a separate command with ownership refusal, not `update`

Fixes #489

## Test plan
- [x] ADR records options, decision, consequences, validation plan
- [ ] CI green

Made with [Cursor](https://cursor.com)