### PR TITLE
feat(v): swarm CLI REDESIGN (filesystem SoT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V `swarm` REDESIGN (recipes/start/status/doctor/approve/reject/cancel; filesystem SoT) (Closes #524)
 - **Feat** — Execute MUST-platform V artifacts (`--version`/`--help`/`inventory`/`doctor`) with arch mismatch fail (Closes #531)
 - **Feat** — Native V MUST build matrix (linux x86_64/arm64, macos arm64/x86_64, windows x86_64; experimental names) (Closes #529)
 - **Feat** — Experimental native V CI artifacts (linux-x86_64, macos-arm64, windows-x86_64; experimental names only) (Closes #562)

--- a/docs/v/advanced-command-disposition.md
+++ b/docs/v/advanced-command-disposition.md
@@ -34,7 +34,7 @@ Legend: **PORT** 1:1 V rewrite · **REDESIGN** V rewrite with a different shape 
 1. PORT `workspace` → `memory` → `project` (shared workspace root).
 2. PORT `devcompanion` (queue is independent of loops).
 3. REDESIGN `loop` after [#528](https://github.com/ulises-jeremias/agent-toolkit/issues/528) / [ADR-020](../adrs/ADR-020-v-concurrency.md) (process-per-run supervisor).
-4. REDESIGN `swarm` after loop/process patterns exist.
+4. REDESIGN `swarm` after loop/process patterns exist (`docs/v/swarm.md`).
 5. Close #526/#527 as dispositioned without V implementations.
 
 Python remains available for DEPRECATE/REMOVE commands until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540), matching [ADR-012](../adrs/ADR-012-python-v-coexistence.md) (no per-command mixed engine).

--- a/docs/v/cutover.md
+++ b/docs/v/cutover.md
@@ -21,7 +21,7 @@ Native artifacts stay **experimental** until [#562](https://github.com/ulises-je
 
 ## Python fallback (advanced commands)
 
-EPIC 5 remaining commands (`loop`, `swarm`, `insights`, `release`) may still be `not_implemented` in V. `workspace` (#520), `memory` (#521), `project` (#522), and `devcompanion`/`dc` (#525) are implemented in V. Run the Python CLI explicitly for unfinished advanced commands:
+EPIC 5 remaining commands (`loop`, `insights`, `release`) may still be `not_implemented` in V. `workspace` (#520), `memory` (#521), `project` (#522), `devcompanion`/`dc` (#525), and `swarm` (#524, ADR-008 filesystem SoT) are implemented in V. Run the Python CLI explicitly for unfinished advanced commands:
 
 ```bash
 agent-toolkit-py loop status

--- a/docs/v/swarm.md
+++ b/docs/v/swarm.md
@@ -1,0 +1,12 @@
+# V `swarm` command family
+
+**Issue:** [#524](https://github.com/ulises-jeremias/agent-toolkit/issues/524) (EPIC 5 [#462](https://github.com/ulises-jeremias/agent-toolkit/issues/462), disposition [#560](https://github.com/ulises-jeremias/agent-toolkit/issues/560) **REDESIGN**)  
+**Architecture:** [ADR-008](../adrs/ADR-008-swarm-orchestration.md) · [ADR-020](../adrs/ADR-020-v-concurrency.md)
+
+Not a 1:1 port of Python threads/Herdr socket calls. The V CLI owns **filesystem state** under `.agent-toolkit/swarm/runs/<run-id>/`. UI backends (Herdr, tmux, headless) are isolated probes — this module does **not** invent Herdr APIs.
+
+Subcommands: `recipes` / `backends` / `doctor` / `start` / `list` / `status` / `approve` / `reject` / `cancel`.
+
+- Built-in recipes: `pair`, `team`, `full` (plan gate on team/full; final gate always).
+- `start --dry-run` plans without writes. Real start writes `state.json` + `approvals.json`; UI spawn is **fail-closed** until ProcessService stdin exists.
+- **Windows:** tmux/herdr unsupported; use `--backend headless`.

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -147,6 +147,14 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_devcompanion(opts)
 		return render(agent_toolkit_core.devcompanion_result(report), mode)
 	}
+	if cmd_name == 'swarm' {
+		opts := parse_swarm_options(argv[1..]) or {
+			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
+			return render_error(e, mode)
+		}
+		report := agent_toolkit_core.run_swarm(opts)
+		return render(agent_toolkit_core.swarm_result(report), mode)
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
@@ -747,6 +755,111 @@ fn parse_dc_options(args []string) !agent_toolkit_core.DevcompanionOptions {
 	}
 }
 
+fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
+	mut sub := ''
+	mut workspace_path := ''
+	mut run_id := ''
+	mut gate_id := ''
+	mut recipe := ''
+	mut backend := ''
+	mut reason := ''
+	mut dry_run := false
+	mut force := false
+	mut task_parts := []string{}
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--dry-run' {
+			dry_run = true
+			i++
+			continue
+		}
+		if a == '--force' {
+			force = true
+			i++
+			continue
+		}
+		if a in ['--recipe', '--backend', '--ui', '--workspace', '--reason'] {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			val := args[i + 1]
+			match a {
+				'--recipe' { recipe = val }
+				'--backend' { backend = val }
+				'--ui' { backend = val }
+				'--workspace' { workspace_path = val }
+				'--reason' { reason = val }
+				else {}
+			}
+			i += 2
+			continue
+		}
+		if a.starts_with('--recipe=') {
+			recipe = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--backend=') || a.starts_with('--ui=') {
+			backend = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--reason=') {
+			reason = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		if run_id.len == 0 {
+			run_id = a
+			i++
+			continue
+		}
+		if gate_id.len == 0 && sub in ['approve', 'reject'] {
+			gate_id = a
+			i++
+			continue
+		}
+		task_parts << a
+		i++
+	}
+	mut task := task_parts.join(' ')
+	if sub == 'start' && task.len == 0 {
+		task = run_id
+		run_id = ''
+	}
+	return agent_toolkit_core.SwarmOptions{
+		subcommand:     sub
+		workspace_path: workspace_path
+		run_id:         run_id
+		gate_id:        gate_id
+		recipe:         recipe
+		backend:        backend
+		task:           task
+		reason:         reason
+		dry_run:        dry_run
+		force:          force
+	}
+}
+
 fn parse_plugin_options(args []string) agent_toolkit_core.PluginOptions {
 	mut sub := ''
 	for a in args {
@@ -940,6 +1053,15 @@ fn allowed_flag(cmd string, a string) bool {
 			return true
 		}
 	}
+	if cmd == 'swarm' {
+		if a in ['--dry-run', '--force', '--recipe', '--backend', '--ui', '--workspace', '--reason'] {
+			return true
+		}
+		if a.starts_with('--recipe') || a.starts_with('--backend') || a.starts_with('--ui')
+			|| a.starts_with('--workspace') || a.starts_with('--reason') {
+			return true
+		}
+	}
 	return false
 }
 
@@ -1115,6 +1237,9 @@ Read-only health checks by default. --fix allowlists profile refresh only.
 	}
 	if name == 'devcompanion' {
 		return agent_toolkit_core.dc_help_text()
+	}
+	if name == 'swarm' {
+		return agent_toolkit_core.swarm_help_text()
 	}
 	mut c := cli.Command{
 		name:        name

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -131,6 +131,11 @@ fn test_dispatch_dc_alias_help() {
 	assert code == 0
 }
 
+fn test_dispatch_swarm_help() {
+	code := dispatch(['agent-toolkit', 'swarm', '--help'])
+	assert code == 0
+}
+
 fn test_dispatch_rollback_alias_allowed() {
 	// No receipts in default dir may exit non-zero; alias must be known (not unknown command).
 	code := dispatch(['agent-toolkit', 'rollback', '--dry-run', '--json'])

--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -1,0 +1,645 @@
+module agent_toolkit_core
+
+import json
+import os
+import time
+
+// SwarmOptions configures the swarm command family (#524 REDESIGN).
+pub struct SwarmOptions {
+pub:
+	subcommand     string
+	workspace_path string
+	run_id         string
+	gate_id        string
+	recipe         string
+	backend        string
+	task           string
+	reason         string
+	dry_run        bool
+	force          bool
+}
+
+// SwarmReport is the domain result for swarm subcommands.
+pub struct SwarmReport {
+pub mut:
+	ok      bool
+	message string
+	data    map[string]string
+}
+
+struct SwarmStateFile {
+	version    int
+	run_id     string
+	recipe     string
+	backend    string
+	run_state  string
+	created_at string
+	task       string
+}
+
+struct SwarmApprovalsFile {
+	gates []SwarmGate
+}
+
+// run_swarm implements recipes/backends/doctor/start/list/status/approve/reject/cancel.
+pub fn run_swarm(opts SwarmOptions) SwarmReport {
+	sub := opts.subcommand
+	if sub.len == 0 || sub in ['help', '-h', '--help'] {
+		return SwarmReport{
+			ok:      true
+			message: swarm_help_text()
+			data:    {
+				'subcommand': 'help'
+			}
+		}
+	}
+	ws := find_swarm_workspace(opts.workspace_path)
+	return match sub {
+		'recipes' {
+			swarm_recipes(opts)
+		}
+		'backends' {
+			swarm_backends()
+		}
+		'doctor' {
+			swarm_doctor(ws)
+		}
+		'start' {
+			swarm_start(ws, opts)
+		}
+		'list' {
+			swarm_list(ws)
+		}
+		'status' {
+			swarm_status(ws, opts)
+		}
+		'approve' {
+			swarm_approve(ws, opts)
+		}
+		'reject' {
+			swarm_reject(ws, opts)
+		}
+		'cancel' {
+			swarm_cancel(ws, opts)
+		}
+		else {
+			SwarmReport{
+				ok:      false
+				message: "Unknown command: ${sub}\nRun 'agent-toolkit swarm help' for usage."
+				data:    {
+					'subcommand': sub
+				}
+			}
+		}
+	}
+}
+
+pub fn swarm_result(report SwarmReport) CommandResult {
+	mut data := report.data.clone()
+	if 'subcommand' !in data {
+		data['subcommand'] = ''
+	}
+	return CommandResult{
+		command: 'swarm'
+		ok:      report.ok
+		message: report.message
+		data:    data
+	}
+}
+
+pub fn swarm_help_text() string {
+	return 'swarm — Multi-agent orchestration (REDESIGN: filesystem SoT, ADR-008/ADR-020).
+
+Usage:
+    agent-toolkit swarm recipes [name]
+    agent-toolkit swarm backends
+    agent-toolkit swarm doctor [--json]
+    agent-toolkit swarm start [--recipe pair|team|full] [--backend auto|herdr|tmux|headless] [--dry-run] [task]
+    agent-toolkit swarm list
+    agent-toolkit swarm status [run-id]
+    agent-toolkit swarm approve <run-id> <gate>
+    agent-toolkit swarm reject <run-id> <gate> --reason TEXT
+    agent-toolkit swarm cancel <run-id>
+    agent-toolkit swarm help
+
+Backends: herdr (recommended), tmux (Unix fallback), headless (filesystem only).
+Windows: tmux/herdr unsupported; use --backend headless.
+Concurrency: process-per-run supervisor; UI spawn is fail-closed without ProcessService stdin.
+State: .agent-toolkit/swarm/runs/<run-id>/ (state.json, approvals.json, trace.jsonl).
+'
+}
+
+fn find_swarm_workspace(override string) string {
+	if override.len > 0 && os.is_dir(override) {
+		return override
+	}
+	if ws := find_workspace_root(override) {
+		return ws
+	}
+	if git := find_git_root('') {
+		return git
+	}
+	return os.getwd()
+}
+
+fn swarm_root(ws string) string {
+	return os.join_path(ws, '.agent-toolkit', 'swarm')
+}
+
+fn swarm_runs_dir(ws string) string {
+	return os.join_path(swarm_root(ws), 'runs')
+}
+
+fn swarm_run_dir(ws string, run_id string) string {
+	return os.join_path(swarm_runs_dir(ws), run_id)
+}
+
+fn swarm_recipes(opts SwarmOptions) SwarmReport {
+	names := ['full', 'pair', 'team']
+	if opts.run_id.len > 0 {
+		name := opts.run_id
+		desc := swarm_recipe_description(name)
+		if desc.len == 0 {
+			return SwarmReport{
+				ok:      false
+				message: "Unknown recipe '${name}'. Built-ins: pair, team, full"
+			}
+		}
+		roles := swarm_recipe_roles(name).join(',')
+		return SwarmReport{
+			ok:      true
+			message: '${name}\t${desc}\nroles: ${roles}'
+			data:    {
+				'subcommand': 'recipes'
+				'recipe':     name
+				'roles':      roles
+			}
+		}
+	}
+	mut lines := []string{}
+	for n in names {
+		lines << '${n}\t${swarm_recipe_description(n)}'
+	}
+	return SwarmReport{
+		ok:      true
+		message: lines.join('\n')
+		data:    {
+			'subcommand': 'recipes'
+			'recipes':    names.join(',')
+		}
+	}
+}
+
+fn swarm_backends() SwarmReport {
+	mut lines := []string{}
+	mut avail := []string{}
+	for n in ['herdr', 'tmux', 'headless'] {
+		d := doctor_backend(n)
+		status := if d.available { 'available' } else { 'unavailable' }
+		detail := if d.version.len > 0 { d.version } else { d.reason }
+		lines << '${n}\t${status}\t${detail}'
+		if d.available {
+			avail << n
+		}
+	}
+	return SwarmReport{
+		ok:      true
+		message: lines.join('\n')
+		data:    {
+			'subcommand': 'backends'
+			'available':  avail.join(',')
+			'herdr':      doctor_flag(doctor_backend('herdr'))
+			'tmux':       doctor_flag(doctor_backend('tmux'))
+			'headless':   'true'
+		}
+	}
+}
+
+fn doctor_flag(d BackendDoctor) string {
+	return if d.available { 'true' } else { 'false' }
+}
+
+fn swarm_doctor(ws string) SwarmReport {
+	git_root := find_git_root(ws) or { '' }
+	git_ok := git_root.len > 0
+	h := doctor_backend('herdr')
+	t := doctor_backend('tmux')
+	recipes := 'full,pair,team'
+	mut lines := []string{}
+	lines << 'Swarm doctor'
+	lines << '  repo: ${ws}'
+	lines << '  git: ${if git_ok { 'ok' } else { 'missing' }}'
+	lines << '  herdr: ${if h.available { 'pass' } else { 'warning' }} - ${if h.version.len > 0 {
+		h.version
+	} else {
+		h.reason
+	}}'
+	lines << '  tmux: ${if t.available { 'pass' } else { 'warning' }} - ${if t.version.len > 0 {
+		t.version
+	} else {
+		t.reason
+	}}'
+	lines << '  recipes: ${recipes}'
+	lines << '  apiVersion: agent-toolkit.dev/v1alpha1'
+	return SwarmReport{
+		ok:      git_ok
+		message: lines.join('\n')
+		data:    {
+			'subcommand': 'doctor'
+			'git':        if git_ok { 'true' } else { 'false' }
+			'repo':       ws
+			'herdr':      doctor_flag(h)
+			'tmux':       doctor_flag(t)
+			'recipes':    recipes
+			'apiVersion': 'agent-toolkit.dev/v1alpha1'
+		}
+	}
+}
+
+fn swarm_start(ws string, opts SwarmOptions) SwarmReport {
+	recipe := if opts.recipe.len > 0 { opts.recipe } else { 'pair' }
+	if swarm_recipe_description(recipe).len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: "Unknown recipe '${recipe}'. Built-ins: pair, team, full"
+		}
+	}
+	requested := if opts.backend.len > 0 { opts.backend } else { 'auto' }
+	if requested !in swarm_backend_names() {
+		return SwarmReport{
+			ok:      false
+			message: "Unknown backend '${requested}'. Use auto|herdr|tmux|headless"
+		}
+	}
+	backend := resolve_swarm_backend(requested)
+	doc := doctor_backend(backend)
+	if requested in ['herdr', 'tmux'] && !doc.available {
+		return SwarmReport{
+			ok:      false
+			message: '${requested} was requested but is unavailable: ${doc.reason}'
+			data:    {
+				'subcommand': 'start'
+				'backend':    requested
+			}
+		}
+	}
+	rid := swarm_new_run_id()
+	if opts.dry_run {
+		return SwarmReport{
+			ok:      true
+			message: '[swarm] dry-run start recipe=${recipe} backend=${backend} run_id=${rid}\n  roles: ${swarm_recipe_roles(recipe).join(', ')}\n  no filesystem writes; UI spawn skipped (ADR-020 fail-closed)'
+			data:    {
+				'subcommand': 'start'
+				'mode':       'dry-run'
+				'recipe':     recipe
+				'backend':    backend
+				'run_id':     rid
+			}
+		}
+	}
+	run_dir := swarm_run_dir(ws, rid)
+	ensure_swarm_run_dirs(run_dir) or {
+		return SwarmReport{
+			ok:      false
+			message: 'mkdir run failed: ${err}'
+		}
+	}
+	initial := if swarm_require_plan_approval(recipe) {
+		'awaiting_plan_approval'
+	} else {
+		'running'
+	}
+	st := SwarmStateFile{
+		version:    1
+		run_id:     rid
+		recipe:     recipe
+		backend:    backend
+		run_state:  initial
+		created_at: time.utc().format_rfc3339()
+		task:       opts.task
+	}
+	write_swarm_state(run_dir, st) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write state failed: ${err}'
+		}
+	}
+	write_swarm_approvals(run_dir, swarm_default_gates(recipe)) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write approvals failed: ${err}'
+		}
+	}
+	append_swarm_trace(run_dir, 'run_created', rid)
+	return SwarmReport{
+		ok:      true
+		message: '[swarm] started ${rid} recipe=${recipe} backend=${backend} state=${initial}\n  ${run_dir}\n  UI spawn fail-closed (ADR-020); filesystem state is authoritative (ADR-008).'
+		data:    {
+			'subcommand': 'start'
+			'run_id':     rid
+			'recipe':     recipe
+			'backend':    backend
+			'run_state':  initial
+			'workspace':  ws
+		}
+	}
+}
+
+fn swarm_list(ws string) SwarmReport {
+	dir := swarm_runs_dir(ws)
+	if !os.is_dir(dir) {
+		return SwarmReport{
+			ok:      true
+			message: 'No swarm runs found.'
+			data:    {
+				'subcommand': 'list'
+				'count':      '0'
+			}
+		}
+	}
+	mut names := os.ls(dir) or { []string{} }
+	names.sort()
+	mut lines := []string{}
+	mut count := 0
+	for n in names {
+		rd := os.join_path(dir, n)
+		st := read_swarm_state(rd) or { continue }
+		lines << '${st.run_id}\t${st.recipe}\t${st.run_state}\t${st.created_at}'
+		count++
+	}
+	if lines.len == 0 {
+		return SwarmReport{
+			ok:      true
+			message: 'No swarm runs found.'
+			data:    {
+				'subcommand': 'list'
+				'count':      '0'
+			}
+		}
+	}
+	return SwarmReport{
+		ok:      true
+		message: lines.join('\n')
+		data:    {
+			'subcommand': 'list'
+			'count':      '${count}'
+		}
+	}
+}
+
+fn swarm_status(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 {
+		return swarm_list(ws)
+	}
+	if !swarm_valid_run_id(opts.run_id) {
+		return SwarmReport{
+			ok:      false
+			message: "Invalid run_id '${opts.run_id}'"
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	st := read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	gates := read_swarm_approvals(rd)
+	mut gtxt := []string{}
+	for g in gates {
+		mark := if g.approved {
+			'approved'
+		} else if g.rejected {
+			'rejected'
+		} else {
+			'pending'
+		}
+		gtxt << '${g.id}:${mark}'
+	}
+	return SwarmReport{
+		ok:      true
+		message: 'run ${st.run_id} recipe=${st.recipe} backend=${st.backend} state=${st.run_state}\ngates: ${gtxt.join(', ')}'
+		data:    {
+			'subcommand': 'status'
+			'run_id':     st.run_id
+			'recipe':     st.recipe
+			'backend':    st.backend
+			'run_state':  st.run_state
+			'gates':      gtxt.join(',')
+		}
+	}
+}
+
+fn swarm_approve(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 || opts.gate_id.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Usage: agent-toolkit swarm approve <run-id> <gate>'
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	mut st := read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	mut gates := read_swarm_approvals(rd)
+	mut found := false
+	for mut g in gates {
+		if g.id == opts.gate_id {
+			g.approved = true
+			g.rejected = false
+			g.reason = ''
+			found = true
+		}
+	}
+	if !found {
+		return SwarmReport{
+			ok:      false
+			message: 'Gate not found: ${opts.gate_id}'
+		}
+	}
+	write_swarm_approvals(rd, gates) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write approvals failed: ${err}'
+		}
+	}
+	if opts.gate_id == 'plan' && st.run_state == 'awaiting_plan_approval' {
+		if !swarm_can_transition(st.run_state, 'running') {
+			return SwarmReport{
+				ok:      false
+				message: 'illegal transition ${st.run_state} → running'
+			}
+		}
+		st = SwarmStateFile{
+			...st
+			run_state: 'running'
+		}
+		write_swarm_state(rd, st) or {
+			return SwarmReport{
+				ok:      false
+				message: 'write state failed: ${err}'
+			}
+		}
+	}
+	append_swarm_trace(rd, 'approval_granted', opts.gate_id)
+	return SwarmReport{
+		ok:      true
+		message: 'Approved ${opts.gate_id} for ${opts.run_id}'
+		data:    {
+			'subcommand': 'approve'
+			'run_id':     opts.run_id
+			'gate':       opts.gate_id
+			'run_state':  st.run_state
+		}
+	}
+}
+
+fn swarm_reject(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 || opts.gate_id.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Usage: agent-toolkit swarm reject <run-id> <gate> --reason TEXT'
+		}
+	}
+	if opts.reason.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: '--reason is required for reject'
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	mut gates := read_swarm_approvals(rd)
+	mut found := false
+	for mut g in gates {
+		if g.id == opts.gate_id {
+			g.approved = false
+			g.rejected = true
+			g.reason = opts.reason
+			found = true
+		}
+	}
+	if !found {
+		return SwarmReport{
+			ok:      false
+			message: 'Gate not found: ${opts.gate_id}'
+		}
+	}
+	write_swarm_approvals(rd, gates) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write approvals failed: ${err}'
+		}
+	}
+	append_swarm_trace(rd, 'approval_rejected', opts.gate_id)
+	return SwarmReport{
+		ok:      true
+		message: 'Rejected ${opts.gate_id} for ${opts.run_id}: ${opts.reason}'
+		data:    {
+			'subcommand': 'reject'
+			'run_id':     opts.run_id
+			'gate':       opts.gate_id
+		}
+	}
+}
+
+fn swarm_cancel(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Usage: agent-toolkit swarm cancel <run-id>'
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	st := read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	if !swarm_can_transition(st.run_state, 'cancelled') {
+		return SwarmReport{
+			ok:      false
+			message: 'Cannot cancel from state ${st.run_state}'
+		}
+	}
+	next := SwarmStateFile{
+		...st
+		run_state: 'cancelled'
+	}
+	write_swarm_state(rd, next) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write state failed: ${err}'
+		}
+	}
+	append_swarm_trace(rd, 'run_cancelled', opts.run_id)
+	return SwarmReport{
+		ok:      true
+		message: 'Cancelled ${opts.run_id}'
+		data:    {
+			'subcommand': 'cancel'
+			'run_id':     opts.run_id
+			'run_state':  'cancelled'
+		}
+	}
+}
+
+fn ensure_swarm_run_dirs(run_dir string) ! {
+	for sub in ['artifacts', 'handoffs/outbox', 'handoffs/queued', 'handoffs/active',
+		'handoffs/completed', 'handoffs/failed', 'prompts', 'worktrees'] {
+		os.mkdir_all(os.join_path(run_dir, sub))!
+	}
+}
+
+fn write_swarm_state(run_dir string, st SwarmStateFile) ! {
+	os.write_file(os.join_path(run_dir, 'state.json'), json.encode(st) + '\n')!
+}
+
+fn read_swarm_state(run_dir string) ?SwarmStateFile {
+	path := os.join_path(run_dir, 'state.json')
+	if !os.is_file(path) {
+		return none
+	}
+	text := os.read_file(path) or { return none }
+	return json.decode(SwarmStateFile, text) or { none }
+}
+
+fn write_swarm_approvals(run_dir string, gates []SwarmGate) ! {
+	payload := SwarmApprovalsFile{
+		gates: gates
+	}
+	os.write_file(os.join_path(run_dir, 'approvals.json'), json.encode(payload) + '\n')!
+}
+
+fn read_swarm_approvals(run_dir string) []SwarmGate {
+	path := os.join_path(run_dir, 'approvals.json')
+	if !os.is_file(path) {
+		return []
+	}
+	text := os.read_file(path) or { return [] }
+	file := json.decode(SwarmApprovalsFile, text) or { return [] }
+	return file.gates
+}
+
+fn append_swarm_trace(run_dir string, kind string, detail string) {
+	line := '{"ts":${json.encode(time.utc().format_rfc3339())},"kind":${json.encode(kind)},"detail":${json.encode(detail)}}\n'
+	path := os.join_path(run_dir, 'trace.jsonl')
+	existing := os.read_file(path) or { '' }
+	os.write_file(path, existing + line) or {}
+}
+
+fn swarm_new_run_id() string {
+	rfc := time.utc().format_rfc3339()
+	date := rfc[..10].clone().replace('-', '')
+	clock := if rfc.len >= 19 { rfc[11..19].clone().replace(':', '') } else { '000000' }
+	return 's${date}T${clock}Z'
+}

--- a/modules/agent_toolkit_core/swarm_backend.v
+++ b/modules/agent_toolkit_core/swarm_backend.v
@@ -1,0 +1,125 @@
+module agent_toolkit_core
+
+import os
+import time
+
+// BackendDoctor is the isolated UI-backend probe (ADR-008). No invented Herdr APIs.
+pub struct BackendDoctor {
+pub:
+	name      string
+	available bool
+	version   string
+	reason    string
+}
+
+pub fn swarm_backend_names() []string {
+	return ['herdr', 'tmux', 'headless', 'auto']
+}
+
+pub fn doctor_backend(name string) BackendDoctor {
+	n := if name == 'auto' { 'headless' } else { name }
+	return match n {
+		'headless' {
+			BackendDoctor{
+				name:      'headless'
+				available: true
+				version:   'filesystem'
+				reason:    'always available (ADR-008 filesystem SoT)'
+			}
+		}
+		'tmux' {
+			probe_unix_bin('tmux', ['tmux', '-V'])
+		}
+		'herdr' {
+			probe_unix_bin('herdr', ['herdr', '--version'])
+		}
+		else {
+			BackendDoctor{
+				name:      n
+				available: false
+				reason:    'unknown backend'
+			}
+		}
+	}
+}
+
+pub fn resolve_swarm_backend(requested string) string {
+	name := if requested.len == 0 { 'auto' } else { requested }
+	if name == 'auto' {
+		h := doctor_backend('herdr')
+		if h.available {
+			return 'herdr'
+		}
+		t := doctor_backend('tmux')
+		if t.available {
+			return 'tmux'
+		}
+		return 'headless'
+	}
+	return name
+}
+
+fn probe_unix_bin(name string, argv []string) BackendDoctor {
+	$if windows {
+		return BackendDoctor{
+			name:      name
+			available: false
+			reason:    '${name} is Unix-only; not supported on Windows'
+		}
+	}
+	ps := new_process_service()
+	res := ps.run(RunOptions{
+		argv:    argv
+		timeout: 5 * time.second
+	}) or { return BackendDoctor{
+		name:      name
+		available: false
+		reason:    err.msg()
+	} }
+	if res.timed_out {
+		return BackendDoctor{
+			name:      name
+			available: false
+			reason:    '${name} probe timed out'
+		}
+	}
+	if res.exit_code != 0 {
+		mut msg := res.stderr.trim_space()
+		if msg.len == 0 {
+			msg = res.stdout.trim_space()
+		}
+		if msg.len == 0 {
+			msg = 'exit ${res.exit_code}'
+		}
+		return BackendDoctor{
+			name:      name
+			available: false
+			reason:    msg
+		}
+	}
+	mut ver := res.stdout.trim_space()
+	if ver.len == 0 {
+		ver = res.stderr.trim_space()
+	}
+	return BackendDoctor{
+		name:      name
+		available: true
+		version:   ver
+	}
+}
+
+fn find_git_root(start string) ?string {
+	mut cur := if start.len > 0 { start } else { os.getwd() }
+	for {
+		git_dir := os.join_path(cur, '.git')
+		if os.is_dir(git_dir) || os.is_file(git_dir) {
+			return cur
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	return none
+}

--- a/modules/agent_toolkit_core/swarm_backend_test.v
+++ b/modules/agent_toolkit_core/swarm_backend_test.v
@@ -1,0 +1,20 @@
+module agent_toolkit_core
+
+fn test_headless_always_available() {
+	d := doctor_backend('headless')
+	assert d.available
+	assert d.name == 'headless'
+}
+
+fn test_unknown_backend() {
+	d := doctor_backend('nope')
+	assert !d.available
+}
+
+fn test_resolve_auto_falls_back() {
+	// auto may pick herdr/tmux if installed; still a known name
+	n := resolve_swarm_backend('auto')
+	assert n in ['herdr', 'tmux', 'headless']
+	forced := resolve_swarm_backend('headless')
+	assert forced == 'headless'
+}

--- a/modules/agent_toolkit_core/swarm_state.v
+++ b/modules/agent_toolkit_core/swarm_state.v
@@ -1,0 +1,126 @@
+module agent_toolkit_core
+
+// Swarm run/role state machine + approval gates (#524 REDESIGN / ADR-008).
+
+pub struct SwarmGate {
+pub mut:
+	id          string
+	description string
+	required    bool
+	approved    bool
+	rejected    bool
+	reason      string
+}
+
+pub fn swarm_can_transition(from_state string, to_state string) bool {
+	allowed := swarm_run_transitions(from_state)
+	return to_state in allowed
+}
+
+pub fn swarm_run_transitions(from_state string) []string {
+	return match from_state {
+		'planning' {
+			['awaiting_plan_approval', 'running', 'failed', 'cancelled']
+		}
+		'awaiting_plan_approval' {
+			['running', 'cancelled', 'failed']
+		}
+		'running' {
+			['awaiting_human', 'paused', 'completed', 'failed', 'cancelled', 'budget_exhausted']
+		}
+		'awaiting_human' {
+			['running', 'paused', 'completed', 'failed', 'cancelled']
+		}
+		'paused' {
+			['running', 'cancelled', 'failed']
+		}
+		'completed' {
+			['cleanup_pending']
+		}
+		'failed' {
+			['cleanup_pending', 'running']
+		}
+		'cancelled' {
+			['cleanup_pending']
+		}
+		'budget_exhausted' {
+			['running', 'cancelled', 'cleanup_pending']
+		}
+		else {
+			[]string{}
+		}
+	}
+}
+
+pub fn swarm_recipe_roles(recipe string) []string {
+	return match recipe {
+		'pair' {
+			['implementer', 'reviewer', 'integrator']
+		}
+		'team' {
+			['planner', 'implementer', 'reviewer', 'architect']
+		}
+		'full' {
+			['planner', 'implementer', 'refactorer', 'architect', 'hardener', 'qa']
+		}
+		else {
+			[]string{}
+		}
+	}
+}
+
+pub fn swarm_recipe_description(recipe string) string {
+	return match recipe {
+		'pair' {
+			'Two-role implementer + reviewer/integrator workflow'
+		}
+		'team' {
+			'Four-role planner → implementer → reviewer → architect workflow'
+		}
+		'full' {
+			'Six-role planner → implementer → refactorer → architect → hardener → qa workflow'
+		}
+		else {
+			''
+		}
+	}
+}
+
+pub fn swarm_require_plan_approval(recipe string) bool {
+	return recipe in ['team', 'full']
+}
+
+pub fn swarm_default_gates(recipe string) []SwarmGate {
+	mut gates := []SwarmGate{}
+	if swarm_require_plan_approval(recipe) {
+		gates << SwarmGate{
+			id:          'plan'
+			description: 'Plan approval: review task contract before implementation.'
+			required:    true
+		}
+	}
+	gates << SwarmGate{
+		id:          'final'
+		description: 'Final integration approval: required before base-branch merge.'
+		required:    true
+	}
+	return gates
+}
+
+pub fn swarm_valid_run_id(id string) bool {
+	if id.len < 3 || id.len > 65 {
+		return false
+	}
+	c0 := id[0]
+	if !((c0 >= `a` && c0 <= `z`) || (c0 >= `A` && c0 <= `Z`) || (c0 >= `0` && c0 <= `9`)) {
+		return false
+	}
+	for c in id {
+		ok := (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`)
+			|| (c >= `0` && c <= `9`) || c == `.` || c == `_` || c == `-`
+		if !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/agent_toolkit_core/swarm_state_test.v
+++ b/modules/agent_toolkit_core/swarm_state_test.v
@@ -1,0 +1,30 @@
+module agent_toolkit_core
+
+fn test_swarm_transitions() {
+	assert swarm_can_transition('planning', 'awaiting_plan_approval')
+	assert swarm_can_transition('awaiting_plan_approval', 'running')
+	assert swarm_can_transition('running', 'cancelled')
+	assert !swarm_can_transition('completed', 'running')
+	assert !swarm_can_transition('cleanup_pending', 'running')
+}
+
+fn test_swarm_gates_and_recipes() {
+	assert swarm_recipe_roles('pair').len == 3
+	assert swarm_recipe_roles('team').len == 4
+	assert swarm_recipe_roles('full').len == 6
+	assert !swarm_require_plan_approval('pair')
+	assert swarm_require_plan_approval('team')
+	pair_gates := swarm_default_gates('pair')
+	assert pair_gates.len == 1
+	assert pair_gates[0].id == 'final'
+	team_gates := swarm_default_gates('team')
+	assert team_gates.len == 2
+	assert team_gates[0].id == 'plan'
+}
+
+fn test_swarm_run_id() {
+	assert swarm_valid_run_id('s20260813T010203Z')
+	assert !swarm_valid_run_id('ab')
+	assert !swarm_valid_run_id('../etc')
+	assert !swarm_valid_run_id('')
+}

--- a/modules/agent_toolkit_core/swarm_test.v
+++ b/modules/agent_toolkit_core/swarm_test.v
@@ -1,0 +1,112 @@
+module agent_toolkit_core
+
+import os
+
+fn test_swarm_help() {
+	r := run_swarm(SwarmOptions{
+		subcommand: 'help'
+	})
+	assert r.ok
+	assert r.message.contains('start')
+	assert r.message.contains('approve')
+	assert r.message.contains('ADR-008')
+}
+
+fn test_swarm_recipes() {
+	r := run_swarm(SwarmOptions{
+		subcommand: 'recipes'
+	})
+	assert r.ok
+	assert r.data['recipes'].contains('pair')
+	one := run_swarm(SwarmOptions{
+		subcommand: 'recipes'
+		run_id:     'pair'
+	})
+	assert one.ok
+	assert one.data['roles'].contains('implementer')
+}
+
+fn test_swarm_start_status_approve_cancel() {
+	old_h := os.getenv('HARNESS_DIR')
+	old_ws := os.getenv('AGENT_TOOLKIT_WORKSPACE')
+	os.unsetenv('HARNESS_DIR')
+	os.unsetenv('AGENT_TOOLKIT_WORKSPACE')
+	base := os.join_path(os.temp_dir(), 'at-swarm-${os.getpid()}')
+	os.mkdir_all(os.join_path(base, '.git')) or { assert false, err.msg() }
+	defer {
+		if old_h.len > 0 {
+			os.setenv('HARNESS_DIR', old_h, true)
+		}
+		if old_ws.len > 0 {
+			os.setenv('AGENT_TOOLKIT_WORKSPACE', old_ws, true)
+		}
+		os.rmdir_all(base) or {}
+	}
+
+	dry := run_swarm(SwarmOptions{
+		subcommand:     'start'
+		workspace_path: base
+		recipe:         'team'
+		backend:        'headless'
+		dry_run:        true
+		task:           'demo'
+	})
+	assert dry.ok, dry.message
+	assert dry.data['mode'] == 'dry-run'
+	assert !os.is_dir(os.join_path(base, '.agent-toolkit', 'swarm', 'runs'))
+
+	start := run_swarm(SwarmOptions{
+		subcommand:     'start'
+		workspace_path: base
+		recipe:         'team'
+		backend:        'headless'
+		task:           'demo'
+	})
+	assert start.ok, start.message
+	assert start.data['run_state'] == 'awaiting_plan_approval'
+	rid := start.data['run_id']
+	assert swarm_valid_run_id(rid)
+	assert os.is_file(os.join_path(base, '.agent-toolkit', 'swarm', 'runs', rid, 'state.json'))
+
+	st := run_swarm(SwarmOptions{
+		subcommand:     'status'
+		workspace_path: base
+		run_id:         rid
+	})
+	assert st.ok, st.message
+	assert st.data['gates'].contains('plan:pending')
+
+	ap := run_swarm(SwarmOptions{
+		subcommand:     'approve'
+		workspace_path: base
+		run_id:         rid
+		gate_id:        'plan'
+	})
+	assert ap.ok, ap.message
+	assert ap.data['run_state'] == 'running'
+
+	rej := run_swarm(SwarmOptions{
+		subcommand:     'reject'
+		workspace_path: base
+		run_id:         rid
+		gate_id:        'final'
+		reason:         'not yet'
+	})
+	assert rej.ok, rej.message
+
+	can := run_swarm(SwarmOptions{
+		subcommand:     'cancel'
+		workspace_path: base
+		run_id:         rid
+	})
+	assert can.ok, can.message
+	assert can.data['run_state'] == 'cancelled'
+
+	doc := run_swarm(SwarmOptions{
+		subcommand:     'doctor'
+		workspace_path: base
+	})
+	assert doc.ok, doc.message
+	assert doc.data['git'] == 'true'
+	assert doc.data['recipes'].contains('pair')
+}

--- a/tests/parity/fixtures/seed.json
+++ b/tests/parity/fixtures/seed.json
@@ -496,6 +496,33 @@
         "queue",
         "status"
       ]
+    },
+    {
+      "command": "swarm-help",
+      "args": [
+        "swarm",
+        "--help"
+      ],
+      "class": "SEMANTIC",
+      "must_contain": [
+        "start",
+        "doctor",
+        "approve"
+      ]
+    },
+    {
+      "command": "swarm-recipes",
+      "args": [
+        "swarm",
+        "recipes",
+        "--json"
+      ],
+      "class": "SCHEMA",
+      "expect_v_exit": 0,
+      "required_keys": [
+        "command",
+        "recipes"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- REDESIGN of `agent-toolkit swarm` in V (Fixes #524): recipes/backends/doctor/start/list/status/approve/reject/cancel with ADR-008 filesystem state.
- Isolated Herdr/tmux/headless backend probes (no invented Herdr APIs); UI spawn fail-closed (ADR-020); Windows uses headless only.
- Approval gate state machine; `start --dry-run`; SCHEMA fixture for `swarm recipes --json`.

## Test plan
- [x] `VMODULES=$PWD/modules v test modules/agent_toolkit_core/swarm_test.v modules/agent_toolkit_core/swarm_state_test.v modules/agent_toolkit_core/swarm_backend_test.v modules/agent_toolkit_cli/dispatch_test.v`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)