### PR TITLE
feat(release): native V GitHub Release assets + SHA256SUMS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ name: Release
 # Manual TestPyPI/PyPI republish: workflow "Publish (manual)" only.
 #
 # Job graph:
-#   create-release ─┬─► publish-pypi
-#                   ├─► build-binaries ─► upload-assets
-#                   └─► sbom (attach after release exists)
+#   create-release ─┬─► publish-pypi (Linux V wheel)
+#                   ├─► build-binaries (native V, ADR-018 names) ─► pack SHA256SUMS+manifest
+#                   └─► sbom (SHOULD CycloneDX; does not prove “secure software”)
 
 on:
   push:
@@ -125,64 +125,122 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # darwin-x86_64 intentionally deferred — x86_64 Intel Macs are legacy;
-        # arm64 covers Apple Silicon. Revisit if demand justifies a second macOS runner (see #256).
         include:
-          - {os: ubuntu-latest, artifact: agent-toolkit-linux-x86_64}
-          - {os: macos-latest, artifact: agent-toolkit-macos-arm64}
-          - {os: windows-latest, artifact: agent-toolkit-windows-x86_64}
+          - os: ubuntu-latest
+            artifact: agent-toolkit-linux-x86_64
+            v_zip: v_linux.zip
+            bin: agent-toolkit
+            expect_arch: x86_64
+          - os: ubuntu-24.04-arm
+            artifact: agent-toolkit-linux-arm64
+            v_zip: v_linux_arm64.zip
+            bin: agent-toolkit
+            expect_arch: arm64
+          - os: macos-latest
+            artifact: agent-toolkit-macos-arm64
+            v_zip: v_macos_arm64.zip
+            bin: agent-toolkit
+            expect_arch: arm64
+          - os: macos-15-intel
+            artifact: agent-toolkit-macos-x86_64
+            v_zip: v_macos_x86_64.zip
+            bin: agent-toolkit
+            expect_arch: x86_64
+          - os: windows-latest
+            artifact: agent-toolkit-windows-x86_64.exe
+            v_zip: v_windows.zip
+            bin: agent-toolkit.exe
+            expect_arch: x86_64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Install package and PyInstaller
-        run: |
-          uv sync --package agent-toolkit-cli --extra all
-          uv pip install pyinstaller
-      - name: Build standalone binary
+
+      - name: Install pinned V from GitHub Release
         shell: bash
-        run: >-
-          uv run --package agent-toolkit-cli pyinstaller --onefile --name agent-toolkit
-          --add-data "skills:skills"
-          --add-data "agents:agents"
-          --add-data "loops:loops"
-          --add-data "profiles:profiles"
-          --add-data "mcp:mcp"
-          --add-data "catalogs:catalogs"
-          packages/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+        env:
+          V_ZIP: ${{ matrix.v_zip }}
+        run: |
+          set -euo pipefail
+          PIN="$(tr -d '[:space:]' < .v-version)"
+          curl -fsSL -o /tmp/v.zip "https://github.com/vlang/v/releases/download/${PIN}/${V_ZIP}"
+          rm -rf "${HOME}/vlang"
+          mkdir -p "${HOME}/vlang"
+          unzip -q /tmp/v.zip -d "${HOME}/vlang"
+          VBIN="$(find "${HOME}/vlang" -type f \( -name v -o -name v.exe \) | head -n 1)"
+          test -n "$VBIN"
+          echo "VBIN=${VBIN}" >> "$GITHUB_ENV"
+          echo "$(dirname "${VBIN}")" >> "$GITHUB_PATH"
+          "${VBIN}" version
+
+      - name: Build native V CLI
+        shell: bash
+        env:
+          OUT_BIN: ${{ matrix.bin }}
+          ASSET: ${{ matrix.artifact }}
+          VMODULES: ${{ github.workspace }}/modules
+          EXPECT_ARCH: ${{ matrix.expect_arch }}
+        run: |
+          set -euo pipefail
+          got="$(uname -m | tr 'A-Z' 'a-z')"
+          case "${got}" in
+            aarch64|arm64) got=arm64 ;;
+            x86_64|amd64) got=x86_64 ;;
+          esac
+          if [ "${got}" != "${EXPECT_ARCH}" ]; then
+            echo "architecture mismatch: ${got} != ${EXPECT_ARCH}" >&2
+            exit 1
+          fi
+          mkdir -p build
+          COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+          "${VBIN}" -d "commit=${COMMIT}" -o "build/${OUT_BIN}" cmd/agent-toolkit
+          cp -f "build/${OUT_BIN}" "build/${ASSET}"
+          "build/${OUT_BIN}" --version
+          "build/${OUT_BIN}" --help | head -n 20
+
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
-          path: dist/agent-toolkit*
+          path: build/${{ matrix.artifact }}
+          if-no-files-found: error
           retention-days: 7
 
   upload-assets:
