### PR TITLE
docs(aur): agent-toolkit-bin V binary contract

### DIFF
--- a/.github/workflows/notify-aur.yml
+++ b/.github/workflows/notify-aur.yml
@@ -35,13 +35,13 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Notifying AUR packages for v$VERSION"
 
-      - name: Wait for GitHub Release + source tarball
+      - name: Wait for GitHub Release + linux V binary
         env:
           GH_TOKEN: ${{ secrets.AUR_REPO_TOKEN }}
         run: |
           VERSION="${{ steps.ver.outputs.version }}"
           TAG="v${VERSION}"
-          URL="https://github.com/ulises-jeremias/agent-toolkit/archive/refs/tags/${TAG}.tar.gz"
+          URL="https://github.com/ulises-jeremias/agent-toolkit/releases/download/${TAG}/agent-toolkit-linux-x86_64"
           for attempt in $(seq 1 36); do
             REL_OK=0
             TAR_OK=0
@@ -53,13 +53,13 @@ jobs:
               TAR_OK=1
             fi
             if [ "$REL_OK" = "1" ] && [ "$TAR_OK" = "1" ]; then
-              echo "✓ Release $TAG and tarball are available"
+              echo "✓ Release $TAG and linux-x86_64 V binary are available"
               exit 0
             fi
-            echo "Attempt $attempt/36: release=$REL_OK tarball_http=$CODE — waiting 15s..."
+            echo "Attempt $attempt/36: release=$REL_OK binary_http=$CODE — waiting 15s..."
             sleep 15
           done
-          echo "::error::Release/tarball not available after retries"
+          echo "::error::Release/linux-x86_64 binary not available after retries"
           exit 1
 
       - name: Dispatch to aur-packages (retry)
@@ -70,9 +70,9 @@ jobs:
           for attempt in $(seq 1 8); do
             if gh api /repos/ulises-jeremias/aur-packages/dispatches \
               -f event_type="new-release" \
-              -f "client_payload[package_name]=agent-toolkit" \
+              -f "client_payload[package_name]=agent-toolkit-bin" \
               -f "client_payload[version]=$VERSION"; then
-              echo "✓ Dispatched new-release to aur-packages for v$VERSION"
+              echo "✓ Dispatched new-release agent-toolkit-bin to aur-packages for v$VERSION"
               exit 0
             fi
             echo "Attempt $attempt/8: dispatch failed; retrying in 20s..."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — AUR adapter contract: `agent-toolkit-bin` consumes GitHub Release V binaries (Closes #539)
 - **Docs** — Distribution wrapper threat model (wheel-bundle vs runtime download) (Closes #563)
 - **Docs** — ADR-022 machine-readable GitHub Release `manifest.json` (Closes #488)
 - **Feat** — PyPI `agent-toolkit` is a thin launcher over the bundled V binary (Closes #535)

--- a/distribution/aur/README.md
+++ b/distribution/aur/README.md
@@ -1,13 +1,19 @@
 # AUR adapter
 
-**Issue:** [#539](https://github.com/ulises-jeremias/agent-toolkit/issues/539) · **ADR:** [#491](https://github.com/ulises-jeremias/agent-toolkit/issues/491)
+**Issue:** [#539](https://github.com/ulises-jeremias/agent-toolkit/issues/539) · **ADR:** [#491](https://github.com/ulises-jeremias/agent-toolkit/issues/491) (ADR-024)
 
-**Owner:** `ulises-jeremias/aur-packages` (not this tree). Playbook: [docs/AUR_PLAYBOOK.md](../../docs/AUR_PLAYBOOK.md). Notify: `.github/workflows/notify-aur.yml`.
+**Owner:** [`ulises-jeremias/aur-packages`](https://github.com/ulises-jeremias/aur-packages) (not this tree). Playbook: [docs/AUR_PLAYBOOK.md](../../docs/AUR_PLAYBOOK.md). Notify: `.github/workflows/notify-aur.yml`.
+
+**Implementation:** [aur-packages#5](https://github.com/ulises-jeremias/aur-packages/issues/5) / [aur-packages#6](https://github.com/ulises-jeremias/aur-packages/pull/6).
 
 Contract:
 
 - PKGBUILD lives **only** in `aur-packages`. This repo MUST NOT copy a PKGBUILD.
-- Package name advertised to users: `agent-toolkit` (`yay -S agent-toolkit`). A `-bin` split is an ADR-491 decision.
+- **Canonical package:** `agent-toolkit-bin` — linux x86_64/arm64 V binaries from GitHub Releases (ADR-018 names + sha256). `provides`/`conflicts` `agent-toolkit`.
+- Optional source/Python package `agent-toolkit` may remain; it is **not** the product (ADR-024).
 - `pacman -Syu` / AUR helpers own the binary. `agent-toolkit update` is capability/profile refresh only (ADR-017).
+- First AUR publish needs an empty `ssh://aur@aur.archlinux.org/agent-toolkit-bin.git`.
 
-Until V promotion, AUR may still wrap the Python package.
+```bash
+yay -S agent-toolkit-bin
+```


### PR DESCRIPTION
## Summary
- \`distribution/aur/README.md\` advertises \`yay -S agent-toolkit-bin\` as the canonical Arch install (Fixes #539, ADR-024 / #491).
- \`notify-aur.yml\` waits for \`agent-toolkit-linux-x86_64\` and dispatches \`package_name=agent-toolkit-bin\`.
- PKGBUILD implementation: [aur-packages#6](https://github.com/ulises-jeremias/aur-packages/pull/6).

## Test plan
- [ ] Markdown lint
- [ ] Notify wait URL matches ADR-018 linux-x86_64 name


Made with [Cursor](https://cursor.com)