### PR TITLE
docs(homebrew): V binary Formula contract

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -41,22 +41,23 @@ jobs:
         run: |
           VERSION="${{ steps.ver.outputs.version }}"
           TAG="v${VERSION}"
-          URL="https://github.com/ulises-jeremias/agent-toolkit/archive/refs/tags/${TAG}.tar.gz"
+          # Wait for a darwin V binary (Formula does not use the source tarball).
+          ASSET_URL="https://github.com/ulises-jeremias/agent-toolkit/releases/download/${TAG}/agent-toolkit-macos-arm64"
           for attempt in $(seq 1 36); do
             REL_OK=0
-            TAR_OK=0
+            BIN_OK=0
             if gh release view "$TAG" --repo ulises-jeremias/agent-toolkit >/dev/null 2>&1; then
               REL_OK=1
             fi
-            CODE=$(curl -fsSL -o /dev/null -w '%{http_code}' --head "$URL" 2>/dev/null || echo 000)
+            CODE=$(curl -fsSL -o /dev/null -w '%{http_code}' --head "$ASSET_URL" 2>/dev/null || echo 000)
             if [ "$CODE" = "200" ] || [ "$CODE" = "302" ]; then
-              TAR_OK=1
+              BIN_OK=1
             fi
-            if [ "$REL_OK" = "1" ] && [ "$TAR_OK" = "1" ]; then
-              echo "✓ Release $TAG and tarball are available"
+            if [ "$REL_OK" = "1" ] && [ "$BIN_OK" = "1" ]; then
+              echo "✓ Release $TAG and macos-arm64 V binary are available"
               exit 0
             fi
-            echo "Attempt $attempt/36: release=$REL_OK tarball_http=$CODE — waiting 15s..."
+            echo "Attempt $attempt/36: release=$REL_OK binary_http=$CODE — waiting 15s..."
             sleep 15
           done
           echo "::error::Release/tarball not available after retries"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Homebrew adapter contract: Formula consumes GitHub Release V binaries (Closes #538)
 - **Docs** — ADR-022 machine-readable GitHub Release `manifest.json` (Closes #488)
 - **Feat** — PyPI `agent-toolkit` is a thin launcher over the bundled V binary (Closes #535)
 - **Docs** — ADR-021 PyPI ships platform wheels with bundled V binary + thin launcher (Closes #486)

--- a/distribution/homebrew/README.md
+++ b/distribution/homebrew/README.md
@@ -1,13 +1,20 @@
 # Homebrew adapter
 
-**Issue:** [#538](https://github.com/ulises-jeremias/agent-toolkit/issues/538) · **ADR:** [#490](https://github.com/ulises-jeremias/agent-toolkit/issues/490)
+**Issue:** [#538](https://github.com/ulises-jeremias/agent-toolkit/issues/538) · **ADR:** [#490](https://github.com/ulises-jeremias/agent-toolkit/issues/490) (ADR-023)
 
-**Owner:** `ulises-jeremias/homebrew-tap` (not this tree). Notify workflow: `.github/workflows/notify-homebrew.yml`.
+**Owner:** [`ulises-jeremias/homebrew-tap`](https://github.com/ulises-jeremias/homebrew-tap) (not this tree). Notify: `.github/workflows/notify-homebrew.yml`.
+
+**Implementation:** [homebrew-tap#4](https://github.com/ulises-jeremias/homebrew-tap/issues/4) / [homebrew-tap#5](https://github.com/ulises-jeremias/homebrew-tap/pull/5).
 
 Contract:
 
 - Formula lives **only** in the tap. This repo MUST NOT copy a Formula.
-- Canonical download URL is the GitHub Release stable floating name for the host OS/arch (ADR-018).
+- Formula installs **GitHub Release V binaries** (ADR-018 floating names), not a Python wheel and not a Homebrew bottle of a source build (ADR-023 option A).
+- Canonical URLs: `agent-toolkit-macos-arm64`, `agent-toolkit-macos-x86_64`, `agent-toolkit-linux-x86_64`, `agent-toolkit-linux-arm64`.
 - `brew upgrade` owns the binary. `agent-toolkit update` is capability/profile refresh only (ADR-017).
+- Tap updater opens an **auditable PR** with per-arch sha256; it must not force-push `main`.
 
-Until V promotion, the tap may still ship the Python formula; the ADR records the binary vs bottle vs source choice.
+```bash
+brew tap ulises-jeremias/homebrew-tap
+brew install agent-toolkit
+```


### PR DESCRIPTION
## Summary
- \`distribution/homebrew/README.md\` now requires the tap Formula to install GitHub Release V binaries (Fixes #538, ADR-023 / #490).
- \`notify-homebrew.yml\` waits for \`agent-toolkit-macos-arm64\` instead of the source tarball.
- Formula implementation: [homebrew-tap#5](https://github.com/ulises-jeremias/homebrew-tap/pull/5).

## Test plan
- [ ] Markdown lint
- [ ] Notify wait URL matches ADR-018 macos-arm64 name


Made with [Cursor](https://cursor.com)