### PR TITLE
chore: resolve leftover CHANGELOG conflict markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-<<<<<<< HEAD
 - **Feat** — GitHub Releases attach native V binaries, SHA256SUMS, and `manifest.json` (Closes #530)
-=======
 - **Docs** — ADR-023 Homebrew Formula installs GitHub Release V binaries (Closes #490)
->>>>>>> origin/main
 - **Docs** — Distribution wrapper threat model (wheel-bundle vs runtime download) (Closes #563)
 - **Docs** — ADR-022 machine-readable GitHub Release `manifest.json` (Closes #488)
 - **Feat** — PyPI `agent-toolkit` is a thin launcher over the bundled V binary (Closes #535)


### PR DESCRIPTION
## Summary
- The #637 squash-merge left Git conflict markers in \`CHANGELOG.md\` on \`main\`. Keep both Unreleased bullets (#530 and #490).

## Test plan
- [ ] No \`<<<<<<<\` markers in CHANGELOG.md
- [ ] Unreleased lists #530 and #490


Made with [Cursor](https://cursor.com)