-    name: Attach binaries to release
+    name: Attach V binaries, archives, SHA256SUMS, manifest
     needs: [create-release, build-binaries]
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/download-artifact@v8
         with:
           path: binaries/
           merge-multiple: true
-      - name: Upload binaries (retry)
+      - name: Pack archives + SHA256SUMS + manifest.json
+        env:
+          RELEASE_BIN_DIR: binaries
+          RELEASE_OUT_DIR: release-assets
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          export RELEASE_VERSION="${GITHUB_REF_NAME#v}"
+          python3 scripts/pack_release_assets.py
+          ls -lh release-assets/
+      - name: Upload release assets (retry)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           for attempt in $(seq 1 10); do
-            if gh release upload "${GITHUB_REF_NAME}" binaries/agent-toolkit* --clobber; then
-              echo "✓ Binaries attached"
+            if gh release upload "${GITHUB_REF_NAME}" release-assets/* --clobber; then
+              echo "✓ V binaries, archives, SHA256SUMS, manifest attached"
               exit 0
             fi
             echo "Attempt $attempt/10 failed; retrying in 10s..."
             sleep 10
           done
-          echo "::error::Failed to attach binaries"
+          echo "::error::Failed to attach release assets"
           exit 1
 
   sbom:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — GitHub Releases attach native V binaries, SHA256SUMS, and `manifest.json` (Closes #530)
 - **Docs** — Distribution wrapper threat model (wheel-bundle vs runtime download) (Closes #563)
 - **Docs** — ADR-022 machine-readable GitHub Release `manifest.json` (Closes #488)
 - **Feat** — PyPI `agent-toolkit` is a thin launcher over the bundled V binary (Closes #535)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -64,15 +64,25 @@ python3 scripts/bump-version.py 1.3.0         # writes files
 
 ## Asset naming
 
-Release binaries are platform-suffixed to avoid upload collisions (see #256 and [ADR-018](adrs/ADR-018-release-artifacts.md)):
+Stable GitHub Release assets are **native V binaries** (not PyInstaller). Names follow [ADR-018](adrs/ADR-018-release-artifacts.md):
 
-* `agent-toolkit-linux-x86_64`
-* `agent-toolkit-macos-arm64`
+* `agent-toolkit-linux-x86_64` / `agent-toolkit-linux-arm64` (glibc, [ADR-019](adrs/ADR-019-linux-libc.md))
+* `agent-toolkit-macos-arm64` / `agent-toolkit-macos-x86_64`
 * `agent-toolkit-windows-x86_64.exe`
+* Versioned archives `agent-toolkit-<semver>-<os>-<arch>.tar.gz` (Windows `.zip`) containing `agent-toolkit` + `LICENSE`
+* `SHA256SUMS` and `manifest.json` ([ADR-022](adrs/ADR-022-release-manifest.md))
 
-**Stable channel:** those floating names. **Linux (`linux-x86_64` / `linux-arm64`) is glibc** ([ADR-019](adrs/ADR-019-linux-libc.md)); an optional musl extra uses a distinct name (`agent-toolkit-linux-x86_64-musl`) and must not overwrite the stable glibc artifact. **Versioned archives** (`agent-toolkit-<semver>-<os>-<arch>.tar.gz` / Windows `.zip`) are the checksum and attestation unit. **Experimental V** assets use `agent-toolkit-v-experimental-<os>-<arch>` ([#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562), workflow `experimental-v.yml`, [docs/v/experimental-binaries.md](v/experimental-binaries.md)) and must not overwrite stable names.
+**Checksums are MUST.** Verify:
 
-Darwin x86_64 is intentionally deferred (documented skip). Release notes / this doc mention naming.
+```bash
+curl -fsSL -O "https://github.com/ulises-jeremias/agent-toolkit/releases/download/v1.10.0/SHA256SUMS"
+curl -fsSL -O "https://github.com/ulises-jeremias/agent-toolkit/releases/download/v1.10.0/agent-toolkit-linux-x86_64"
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+**SBOM (SHOULD):** `sbom.cyclonedx.json` lists ingredients; it is not a vulnerability scan. **Artifact attestations (FUTURE / SHOULD when enabled):** they record which workflow produced an asset; they do not prove the software is secure. **Code signing / notarization:** [#543](https://github.com/ulises-jeremias/agent-toolkit/issues/543).
+
+**Experimental V** CI artifacts use `agent-toolkit-v-experimental-<os>-<arch>` and must not overwrite stable names. Optional musl extra uses `agent-toolkit-linux-x86_64-musl`.
 
 Packaging **adapter contracts** (this repo, no Formula/PKGBUILD copies): [`distribution/README.md`](../distribution/README.md) ([#534](https://github.com/ulises-jeremias/agent-toolkit/issues/534)).
 

--- a/scripts/pack_release_assets.py
+++ b/scripts/pack_release_assets.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Pack ADR-018 floating binaries + versioned archives, SHA256SUMS, and manifest.json (#530 / ADR-022)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tarfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+FLOATING = (
+    ("agent-toolkit-linux-x86_64", "linux", "x86_64", "gnu", "tar"),
+    ("agent-toolkit-linux-arm64", "linux", "arm64", "gnu", "tar"),
+    ("agent-toolkit-macos-arm64", "macos", "arm64", None, "tar"),
+    ("agent-toolkit-macos-x86_64", "macos", "x86_64", None, "tar"),
+    ("agent-toolkit-windows-x86_64.exe", "windows", "x86_64", None, "zip"),
+)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    src = Path(os.environ.get("RELEASE_BIN_DIR", "binaries"))
+    out = Path(os.environ.get("RELEASE_OUT_DIR", "release-assets"))
+    version = os.environ["RELEASE_VERSION"]  # semver without v
+    tag = os.environ.get("RELEASE_TAG", f"v{version}")
+    license_path = Path(os.environ.get("LICENSE_PATH", "LICENSE"))
+    out.mkdir(parents=True, exist_ok=True)
+
+    assets: list[dict] = []
+    packed: list[Path] = []
+
+    for floating, os_name, arch, libc, archive_kind in FLOATING:
+        src_bin = src / floating
+        if not src_bin.is_file():
+            # Windows job may upload without .exe suffix; accept that alias.
+            alt = src / floating.removesuffix(".exe")
+            if alt.is_file():
+                src_bin = alt
+            else:
+                print(f"skip missing {floating}")
+                continue
+        dest_float = out / floating
+        dest_float.write_bytes(src_bin.read_bytes())
+        dest_float.chmod(0o755)
+        packed.append(dest_float)
+        inner = "agent-toolkit.exe" if os_name == "windows" else "agent-toolkit"
+        if archive_kind == "zip":
+            archive_name = f"agent-toolkit-{version}-windows-{arch}.zip"
+            archive_path = out / archive_name
+            with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                zf.write(dest_float, arcname=inner)
+                if license_path.is_file():
+                    zf.write(license_path, arcname="LICENSE")
+        else:
+            archive_name = f"agent-toolkit-{version}-{os_name}-{arch}.tar.gz"
+            archive_path = out / archive_name
+            with tarfile.open(archive_path, "w:gz") as tf:
+                tf.add(dest_float, arcname=inner)
+                if license_path.is_file():
+                    tf.add(license_path, arcname="LICENSE")
+        packed.append(archive_path)
+
+        base_url = f"https://github.com/ulises-jeremias/agent-toolkit/releases/download/{tag}"
+        bin_entry = {
+            "os": os_name,
+            "arch": arch,
+            "channel": "stable",
+            "kind": "binary",
+            "filename": floating,
+            "sha256": sha256_file(dest_float),
+            "url": f"{base_url}/{floating}",
+        }
+        if libc:
+            bin_entry["libc"] = libc
+        assets.append(bin_entry)
+        arch_entry = {
+            "os": os_name,
+            "arch": arch,
+            "channel": "stable",
+            "kind": "archive",
+            "filename": archive_name,
+            "sha256": sha256_file(archive_path),
+            "url": f"{base_url}/{archive_name}",
+        }
+        if libc:
+            arch_entry["libc"] = libc
+        assets.append(arch_entry)
+
+    sums_path = out / "SHA256SUMS"
+    lines = [f"{sha256_file(p)}  {p.name}\n" for p in sorted(packed, key=lambda x: x.name)]
+    sums_path.write_text("".join(lines), encoding="utf-8")
+
+    manifest = {
+        "schemaVersion": 1,
+        "name": "agent-toolkit",
+        "version": version,
+        "gitTag": tag,
+        "channel": "stable",
+        "releasedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "assets": assets,
+    }
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"packed {len(list(out.iterdir()))} files in {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pack_release_assets.py
+++ b/tests/test_pack_release_assets.py
@@ -1,0 +1,44 @@
+"""pack_release_assets.py — SHA256SUMS + ADR-022 manifest (#530)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import importlib.util
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "pack_release_assets", ROOT / "scripts" / "pack_release_assets.py"
+)
+_pack = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_pack)
+pack_main = _pack.main
+
+
+def test_pack_release_assets_manifest_and_sums(tmp_path: Path, monkeypatch) -> None:
+    src = tmp_path / "binaries"
+    src.mkdir()
+    (src / "agent-toolkit-linux-x86_64").write_bytes(b"\x7fELF" + b"x" * 200)
+    (src / "agent-toolkit-macos-arm64").write_bytes(b"mach" + b"y" * 200)
+    license_file = tmp_path / "LICENSE"
+    license_file.write_text("MIT\n")
+    out = tmp_path / "out"
+    monkeypatch.setenv("RELEASE_BIN_DIR", str(src))
+    monkeypatch.setenv("RELEASE_OUT_DIR", str(out))
+    monkeypatch.setenv("RELEASE_VERSION", "1.10.0")
+    monkeypatch.setenv("RELEASE_TAG", "v1.10.0")
+    monkeypatch.setenv("LICENSE_PATH", str(license_file))
+    assert pack_main() == 0
+    assert (out / "SHA256SUMS").is_file()
+    sums = (out / "SHA256SUMS").read_text()
+    assert "agent-toolkit-linux-x86_64" in sums
+    manifest = json.loads((out / "manifest.json").read_text())
+    schema = json.loads((ROOT / "schemas" / "release-manifest.schema.json").read_text())
+    jsonschema.Draft202012Validator(schema).validate(manifest)
+    kinds = {a["kind"] for a in manifest["assets"]}
+    assert kinds == {"binary", "archive"}
+    assert (out / "agent-toolkit-1.10.0-linux-x86_64.tar.gz").is_file()


### PR DESCRIPTION
## Summary
- Replace PyInstaller in \`release.yml\` with the MUST-platform native V matrix (ADR-018 floating names) (Fixes #530).
- Pack versioned archives, \`SHA256SUMS\`, and ADR-022 \`manifest.json\`. SBOM stays SHOULD; attestations/code-signing remain FUTURE (#543). Checksums do not claim “secure software”.
- Homebrew/AUR/PyPI adapters can fetch named V assets on the next \`v*\` tag.

## Test plan
- [x] \`uv run pytest tests/test_pack_release_assets.py\`
- [ ] Next tag: Release contains \`agent-toolkit-linux-x86_64\`, macos/windows counterparts, \`SHA256SUMS\`, \`manifest.json\`
- [ ] \`sha256sum -c SHA256SUMS --ignore-missing\` succeeds


Made with [Cursor](https://cursor.com)