### PR TITLE
ci(v): native V MUST build matrix (#529)

### DIFF
--- a/.github/workflows/experimental-v.yml
+++ b/.github/workflows/experimental-v.yml
@@ -1,7 +1,7 @@
 name: Experimental V binaries
 
-# Spike (#562): native V CI artifacts with experimental names only.
-# MUST NOT upload over stable channel names (ADR-018). Full matrix/promotion is #529.
+# Native V MUST matrix (#529) with experimental artifact names (#562 / ADR-018).
+# MUST NOT upload over stable PyInstaller channel names. Promotion is a later release decision.
 
 on:
   workflow_dispatch:
@@ -10,12 +10,14 @@ on:
       - ".github/workflows/experimental-v.yml"
       - ".v-version"
       - "docs/v/experimental-binaries.md"
+      - "docs/v/release-matrix.md"
   push:
     branches: [main]
     paths:
       - ".github/workflows/experimental-v.yml"
       - ".v-version"
       - "docs/v/experimental-binaries.md"
+      - "docs/v/release-matrix.md"
 
 permissions:
   contents: read
@@ -36,9 +38,17 @@ jobs:
             asset: agent-toolkit-v-experimental-linux-x86_64
             v_zip: v_linux.zip
             bin: agent-toolkit
+          - os: ubuntu-24.04-arm
+            asset: agent-toolkit-v-experimental-linux-arm64
+            v_zip: v_linux_arm64.zip
+            bin: agent-toolkit
           - os: macos-latest
             asset: agent-toolkit-v-experimental-macos-arm64
             v_zip: v_macos_arm64.zip
+            bin: agent-toolkit
+          - os: macos-15-intel
+            asset: agent-toolkit-v-experimental-macos-x86_64
+            v_zip: v_macos_x86_64.zip
             bin: agent-toolkit
           - os: windows-latest
             asset: agent-toolkit-v-experimental-windows-x86_64.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — Native V MUST build matrix (linux x86_64/arm64, macos arm64/x86_64, windows x86_64; experimental names) (Closes #529)
 - **Feat** — Experimental native V CI artifacts (linux-x86_64, macos-arm64, windows-x86_64; experimental names only) (Closes #562)
 - **Docs** — ADR-020 V concurrency: process-per-run supervisor (no Python threads / no `go` workers) (Closes #528)
 - **Feat** — V `devcompanion`/`dc` filesystem queue (queue/run-once --no-llm/status/done/sync-todos) (Closes #525)

--- a/docs/v/experimental-binaries.md
+++ b/docs/v/experimental-binaries.md
@@ -4,7 +4,9 @@
 **Names:** [ADR-018](../adrs/ADR-018-release-artifacts.md)  
 **Libc:** [ADR-019](../adrs/ADR-019-linux-libc.md) (Linux MUST artifact is glibc)
 
-These are **CI artifacts only**. They are not the stable GitHub Release channel (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe` — those remain PyInstaller until [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529) promotion). Experimental names **must not** overwrite stable names.
+These are **CI artifacts only**. They are not the stable GitHub Release channel (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe` — those remain PyInstaller until promotion after [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531)). Experimental names **must not** overwrite stable names.
+
+The MUST platform matrix (Linux x86_64/ARM64, macOS ARM64/x86_64, Windows x86_64) is documented in [release-matrix.md](release-matrix.md) ([#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529)).
 
 ## Workflow
 
@@ -12,15 +14,9 @@ These are **CI artifacts only**. They are not the stable GitHub Release channel 
 
 Compiler pin: `.v-version` (currently `0.5.2`).
 
-## Runner labels (verified 2026-08-13)
+## Runner labels
 
-| Experimental asset | GitHub-hosted `runs-on` | V zip | Notes |
-|--------------------|-------------------------|-------|--------|
-| `agent-toolkit-v-experimental-linux-x86_64` | `ubuntu-latest` | `v_linux.zip` | glibc (ADR-019). Not musl. |
-| `agent-toolkit-v-experimental-macos-arm64` | `macos-latest` | `v_macos_arm64.zip` | Apple Silicon. `macos-latest` was arm64 on this date; revisit if GitHub retargets the label. |
-| `agent-toolkit-v-experimental-windows-x86_64.exe` | `windows-latest` | `v_windows.zip` | |
-
-No `darwin-x86_64` job (same skip as #256 / ADR-018). Linux arm64 / musl extras are out of this spike (#529 / ADR-019 optional musl).
+Spike (#562) verified `ubuntu-latest` / `macos-latest` / `windows-latest` on 2026-08-13. The full MUST matrix (including `ubuntu-24.04-arm` and `macos-15-intel`) is in [release-matrix.md](release-matrix.md).
 
 ## Smoke
 

--- a/docs/v/release-matrix.md
+++ b/docs/v/release-matrix.md
@@ -1,0 +1,37 @@
+# Native V GitHub Actions build matrix
+
+**Issue:** [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529)  
+**Spike:** [#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562)  
+**Names:** [ADR-018](../adrs/ADR-018-release-artifacts.md) · **Libc:** [ADR-019](../adrs/ADR-019-linux-libc.md)
+
+V **cannot cross-compile to macOS**. Every macOS artifact is built **on** a macOS runner.
+
+Stable GitHub Release names (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe`) remain **PyInstaller** until an explicit promotion after [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531) smoke. This matrix publishes **experimental** names only.
+
+## MUST capabilities (verified 2026-08-13)
+
+| Capability | `runs-on` (this date) | V zip | Experimental asset |
+|------------|----------------------|-------|--------------------|
+| Linux x86_64 (glibc) | `ubuntu-latest` | `v_linux.zip` | `agent-toolkit-v-experimental-linux-x86_64` |
+| Linux ARM64 (glibc) | `ubuntu-24.04-arm` | `v_linux_arm64.zip` | `agent-toolkit-v-experimental-linux-arm64` |
+| macOS ARM64 | `macos-latest` | `v_macos_arm64.zip` | `agent-toolkit-v-experimental-macos-arm64` |
+| macOS x86_64 | `macos-15-intel` | `v_macos_x86_64.zip` | `agent-toolkit-v-experimental-macos-x86_64` |
+| Windows x86_64 | `windows-latest` | `v_windows.zip` | `agent-toolkit-v-experimental-windows-x86_64.exe` |
+
+Labels are **not** forever architecture. Re-verify when GitHub retargets `-latest` or retires `macos-15-intel` / `ubuntu-24.04-arm`. Source: [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) (public repo table, 2026-08-13).
+
+## FUTURE / not in this matrix
+
+| Capability | Notes |
+|------------|--------|
+| Windows ARM64 | Issue #529 FUTURE (`windows-11-arm` exists; not a retirement gate). |
+| Linux musl | Optional extra (ADR-019); must not overwrite glibc names. |
+| Stable floating names | Still PyInstaller in `release.yml` until promotion. |
+
+macOS x86_64 is **MUST here** (experimental channel). The historical #256 skip (`agent-toolkit-darwin-x86_64` / stable `macos-x86_64`) stays for the **stable** floating name until promotion.
+
+## Workflow
+
+`.github/workflows/experimental-v.yml` — `fail-fast: false`, `contents: read`, Actions artifacts only (no `gh release upload`).
+
+Smoke: `--version` / `--help`. Broader smoke is #531.


### PR DESCRIPTION
## Summary
- Expand `.github/workflows/experimental-v.yml` to the #529 MUST matrix: Linux x86_64 + ARM64, macOS ARM64 + x86_64, Windows x86_64.
- Runner labels recorded with verification date **2026-08-13** in `docs/v/release-matrix.md` (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `macos-15-intel`, `windows-latest`).
- macOS artifacts are built **on** macOS runners (no cross-compile). Experimental names only; stable PyInstaller channel in `release.yml` is unchanged until #531 promotion.

Fixes #529

## Type
- [x] CI/CD

## Testing
- [x] This PR triggers the five-platform experimental V workflow
- [x] No secrets; `contents: read` only

## Checklist
- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes

Made with [Cursor](https://cursor.com)