### PR TITLE
docs: add distribution/ adapter contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Add `distribution/` adapter contracts (GitHub Release canonical; no Formula/PKGBUILD copies) (Closes #534)
 - **Feat** — V `loop` REDESIGN (init/run/status/audit/cost/schedule/sync; process-per-run skeleton) (Closes #523)
 - **Feat** — Execute MUST-platform V artifacts (`--version`/`--help`/`inventory`/`doctor`) with arch mismatch fail (Closes #531)
 - **Feat** — Native V MUST build matrix (linux x86_64/arm64, macos arm64/x86_64, windows x86_64; experimental names) (Closes #529)

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,0 +1,31 @@
+# Distribution contracts
+
+**Issue:** [#534](https://github.com/ulises-jeremias/agent-toolkit/issues/534)  
+**EPIC:** [#463](https://github.com/ulises-jeremias/agent-toolkit/issues/463) (binary release engineering)
+
+This directory is **documentation-only contracts** for packaging adapters. It is not `distributions/` (product/target compiler input).
+
+## Canonical source
+
+**GitHub Releases** on `ulises-jeremias/agent-toolkit` are the canonical binary source ([ADR-018](../docs/adrs/ADR-018-release-artifacts.md)). PyPI, Homebrew, AUR, npm, and Docker are **adapters**: they fetch or wrap those artifacts (or, until V promotion, the current Python wheel / PyInstaller names).
+
+Do **not** duplicate Formula/PKGBUILD/npm `package.json` here. Those live in their owner repos:
+
+| Channel | Owner repo (out of this tree) | Contract in this repo |
+|---------|-------------------------------|------------------------|
+| GitHub Release | this repo (`.github/workflows/release.yml`) | [github-release/README.md](github-release/README.md) |
+| PyPI | this repo (`packages/agent-toolkit-cli`) until wrapper [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535) | [pypi/README.md](pypi/README.md) · ADR [#486](https://github.com/ulises-jeremias/agent-toolkit/issues/486) |
+| Homebrew | `ulises-jeremias/homebrew-tap` | [homebrew/README.md](homebrew/README.md) · [#538](https://github.com/ulises-jeremias/agent-toolkit/issues/538) · ADR [#490](https://github.com/ulises-jeremias/agent-toolkit/issues/490) |
+| AUR | `ulises-jeremias/aur-packages` | [aur/README.md](aur/README.md) · [#539](https://github.com/ulises-jeremias/agent-toolkit/issues/539) · ADR [#491](https://github.com/ulises-jeremias/agent-toolkit/issues/491) |
+| npm | future adapter | [npm/README.md](npm/README.md) · [#536](https://github.com/ulises-jeremias/agent-toolkit/issues/536) · ADR [#487](https://github.com/ulises-jeremias/agent-toolkit/issues/487) |
+| Docker | this repo (`.github/workflows/docker.yml`) | [docker/README.md](docker/README.md) · [#537](https://github.com/ulises-jeremias/agent-toolkit/issues/537) |
+
+## Verification
+
+Consumers MUST verify checksums when [#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530) ships `SHA256SUMS`. Attestations/SBOM, if present, prove **provenance of the build**, not “secure software”.
+
+`agent-toolkit update` never replaces the executable ([ADR-017](../docs/adrs/ADR-017-update-ownership.md)). Package managers own binary upgrades.
+
+## Experimental vs stable
+
+Experimental V names (`agent-toolkit-v-experimental-*`) MUST NOT overwrite stable floating names. Promotion is an explicit release decision ([docs/v/release-matrix.md](../docs/v/release-matrix.md)).

--- a/distribution/aur/README.md
+++ b/distribution/aur/README.md
@@ -1,0 +1,13 @@
+# AUR adapter
+
+**Issue:** [#539](https://github.com/ulises-jeremias/agent-toolkit/issues/539) · **ADR:** [#491](https://github.com/ulises-jeremias/agent-toolkit/issues/491)
+
+**Owner:** `ulises-jeremias/aur-packages` (not this tree). Playbook: [docs/AUR_PLAYBOOK.md](../../docs/AUR_PLAYBOOK.md). Notify: `.github/workflows/notify-aur.yml`.
+
+Contract:
+
+- PKGBUILD lives **only** in `aur-packages`. This repo MUST NOT copy a PKGBUILD.
+- Package name advertised to users: `agent-toolkit` (`yay -S agent-toolkit`). A `-bin` split is an ADR-491 decision.
+- `pacman -Syu` / AUR helpers own the binary. `agent-toolkit update` is capability/profile refresh only (ADR-017).
+
+Until V promotion, AUR may still wrap the Python package.

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -1,0 +1,7 @@
+# Docker adapter
+
+**Issue:** [#537](https://github.com/ulises-jeremias/agent-toolkit/issues/537)
+
+Workflow: `.github/workflows/docker.yml` (this repo).
+
+Contract: image is an adapter around the **canonical GitHub Release binary** (or, until promotion, the current Python image). Base image and extra CLI tools (`git`, `gh`) are decided in #537. Do not bake experimental V names into the stable tag without the #531 promotion gate.

--- a/distribution/github-release/README.md
+++ b/distribution/github-release/README.md
@@ -1,0 +1,14 @@
+# GitHub Release adapter
+
+**Owner:** this repository (`.github/workflows/release.yml`).  
+**Names:** [ADR-018](../../docs/adrs/ADR-018-release-artifacts.md).
+
+Stable floating assets (today PyInstaller until V promotion):
+
+- `agent-toolkit-linux-x86_64`
+- `agent-toolkit-macos-arm64`
+- `agent-toolkit-windows-x86_64.exe`
+
+Experimental V assets use the `agent-toolkit-v-experimental-` prefix only ([#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562)).
+
+Checksums, attestations, SBOM: [#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530). Manifest: [#488](https://github.com/ulises-jeremias/agent-toolkit/issues/488).

--- a/distribution/homebrew/README.md
+++ b/distribution/homebrew/README.md
@@ -1,0 +1,13 @@
+# Homebrew adapter
+
+**Issue:** [#538](https://github.com/ulises-jeremias/agent-toolkit/issues/538) · **ADR:** [#490](https://github.com/ulises-jeremias/agent-toolkit/issues/490)
+
+**Owner:** `ulises-jeremias/homebrew-tap` (not this tree). Notify workflow: `.github/workflows/notify-homebrew.yml`.
+
+Contract:
+
+- Formula lives **only** in the tap. This repo MUST NOT copy a Formula.
+- Canonical download URL is the GitHub Release stable floating name for the host OS/arch (ADR-018).
+- `brew upgrade` owns the binary. `agent-toolkit update` is capability/profile refresh only (ADR-017).
+
+Until V promotion, the tap may still ship the Python formula; the ADR records the binary vs bottle vs source choice.

--- a/distribution/npm/README.md
+++ b/distribution/npm/README.md
@@ -1,0 +1,7 @@
+# npm adapter
+
+**Issue:** [#536](https://github.com/ulises-jeremias/agent-toolkit/issues/536) · **ADR:** [#487](https://github.com/ulises-jeremias/agent-toolkit/issues/487)
+
+Future adapter. Topology (optionalDependencies per platform vs single meta-package) is decided in #487. This repo does **not** vendor npm `package.json` here.
+
+When implemented: launcher must forward stdio, signals, and Windows quoting; no forked CLI behavior. Binary sourced from GitHub Releases (ADR-018), not a second compile.

--- a/distribution/pypi/README.md
+++ b/distribution/pypi/README.md
@@ -1,0 +1,11 @@
+# PyPI adapter
+
+**Issue:** [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535) · **ADR:** [#486](https://github.com/ulises-jeremias/agent-toolkit/issues/486)
+
+**Today:** distribution name `agent-toolkit-cli`; console scripts `agent-toolkit` / `agent-toolkit-cli` (Python implementation).
+
+**Target:** PyPI remains an **adapter**, not a second CLI. Prefer platform wheels containing the native binary plus a thin launcher (strategy A in #486). Keep the PyPI **distribution** name `agent-toolkit-cli` unless a coordinated rename is decided in that ADR. Command name stays `agent-toolkit`.
+
+Wrapper constraints (when implemented): forward argv, signals, and exit codes; no forked business logic.
+
+This directory does **not** vendor `setup.py` / wheel internals.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -74,6 +74,8 @@ Release binaries are platform-suffixed to avoid upload collisions (see #256 and 
 
 Darwin x86_64 is intentionally deferred (documented skip). Release notes / this doc mention naming.
 
+Packaging **adapter contracts** (this repo, no Formula/PKGBUILD copies): [`distribution/README.md`](../distribution/README.md) ([#534](https://github.com/ulises-jeremias/agent-toolkit/issues/534)).
+
 ## Downstream publish verification (notify success ≠ publish success)
 
 `notify-homebrew` / `notify-aur` only confirm that a `repository_dispatch` reached the downstream repo (see `.github/workflows/notify-*.yml`). A green `Notify` run does **not** guarantee the Homebrew formula or AUR PKGBUILD was actually published.


### PR DESCRIPTION
## Summary
- Add `distribution/` contracts (Fixes #534): GitHub Releases are canonical; PyPI/Homebrew/AUR/npm/Docker are adapters.
- No Formula/PKGBUILD copies. Channel content remains in #535–#539 / ADRs #486/#487/#490/#491.

## Test plan
- [ ] Skim `distribution/README.md` against ADR-017/018
- [ ] Confirm no Formula/PKGBUILD files in the PR
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)