### PR TITLE
docs(adr): ADR-021 PyPI platform wheels + V launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — ADR-021 PyPI ships platform wheels with bundled V binary + thin launcher (Closes #486)
 - **Feat** — V `swarm` REDESIGN (recipes/start/status/doctor/approve/reject/cancel; filesystem SoT) (Closes #524)
 - **Feat** — V `loop` REDESIGN (init/run/status/audit/cost/schedule/sync; process-per-run skeleton) (Closes #523)
 - **Feat** — Execute MUST-platform V artifacts (`--version`/`--help`/`inventory`/`doctor`) with arch mismatch fail (Closes #531)

--- a/docs/adrs/ADR-012-python-v-coexistence.md
+++ b/docs/adrs/ADR-012-python-v-coexistence.md
@@ -49,7 +49,7 @@ Experimental and stable binaries should expose engine/language, version, and com
 - From-source `make build-cli` / `make install-cli` installs V as `agent-toolkit`.
 - Consumer commands (install lifecycle + skills/mcp/plugin) are implemented in V.
 - GitHub native artifacts remain **experimental** until MUST-platform promotion ([#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562) / [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529)); they must not overwrite stable channel names without that gate.
-- **PyPI/`uvx` still runs the Python wheel** until binary wrappers ([#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535)). That is a packaging lag, not a dual-engine switch.
+- **PyPI/`uvx`:** packaging strategy is [ADR-021](ADR-021-pypi-binary.md) (platform wheels + thin launcher over the V binary). Implementation is [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535). Not a dual-engine switch (options B/C still rejected).
 - Unfinished advanced commands stay `not_implemented` in V. Fallback is a **separate** Python entry (`uvx --from agent-toolkit-cli`), not option C (V exec of Python).
 - Observability: `doctor --json` and `version --json` include `engine`, `version`, and `commit` without changing human stdout.
 

--- a/docs/adrs/ADR-021-pypi-binary.md
+++ b/docs/adrs/ADR-021-pypi-binary.md
@@ -1,0 +1,85 @@
+# ADR-021: PyPI binary strategy (platform wheels + thin launcher)
+
+**Status:** Accepted  
+**Date:** 2026-08-13  
+**Deciders:** maintainers (V migration program [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456), issue [#486](https://github.com/ulises-jeremias/agent-toolkit/issues/486))
+
+## Context
+
+PyPI distribution **`agent-toolkit-cli`** currently ships a full Python CLI (`agent-toolkit` / `agent-toolkit-cli` console scripts). After [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555), V is the in-repo canonical implementation. Leaving PyPI on the Python CLI would keep a second product runtime.
+
+GitHub Releases are the canonical binary source ([ADR-018](ADR-018-release-artifacts.md)). PyPI must be an **adapter**, not a second implementation.
+
+## Options considered
+
+| ID | Option | Summary |
+|----|--------|---------|
+| **A** | Platform wheels containing the native V binary + tiny launcher | `uv tool install agent-toolkit-cli` gets a wheel tagged for the host; entrypoint `exec`s the bundled binary. |
+| **B** | Bootstrap downloader | Wheel has no binary; first run detects OS/arch, downloads a GitHub Release asset, verifies, execs. |
+| **C** | Keep Python CLI on PyPI indefinitely | Simplest packaging; contradicts cutover. |
+| **D** | Rename/replace PyPI project with a non-Python artifact only | PyPI is Python-centric; dropping a wheel breaks `uv`/`pip`. |
+
+## Decision
+
+Adopt **A**.
+
+### Strategy
+
+1. **Product path is the V binary.** The commands `agent-toolkit` and `agent-toolkit-cli` MUST `exec` (or equivalent spawn+wait with signal/stdio/exit forwarding) a native V binary. They MUST NOT run Python business logic.
+2. **Bundle at wheel-build time.** CI downloads the matching GitHub Release asset (stable floating name after promotion; `agent-toolkit-v-experimental-<os>-<arch>` until then) into the wheel. Runtime download (option B) is **not** the default and is blocked on the distribution threat model ([#563](https://github.com/ulises-jeremias/agent-toolkit/issues/563)).
+3. **Thin Python process is allowed.** `uv tool install` may start a tiny Python entrypoint whose only job is locate-binary + `os.execv` / `subprocess` with forwarded argv, env, cwd, stdio, signals, and exit code. **Zero Python implementation**, not zero Python process.
+4. **Python CLI remains a named fallback.** Console script `agent-toolkit-py` keeps the Python implementation until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). It is not the product command.
+
+### Name continuity
+
+| Kind | Decision |
+|------|----------|
+| PyPI **distribution** name | Keep **`agent-toolkit-cli`**. Do not require acquiring the unused `agent-toolkit` name on PyPI. |
+| Console **command** name | **`agent-toolkit`** (and alias `agent-toolkit-cli`) → V launcher. |
+| Python **import** name | `agent_toolkit` stays for the thin launcher and, until #540/#561, the Python modules. Importing `agent_toolkit.cli.main` is advanced/fallback, not the product path. |
+
+### Platform tags (glibc MUST)
+
+Wheels are **platform-specific** (not `py3-none-any` for the product command). Tags follow current packaging specs and [ADR-019](ADR-019-linux-libc.md):
+
+| Wheel tag (illustrative) | Bundled asset (ADR-018) |
+|--------------------------|-------------------------|
+| `manylinux_2_28_x86_64` (or the manylinux tag CI actually produces) | `agent-toolkit-linux-x86_64` (glibc) / experimental equivalent |
+| `manylinux_2_28_aarch64` | `agent-toolkit-linux-arm64` |
+| `macosx_*_arm64` | `agent-toolkit-macos-arm64` |
+| `macosx_*_x86_64` | `agent-toolkit-macos-x86_64` when published; otherwise omit the wheel |
+| `win_amd64` | `agent-toolkit-windows-x86_64.exe` |
+
+Musl/Alpine is **not** a PyPI MUST tag. No `py3-none-any` product wheel that silently runs Python CLI.
+
+### Wrapper constraints (implemented in [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535))
+
+- Forward argv unchanged (no re-parsing into a second CLI).
+- Forward stdio; on POSIX, replace the process (`execv`) so signals hit the V binary.
+- On Windows, spawn with signal/Ctrl-C forwarding and wait; return the native exit code.
+- Version printed by `agent-toolkit version` is the **V binary** version, not the launcher’s packaging version if they ever diverge (they should not).
+- Missing bundled binary in an editable/dev tree is an error pointing at `make build-cli` / `agent-toolkit-py` — not a silent Python fallback.
+
+### Rejected
+
+- **B as default** — install-time or first-run download needs #563; also fails offline `uv tool install`.
+- **C** — PyPI would remain a second implementation after #555.
+- **D** — breaks the `uv`/`pip` install path the docs already advertise.
+
+## Consequences
+
+- **Positive:** `uvx --from agent-toolkit-cli agent-toolkit` runs V; one implementation; checksums happen at wheel build (Release asset → wheel).
+- **Negative:** Must publish several platform wheels per release; sdist cannot usefully contain every native binary; macOS x86_64 wheel omitted until that asset exists.
+- **Follow-on:** [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535) launcher + tests; [#488](https://github.com/ulises-jeremias/agent-toolkit/issues/488) manifest so the build can pick the asset without scraping HTML; [#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530) SHA256SUMS for build-time verify.
+
+## Validation plan
+
+- Unit tests: launcher forwards argv/exit; refuses to import `cli.main` on the product path.
+- One CI job per MUST OS builds or fetches the V binary, packs a wheel, runs `agent-toolkit --help` / `version` from that wheel (not `agent-toolkit-py`).
+- `py3-none-any` wheel, if still built for sdist completeness, must not install `agent-toolkit` as the Python CLI; prefer no universal product wheel.
+
+## References
+
+- Issues [#486](https://github.com/ulises-jeremias/agent-toolkit/issues/486), [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535), [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555), [#563](https://github.com/ulises-jeremias/agent-toolkit/issues/563)
+- [ADR-012](ADR-012-python-v-coexistence.md), [ADR-017](ADR-017-update-ownership.md), [ADR-018](ADR-018-release-artifacts.md), [ADR-019](ADR-019-linux-libc.md)
+- `distribution/pypi/README.md` ([#534](https://github.com/ulises-jeremias/agent-toolkit/issues/534) / #535)


### PR DESCRIPTION
## Summary
- Accept ADR-021 (Fixes #486): PyPI keeps distribution name \`agent-toolkit-cli\`; \`agent-toolkit\` execs a bundled V binary (strategy A). Thin Python process allowed; no Python business logic on the product path.
- Reject runtime GitHub download as default (needs #563). \`agent-toolkit-py\` remains the Python fallback until #540.
- Amends ADR-012 cutover note: PyPI packaging follows ADR-021 / #535, not “Python remains canonical”.

## Test plan
- [ ] Read ADR-021 name-continuity and wrapper-constraint tables
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)