### PR TITLE
docs(v): record EPIC 5 advanced command dispositions (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — EPIC 5 advanced-command disposition (PORT/REDESIGN/DEPRECATE/REMOVE) (Closes #560)
 - **Feat** — V `agent-toolkit install` via InstallTransaction (dry-run/force/receipts) (Closes #607)
 - **Feat** — V `plugin sync|check` gen-surfaces parity (Closes #519)
 - **Feat** — V `mcp` list/setup/health/doctor/uninstall (env names only; no secrets) (Closes #518)

--- a/docs/CLI_SURFACES.md
+++ b/docs/CLI_SURFACES.md
@@ -44,6 +44,8 @@ Still available on the same binary — de-emphasized in top-level help:
 
 Swarm details: `docs/SWARMS.md`, `docs/SWARM_ARCHITECTURE.md`.
 
+V-port dispositions for advanced commands: [`docs/v/advanced-command-disposition.md`](v/advanced-command-disposition.md) (#560).
+
 ## Migration
 
 Existing scripts invoking advanced commands continue to work unchanged.

--- a/docs/v/advanced-command-disposition.md
+++ b/docs/v/advanced-command-disposition.md
@@ -1,0 +1,40 @@
+# Advanced command disposition (EPIC 5)
+
+**Issue:** [#560](https://github.com/ulises-jeremias/agent-toolkit/issues/560)  
+**Parent:** [#462](https://github.com/ulises-jeremias/agent-toolkit/issues/462)
+
+Consumer commands stay **strong-compat** (`install`/`update`/`uninstall`/`doctor`/`diff`/`skills`/`mcp`/`plugin`). Advanced commands are dispositioned here so Python retirement ([#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540)) does **not** require ports marked REMOVE or DEPRECATE.
+
+Legend: **PORT** 1:1 V rewrite · **REDESIGN** V rewrite with a different shape · **MERGE** fold into another command · **DEPRECATE** keep Python until removal, no V requirement · **REMOVE** drop from the V CLI (CI/docs replace it).
+
+| Command | Issue | Disposition | Retirement gate? | Rationale |
+|---------|-------|-------------|------------------|-----------|
+| `workspace` | [#520](https://github.com/ulises-jeremias/agent-toolkit/issues/520) | **PORT** | Yes | L3 harness session contract (`init`/`context`/`sync`). Distinct from `project`. |
+| `memory` | [#521](https://github.com/ulises-jeremias/agent-toolkit/issues/521) | **PORT** | Yes | Workspace knowledge base; `inject`/`todo` are session-start protocol. |
+| `project` | [#522](https://github.com/ulises-jeremias/agent-toolkit/issues/522) | **PORT** | Yes | Repo index (`clone`/`list`/`add`); overlaps conceptually with workspace but different FS layout (`repos/` vs workspace overlay). Do **not** MERGE. |
+| `loop` | [#523](https://github.com/ulises-jeremias/agent-toolkit/issues/523) | **REDESIGN** | Yes | Product differentiator; do not clone Python threads — follow [#528](https://github.com/ulises-jeremias/agent-toolkit/issues/528) + process service. |
+| `swarm` | [#524](https://github.com/ulises-jeremias/agent-toolkit/issues/524) | **REDESIGN** | Yes | Keep surface; backends (Herdr/tmux) behind interfaces (ADR-008). Concurrency via #528. |
+| `devcompanion` | [#525](https://github.com/ulises-jeremias/agent-toolkit/issues/525) | **PORT** | Yes | Filesystem job queue used by AGENTS.md. Keep **`dc` alias** (already in V dispatcher). |
+| `insights` | [#526](https://github.com/ulises-jeremias/agent-toolkit/issues/526) | **DEPRECATE** | **No** | Local DB/path parsers churn with Cursor/OpenCode; privacy-sensitive; not required for consumer cutover or Python removal. Python may keep it until #540; V need not port. |
+| `release` | [#527](https://github.com/ulises-jeremias/agent-toolkit/issues/527) | **REMOVE** | **No** | Maintainer artifact generation belongs in GitHub Actions / `docs/RELEASING.md`, not the runtime CLI. V help may list it as unsupported; do not port. |
+
+## Alias policy
+
+- **`dc` → `devcompanion`:** keep (user muscle memory; already wired).
+- **`rollback` → `uninstall`:** keep (consumer).
+- No new aliases for REMOVE/DEPRECATE commands.
+
+## Overlap notes
+
+- `workspace` vs `project`: workspace scaffolds the overlay (`AGENTS.md`, personas, packs); project manages git clones + `projects/` symlinks. Both PORT; neither absorbs the other.
+- `update` vs binary upgrade: not in this table — see [ADR-017](../adrs/ADR-017-update-ownership.md).
+
+## EPIC 5 sequencing
+
+1. PORT `workspace` → `memory` → `project` (shared workspace root).
+2. PORT `devcompanion` (queue is independent of loops).
+3. REDESIGN `loop` after [#528](https://github.com/ulises-jeremias/agent-toolkit/issues/528).
+4. REDESIGN `swarm` after loop/process patterns exist.
+5. Close #526/#527 as dispositioned without V implementations.
+
+Python remains available for DEPRECATE/REMOVE commands until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540), matching [ADR-012](../adrs/ADR-012-python-v-coexistence.md) (no per-command mixed engine).


### PR DESCRIPTION
## Summary
- Disposition table for workspace/memory/project/loop/swarm/devcompanion/insights/release
- Keep \`dc\` alias; do not MERGE workspace+project; insights DEPRECATE and release REMOVE are not Python-removal gates

Fixes #560

## Test plan
- [x] Table covers all eight commands with rationale
- [ ] CI green

Made with [Cursor](https://cursor.com)