### PR TITLE
docs: Docker native V binary image contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Docker adapter: debian-slim + GitHub Release V binary; git/gh MUST (Closes #537)
 - **Feat** — npm `agent-toolkit-cli` launcher over GitHub Release V binaries with OIDC trusted publish (Closes #536)
 - **Docs** — ADR-025 npm package is `agent-toolkit-cli` with optionalDependencies platform binaries (Closes #487)
 - **Docs** — AUR adapter contract: `agent-toolkit-bin` consumes GitHub Release V binaries (Closes #539)

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -1,7 +1,41 @@
 # Docker adapter
 
-**Issue:** [#537](https://github.com/ulises-jeremias/agent-toolkit/issues/537)
+**Issue:** [#537](https://github.com/ulises-jeremias/agent-toolkit/issues/537)  
+**Workflow:** `.github/workflows/docker.yml`  
+**Image:** `ghcr.io/ulises-jeremias/agent-toolkit`
 
-Workflow: `.github/workflows/docker.yml` (this repo).
+Docker is an **adapter**. The product inside the image is the **GitHub Release V binary** (ADR-018), not a Python interpreter.
 
-Contract: image is an adapter around the **canonical GitHub Release binary** (or, until promotion, the current Python image). Base image and extra CLI tools (`git`, `gh`) are decided in #537. Do not bake experimental V names into the stable tag without the #531 promotion gate.
+## Base image (decision)
+
+| Choice | Class | Rationale |
+|--------|-------|-----------|
+| `debian:bookworm-slim` | **MUST** (stable) | `git` + `gh` + `ca-certificates` needed for `loop`/`project`/`doctor`. Distroless cannot ship those CLIs without a second stage copy of glibc-linked tools. |
+| `gcr.io/distroless/cc` / scratch | **FUTURE** | Only if extra tools move to a sidecar. Not the default. |
+| `python:3.11-slim` + `uv run` | **Transitional** | Current `Dockerfile` until the first Release with V assets. MUST NOT remain the stable `latest` once a V tag exists. |
+| Alpine / musl | **MUST NOT** for stable | ADR-019: glibc is the MUST Linux binary. |
+
+## Tool dependency set
+
+| Tool | Class | Why |
+|------|-------|-----|
+| `agent-toolkit` (V ELF) | **MUST** | Copied from Release `agent-toolkit-linux-x86_64` or `agent-toolkit-linux-arm64` matching `TARGETARCH`. Verify `SHA256SUMS`. |
+| `git` | **MUST** | `project clone`, loops, swarm worktrees |
+| `gh` | **MUST** | GH API in loops / PR skills |
+| `ca-certificates` | **MUST** | TLS |
+| `curl` | **SHOULD** | Fetch checksums in build; not required at runtime if binary is baked |
+| `uv` / CPython | **MUST NOT** in the V image | Product is the native binary. Python image is transitional only. |
+
+`ENTRYPOINT` MUST be `/usr/local/bin/agent-toolkit` (the V binary). `CMD` MAY be `--help`.
+
+## Tags
+
+- `latest` / semver: **stable V** image only after a GitHub Release has floating linux assets.
+- Experimental V names (`agent-toolkit-v-experimental-*`) MUST NOT be baked into `latest`.
+- Multi-arch: `linux/amd64` + `linux/arm64` (glibc), matching ADR-018.
+
+## Implementation gate
+
+Do not rewrite `Dockerfile` to the V copy path until a tagged Release publishes `agent-toolkit-linux-x86_64` (and arm64). Until then the Python image may keep building so `ghcr` is not empty.
+
+Owner of the Dockerfile remains this repo (unlike Homebrew/AUR).


### PR DESCRIPTION
## Summary
- Decide Docker base: \`debian:bookworm-slim\` with GitHub Release glibc V binary; \`git\`+\`gh\` MUST; Alpine/musl MUST NOT (Fixes #537).
- Python \`uv\` image is transitional until a \`v*\` tag has linux assets. No Dockerfile rewrite in this PR.

## Test plan
- [ ] Markdown lint
- [ ] Contract matches ADR-018/019 names


Made with [Cursor](https://cursor.com)