### PR TITLE
ci(v): smoke MUST-platform V artifacts (#531)

### DIFF
--- a/.github/workflows/experimental-v.yml
+++ b/.github/workflows/experimental-v.yml
@@ -11,6 +11,7 @@ on:
       - ".v-version"
       - "docs/v/experimental-binaries.md"
       - "docs/v/release-matrix.md"
+      - "docs/v/artifact-smoke.md"
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - ".v-version"
       - "docs/v/experimental-binaries.md"
       - "docs/v/release-matrix.md"
+      - "docs/v/artifact-smoke.md"
 
 permissions:
   contents: read
@@ -38,22 +40,27 @@ jobs:
             asset: agent-toolkit-v-experimental-linux-x86_64
             v_zip: v_linux.zip
             bin: agent-toolkit
+            expect_arch: x86_64
           - os: ubuntu-24.04-arm
             asset: agent-toolkit-v-experimental-linux-arm64
             v_zip: v_linux_arm64.zip
             bin: agent-toolkit
+            expect_arch: arm64
           - os: macos-latest
             asset: agent-toolkit-v-experimental-macos-arm64
             v_zip: v_macos_arm64.zip
             bin: agent-toolkit
+            expect_arch: arm64
           - os: macos-15-intel
             asset: agent-toolkit-v-experimental-macos-x86_64
             v_zip: v_macos_x86_64.zip
             bin: agent-toolkit
+            expect_arch: x86_64
           - os: windows-latest
             asset: agent-toolkit-v-experimental-windows-x86_64.exe
             v_zip: v_windows.zip
             bin: agent-toolkit.exe
+            expect_arch: x86_64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -93,14 +100,28 @@ jobs:
           "${VBIN}" -d "commit=${COMMIT}" -o "build/${OUT_BIN}" cmd/agent-toolkit
           cp -f "build/${OUT_BIN}" "build/${ASSET}"
 
-      - name: Smoke --version / --help
+      - name: Smoke --version / --help / inventory / doctor
         shell: bash
         env:
           OUT_BIN: ${{ matrix.bin }}
+          EXPECT_ARCH: ${{ matrix.expect_arch }}
+          AGENT_TOOLKIT_ROOT: ${{ github.workspace }}
         run: |
           set -euo pipefail
+          got="$(uname -m | tr 'A-Z' 'a-z')"
+          case "${got}" in
+            aarch64|arm64) got=arm64 ;;
+            x86_64|amd64) got=x86_64 ;;
+          esac
+          if [ "${got}" != "${EXPECT_ARCH}" ]; then
+            echo "architecture mismatch: runner uname -m normalized to ${got}, expected ${EXPECT_ARCH} for this artifact" >&2
+            exit 1
+          fi
+          echo "arch_ok runner=${got} asset_expect=${EXPECT_ARCH}"
           "build/${OUT_BIN}" --version
           "build/${OUT_BIN}" --help | head -n 20
+          "build/${OUT_BIN}" inventory
+          "build/${OUT_BIN}" doctor --json
 
       - uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — Execute MUST-platform V artifacts (`--version`/`--help`/`inventory`/`doctor`) with arch mismatch fail (Closes #531)
 - **Feat** — Native V MUST build matrix (linux x86_64/arm64, macos arm64/x86_64, windows x86_64; experimental names) (Closes #529)
 - **Feat** — Experimental native V CI artifacts (linux-x86_64, macos-arm64, windows-x86_64; experimental names only) (Closes #562)
 - **Docs** — ADR-020 V concurrency: process-per-run supervisor (no Python threads / no `go` workers) (Closes #528)

--- a/docs/v/artifact-smoke.md
+++ b/docs/v/artifact-smoke.md
@@ -1,0 +1,16 @@
+# Per-artifact smoke tests
+
+**Issue:** [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531)  
+**Matrix:** [release-matrix.md](release-matrix.md) ([#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529))
+
+MUST-platform V binaries are **executed on the same runner architecture that built them**. Compile-only is not enough. No QEMU/emulation.
+
+## Checks (each matrix job)
+
+1. **Arch gate** — `uname -m` (normalized: `aarch64`→`arm64`, `amd64`→`x86_64`) must equal the job’s `expect_arch`. A mismatch fails; it cannot silently pass.
+2. **`--version`** and **`--help`**
+3. **`inventory`** and **`doctor --json`** with `AGENT_TOOLKIT_ROOT` set to the checkout (read-only; data is in-tree)
+
+Implemented in `.github/workflows/experimental-v.yml` after `make`-equivalent V build. Failures fail the job (`fail-fast: false` so other platforms still report).
+
+Tag `release.yml` PyInstaller assets are **not** switched here; promotion after smoke stays an explicit decision.

--- a/docs/v/release-matrix.md
+++ b/docs/v/release-matrix.md
@@ -34,4 +34,4 @@ macOS x86_64 is **MUST here** (experimental channel). The historical #256 skip (
 
 `.github/workflows/experimental-v.yml` — `fail-fast: false`, `contents: read`, Actions artifacts only (no `gh release upload`).
 
-Smoke: `--version` / `--help`. Broader smoke is #531.
+Smoke: `--version` / `--help` / `inventory` / `doctor --json` plus an arch mismatch gate ([#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531), [artifact-smoke.md](artifact-smoke.md)).


### PR DESCRIPTION
## Summary
- Execute each MUST-platform V binary on its matching runner: `--version`, `--help`, `inventory`, `doctor --json`.
- Fail the job if normalized `uname -m` does not match `expect_arch` (no silent arch mismatch).
- Native runners only (no QEMU). Stable PyInstaller `release.yml` assets are unchanged.

Fixes #531

## Type
- [x] CI/CD

## Testing
- [x] This PR retriggers `.github/workflows/experimental-v.yml` on all five MUST platforms
- [x] No secrets

## Checklist
- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes

Made with [Cursor](https://cursor.com)