### PR TITLE
docs: Python module API consumer audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Audit: no first-party Python `import agent_toolkit` consumers outside this repo (Closes #561)
 - **Docs** — V development & distribution documentation index (Closes #545)
 
 ## [1.11.0] — 2026-08-13

--- a/docs/v/README.md
+++ b/docs/v/README.md
@@ -39,6 +39,7 @@ Checksums **MUST**. Attestations/SBOM prove provenance only ([code-signing-polic
 | [advanced-command-disposition.md](advanced-command-disposition.md) | PORT/REDESIGN/DEPRECATE/REMOVE (#560) |
 | [../compatibility/cli-contract.yaml](../compatibility/cli-contract.yaml) | Machine-readable flags/IO (#549) |
 | [cutover.md](cutover.md) | Engine cutover |
+| [python-api-consumers.md](python-api-consumers.md) | Python import audit (#561); #540 must cite this |
 | [migration-risk-register.md](migration-risk-register.md) | Risks (#478) |
 
 ## Core services (V)

--- a/docs/v/python-api-consumers.md
+++ b/docs/v/python-api-consumers.md
@@ -1,0 +1,45 @@
+# Python module API consumer audit
+
+**Issue:** [#561](https://github.com/ulises-jeremias/agent-toolkit/issues/561)  
+**Required by:** [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) (do not open #540 until other gates land)
+
+The published PyPI/npm **product** is the CLI. `import agent_toolkit` is not a supported library API. This audit lists who would break if the Python package were removed or reduced to a launcher-only wheel.
+
+## Method (2026-08-13)
+
+- GitHub code search: `import agent_toolkit`, `from agent_toolkit.`, `agent_toolkit.cli`, `agent_toolkit.compiler`, `agent_toolkit.installer` (first-party owner `ulises-jeremias` and global).
+- Local trees: `agentic-workstation`, this repo.
+- Workstation install path: `docs/AGENT_TOOLKIT.md` in agentic-workstation.
+
+## Inventory
+
+| Consumer | How it uses agent-toolkit | Breakage if Python modules go away |
+|----------|---------------------------|------------------------------------|
+| **This repo** (`packages/agent-toolkit-cli`, `tests/`) | First-party: `agent_toolkit.cli`, `compiler`, `installer`, `launcher` | Expected. Tests already use `agent-toolkit-py` / `-m agent_toolkit.cli` where the product launcher would exec V. |
+| **agentic-workstation** | CLI only: `uv tool install --force agent-toolkit-cli && agent-toolkit install` | **None** for library imports. Breaks only if the `agent-toolkit` **command** disappears. After ADR-021 the command is the V launcher. |
+| **agentic-harness** / ai-workspace | Documents CLI (`agent-toolkit workspace`, `memory`, …). No `import agent_toolkit`. | None (CLI). |
+| **homebrew-tap / aur-packages** | Install GitHub Release **binary**, not the Python package | None. |
+| **Unrelated GitHub projects** named `agent_toolkit` (DSPy examples, other toolkits) | Different packages | Out of scope. |
+
+No first-party or known downstream **library** import of `ulises-jeremias/agent-toolkit`’s `agent_toolkit.*` was found outside this repository.
+
+Public import surface today:
+
+- `agent_toolkit.__version__` / `__author__`
+- `agent_toolkit.launcher:main` (product scripts `agent-toolkit`, `agent-toolkit-cli`)
+- `agent_toolkit.cli.main:main` (`agent-toolkit-py`, `python -m agent_toolkit.cli`)
+
+`compiler/` and `installer/` are in-tree implementation, not a versioned library API.
+
+## Migration plan
+
+| Audience | Plan |
+|----------|------|
+| CLI users (`uvx`, brew, AUR, npm) | Stay on the V binary / launcher. No Python import migration. |
+| In-repo tests | Keep calling `agent-toolkit-py` / `-m agent_toolkit.cli` until #540 deletes the Python CLI. |
+| Hypothetical external `import agent_toolkit.compiler` | Unsupported. If discovered later: treat as a bug, add a shim issue, do not block #540 on unknown third parties. |
+| `#540` checklist | **MUST** include: “#561 audit: no first-party library consumers; workstation/harness are CLI-only.” |
+
+## Residual risk
+
+PyPI package name `agent-toolkit-cli` install still ships Python modules until #540. Someone *could* `from agent_toolkit.compiler.loader import load_graph` without us knowing (no telemetry). That is not a supported contract; removal may proceed after #540’s other gates.


### PR DESCRIPTION
## Summary
- Inventory \`import agent_toolkit\` consumers: first-party tests/CLI only; agentic-workstation and harness use the **CLI** (\`uv tool install agent-toolkit-cli\`), not the library (Fixes #561).
- #540 MUST cite this audit. No first-party library breakage expected.

## Test plan
- [ ] Markdown lint
- [ ] Workstation docs still describe CLI-only install


Made with [Cursor](https://cursor.com)