### PR TITLE
chore(ci): experimental native V binaries (#562)

### DIFF
--- a/.github/workflows/experimental-v.yml
+++ b/.github/workflows/experimental-v.yml
@@ -1,0 +1,99 @@
+name: Experimental V binaries
+
+# Spike (#562): native V CI artifacts with experimental names only.
+# MUST NOT upload over stable channel names (ADR-018). Full matrix/promotion is #529.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/experimental-v.yml"
+      - ".v-version"
+      - "docs/v/experimental-binaries.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/experimental-v.yml"
+      - ".v-version"
+      - "docs/v/experimental-binaries.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.ref }}-experimental-v
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.asset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: agent-toolkit-v-experimental-linux-x86_64
+            v_zip: v_linux.zip
+            bin: agent-toolkit
+          - os: macos-latest
+            asset: agent-toolkit-v-experimental-macos-arm64
+            v_zip: v_macos_arm64.zip
+            bin: agent-toolkit
+          - os: windows-latest
+            asset: agent-toolkit-v-experimental-windows-x86_64.exe
+            v_zip: v_windows.zip
+            bin: agent-toolkit.exe
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pinned V from GitHub Release
+        shell: bash
+        env:
+          V_ZIP: ${{ matrix.v_zip }}
+          RUNNER_OS_LABEL: ${{ matrix.os }}
+        run: |
+          set -euo pipefail
+          PIN="$(tr -d '[:space:]' < .v-version)"
+          echo "Installing V ${PIN} (${V_ZIP}) on ${RUNNER_OS_LABEL}"
+          curl -fsSL -o /tmp/v.zip "https://github.com/vlang/v/releases/download/${PIN}/${V_ZIP}"
+          rm -rf "${HOME}/vlang"
+          mkdir -p "${HOME}/vlang"
+          unzip -q /tmp/v.zip -d "${HOME}/vlang"
+          VBIN="$(find "${HOME}/vlang" -type f \( -name v -o -name v.exe \) | head -n 1)"
+          if [ -z "${VBIN}" ]; then
+            echo "Unexpected V zip layout:" >&2
+            find "${HOME}/vlang" -maxdepth 3 >&2 || true
+            exit 1
+          fi
+          echo "VBIN=${VBIN}" >> "${GITHUB_ENV}"
+          echo "$(dirname "${VBIN}")" >> "${GITHUB_PATH}"
+          "${VBIN}" version
+
+      - name: Build experimental V CLI
+        shell: bash
+        env:
+          OUT_BIN: ${{ matrix.bin }}
+          ASSET: ${{ matrix.asset }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+          "${VBIN}" -d "commit=${COMMIT}" -o "build/${OUT_BIN}" cmd/agent-toolkit
+          cp -f "build/${OUT_BIN}" "build/${ASSET}"
+
+      - name: Smoke --version / --help
+        shell: bash
+        env:
+          OUT_BIN: ${{ matrix.bin }}
+        run: |
+          set -euo pipefail
+          "build/${OUT_BIN}" --version
+          "build/${OUT_BIN}" --help | head -n 20
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.asset }}
+          path: build/${{ matrix.asset }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/experimental-v.yml
+++ b/.github/workflows/experimental-v.yml
@@ -75,6 +75,7 @@ jobs:
         env:
           OUT_BIN: ${{ matrix.bin }}
           ASSET: ${{ matrix.asset }}
+          VMODULES: ${{ github.workspace }}/modules
         run: |
           set -euo pipefail
           mkdir -p build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — Experimental native V CI artifacts (linux-x86_64, macos-arm64, windows-x86_64; experimental names only) (Closes #562)
 - **Docs** — ADR-020 V concurrency: process-per-run supervisor (no Python threads / no `go` workers) (Closes #528)
 - **Feat** — V `devcompanion`/`dc` filesystem queue (queue/run-once --no-llm/status/done/sync-todos) (Closes #525)
 - **Docs** — ADR-019 Linux glibc is the MUST/stable binary; musl is an optional extra name (Closes #485)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -70,7 +70,7 @@ Release binaries are platform-suffixed to avoid upload collisions (see #256 and 
 * `agent-toolkit-macos-arm64`
 * `agent-toolkit-windows-x86_64.exe`
 
-**Stable channel:** those floating names. **Linux (`linux-x86_64` / `linux-arm64`) is glibc** ([ADR-019](adrs/ADR-019-linux-libc.md)); an optional musl extra uses a distinct name (`agent-toolkit-linux-x86_64-musl`) and must not overwrite the stable glibc artifact. **Versioned archives** (`agent-toolkit-<semver>-<os>-<arch>.tar.gz` / Windows `.zip`) are the checksum and attestation unit. **Experimental V** assets use `agent-toolkit-v-experimental-<os>-<arch>` and must not overwrite stable names.
+**Stable channel:** those floating names. **Linux (`linux-x86_64` / `linux-arm64`) is glibc** ([ADR-019](adrs/ADR-019-linux-libc.md)); an optional musl extra uses a distinct name (`agent-toolkit-linux-x86_64-musl`) and must not overwrite the stable glibc artifact. **Versioned archives** (`agent-toolkit-<semver>-<os>-<arch>.tar.gz` / Windows `.zip`) are the checksum and attestation unit. **Experimental V** assets use `agent-toolkit-v-experimental-<os>-<arch>` ([#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562), workflow `experimental-v.yml`, [docs/v/experimental-binaries.md](v/experimental-binaries.md)) and must not overwrite stable names.
 
 Darwin x86_64 is intentionally deferred (documented skip). Release notes / this doc mention naming.
 

--- a/docs/v/experimental-binaries.md
+++ b/docs/v/experimental-binaries.md
@@ -1,0 +1,35 @@
+# Experimental native V binaries
+
+**Issue:** [#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562)  
+**Names:** [ADR-018](../adrs/ADR-018-release-artifacts.md)  
+**Libc:** [ADR-019](../adrs/ADR-019-linux-libc.md) (Linux MUST artifact is glibc)
+
+These are **CI artifacts only**. They are not the stable GitHub Release channel (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe` — those remain PyInstaller until [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529) promotion). Experimental names **must not** overwrite stable names.
+
+## Workflow
+
+`.github/workflows/experimental-v.yml` (`workflow_dispatch`, and on changes to that workflow / `.v-version`).
+
+Compiler pin: `.v-version` (currently `0.5.2`).
+
+## Runner labels (verified 2026-08-13)
+
+| Experimental asset | GitHub-hosted `runs-on` | V zip | Notes |
+|--------------------|-------------------------|-------|--------|
+| `agent-toolkit-v-experimental-linux-x86_64` | `ubuntu-latest` | `v_linux.zip` | glibc (ADR-019). Not musl. |
+| `agent-toolkit-v-experimental-macos-arm64` | `macos-latest` | `v_macos_arm64.zip` | Apple Silicon. `macos-latest` was arm64 on this date; revisit if GitHub retargets the label. |
+| `agent-toolkit-v-experimental-windows-x86_64.exe` | `windows-latest` | `v_windows.zip` | |
+
+No `darwin-x86_64` job (same skip as #256 / ADR-018). Linux arm64 / musl extras are out of this spike (#529 / ADR-019 optional musl).
+
+## Smoke
+
+Each job runs `--version` and `--help` on the freshly built binary. Broader smoke (`inventory` / `doctor`) is [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531).
+
+## How to fetch
+
+Actions → **Experimental V binaries** → workflow run → Artifacts. Do not `gh release upload` these names onto a stable `v*` tag.
+
+```bash
+gh run download <run-id> --name agent-toolkit-v-experimental-linux-x86_64
+```


### PR DESCRIPTION
## Summary
- Add `.github/workflows/experimental-v.yml`: Linux x86_64 (`ubuntu-latest`), macOS arm64 (`macos-latest`), Windows x86_64 (`windows-latest`).
- Artifacts named `agent-toolkit-v-experimental-*` (ADR-018). **Does not** overwrite stable `agent-toolkit-linux-x86_64` / macos / windows PyInstaller names.
- Smoke `--version` / `--help`. Runner labels + verification date in `docs/v/experimental-binaries.md` (2026-08-13).

Fixes #562

## Type
- [x] CI/CD

## Testing
- [x] This PR triggers the new workflow (path filter includes the workflow file)
- [x] No secrets; `contents: read` only

## Checklist
- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes

Made with [Cursor](https://cursor.com)