### PR TITLE
fix(v): apply merged JSON install writes without --force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Fixed** — V install JSON merge (`ownership=merged`) writes without `--force` (Closes #611)
 - **Feat** — V `agent-toolkit install` via InstallTransaction (dry-run/force/receipts) (Closes #607)
 - **Feat** — V `plugin sync|check` gen-surfaces parity (Closes #519)
 - **Feat** — V `mcp` list/setup/health/doctor/uninstall (env names only; no secrets) (Closes #518)

--- a/docs/v/install-transaction.md
+++ b/docs/v/install-transaction.md
@@ -6,6 +6,7 @@
 
 - refuse path-escape at stage time
 - `--dry-run` / preserve-without-`--force` parity with Python `cli/install.py`
+- `ownership=merged` JSON writes apply without `--force` ([#611](https://github.com/ulises-jeremias/agent-toolkit/issues/611))
 - receipt save only after successful commit (`save_install_receipt`)
 
 Depends on [#512](https://github.com/ulises-jeremias/agent-toolkit/issues/512) receipt parser. Consumer CLI wiring is [#607](https://github.com/ulises-jeremias/agent-toolkit/issues/607). Uninstall/rollback CLI is [#514](https://github.com/ulises-jeremias/agent-toolkit/issues/514).

--- a/modules/agent_toolkit_core/install_tx.v
+++ b/modules/agent_toolkit_core/install_tx.v
@@ -166,8 +166,9 @@ fn (mut tx InstallTransaction) apply_one(op StagedOp) ! {
 			// Idempotent: already up to date — do not re-record.
 			return
 		}
-		if !tx.force {
+		if !tx.force && op.ownership != 'merged' {
 			// Preserve user-owned file (Python install skip without --force).
+			// ownership=merged is a non-destructive JSON merge already computed by the caller.
 			return
 		}
 		tx.fs.write_atomic(dest, op.content)!

--- a/modules/agent_toolkit_core/install_tx_test.v
+++ b/modules/agent_toolkit_core/install_tx_test.v
@@ -214,3 +214,40 @@ fn test_save_install_receipt_roundtrip() {
 	}
 	assert loaded.config_patches_json.contains('/toolkit')
 }
+
+fn test_install_tx_merged_ownership_writes_without_force() {
+	base := os.join_path(os.temp_dir(), 'at-tx-merge-${os.getpid()}')
+	dest_root := os.join_path(base, 'dst')
+	receipt_dir := os.join_path(base, 'receipts')
+	os.mkdir_all(dest_root) or { assert false, err.msg() }
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	dest := os.join_path(dest_root, 'opencode.json')
+	os.write_file(dest, '{"theme":"dark"}\n') or {
+		assert false, err.msg()
+		return
+	}
+	mut tx := new_install_transaction('opencode', InstallTxOptions{
+		receipt_dir:   receipt_dir
+		version:       '1.0.0'
+		source_digest: 'x'
+	})
+	tx.stage_write_owned(dest, '{"schema":"x","theme":"dark"}\n', 'merged') or {
+		assert false, err.msg()
+		return
+	}
+	tx.commit() or {
+		assert false, err.msg()
+		return
+	}
+	got := os.read_file(dest) or { '' }
+	assert got.contains('schema')
+	assert got.contains('theme')
+	loaded := load_install_receipt('opencode', profiles_product, receipt_dir) or {
+		assert false, 'receipt missing'
+		return
+	}
+	assert loaded.artifacts.len == 1
+	assert loaded.artifacts[0].ownership == 'merged'
+}


### PR DESCRIPTION
## Summary
- `InstallTransaction.apply_one` now commits `ownership=merged` JSON without requiring `--force`
- Preserve-without-`--force` still applies to `created` copies
- Unit test covers merged receipt + dest content

Fixes #611

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/install_tx_test.v modules/agent_toolkit_core/install_test.v`
- [ ] CI green


Made with [Cursor](https://cursor.com)