### PR TITLE
feat(v): implement devcompanion/dc filesystem queue (#525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `devcompanion`/`dc` filesystem queue (queue/run-once --no-llm/status/done/sync-todos) (Closes #525)
 - **Docs** — ADR-019 Linux glibc is the MUST/stable binary; musl is an optional extra name (Closes #485)
 - **Feat** — V `project` init/clone/list/add/remove/scan (repos/ + projects/ symlinks) (Closes #522)
 - **Feat** — V `memory` add/search/inject/review/todo (knowledge markdown; atomic writes) (Closes #521)

--- a/docs/v/cutover.md
+++ b/docs/v/cutover.md
@@ -21,7 +21,7 @@ Native artifacts stay **experimental** until [#562](https://github.com/ulises-je
 
 ## Python fallback (advanced commands)
 
-EPIC 5 remaining commands (`loop`, `swarm`, `devcompanion`, `insights`, `release`) may still be `not_implemented` in V. `workspace` (#520), `memory` (#521), and `project` (#522) are implemented in V. Run the Python CLI explicitly for unfinished advanced commands:
+EPIC 5 remaining commands (`loop`, `swarm`, `insights`, `release`) may still be `not_implemented` in V. `workspace` (#520), `memory` (#521), `project` (#522), and `devcompanion`/`dc` (#525) are implemented in V. Run the Python CLI explicitly for unfinished advanced commands:
 
 ```bash
 agent-toolkit-py loop status

--- a/docs/v/devcompanion.md
+++ b/docs/v/devcompanion.md
@@ -1,0 +1,11 @@
+# V `devcompanion` / `dc` command family
+
+**Issue:** [#525](https://github.com/ulises-jeremias/agent-toolkit/issues/525) (EPIC 5 [#462](https://github.com/ulises-jeremias/agent-toolkit/issues/462), disposition [#560](https://github.com/ulises-jeremias/agent-toolkit/issues/560) **PORT**)
+
+Filesystem job queue matching Python `cli/devcompanion.py` (alias **`dc` retained**):
+
+- `queue <project> --request "..." | --template NAME` — write pending job JSON
+- `run-once [--no-llm]` — oldest pending job; **`--no-llm` is skeleton-only (no network)**
+- `status` / `done <job-id>` / `sync-todos`
+
+Queue layout: workspace `.devcompanion/queue/*.json`, or harness dirs when `HARNESS_DC_HOME` / `HARNESS_DIR` is set. LLM runners stay a workstation concern; V falls back to the skeleton plan (same as Python when no runner is found). No tmux/Herdr.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -139,6 +139,14 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_project(opts)
 		return render(agent_toolkit_core.project_result(report), mode)
 	}
+	if cmd_name == 'devcompanion' {
+		opts := parse_dc_options(argv[1..]) or {
+			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
+			return render_error(e, mode)
+		}
+		report := agent_toolkit_core.run_devcompanion(opts)
+		return render(agent_toolkit_core.devcompanion_result(report), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
@@ -653,6 +661,92 @@ fn parse_project_options(args []string) !agent_toolkit_core.ProjectOptions {
 	}
 }
 
+fn parse_dc_options(args []string) !agent_toolkit_core.DevcompanionOptions {
+	mut sub := ''
+	mut workspace_path := ''
+	mut project := ''
+	mut template := ''
+	mut request := ''
+	mut job_id := ''
+	mut no_llm := false
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--no-llm' {
+			no_llm = true
+			i++
+			continue
+		}
+		if a in ['--template', '-t', '--request', '-r', '--id', '--workspace'] {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			val := args[i + 1]
+			match a {
+				'--template', '-t' { template = val }
+				'--request', '-r' { request = val }
+				'--id' { job_id = val }
+				'--workspace' { workspace_path = val }
+				else {}
+			}
+			i += 2
+			continue
+		}
+		if a.starts_with('--template=') {
+			template = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--request=') {
+			request = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--id=') {
+			job_id = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		if sub == 'queue' && project.len == 0 {
+			project = a
+		} else if sub == 'done' && job_id.len == 0 {
+			job_id = a
+		}
+		i++
+	}
+	mut arg := project
+	if sub == 'done' && job_id.len > 0 {
+		arg = job_id
+	}
+	return agent_toolkit_core.DevcompanionOptions{
+		subcommand:     sub
+		workspace_path: workspace_path
+		arg:            arg
+		template:       template
+		request:        request
+		job_id:         job_id
+		no_llm:         no_llm
+	}
+}
+
 fn parse_plugin_options(args []string) agent_toolkit_core.PluginOptions {
 	mut sub := ''
 	for a in args {
@@ -837,6 +931,15 @@ fn allowed_flag(cmd string, a string) bool {
 			return true
 		}
 	}
+	if cmd == 'devcompanion' {
+		if a in ['--no-llm', '--template', '--request', '--id', '--workspace', '-t', '-r'] {
+			return true
+		}
+		if a.starts_with('--template') || a.starts_with('--request') || a.starts_with('--id')
+			|| a.starts_with('--workspace') {
+			return true
+		}
+	}
 	return false
 }
 
@@ -1009,6 +1112,9 @@ Read-only health checks by default. --fix allowlists profile refresh only.
 	}
 	if name == 'memory' {
 		return agent_toolkit_core.memory_help_text()
+	}
+	if name == 'devcompanion' {
+		return agent_toolkit_core.dc_help_text()
 	}
 	mut c := cli.Command{
 		name:        name

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -22,8 +22,12 @@ fn test_dispatch_unknown_flag_exit_two() {
 
 fn test_dispatch_dc_alias_not_unknown() {
 	code := dispatch(['agent-toolkit', 'dc'])
-	// not implemented → user exit 1, but known command
-	assert code == 1
+	assert code == 0
+}
+
+fn test_dispatch_devcompanion_help() {
+	code := dispatch(['agent-toolkit', 'devcompanion', '--help'])
+	assert code == 0
 }
 
 fn test_dispatch_matrix_exit_zero() {
@@ -119,6 +123,11 @@ fn test_dispatch_project_help() {
 
 fn test_dispatch_memory_help() {
 	code := dispatch(['agent-toolkit', 'memory', '--help'])
+	assert code == 0
+}
+
+fn test_dispatch_dc_alias_help() {
+	code := dispatch(['agent-toolkit', 'dc', '--help'])
 	assert code == 0
 }
 

--- a/modules/agent_toolkit_core/devcompanion.v
+++ b/modules/agent_toolkit_core/devcompanion.v
@@ -1,0 +1,984 @@
+module agent_toolkit_core
+
+import json
+import os
+import time
+
+const mutating_dc_templates = ['create-pr', 'fix-ci', 'refactor', 'implement', 'investigate']
+
+// DevcompanionOptions configures the devcompanion / dc command family (#525).
+pub struct DevcompanionOptions {
+pub:
+	subcommand     string
+	workspace_path string
+	arg            string // project name or job id
+	template       string
+	request        string
+	job_id         string
+	no_llm         bool
+}
+
+// DevcompanionReport is the domain result for queue subcommands.
+pub struct DevcompanionReport {
+pub mut:
+	ok      bool
+	message string
+	data    map[string]string
+}
+
+struct DcJob {
+pub mut:
+	id           string
+	created_at   string
+	project      string
+	project_path string
+	repo_path    string
+	request      string
+	template     string
+	status       string
+	completed_at string
+	llm          bool
+}
+
+struct DcConfig {
+	harness_mode     bool
+	dc_home          string
+	queue_dir        string
+	runs_dir         string
+	queue_pending    string
+	queue_processing string
+	queue_done       string
+	queue_failed     string
+}
+
+// run_devcompanion implements queue/run-once/status/done/sync-todos (Python cli/devcompanion.py).
+pub fn run_devcompanion(opts DevcompanionOptions) DevcompanionReport {
+	sub := opts.subcommand
+	if sub.len == 0 || sub in ['help', '-h', '--help'] {
+		ws := find_devcompanion_workspace(opts.workspace_path)
+		cfg := get_dc_config(ws)
+		return DevcompanionReport{
+			ok:      true
+			message: devcompanion_help_text(cfg)
+			data:    {
+				'subcommand': 'help'
+				'workspace':  ws
+			}
+		}
+	}
+	ws := find_devcompanion_workspace(opts.workspace_path)
+	cfg := get_dc_config(ws)
+	return match sub {
+		'queue' { dc_queue(ws, cfg, opts) }
+		'run-once' { dc_run_once(cfg, opts) }
+		'status' { dc_status(cfg, ws) }
+		'done' { dc_done(cfg, opts) }
+		'sync-todos' { dc_sync_todos(ws, cfg) }
+		else {
+			DevcompanionReport{
+				ok:      false
+				message: "Unknown subcommand: ${sub}\nRun 'agent-toolkit devcompanion help' for usage."
+				data:    {
+					'subcommand': sub
+					'workspace':  ws
+				}
+			}
+		}
+	}
+}
+
+// devcompanion_result maps DevcompanionReport to CommandResult.
+pub fn devcompanion_result(report DevcompanionReport) CommandResult {
+	mut data := report.data.clone()
+	if 'subcommand' !in data {
+		data['subcommand'] = ''
+	}
+	return CommandResult{
+		command: 'devcompanion'
+		ok:      report.ok
+		message: report.message
+		data:    data
+	}
+}
+
+// devcompanion_help_text matches Python cli/devcompanion.py help.
+pub fn devcompanion_help_text(cfg DcConfig) string {
+	mode := if cfg.harness_mode { 'harness (.job files)' } else { 'workspace (.json files)' }
+	queue_loc := if cfg.harness_mode {
+		os.join_path(cfg.dc_home, 'queue')
+	} else {
+		cfg.queue_dir
+	}
+	return 'agent-toolkit devcompanion — background job queue for AI Workspace
+
+Usage:
+  agent-toolkit devcompanion queue <project> [options]   Queue a job
+  agent-toolkit devcompanion run-once [--no-llm]         Run oldest pending job
+  agent-toolkit devcompanion status                      Show all jobs
+  agent-toolkit devcompanion done <job-id>               Mark a job as done
+  agent-toolkit devcompanion sync-todos                  Sync todos from plan.md files
+
+Queue options:
+  --template NAME    Job template from templates/jobs/ directory
+  --request "..."    Custom request string (required if no --template)
+  --id ID            Custom job ID (default: <project>-<timestamp>)
+
+Workspace detection:
+  AGENT_TOOLKIT_WORKSPACE env var, or walk up from CWD looking for .devcompanion/
+
+Queue mode:
+  ${mode}
+  HARNESS_DC_HOME or HARNESS_DIR → harness queue under ~/.local/share/agentic-harness/dev-companion
+
+Queue location:
+  ${queue_loc}
+
+Runs location:
+  ${cfg.runs_dir}
+
+Examples:
+  agent-toolkit devcompanion queue my-api --template code-review
+  agent-toolkit devcompanion queue my-api --request "add pagination to GET /users"
+  agent-toolkit devcompanion run-once
+  agent-toolkit devcompanion run-once --no-llm
+  agent-toolkit devcompanion status
+  agent-toolkit devcompanion done my-api-20260804-120000
+  agent-toolkit devcompanion sync-todos
+
+Alias:
+  agent-toolkit dc <subcommand>
+'
+}
+
+pub fn dc_help_text() string {
+	return devcompanion_help_text(DcConfig{})
+}
+
+fn find_devcompanion_workspace(override string) string {
+	if override.len > 0 && os.is_dir(override) {
+		return override
+	}
+	if ws := find_workspace_root(override) {
+		return ws
+	}
+	mut cur := os.getwd()
+	for {
+		if os.is_dir(os.join_path(cur, '.devcompanion')) {
+			return cur
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	return os.getwd()
+}
+
+fn default_harness_dc_home() string {
+	return os.join_path(os.home_dir(), '.local', 'share', 'agentic-harness', 'dev-companion')
+}
+
+fn resolve_harness_dc_home() ?string {
+	explicit := os.getenv('HARNESS_DC_HOME').trim_space()
+	if explicit.len > 0 {
+		return os.expand_tilde_to_home(explicit)
+	}
+	if os.getenv('HARNESS_DIR').trim_space().len > 0 {
+		return default_harness_dc_home()
+	}
+	return none
+}
+
+fn get_dc_config(workspace_root string) DcConfig {
+	if home := resolve_harness_dc_home() {
+		queue_root := os.join_path(home, 'queue')
+		return DcConfig{
+			harness_mode:     true
+			dc_home:          home
+			queue_dir:        queue_root
+			runs_dir:         os.join_path(queue_root, 'artifacts')
+			queue_pending:    os.join_path(queue_root, 'pending')
+			queue_processing: os.join_path(queue_root, 'processing')
+			queue_done:       os.join_path(queue_root, 'done')
+			queue_failed:     os.join_path(queue_root, 'failed')
+		}
+	}
+	dc_home := os.join_path(workspace_root, '.devcompanion')
+	queue_dir := os.join_path(dc_home, 'queue')
+	return DcConfig{
+		harness_mode:     false
+		dc_home:          dc_home
+		queue_dir:        queue_dir
+		runs_dir:         os.join_path(dc_home, 'runs')
+		queue_pending:    queue_dir
+		queue_processing: queue_dir
+		queue_done:       queue_dir
+		queue_failed:     queue_dir
+	}
+}
+
+fn utc_now() string {
+	rfc := time.utc().format_rfc3339()
+	if rfc.ends_with('Z') {
+		return rfc
+	}
+	if rfc.len >= 19 {
+		return rfc[..19] + 'Z'
+	}
+	return rfc
+}
+
+fn job_id_stamp() string {
+	rfc := time.utc().format_rfc3339()
+	date := rfc[..10].replace('-', '')
+	clock := if rfc.len >= 19 { rfc[11..19].replace(':', '') } else { '000000' }
+	return '${date}-${clock}'
+}
+
+fn dc_queue(ws string, cfg DcConfig, opts DevcompanionOptions) DevcompanionReport {
+	project := opts.arg
+	if project.len == 0 {
+		return DevcompanionReport{
+			ok:      false
+			message: 'Usage: agent-toolkit devcompanion queue <project> [--template NAME] [--request "..."]'
+			data:    {
+				'subcommand': 'queue'
+				'workspace':  ws
+			}
+		}
+	}
+	project_path := resolve_dc_project(ws, project) or {
+		mut lines := []string{}
+		lines << "Project not found: '${project}'"
+		known := list_dc_projects(ws)
+		if known.len > 0 {
+			lines << ''
+			lines << 'Known projects:'
+			for name, target in known {
+				if target.len > 0 {
+					lines << '  ${name} → ${target}'
+				} else {
+					lines << '  ${name} → (broken)'
+				}
+			}
+		} else {
+			lines << '  (no projects indexed)'
+		}
+		return DevcompanionReport{
+			ok:      false
+			message: lines.join('\n')
+			data:    {
+				'subcommand': 'queue'
+				'workspace':  ws
+			}
+		}
+	}
+	mut request := ''
+	if opts.template.len > 0 {
+		tpl := load_dc_template(ws, opts.template) or {
+			return DevcompanionReport{
+				ok:      false
+				message: err.msg()
+				data:    {
+					'subcommand': 'queue'
+					'workspace':  ws
+				}
+			}
+		}
+		request = tpl
+		if opts.request.len > 0 {
+			request = '${request}\n\n---\n\n${opts.request}'
+		}
+	} else if opts.request.len > 0 {
+		request = opts.request
+	} else {
+		return DevcompanionReport{
+			ok:      false
+			message: 'Provide --request or --template'
+			data:    {
+				'subcommand': 'queue'
+				'workspace':  ws
+			}
+		}
+	}
+	job_id := if opts.job_id.len > 0 { opts.job_id } else { '${project}-${job_id_stamp()}' }
+	job_file := queue_job_path(cfg, job_id)
+	if cfg.harness_mode {
+		os.mkdir_all(cfg.queue_pending) or {}
+		body := '{
+  "id": ${json.encode(job_id)},
+  "created_at": ${json.encode(utc_now())},
+  "request": ${json.encode(request)},
+  "repo_path": ${json.encode(project_path)},
+  "llm": true,
+  "limits": {"timeout_sec": 1800, "max_steps": 25},
+  "actions_allowed": ["plan_only"]
+}
+'
+		os.write_file(job_file, body) or {
+			return DevcompanionReport{
+				ok:      false
+				message: 'write job failed: ${err}'
+			}
+		}
+	} else {
+		os.mkdir_all(cfg.queue_dir) or {}
+		job := DcJob{
+			id:           job_id
+			created_at:   utc_now()
+			project:      project
+			project_path: project_path
+			request:      request
+			template:     opts.template
+			status:       'pending'
+		}
+		write_dc_job(job_file, job) or {
+			return DevcompanionReport{
+				ok:      false
+				message: 'write job failed: ${err}'
+			}
+		}
+	}
+	mut lines := []string{}
+	lines << '[devcompanion] Project : ${project}'
+	lines << '[devcompanion] Path    : ${project_path}'
+	lines << '[devcompanion] Job ID  : ${job_id}'
+	lines << '[devcompanion] Job written → ${job_file}'
+	lines << ''
+	lines << 'Plan stub:'
+	lines << "  Run 'agent-toolkit devcompanion run-once' to execute"
+	lines << "  Run 'agent-toolkit devcompanion status' to check progress"
+	return DevcompanionReport{
+		ok:      true
+		message: lines.join('\n')
+		data:    {
+			'subcommand': 'queue'
+			'workspace':  ws
+			'job_id':     job_id
+			'project':    project
+		}
+	}
+}
+
+fn dc_run_once(cfg DcConfig, opts DevcompanionOptions) DevcompanionReport {
+	pending := pending_dc_jobs(cfg)
+	if pending.len == 0 {
+		return DevcompanionReport{
+			ok:      true
+			message: '[devcompanion] No pending jobs.'
+			data:    {
+				'subcommand': 'run-once'
+				'count':      '0'
+			}
+		}
+	}
+	mut job_file := pending[0].path
+	mut job := pending[0].job
+	job_id := if job.id.len > 0 { job.id } else { os.file_name(job_file).all_before_last('.') }
+	out_dir := os.join_path(cfg.runs_dir, job_id)
+	mut lines := []string{}
+	lines << '[devcompanion] Running job: ${job_id}'
+	lines << '[devcompanion] Project    : ${dc_job_project_name(job)}'
+	lines << '[devcompanion] Artifacts  → ${out_dir}'
+	if cfg.harness_mode {
+		os.mkdir_all(cfg.queue_processing) or {}
+		processing := os.join_path(cfg.queue_processing, os.file_name(job_file))
+		os.mv(job_file, processing) or {}
+		job_file = processing
+	} else {
+		job.status = 'running'
+		write_dc_job(job_file, job) or {}
+	}
+	rc, extra := dispatch_dc_run(cfg, job_file, job, out_dir, opts.no_llm)
+	lines << extra
+	if cfg.harness_mode {
+		dest_dir := if rc == 0 { cfg.queue_done } else { cfg.queue_failed }
+		os.mkdir_all(dest_dir) or {}
+		if os.exists(job_file) {
+			os.mv(job_file, os.join_path(dest_dir, os.file_name(job_file))) or {}
+		}
+	} else {
+		job.status = if rc == 0 { 'done' } else { 'failed' }
+		job.completed_at = utc_now()
+		write_dc_job(job_file, job) or {}
+	}
+	if rc == 0 {
+		lines << '[devcompanion] Job done: ${job_id}'
+		plan_path := os.join_path(out_dir, 'plan.md')
+		if os.is_file(plan_path) {
+			plan := os.read_file(plan_path) or { '' }
+			clip := if plan.len > 2000 { plan[..2000] } else { plan }
+			lines << ''
+			lines << '── plan.md ──────────────────────────────────────────────────'
+			lines << clip
+		}
+		return DevcompanionReport{
+			ok:      true
+			message: lines.join('\n')
+			data:    {
+				'subcommand': 'run-once'
+				'job_id':     job_id
+				'status':     'done'
+			}
+		}
+	}
+	lines << '[devcompanion] Job failed: ${job_id}'
+	return DevcompanionReport{
+		ok:      false
+		message: lines.join('\n')
+		data:    {
+			'subcommand': 'run-once'
+			'job_id':     job_id
+			'status':     'failed'
+		}
+	}
+}
+
+fn dc_status(cfg DcConfig, ws string) DevcompanionReport {
+	jobs := iter_dc_jobs(cfg)
+	mut lines := []string{}
+	lines << ''
+	lines << '=== devcompanion queue status ==='
+	lines << ''
+	if jobs.len == 0 {
+		lines << '  (queue is empty)'
+		lines << ''
+		return DevcompanionReport{
+			ok:      true
+			message: lines.join('\n')
+			data:    {
+				'subcommand': 'status'
+				'workspace':  ws
+				'count':      '0'
+			}
+		}
+	}
+	if cfg.harness_mode {
+		for state in ['pending', 'processing', 'done', 'failed'] {
+			mut n := 0
+			mut shown := 0
+			for item in jobs {
+				if item.status != state {
+					continue
+				}
+				n++
+			}
+			lines << '${state} ${n} job(s)'
+			for item in jobs {
+				if item.status != state {
+					continue
+				}
+				if shown >= 5 {
+					continue
+				}
+				jid := if item.job.id.len > 0 {
+					item.job.id
+				} else {
+					os.file_name(item.path).all_before_last('.')
+				}
+				req := item.job.request.all_before('\n')
+				clip := if req.len > 60 { req[..60] } else { req }
+				lines << '  ${jid} [${dc_job_project_name(item.job)}] ${clip}'
+				shown++
+			}
+			if n > 5 {
+				lines << '  … and ${n - 5} more'
+			}
+			lines << ''
+		}
+	} else {
+		lines << 'JOB ID                                      PROJECT               STATUS        CREATED AT'
+		for item in jobs {
+			jid := if item.job.id.len > 0 {
+				item.job.id
+			} else {
+				os.file_name(item.path).all_before_last('.')
+			}
+			lines << '${jid}  ${dc_job_project_name(item.job)}  ${item.status}  ${item.job.created_at}'
+		}
+		lines << ''
+	}
+	return DevcompanionReport{
+		ok:      true
+		message: lines.join('\n')
+		data:    {
+			'subcommand': 'status'
+			'workspace':  ws
+			'count':      '${jobs.len}'
+		}
+	}
+}
+
+fn dc_done(cfg DcConfig, opts DevcompanionOptions) DevcompanionReport {
+	job_id := opts.arg
+	if job_id.len == 0 {
+		return DevcompanionReport{
+			ok:      false
+			message: 'Usage: agent-toolkit devcompanion done <job-id>'
+			data:    {
+				'subcommand': 'done'
+			}
+		}
+	}
+	if cfg.harness_mode {
+		if mark_job_done(cfg, job_id, utc_now()) {
+			return DevcompanionReport{
+				ok:      true
+				message: '[devcompanion] Marked as done: ${job_id}'
+				data:    {
+					'subcommand': 'done'
+					'job_id':     job_id
+					'status':     'done'
+				}
+			}
+		}
+		return DevcompanionReport{
+			ok:      false
+			message: '[devcompanion] Job file not found: ${job_id}.job'
+			data:    {
+				'subcommand': 'done'
+				'job_id':     job_id
+			}
+		}
+	}
+	job_file := find_job_path(cfg, job_id) or {
+		return DevcompanionReport{
+			ok:      false
+			message: '[devcompanion] Job file not found: ${job_id}.json'
+			data:    {
+				'subcommand': 'done'
+				'job_id':     job_id
+			}
+		}
+	}
+	mut job := read_dc_job(job_file) or {
+		return DevcompanionReport{
+			ok:      false
+			message: 'unreadable job: ${err}'
+		}
+	}
+	job.status = 'done'
+	job.completed_at = utc_now()
+	write_dc_job(job_file, job) or {
+		return DevcompanionReport{
+			ok:      false
+			message: 'write job failed: ${err}'
+		}
+	}
+	return DevcompanionReport{
+		ok:      true
+		message: '[devcompanion] Marked as done: ${job_id}'
+		data:    {
+			'subcommand': 'done'
+			'job_id':     job_id
+			'status':     'done'
+		}
+	}
+}
+
+fn dc_sync_todos(ws string, cfg DcConfig) DevcompanionReport {
+	mut todos := []string{}
+	collect_plan_todos(cfg.runs_dir, mut todos)
+	knowledge := os.join_path(ws, 'knowledge', 'todos', 'pending.md')
+	if todos.len == 0 {
+		return DevcompanionReport{
+			ok:      true
+			message: "[devcompanion] No '- [ ]' items found in run plans."
+			data:    {
+				'subcommand': 'sync-todos'
+				'workspace':  ws
+				'count':      '0'
+			}
+		}
+	}
+	os.mkdir_all(os.dir(knowledge)) or {}
+	existing := if os.is_file(knowledge) { os.read_file(knowledge) or { '' } } else { '' }
+	block := '\n## Synced from devcompanion runs\n\n' + todos.join('\n') + '\n'
+	marker := '\n## Synced from devcompanion runs\n'
+	mut text := ''
+	if existing.contains(marker) {
+		idx := existing.index(marker) or { existing.len }
+		text = existing[..idx] + block
+	} else if existing.len > 0 {
+		text = existing.trim_right(' \n\t\r') + '\n' + block
+	} else {
+		text = block
+	}
+	os.write_file(knowledge, text) or {
+		return DevcompanionReport{
+			ok:      false
+			message: 'write todos failed: ${err}'
+		}
+	}
+	return DevcompanionReport{
+		ok:      true
+		message: '[devcompanion] Synced ${todos.len} todo(s) → ${knowledge}'
+		data:    {
+			'subcommand': 'sync-todos'
+			'workspace':  ws
+			'count':      '${todos.len}'
+		}
+	}
+}
+
+fn dispatch_dc_run(_cfg DcConfig, _job_file string, job DcJob, out_dir string, no_llm bool) (int, string) {
+	if no_llm {
+		return skeleton_run(job, out_dir)
+	}
+	if job_is_mutating(job) && !exe_on_path('gh') {
+		tpl := if job.template.len > 0 { job.template } else { 'custom' }
+		return 2, '[devcompanion] Mutating devcompanion job requires `gh` on PATH for loop-gh-gate (template=${tpl})'
+	}
+	// ProcessService has no stdin yet, so PATH LLM binaries are not invoked (would hang
+	// without the Python prompt pipe). Fall back to the same skeleton as --no-llm.
+	rc, msg := skeleton_run(job, out_dir)
+	return rc, '[devcompanion] No LLM runner found, falling back to skeleton plan.\n${msg}'
+}
+
+fn skeleton_run(job DcJob, out_dir string) (int, string) {
+	os.mkdir_all(out_dir) or {
+		return 1, '[devcompanion] Skeleton runner failed: ${err}'
+	}
+	job_id := if job.id.len > 0 { job.id } else { 'unknown' }
+	project := dc_job_project_name(job)
+	request := if job.request.len > 0 { job.request } else { '(no request)' }
+	path := dc_job_project_path(job)
+	plan := '# Plan — ${job_id}
+
+**Generated**: ${utc_now()}
+**Mode**: skeleton (no LLM)
+**Project**: ${project}
+
+## Request
+
+${request}
+
+## Steps
+
+> This is a skeleton plan. Run without --no-llm for AI-generated steps.
+
+- [ ] Read project README and AGENTS.md
+- [ ] Understand existing conventions and patterns
+- [ ] Analyse the request in context
+- [ ] Implement changes following project conventions
+- [ ] Run tests and verify
+- [ ] Create PR
+
+## Notes
+
+- Job ID: ${job_id}
+- Project path: ${if path.len > 0 { path } else { 'not set' }}
+'
+	plan_path := os.join_path(out_dir, 'plan.md')
+	os.write_file(plan_path, plan) or {
+		return 1, '[devcompanion] Skeleton runner failed: ${err}'
+	}
+	return 0, '[devcompanion] Skeleton plan written → ${plan_path}'
+}
+
+fn job_is_mutating(job DcJob) bool {
+	if job.template in mutating_dc_templates {
+		return true
+	}
+	return false
+}
+
+fn exe_on_path(name string) bool {
+	os.find_abs_path_of_executable(name) or { return false }
+	return true
+}
+
+fn resolve_dc_project(ws string, name string) ?string {
+	projects_dir := os.join_path(ws, 'projects')
+	if !os.is_dir(projects_dir) {
+		return none
+	}
+	link := os.join_path(projects_dir, name)
+	if os.is_link(link) {
+		target := os.readlink(link) or { return none }
+		abs := if os.is_abs_path(target) { target } else { os.join_path(os.dir(link), target) }
+		if os.is_dir(abs) {
+			return os.real_path(abs)
+		}
+		return none
+	}
+	entries := os.ls(projects_dir) or { return none }
+	for entry in entries {
+		p := os.join_path(projects_dir, entry)
+		if os.is_link(p) && entry.contains(name) {
+			target := os.readlink(p) or { continue }
+			abs := if os.is_abs_path(target) { target } else { os.join_path(os.dir(p), target) }
+			if os.is_dir(abs) {
+				return os.real_path(abs)
+			}
+		}
+	}
+	return none
+}
+
+fn list_dc_projects(ws string) map[string]string {
+	mut out := map[string]string{}
+	projects_dir := os.join_path(ws, 'projects')
+	if !os.is_dir(projects_dir) {
+		return out
+	}
+	mut names := os.ls(projects_dir) or { return out }
+	names.sort()
+	for name in names {
+		p := os.join_path(projects_dir, name)
+		if !os.is_link(p) {
+			continue
+		}
+		target := os.readlink(p) or { '' }
+		abs := if os.is_abs_path(target) { target } else { os.join_path(os.dir(p), target) }
+		if os.is_dir(abs) {
+			out[name] = os.real_path(abs)
+		} else {
+			out[name] = ''
+		}
+	}
+	return out
+}
+
+fn load_dc_template(ws string, name string) !string {
+	tpl_file := os.join_path(ws, 'templates', 'jobs', '${name}.yaml')
+	if !os.is_file(tpl_file) {
+		return error('Template not found: ${name}  (looked in ${os.dir(tpl_file)}/)')
+	}
+	text := os.read_file(tpl_file) or { return error('read template failed: ${err}') }
+	lines := text.split_into_lines()
+	for i, line in lines {
+		stripped := line.trim_space()
+		if stripped.starts_with('#') {
+			continue
+		}
+		if stripped == 'request: |' || stripped.starts_with('request: |') {
+			mut block := []string{}
+			for j in i + 1 .. lines.len {
+				bl := lines[j]
+				if bl.len > 0 && !bl.starts_with(' ') && !bl.starts_with('\t') && !bl.starts_with('#') {
+					break
+				}
+				if bl.trim_space().starts_with('#') {
+					continue
+				}
+				block << if bl.starts_with('  ') { bl[2..] } else { bl }
+			}
+			return block.join('\n').trim_space()
+		}
+		if stripped.starts_with('request:') {
+			return stripped.all_after('request:').trim_space().trim('"\'')
+		}
+	}
+	return ''
+}
+
+struct DcJobItem {
+	status string
+	path   string
+	job    DcJob
+}
+
+fn pending_dc_jobs(cfg DcConfig) []DcJobItem {
+	mut items := []DcJobItem{}
+	dir := if cfg.harness_mode { cfg.queue_pending } else { cfg.queue_dir }
+	os.mkdir_all(dir) or {}
+	entries := os.ls(dir) or { return items }
+	mut paths := []string{}
+	for name in entries {
+		p := os.join_path(dir, name)
+		if cfg.harness_mode {
+			if name.ends_with('.job') {
+				paths << p
+			}
+		} else if name.ends_with('.json') {
+			paths << p
+		}
+	}
+	paths.sort_with_compare(fn (a &string, b &string) int {
+		ma := os.file_last_mod_unix(*a)
+		mb := os.file_last_mod_unix(*b)
+		if ma < mb {
+			return -1
+		}
+		if ma > mb {
+			return 1
+		}
+		return 0
+	})
+	for p in paths {
+		job := read_dc_job(p) or { continue }
+		if cfg.harness_mode {
+			items << DcJobItem{
+				status: 'pending'
+				path:   p
+				job:    job
+			}
+		} else if job.status == 'pending' {
+			items << DcJobItem{
+				status: 'pending'
+				path:   p
+				job:    job
+			}
+		}
+	}
+	return items
+}
+
+fn iter_dc_jobs(cfg DcConfig) []DcJobItem {
+	mut items := []DcJobItem{}
+	if cfg.harness_mode {
+		states := {
+			'pending':    cfg.queue_pending
+			'processing': cfg.queue_processing
+			'done':       cfg.queue_done
+			'failed':     cfg.queue_failed
+		}
+		for state, directory in states {
+			if !os.is_dir(directory) {
+				continue
+			}
+			entries := os.ls(directory) or { continue }
+			for name in entries {
+				if !name.ends_with('.job') {
+					continue
+				}
+				p := os.join_path(directory, name)
+				job := read_dc_job(p) or { continue }
+				items << DcJobItem{
+					status: state
+					path:   p
+					job:    job
+				}
+			}
+		}
+	} else if os.is_dir(cfg.queue_dir) {
+		entries := os.ls(cfg.queue_dir) or { []string{} }
+		for name in entries {
+			if !name.ends_with('.json') {
+				continue
+			}
+			p := os.join_path(cfg.queue_dir, name)
+			job := read_dc_job(p) or { continue }
+			st := if job.status.len > 0 { job.status } else { '?' }
+			items << DcJobItem{
+				status: st
+				path:   p
+				job:    job
+			}
+		}
+	}
+	items.sort_with_compare(fn (a &DcJobItem, b &DcJobItem) int {
+		ma := os.file_last_mod_unix(a.path)
+		mb := os.file_last_mod_unix(b.path)
+		if ma < mb {
+			return -1
+		}
+		if ma > mb {
+			return 1
+		}
+		return 0
+	})
+	return items
+}
+
+fn queue_job_path(cfg DcConfig, job_id string) string {
+	if cfg.harness_mode {
+		return os.join_path(cfg.queue_pending, '${job_id}.job')
+	}
+	return os.join_path(cfg.queue_dir, '${job_id}.json')
+}
+
+fn find_job_path(cfg DcConfig, job_id string) ?string {
+	if cfg.harness_mode {
+		for directory in [cfg.queue_pending, cfg.queue_processing, cfg.queue_done, cfg.queue_failed] {
+			p := os.join_path(directory, '${job_id}.job')
+			if os.exists(p) {
+				return p
+			}
+		}
+		return none
+	}
+	p := os.join_path(cfg.queue_dir, '${job_id}.json')
+	if os.exists(p) {
+		return p
+	}
+	return none
+}
+
+fn mark_job_done(cfg DcConfig, job_id string, completed_at string) bool {
+	if cfg.harness_mode {
+		for src_dir in [cfg.queue_pending, cfg.queue_processing, cfg.queue_failed] {
+			src := os.join_path(src_dir, '${job_id}.job')
+			if os.exists(src) {
+				os.mkdir_all(cfg.queue_done) or {}
+				os.mv(src, os.join_path(cfg.queue_done, '${job_id}.job')) or { return false }
+				return true
+			}
+		}
+		return os.exists(os.join_path(cfg.queue_done, '${job_id}.job'))
+	}
+	path := os.join_path(cfg.queue_dir, '${job_id}.json')
+	if !os.exists(path) {
+		return false
+	}
+	mut job := read_dc_job(path) or { return false }
+	job.status = 'done'
+	job.completed_at = completed_at
+	write_dc_job(path, job) or { return false }
+	return true
+}
+
+fn read_dc_job(path string) !DcJob {
+	text := os.read_file(path) or { return error('read failed: ${err}') }
+	job := json.decode(DcJob, text) or { return error('decode failed: ${err}') }
+	return job
+}
+
+fn write_dc_job(path string, job DcJob) ! {
+	os.mkdir_all(os.dir(path)) or { return err }
+	payload := json.encode(job)
+	os.write_file(path, payload + '\n') or { return err }
+}
+
+fn dc_job_project_path(job DcJob) string {
+	if job.project_path.len > 0 {
+		return job.project_path
+	}
+	return job.repo_path
+}
+
+fn dc_job_project_name(job DcJob) string {
+	if job.project.len > 0 {
+		return job.project
+	}
+	p := dc_job_project_path(job)
+	if p.len == 0 {
+		return '?'
+	}
+	return os.file_name(p)
+}
+
+fn collect_plan_todos(dir string, mut todos []string) {
+	if !os.is_dir(dir) {
+		return
+	}
+	entries := os.ls(dir) or { return }
+	for name in entries {
+		p := os.join_path(dir, name)
+		if os.is_dir(p) {
+			collect_plan_todos(p, mut todos)
+			continue
+		}
+		if name != 'plan.md' {
+			continue
+		}
+		text := os.read_file(p) or { continue }
+		for line in text.split_into_lines() {
+			if line.trim_space().starts_with('- [ ]') {
+				todos << line.trim_space()
+			}
+		}
+	}
+}

--- a/modules/agent_toolkit_core/devcompanion_test.v
+++ b/modules/agent_toolkit_core/devcompanion_test.v
@@ -1,0 +1,113 @@
+module agent_toolkit_core
+
+import os
+
+fn dc_ws(suffix string) string {
+	base := os.join_path(os.temp_dir(), 'at-dc-${suffix}-${os.getpid()}')
+	os.mkdir_all(base) or { assert false, err.msg() }
+	os.write_file(os.join_path(base, 'AGENTS.md'), '# test\n') or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(base, 'knowledge', 'todos')) or { assert false, err.msg() }
+	return base
+}
+
+fn test_dc_help_lists_family() {
+	h := dc_help_text()
+	assert h.contains('queue')
+	assert h.contains('run-once')
+	assert h.contains('status')
+	assert h.contains('sync-todos')
+	assert h.contains('agent-toolkit dc')
+}
+
+fn test_dc_queue_run_once_no_llm_status_done() {
+	$if windows {
+		return
+	}
+	base := dc_ws('q')
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	repo := os.join_path(base, 'repos', 'demo')
+	os.mkdir_all(repo) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(base, 'projects')) or { assert false, err.msg() }
+	os.symlink(repo, os.join_path(base, 'projects', 'demo')) or { assert false, err.msg() }
+	q := run_devcompanion(DevcompanionOptions{
+		subcommand:     'queue'
+		workspace_path: base
+		arg:            'demo'
+		request:        'review the README'
+		job_id:         'demo-test-1'
+	})
+	assert q.ok, q.message
+	assert q.data['job_id'] == 'demo-test-1'
+	jf := os.join_path(base, '.devcompanion', 'queue', 'demo-test-1.json')
+	assert os.is_file(jf)
+	st := run_devcompanion(DevcompanionOptions{
+		subcommand:     'status'
+		workspace_path: base
+	})
+	assert st.ok, st.message
+	assert st.data['count'] == '1'
+	assert st.message.contains('demo-test-1')
+	run := run_devcompanion(DevcompanionOptions{
+		subcommand:     'run-once'
+		workspace_path: base
+		no_llm:         true
+	})
+	assert run.ok, run.message
+	plan := os.join_path(base, '.devcompanion', 'runs', 'demo-test-1', 'plan.md')
+	assert os.is_file(plan)
+	text := os.read_file(plan) or { '' }
+	assert text.contains('skeleton')
+	assert text.contains('review the README')
+	job := os.read_file(jf) or { '' }
+	assert job.contains('"status":"done"') || job.contains('"status": "done"')
+	sync := run_devcompanion(DevcompanionOptions{
+		subcommand:     'sync-todos'
+		workspace_path: base
+	})
+	assert sync.ok, sync.message
+	assert sync.data['count'] != '0'
+	todos := os.read_file(os.join_path(base, 'knowledge', 'todos', 'pending.md')) or { '' }
+	assert todos.contains('Synced from devcompanion')
+}
+
+fn test_dc_queue_requires_request() {
+	base := dc_ws('noreq')
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	os.mkdir_all(os.join_path(base, 'projects')) or {}
+	os.mkdir_all(os.join_path(base, 'repos', 'demo')) or {}
+	$if !windows {
+		os.symlink(os.join_path(base, 'repos', 'demo'), os.join_path(base, 'projects', 'demo')) or {}
+		r := run_devcompanion(DevcompanionOptions{
+			subcommand:     'queue'
+			workspace_path: base
+			arg:            'demo'
+		})
+		assert !r.ok
+		assert r.message.contains('--request') || r.message.contains('--template')
+	}
+}
+
+fn test_dc_done_missing_job() {
+	base := dc_ws('done')
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	r := run_devcompanion(DevcompanionOptions{
+		subcommand:     'done'
+		workspace_path: base
+		arg:            'nope'
+	})
+	assert !r.ok
+}
+
+fn test_dc_unknown_subcommand() {
+	r := run_devcompanion(DevcompanionOptions{
+		subcommand: 'nope'
+	})
+	assert !r.ok
+	assert r.message.contains('Unknown subcommand')
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -470,6 +470,32 @@
         "workspace",
         "subcommand"
       ]
+    },
+    {
+      "command": "devcompanion-help",
+      "args": [
+        "devcompanion",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "queue",
+        "run-once",
+        "status",
+        "sync-todos"
+      ]
+    },
+    {
+      "command": "dc-help",
+      "args": [
+        "dc",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "queue",
+        "status"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Port `agent-toolkit devcompanion` (alias **`dc`**) to V: `queue` / `run-once --no-llm` / `status` / `done` / `sync-todos`.
- Workspace queue (`.devcompanion/queue/*.json`) and harness queue (`HARNESS_DC_HOME` / `HARNESS_DIR`) match Python.
- `--no-llm` writes a skeleton `plan.md` with no network (AC). LLM PATH binaries are not invoked (ProcessService has no stdin pipe yet); V falls back to the same skeleton Python uses when no runner is found.

Fixes #525

## Type
- [x] Other

## Testing
- [x] `v test modules/agent_toolkit_core/devcompanion_test.v`
- [x] `v test modules/agent_toolkit_cli/dispatch_test.v`
- [x] Parity fixtures: `devcompanion-help`, `dc-help`
- [x] No secrets

## Checklist
- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes

Made with [Cursor](https://cursor.com)