### PR TITLE
docs(ci): CI cost tiers for dual Python+V

### DIFF
--- a/.github/workflows/experimental-v.yml
+++ b/.github/workflows/experimental-v.yml
@@ -32,6 +32,7 @@ jobs:
   build:
     name: ${{ matrix.asset }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -3,7 +3,23 @@ name: Parity (Python↔V)
 on:
   push:
     branches: [main]
+    paths:
+      - "modules/**"
+      - "cmd/**"
+      - "tests/parity/**"
+      - "packages/agent-toolkit-cli/**"
+      - "Makefile"
+      - ".v-version"
+      - ".github/workflows/parity.yml"
   pull_request:
+    paths:
+      - "modules/**"
+      - "cmd/**"
+      - "tests/parity/**"
+      - "packages/agent-toolkit-cli/**"
+      - "Makefile"
+      - ".v-version"
+      - ".github/workflows/parity.yml"
   workflow_dispatch:
 
 permissions:
@@ -17,6 +33,7 @@ jobs:
   parity-seed:
     name: Golden CLI parity (seed)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       tag: ${{ github.ref_name }}
     steps:
@@ -97,6 +98,7 @@ jobs:
     name: Build ${{ matrix.artifact }}
     needs: create-release
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     environment: release
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — CI cost tiers (PR/main/release) with path filters, timeouts, Python-lane retirement trigger (Closes #532)
 - **Feat** — V `loop` REDESIGN (init/run/status/audit/cost/schedule/sync; process-per-run skeleton) (Closes #523)
 - **Feat** — Execute MUST-platform V artifacts (`--version`/`--help`/`inventory`/`doctor`) with arch mismatch fail (Closes #531)
 - **Feat** — Native V MUST build matrix (linux x86_64/arm64, macos arm64/x86_64, windows x86_64; experimental names) (Closes #529)

--- a/docs/v/ci-cost-tiers.md
+++ b/docs/v/ci-cost-tiers.md
@@ -1,0 +1,47 @@
+# CI cost tiers (dual Python + V)
+
+**Issue:** [#532](https://github.com/ulises-jeremias/agent-toolkit/issues/532)  
+**Parent:** [#463](https://github.com/ulises-jeremias/agent-toolkit/issues/463)  
+**Related:** parity harness [#548](https://github.com/ulises-jeremias/agent-toolkit/issues/548) · MUST matrix [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529) · smoke [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531) · attestations [#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530) · Python removal [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540)
+
+Dual implementation CI is expensive. Workflows follow three **cost tiers**. Distribution smoke must not run on docs-only PRs.
+
+## Tiers
+
+| Tier | When | What runs | Budget |
+|------|------|-----------|--------|
+| **PR** | `pull_request` | Lint/fmt/validate; Python unit (validate.yml); V compile via parity seed + dispatch tests in validate if present; golden parity (`parity.yml`) only when CLI/V/Python CLI paths change | Wall: parity ≤ 15 min; experimental-v **skipped** unless its path filter matches. Cancel-in-progress: yes |
+| **main** | `push` to `main` | PR set plus fuller compile. Experimental V MUST matrix (`experimental-v.yml`) only on V/release-doc path changes | Wall: experimental-v job ≤ 25 min/platform. Cancel-in-progress: yes |
+| **release** | `v*` tags (`release.yml`) | Full native **stable** PyInstaller matrix, PyPI publish, SHA256SUMS/attestations/SBOM (#530) | Wall: release workflow ≤ 60 min. Cancel-in-progress: **no** |
+
+Experimental native V artifacts stay on the **experimental** channel ([ADR-018](../adrs/ADR-018-release-artifacts.md)) until an explicit promotion. They are **not** the release-tier stable upload.
+
+## Path filters (distribution smoke)
+
+`.github/workflows/experimental-v.yml` already lists paths (workflow, `.v-version`, `docs/v/{experimental-binaries,release-matrix,artifact-smoke}.md`). Docs-only PRs that do not touch those files **must not** pay the 5-runner MUST matrix.
+
+`.github/workflows/parity.yml` is limited to CLI/V/parity/Makefile/`.v-version` paths so markdown-only PRs skip the golden harness.
+
+## Python lane retirement trigger
+
+Remove the `test-package` OS × CPython matrix from `.github/workflows/validate.yml` **only when all of**:
+
+1. [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) gates are actually met (not merely “V is default in-repo”).
+2. [#561](https://github.com/ulises-jeremias/agent-toolkit/issues/561) consumer audit is closed with no remaining in-tree Python API dependents (or they are documented exceptions).
+3. PyPI/Homebrew/AUR no longer require the Python CLI as the shipped runtime ([#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535) / [#486](https://github.com/ulises-jeremias/agent-toolkit/issues/486)).
+
+Until then, Python tests stay on **PR** and **main**. Do not drop them to save CI minutes while Python is still the stable distribution.
+
+## Timeouts (recorded)
+
+| Workflow / job | `timeout-minutes` |
+|----------------|-------------------|
+| `parity.yml` / `parity-seed` | 15 |
+| `experimental-v.yml` / matrix build | 25 |
+| `release.yml` overall | 60 (job-level in workflow as added) |
+
+`concurrency.cancel-in-progress: true` on PR/main validate, parity, and experimental-v. Release concurrency must not cancel.
+
+## Cost notes
+
+The expensive axis is **Python 3.10–3.13 × ubuntu+macos** plus **five** experimental V runners. Path filters are the lever before shrinking the Python matrix. Do not add a sixth experimental OS without an issue.

--- a/docs/v/release-matrix.md
+++ b/docs/v/release-matrix.md
@@ -35,3 +35,5 @@ macOS x86_64 is **MUST here** (experimental channel). The historical #256 skip (
 `.github/workflows/experimental-v.yml` — `fail-fast: false`, `contents: read`, Actions artifacts only (no `gh release upload`).
 
 Smoke: `--version` / `--help` / `inventory` / `doctor --json` plus an arch mismatch gate ([#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531), [artifact-smoke.md](artifact-smoke.md)).
+
+CI cost tiers (PR / main / release) and Python-lane retirement: [ci-cost-tiers.md](ci-cost-tiers.md) ([#532](https://github.com/ulises-jeremias/agent-toolkit/issues/532)).


### PR DESCRIPTION
## Summary
- Written PR/main/release CI cost policy (Fixes #532) in `docs/v/ci-cost-tiers.md`, including Python-lane retirement trigger (#540/#561) and recorded timeouts.
- Path-filter golden parity so docs-only PRs skip the harness; timeout experimental V matrix (25m) and release binary builds (45m).

## Test plan
- [ ] Confirm docs-only PRs do not start `parity.yml` / `experimental-v.yml`
- [ ] Confirm CLI/V path PRs still run golden parity
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)