### PR TITLE
feat(pypi): agent-toolkit launches bundled V binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,31 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Build wheel and sdist
+      - name: Install pinned V from GitHub Release
         run: |
-          bash scripts/prepare-package-data.sh && uv build --package agent-toolkit-cli
+          set -euo pipefail
+          PIN="$(tr -d '[:space:]' < .v-version)"
+          curl -fsSL -o /tmp/v.zip "https://github.com/vlang/v/releases/download/${PIN}/v_linux.zip"
+          sudo rm -rf /usr/local/v
+          sudo unzip -q /tmp/v.zip -d /usr/local
+          if [ -x /usr/local/v/v ]; then
+            echo "/usr/local/v" >> "$GITHUB_PATH"
+          elif [ -x /usr/local/v_linux/v ]; then
+            echo "/usr/local/v_linux" >> "$GITHUB_PATH"
+          else
+            echo "Unexpected V zip layout" >&2
+            exit 1
+          fi
+      - name: Build sdist then Linux V wheel
+        env:
+          VMODULES: ${{ github.workspace }}/modules
+        run: |
+          set -euo pipefail
+          bash scripts/prepare-package-data.sh
+          uv build --sdist --package agent-toolkit-cli
+          make build-cli
+          bash scripts/prepare-native-bin.sh
+          uv build --wheel --package agent-toolkit-cli
           ls -lh dist/
       - name: Publish to PyPI (Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Sync workspace (packages/agent-toolkit-cli)
         run: uv sync --all-extras
 
-      - name: Smoke-test CLI entry-point (version)
-        run: uv run agent-toolkit version
+      - name: Smoke-test Python fallback CLI (version)
+        run: uv run agent-toolkit-py version
 
-      - name: Smoke-test CLI entry-point (help)
-        run: uv run agent-toolkit help
+      - name: Smoke-test Python fallback CLI (help)
+        run: uv run agent-toolkit-py help
 
       - name: Run test suite
         run: uv run pytest tests/ -v --tb=short
@@ -455,15 +455,39 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Build wheel and sdist from workspace package
+      - name: Install pinned V from GitHub Release
         run: |
-          bash scripts/prepare-package-data.sh && uv build --package agent-toolkit-cli
+          set -euo pipefail
+          PIN="$(tr -d '[:space:]' < .v-version)"
+          curl -fsSL -o /tmp/v.zip "https://github.com/vlang/v/releases/download/${PIN}/v_linux.zip"
+          sudo rm -rf /usr/local/v
+          sudo unzip -q /tmp/v.zip -d /usr/local
+          if [ -x /usr/local/v/v ]; then
+            echo "/usr/local/v" >> "$GITHUB_PATH"
+          elif [ -x /usr/local/v_linux/v ]; then
+            echo "/usr/local/v_linux" >> "$GITHUB_PATH"
+          else
+            echo "Unexpected V zip layout" >&2
+            exit 1
+          fi
+
+      - name: Build wheel and sdist from workspace package
+        env:
+          VMODULES: ${{ github.workspace }}/modules
+        run: |
+          set -euo pipefail
+          bash scripts/prepare-package-data.sh
+          uv build --sdist --package agent-toolkit-cli
+          make build-cli
+          bash scripts/prepare-native-bin.sh
+          uv build --wheel --package agent-toolkit-cli
           ls -lh dist/
 
-      - name: Install built wheel and smoke-test
+      - name: Install built wheel and smoke-test V launcher
         run: |
           pip install dist/*.whl
           agent-toolkit version
+          agent-toolkit-py version
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
@@ -494,23 +518,33 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Install from wheel (simulates pip install agent-toolkit-cli)
+      - name: Install from dist (Linux wheel with V binary; sdist elsewhere)
         shell: bash
-        run: pip install dist/*.whl
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            pip install dist/*.whl
+          else
+            pip install dist/*.tar.gz
+          fi
 
-      - name: "CLI: version"
+      - name: "CLI: V launcher version (Linux wheel)"
+        if: runner.os == 'Linux'
         run: agent-toolkit version
 
+      - name: "CLI: version"
+        run: agent-toolkit-py version
+
       - name: "CLI: version via alias"
-        run: agent-toolkit-cli version
+        run: agent-toolkit-py version
 
       - name: "CLI: help"
-        run: agent-toolkit help
+        run: agent-toolkit-py help
 
       - name: "CLI: doctor (no tools installed in CI — expect warnings, not errors)"
         shell: bash
         run: |
-          agent-toolkit doctor 2>&1 | tee doctor_output.txt
+          agent-toolkit-py doctor 2>&1 | tee doctor_output.txt
           # Must not crash; errors are OK for missing tools but exit code should be 0
           # (doctor returns 0 even with warnings, only 1 on true errors)
           if grep -q "✗" doctor_output.txt; then
@@ -521,7 +555,7 @@ jobs:
       - name: "CLI: skills list (all domains)"
         shell: bash
         run: |
-          agent-toolkit skills list 2>&1 | tee skills_output.txt
+          agent-toolkit-py skills list 2>&1 | tee skills_output.txt
           # Verify: must contain at least 50 skills and show descriptions (not ">-")
           COUNT=$(grep -c "^  ✓" skills_output.txt || echo 0)
           echo "Skills found: $COUNT"
@@ -537,18 +571,18 @@ jobs:
           echo "✓ Skills list: $COUNT skills with proper descriptions"
 
       - name: "CLI: skills list --domain core"
-        run: agent-toolkit skills list --domain core
+        run: agent-toolkit-py skills list --domain core
 
       - name: "CLI: skills list --domain forge"
-        run: agent-toolkit skills list --domain forge
+        run: agent-toolkit-py skills list --domain forge
 
       - name: "CLI: skills validate"
-        run: agent-toolkit skills validate
+        run: agent-toolkit-py skills validate
 
       - name: "CLI: loop status (must show 10 bundled templates)"
         shell: bash
         run: |
-          agent-toolkit loop status 2>&1 | tee loops_output.txt
+          agent-toolkit-py loop status 2>&1 | tee loops_output.txt
           COUNT=$(grep -c "tier=" loops_output.txt || echo 0)
           echo "Loop templates found: $COUNT"
           if [ "$COUNT" -lt 10 ]; then
@@ -566,15 +600,15 @@ jobs:
           echo "✓ Loop status: $COUNT templates including OSS patterns"
 
       - name: "CLI: loop cost daily-triage"
-        run: agent-toolkit loop cost daily-triage
+        run: agent-toolkit-py loop cost daily-triage
 
       - name: "CLI: loop audit (no runs — should exit cleanly)"
-        run: agent-toolkit loop audit
+        run: agent-toolkit-py loop audit
 
       - name: "CLI: mcp list (all 6 providers)"
         shell: bash
         run: |
-          agent-toolkit mcp list 2>&1 | tee mcp_output.txt
+          agent-toolkit-py mcp list 2>&1 | tee mcp_output.txt
           for provider in github slack notion linear figma clickup; do
             if ! grep -q "$provider" mcp_output.txt; then
               echo "::error::MCP provider '$provider' not found in list"
@@ -584,13 +618,13 @@ jobs:
           echo "✓ MCP list: all 6 providers shown"
 
       - name: "CLI: plugin check (surfaces in sync)"
-        run: agent-toolkit plugin check
+        run: agent-toolkit-py plugin check
 
       - name: "CLI: install --dry-run --tools claude-code,cursor"
         shell: bash
         run: |
           # Should not prompt for Copilot, should not crash, should list what would be installed
-          agent-toolkit install --dry-run --tools claude-code,cursor 2>&1 | tee install_output.txt
+          agent-toolkit-py install --dry-run --tools claude-code,cursor 2>&1 | tee install_output.txt
           if grep -Eiq "(traceback|exception|✗|\[error\])" install_output.txt; then
             echo "::error::install --dry-run produced errors"
             cat install_output.txt
@@ -601,7 +635,7 @@ jobs:
       - name: "CLI: install --dry-run (auto-detect, no stdin = no Copilot prompt)"
         shell: bash
         run: |
-          agent-toolkit install --dry-run --tools cursor 2>&1 | tee install_auto_output.txt
+          agent-toolkit-py install --dry-run --tools cursor 2>&1 | tee install_auto_output.txt
           if grep -q "Copilot instructions for a project?\n          # Copilot is never auto-detected — only via --tools copilot" install_auto_output.txt; then
             echo "::error::install prompted for Copilot in non-interactive mode"
             exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -485,7 +485,7 @@ jobs:
 
       - name: Install built wheel and smoke-test V launcher
         run: |
-          pip install dist/*.whl
+          uv pip install dist/*.whl
           agent-toolkit version
           agent-toolkit-py version
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ node_modules/
 # Build artifacts
 dist/
 build/
+packages/agent-toolkit-cli/src/agent_toolkit/bin/agent-toolkit
+packages/agent-toolkit-cli/src/agent_toolkit/bin/agent-toolkit.exe
 
 # Editor
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — PyPI `agent-toolkit` is a thin launcher over the bundled V binary (Closes #535)
 - **Docs** — CI cost tiers (PR/main/release) with path filters, timeouts, Python-lane retirement trigger (Closes #532)
 - **Feat** — V `swarm` REDESIGN (recipes/start/status/doctor/approve/reject/cancel; filesystem SoT) (Closes #524)
 - **Feat** — V `loop` REDESIGN (init/run/status/audit/cost/schedule/sync; process-per-run skeleton) (Closes #523)

--- a/docs/v/cutover.md
+++ b/docs/v/cutover.md
@@ -3,7 +3,7 @@
 **Issue:** [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)  
 **ADR:** [ADR-012](../adrs/ADR-012-python-v-coexistence.md)
 
-V is the **canonical implementation** of consumer `agent-toolkit` (install lifecycle + skills/mcp/plugin). Python remains a **fallback package** for unfinished advanced commands and for PyPI/`uvx` until native binary wrappers ship ([#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535) / [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529)).
+V is the **canonical implementation** of consumer `agent-toolkit` (install lifecycle + skills/mcp/plugin). Python remains a **fallback** via `agent-toolkit-py` for unfinished advanced commands. PyPI/`uvx` runs a **thin launcher** over the bundled V binary ([ADR-021](../adrs/ADR-021-pypi-binary.md) / [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535)).
 
 ## What changed
 
@@ -12,7 +12,7 @@ V is the **canonical implementation** of consumer `agent-toolkit` (install lifec
 | From-source CLI | V (`make build-cli` / `make install-cli`) | Installs `PREFIX/bin/agent-toolkit` (default `~/.local/bin`) |
 | `doctor --json` / `version --json` | engine=`v`, version, commit | Human stdout unchanged (no engine/commit pollution) |
 | Unfinished advanced commands | `not_implemented` in V | Use `agent-toolkit-py` (Python extra script); **no** in-process Python exec (ADR-012 rejected C) |
-| PyPI `uvx` / `uv tool install` | Python wheel **until** binary wrappers | Transitional; not silent mixed engines |
+| PyPI `uvx` / `uv tool install` | V binary via thin launcher (ADR-021) | `agent-toolkit-py` is the Python fallback; not a dual-engine switch |
 | GitHub Release binaries | Experimental until MUST-platform promotion | See [rollback](rollback.md) |
 
 ## Experimental → stable promotion
@@ -24,9 +24,9 @@ Native artifacts stay **experimental** until [#562](https://github.com/ulises-je
 EPIC 5 remaining commands (`insights`, `release`) may still be `not_implemented` in V. `workspace` (#520), `memory` (#521), `project` (#522), `devcompanion`/`dc` (#525), `loop` (#523, ADR-020 process-per-run), and `swarm` (#524, ADR-008 filesystem SoT) are implemented in V. Run the Python CLI explicitly for unfinished advanced commands:
 
 ```bash
-agent-toolkit-py loop status
-# or:
-uvx --from agent-toolkit-cli agent-toolkit loop status
+agent-toolkit-py insights opencode
+# product command (V):
+uvx --from agent-toolkit-cli agent-toolkit doctor
 ```
 
 Do **not** set an engine env var (ADR-012 rejected option B).

--- a/docs/v/pypi-launcher.md
+++ b/docs/v/pypi-launcher.md
@@ -1,0 +1,18 @@
+# PyPI thin V launcher
+
+**Issue:** [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535)  
+**ADR:** [ADR-021](../adrs/ADR-021-pypi-binary.md)
+
+`agent-toolkit` and `agent-toolkit-cli` console scripts call `agent_toolkit.launcher:main`, which `exec`s (POSIX) or spawns (Windows) the bundled native binary. There is no Python business logic on that path.
+
+| Script | Implementation |
+|--------|----------------|
+| `agent-toolkit` | V launcher |
+| `agent-toolkit-cli` | V launcher (alias) |
+| `agent-toolkit-py` | Python CLI (fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540)) |
+
+Resolution order: `AGENT_TOOLKIT_BIN` → `agent_toolkit/bin/agent-toolkit` inside the wheel → `AGENT_TOOLKIT_ROOT/build/agent-toolkit{,-v}`.
+
+Wheel builds: `scripts/prepare-native-bin.sh` after `make build-cli`. Hatch `hatch_build.py` sets `pure_python = False` when a native file is present so pip will not install a Linux wheel on macOS.
+
+Missing binary exits **127** and points at `agent-toolkit-py` / `make build-cli`.

--- a/packages/agent-toolkit-cli/README.md
+++ b/packages/agent-toolkit-cli/README.md
@@ -36,9 +36,10 @@
 
 ## What is this package?
 
-`agent-toolkit-cli` is the **published Python entrypoint** for the agent-toolkit monorepo. It ships:
+`agent-toolkit-cli` is the **PyPI adapter** for the agent-toolkit monorepo ([ADR-021](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-021-pypi-binary.md)). Platform wheels bundle the native V binary; `agent-toolkit` / `agent-toolkit-cli` are a thin launcher. The Python implementation remains as `agent-toolkit-py` until retirement.
 
-- the `agent-toolkit` / `agent-toolkit-cli` console scripts
+It also ships:
+
 - bundled skills, agents, loops, profiles, packs, and MCP templates
 - install / doctor / sync workflows that deploy the right artifacts per AI tool
 

--- a/packages/agent-toolkit-cli/hatch_build.py
+++ b/packages/agent-toolkit-cli/hatch_build.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import sysconfig
 from pathlib import Path
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
+def _platform_tag() -> str:
+    # linux-x86_64 → linux_x86_64; macosx-15.0-arm64 → macosx_15_0_arm64
+    return sysconfig.get_platform().replace("-", "_").replace(".", "_")
+
+
 class CustomBuildHook(BuildHookInterface):
-    def initialize(self, version: str, build_data: dict) -> None:  # type: ignore[override]
+    def initialize(self, version: str, build_data: dict) -> None:
         pkg_bin = Path(self.root) / "src" / "agent_toolkit" / "bin"
         has_native = False
         if pkg_bin.is_dir():
@@ -17,5 +23,7 @@ class CustomBuildHook(BuildHookInterface):
                     has_native = True
                     break
         if has_native:
+            # Binary is CPython-ABI agnostic; cp311-cp311-* wheels fail on other Pythons.
             build_data["pure_python"] = False
-            build_data["infer_tag"] = True
+            build_data["infer_tag"] = False
+            build_data["tag"] = f"py3-none-{_platform_tag()}"

--- a/packages/agent-toolkit-cli/hatch_build.py
+++ b/packages/agent-toolkit-cli/hatch_build.py
@@ -1,0 +1,21 @@
+"""Hatch hook: platform-tag wheels that contain the native V binary (ADR-021)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version: str, build_data: dict) -> None:  # type: ignore[override]
+        pkg_bin = Path(self.root) / "src" / "agent_toolkit" / "bin"
+        has_native = False
+        if pkg_bin.is_dir():
+            for p in pkg_bin.iterdir():
+                if p.is_file() and p.name.startswith("agent-toolkit") and p.name != ".gitkeep":
+                    has_native = True
+                    break
+        if has_native:
+            build_data["pure_python"] = False
+            build_data["infer_tag"] = True

--- a/packages/agent-toolkit-cli/pyproject.toml
+++ b/packages/agent-toolkit-cli/pyproject.toml
@@ -34,8 +34,8 @@ yaml = ["pyyaml>=6.0"]
 all = ["pyyaml>=6.0"]
 
 [project.scripts]
-agent-toolkit = "agent_toolkit.cli.main:main"
-agent-toolkit-cli = "agent_toolkit.cli.main:main"
+agent-toolkit = "agent_toolkit.launcher:main"
+agent-toolkit-cli = "agent_toolkit.launcher:main"
 agent-toolkit-py = "agent_toolkit.cli.main:main"
 
 [project.urls]
@@ -52,6 +52,9 @@ path = "src/agent_toolkit/__init__.py"
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_toolkit"]
 
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
 # Capability trees are copied into src/agent_toolkit/data/ by
 # scripts/prepare-package-data.sh before sdist/wheel builds. Editable
 # installs resolve monorepo root via agent_toolkit._paths (no packed data).
@@ -62,4 +65,5 @@ include = [
     "LICENSE",
     "CHANGELOG.md",
     "pyproject.toml",
+    "hatch_build.py",
 ]

--- a/packages/agent-toolkit-cli/src/agent_toolkit/__main__.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/__main__.py
@@ -1,5 +1,5 @@
-"""agent-toolkit — run as python -m agent_toolkit"""
+"""agent-toolkit — run as python -m agent_toolkit (thin V launcher, ADR-021)."""
 
-from agent_toolkit.cli.main import main
+from agent_toolkit.launcher import main
 
 main()

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/__main__.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/__main__.py
@@ -1,0 +1,5 @@
+"""Python CLI fallback — python -m agent_toolkit.cli (ADR-021)."""
+
+from agent_toolkit.cli.main import main
+
+main()

--- a/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/cli/doctor.py
@@ -219,7 +219,7 @@ def _check_loop_runtime(toolkit_dir: Path | None) -> list[CheckResult]:
     # Check if `agent-toolkit loop` resolves (basic import test)
     try:
         subprocess.run(
-            [sys.executable, "-m", "agent_toolkit", "loop", "--help"],
+            [sys.executable, "-m", "agent_toolkit.cli", "loop", "--help"],
             capture_output=True,
             timeout=10,
         )

--- a/packages/agent-toolkit-cli/src/agent_toolkit/launcher.py
+++ b/packages/agent-toolkit-cli/src/agent_toolkit/launcher.py
@@ -1,0 +1,69 @@
+"""Thin PyPI launcher — replace this process with the bundled V binary (ADR-021 / #535).
+
+No Python business logic. Product commands agent-toolkit and agent-toolkit-cli
+hand off to the native binary.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_BIN_DIR = Path(__file__).resolve().parent / "bin"
+_NATIVE_NAMES = ("agent-toolkit.exe", "agent-toolkit")
+
+
+def bundled_binary() -> Path | None:
+    for name in _NATIVE_NAMES:
+        cand = _BIN_DIR / name
+        if cand.is_file():
+            return cand
+    return None
+
+
+def resolve_native_bin() -> Path | None:
+    env = os.environ.get("AGENT_TOOLKIT_BIN", "").strip()
+    if env:
+        p = Path(env)
+        if p.is_file():
+            return p
+        return None
+    bundled = bundled_binary()
+    if bundled is not None:
+        return bundled
+    root = os.environ.get("AGENT_TOOLKIT_ROOT", "").strip()
+    if root:
+        for rel in ("build/agent-toolkit", "build/agent-toolkit-v", "build/agent-toolkit.exe"):
+            cand = Path(root) / rel
+            if cand.is_file():
+                return cand
+    return None
+
+
+def run_native(bin_path: Path, rest: list[str]) -> None:
+    argv = [str(bin_path), *rest]
+    if os.name == "nt":
+        proc = subprocess.run(argv, check=False)
+        raise SystemExit(int(proc.returncode))
+    os.execv(argv[0], argv)
+
+
+def missing_binary_message() -> str:
+    return (
+        "agent-toolkit: native V binary not found (ADR-021).\n"
+        "  Packaged wheels bundle the binary under agent_toolkit/bin/.\n"
+        "  Dev: make build-cli, or set AGENT_TOOLKIT_BIN to that executable.\n"
+        "  Python implementation (fallback): agent-toolkit-py\n"
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = list(sys.argv if argv is None else argv)
+    rest = args[1:] if len(args) > 1 else []
+    bin_path = resolve_native_bin()
+    if bin_path is None:
+        sys.stderr.write(missing_binary_message())
+        raise SystemExit(127)
+    run_native(bin_path, rest)

--- a/scripts/prepare-native-bin.sh
+++ b/scripts/prepare-native-bin.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copy a native V binary into the PyPI package tree for platform wheels (ADR-021 / #535).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/packages/agent-toolkit-cli/src/agent_toolkit/bin"
+mkdir -p "$DEST"
+SRC="${AGENT_TOOLKIT_NATIVE_BIN:-}"
+if [[ -z "$SRC" ]]; then
+  for cand in "$ROOT/build/agent-toolkit" "$ROOT/build/agent-toolkit-v" "$ROOT/build/agent-toolkit.exe"; do
+    if [[ -f "$cand" ]]; then
+      SRC="$cand"
+      break
+    fi
+  done
+fi
+if [[ -z "$SRC" || ! -f "$SRC" ]]; then
+  echo "prepare-native-bin: no binary (set AGENT_TOOLKIT_NATIVE_BIN or make build-cli)" >&2
+  exit 1
+fi
+if [[ "$SRC" == *.exe ]]; then
+  OUT="$DEST/agent-toolkit.exe"
+else
+  OUT="$DEST/agent-toolkit"
+fi
+cp -f "$SRC" "$OUT"
+chmod +x "$OUT" 2>/dev/null || true
+echo "Copied $SRC → $OUT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import sys
 
 def test_help():
     result = subprocess.run(
-        [sys.executable, "-m", "agent_toolkit", "help"],
+        [sys.executable, "-m", "agent_toolkit.cli", "help"],
         capture_output=True,
         text=True,
         cwd=str(__file__).split("tests")[0],
@@ -18,7 +18,7 @@ def test_help():
 
 def test_version():
     result = subprocess.run(
-        [sys.executable, "-m", "agent_toolkit", "version"],
+        [sys.executable, "-m", "agent_toolkit.cli", "version"],
         capture_output=True,
         text=True,
         cwd=str(__file__).split("tests")[0],

--- a/tests/test_doctor_provenance.py
+++ b/tests/test_doctor_provenance.py
@@ -10,10 +10,9 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
 def _run_doctor(extra_args=None, env=None, cwd=None):
-    # Use uv run
-    # Fallback to `uv run agent-toolkit doctor --json`
+    # Python doctor (product `agent-toolkit` is the V launcher).
     result = subprocess.run(
-        ["uv", "run", "agent-toolkit", "doctor", "--json"] + (extra_args or []),
+        ["uv", "run", "agent-toolkit-py", "doctor", "--json"] + (extra_args or []),
         capture_output=True,
         text=True,
         cwd=cwd or str(ROOT),
@@ -39,7 +38,7 @@ def test_doctor_has_provenance_packs_mcp_categories():
 def test_doctor_provenance_flag():
     # --provenance should be accepted and still produce same categories (prints to stderr)
     result = subprocess.run(
-        ["uv", "run", "agent-toolkit", "doctor", "--provenance", "--json"],
+        ["uv", "run", "agent-toolkit-py", "doctor", "--provenance", "--json"],
         capture_output=True,
         text=True,
         cwd=str(ROOT),

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,61 @@
+"""Thin PyPI V launcher (ADR-021 / #535)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_toolkit import launcher
+
+
+def test_missing_binary_exits_127(monkeypatch, capsys):
+    monkeypatch.delenv("AGENT_TOOLKIT_BIN", raising=False)
+    monkeypatch.delenv("AGENT_TOOLKIT_ROOT", raising=False)
+    monkeypatch.setattr(launcher, "bundled_binary", lambda: None)
+    with pytest.raises(SystemExit) as ei:
+        launcher.main(["agent-toolkit", "version"])
+    assert ei.value.code == 127
+    err = capsys.readouterr().err
+    assert "native V binary not found" in err
+    assert "agent-toolkit-py" in err
+
+
+def test_env_bin_posix_execv(monkeypatch, tmp_path: Path):
+    fake = tmp_path / "agent-toolkit"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("AGENT_TOOLKIT_BIN", str(fake))
+    recorded: list[list[str]] = []
+
+    def fake_execv(path: str, args: list[str]) -> None:
+        recorded.append([path, *args])
+        raise OSError("execv mocked")
+
+    monkeypatch.setattr(launcher.os, "execv", fake_execv)
+    monkeypatch.setattr(launcher.os, "name", "posix")
+    with pytest.raises(OSError, match="execv mocked"):
+        launcher.main(["agent-toolkit", "skills", "list"])
+    assert recorded
+    assert recorded[0][0] == str(fake)
+    assert recorded[0][1] == str(fake)
+    assert recorded[0][2:] == ["skills", "list"]
+
+
+def test_resolve_from_toolkit_root_build(monkeypatch, tmp_path: Path):
+    build = tmp_path / "build"
+    build.mkdir()
+    native = build / "agent-toolkit-v"
+    native.write_text("x")
+    monkeypatch.delenv("AGENT_TOOLKIT_BIN", raising=False)
+    monkeypatch.setenv("AGENT_TOOLKIT_ROOT", str(tmp_path))
+    monkeypatch.setattr(launcher, "bundled_binary", lambda: None)
+    assert launcher.resolve_native_bin() == native
+
+
+def test_product_scripts_point_at_launcher():
+    pyproject = Path(__file__).resolve().parents[1] / "packages/agent-toolkit-cli/pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    assert 'agent-toolkit = "agent_toolkit.launcher:main"' in text
+    assert 'agent-toolkit-cli = "agent_toolkit.launcher:main"' in text
+    assert 'agent-toolkit-py = "agent_toolkit.cli.main:main"' in text

--- a/tests/test_swarm_cli.py
+++ b/tests/test_swarm_cli.py
@@ -20,7 +20,7 @@ def run_swarm(args, cwd, extra_env=None):
         "run",
         "--project",
         str(repo_root),
-        "agent-toolkit",
+        "agent-toolkit-py",
         "swarm",
     ] + args
     res = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, env=env, timeout=15)


### PR DESCRIPTION
## Summary
- PyPI product scripts \`agent-toolkit\` / \`agent-toolkit-cli\` exec the bundled native V binary (Fixes #535, ADR-021). Python CLI remains \`agent-toolkit-py\`.
- Hatch platform-tags wheels that contain \`agent_toolkit/bin/\`; CI/release build V then \`prepare-native-bin.sh\` before the wheel. Sdist is built first so it does not embed the Linux binary.
- Integration tests on macOS/Windows install the sdist and run \`agent-toolkit-py\`; Linux installs the V wheel and smokes \`agent-toolkit version\`.

## Test plan
- [x] \`uv run pytest tests/test_launcher.py -v\`
- [ ] Linux CI: wheel \`agent-toolkit version\` is the V binary
- [ ] macOS/Windows CI: \`agent-toolkit-py\` integration still green
- [ ] Missing binary exits 127 (no silent Python fallback)


Made with [Cursor](https://cursor.com)