### PR TITLE
docs(adr): add ADR-019 Linux glibc vs musl (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — ADR-019 Linux glibc is the MUST/stable binary; musl is an optional extra name (Closes #485)
 - **Feat** — V `project` init/clone/list/add/remove/scan (repos/ + projects/ symlinks) (Closes #522)
 - **Feat** — V `memory` add/search/inject/review/todo (knowledge markdown; atomic writes) (Closes #521)
 - **Docs** — ADR-018 canonical release artifact names (floating stable + versioned archives; experimental prefix) (Closes #484)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -70,7 +70,7 @@ Release binaries are platform-suffixed to avoid upload collisions (see #256 and 
 * `agent-toolkit-macos-arm64`
 * `agent-toolkit-windows-x86_64.exe`
 
-**Stable channel:** those floating names. **Versioned archives** (`agent-toolkit-<semver>-<os>-<arch>.tar.gz` / Windows `.zip`) are the checksum and attestation unit. **Experimental V** assets use `agent-toolkit-v-experimental-<os>-<arch>` and must not overwrite stable names.
+**Stable channel:** those floating names. **Linux (`linux-x86_64` / `linux-arm64`) is glibc** ([ADR-019](adrs/ADR-019-linux-libc.md)); an optional musl extra uses a distinct name (`agent-toolkit-linux-x86_64-musl`) and must not overwrite the stable glibc artifact. **Versioned archives** (`agent-toolkit-<semver>-<os>-<arch>.tar.gz` / Windows `.zip`) are the checksum and attestation unit. **Experimental V** assets use `agent-toolkit-v-experimental-<os>-<arch>` and must not overwrite stable names.
 
 Darwin x86_64 is intentionally deferred (documented skip). Release notes / this doc mention naming.
 

--- a/docs/adrs/ADR-018-release-artifacts.md
+++ b/docs/adrs/ADR-018-release-artifacts.md
@@ -33,7 +33,7 @@ Retain the existing tokens (OS: `linux` / `macos` / `windows`; arch: `x86_64` / 
 
 | Asset | Notes |
 |-------|--------|
-| `agent-toolkit-linux-x86_64` | ELF; no extension |
+| `agent-toolkit-linux-x86_64` | ELF; **glibc** ([ADR-019](ADR-019-linux-libc.md)); no extension |
 | `agent-toolkit-linux-arm64` | When MUST-platform matrix includes it ([#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529)) |
 | `agent-toolkit-macos-arm64` | Mach-O |
 | `agent-toolkit-windows-x86_64.exe` | PE; `.exe` required |

--- a/docs/adrs/ADR-019-linux-libc.md
+++ b/docs/adrs/ADR-019-linux-libc.md
@@ -1,0 +1,54 @@
+# ADR-019: Linux glibc vs musl (or both)
+
+**Status:** Accepted  
+**Date:** 2026-08-13  
+**Deciders:** maintainers (V migration program [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456), issue [#485](https://github.com/ulises-jeremias/agent-toolkit/issues/485))
+
+## Context
+
+Native Linux `agent-toolkit` binaries will run on developer workstations, CI images, Docker, and (later) package wrappers. V can link against **glibc** or **musl**. Musl static binaries look attractive for Alpine/scratch images and “copy one file” installs, but they are not automatically better: DNS (`nsswitch`), TLS (OpenSSL vs bundled), NSS plugins, and binary size all change. Python wheels already follow **manylinux** (glibc) for PyPI.
+
+Canonical asset names are [ADR-018](ADR-018-release-artifacts.md): the floating name `agent-toolkit-linux-x86_64` is the **stable** Linux x86_64 artifact.
+
+## Options considered
+
+| ID | Option | Summary |
+|----|--------|---------|
+| **A** | glibc only | One Linux binary, built on a manylinux-like / Ubuntu runner; matches PyPI/Docker Debian-ubuntu users. |
+| **B** | musl static only | One fully static (or musl-dynamic) binary; Alpine-first; hope it runs everywhere. |
+| **C** | Both: glibc is MUST/stable; musl is optional extra | Stable name is glibc; musl ships as a distinctly named extra when the matrix can afford it. |
+| **D** | Distroless “universal” via zig cc / extra flags | One builder produces both; still need two artifacts and two smoke jobs. |
+
+## Decision
+
+Adopt **C**.
+
+1. **MUST Linux artifact is glibc.** `agent-toolkit-linux-x86_64` (and `linux-arm64` when #529 includes it) is built against a **supported glibc** (manylinux_2_28-class or Ubuntu LTS used in #529). This is the binary wrappers, Docker (Debian/Ubuntu), and `docs/RELEASING.md` mean by “Linux”.
+2. **Do not assume musl is superior.** Static musl can regress DNS/TLS (no glibc NSS; extra care for certificates). Size is an empirical #533 measurement, not a reason to default musl.
+3. **Optional musl extra.** If #529/#532 cost tiers allow, publish `agent-toolkit-linux-x86_64-musl` (versioned archive too) as **non-stable** / documented for Alpine. It MUST NOT overwrite the floating glibc name. Experimental V (#562) may use musl only under the experimental prefix ([ADR-018](ADR-018-release-artifacts.md)).
+4. **Docker:** default image tracks glibc (Debian/Ubuntu). An Alpine variant is a separate tag, not a replacement.
+
+### Rejected
+
+- **B** — breaks the majority workstation/CI glibc install base; TLS/DNS surprises.
+- **A forever** — forbids an Alpine extra even when we can afford it.
+- **D as the product default** — extra toolchain risk; still two artifacts to smoke (#531).
+
+## Consequences
+
+- **Positive:** Matches PyPI manylinux expectations; stable name is unambiguous; Alpine is opt-in.
+- **Negative:** Two Linux builds when musl is enabled (CI cost — #532).
+- **Follow-on:** #529 matrix lists glibc as MUST; musl as SHOULD/MAY. #531 smokes glibc always; musl only if the extra asset exists.
+
+## Validation plan
+
+- Release notes / ADR-018 table: `linux-x86_64` = glibc.
+- Smoke (#531) on the glibc artifact: `--version` / `--help` / `inventory` / `doctor`.
+- If musl extra ships: separate smoke job; document Alpine install in `docs/RELEASING.md` without changing the stable name.
+
+## References
+
+- Issues [#485](https://github.com/ulises-jeremias/agent-toolkit/issues/485), [#484](https://github.com/ulises-jeremias/agent-toolkit/issues/484), [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529), [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531), [#532](https://github.com/ulises-jeremias/agent-toolkit/issues/532), [#533](https://github.com/ulises-jeremias/agent-toolkit/issues/533)
+- [ADR-018](ADR-018-release-artifacts.md) artifact names
+
+**Verified:** 2026-08-13


### PR DESCRIPTION
## Summary
- Record **glibc** as the MUST/stable Linux artifact (`agent-toolkit-linux-x86_64`); musl is an optional extra name that must not overwrite the floating stable binary.
- Cross-link ADR-018 and `docs/RELEASING.md`.

Fixes #485

## Type
- [x] Documentation
- [x] Other

## Changes
- `docs/adrs/ADR-019-linux-libc.md` — accepted ADR (options A–D; decision C)
- `docs/adrs/ADR-018-release-artifacts.md` — Linux row notes glibc
- `docs/RELEASING.md` — asset naming
- `CHANGELOG.md` — Unreleased bullet

## Testing
- [x] Documentation-only; no runtime change
- [x] No secrets

## Checklist
- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes
- [x] Branding-neutral
- [x] Commit messages are in English and follow conventional commits format

Made with [Cursor](https://cursor.com)