### PR TITLE
docs: Agentic Workstation bootstrap contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Agentic Workstation adapter: CLI-only bootstrap, channel preference, no `import agent_toolkit` (#469)
 - **Docs** — V vs Python CLI performance baseline (startup/help/inventory/doctor) (Closes #533)
 - **Docs** — Audit: no first-party Python `import agent_toolkit` consumers outside this repo (Closes #561)
 - **Docs** — V development & distribution documentation index (Closes #545)

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -19,6 +19,7 @@ Do **not** duplicate Formula/PKGBUILD/npm `package.json` here. Those live in the
 | AUR | `ulises-jeremias/aur-packages` | [aur/README.md](aur/README.md) · [#539](https://github.com/ulises-jeremias/agent-toolkit/issues/539) · ADR [#491](https://github.com/ulises-jeremias/agent-toolkit/issues/491) |
 | npm | future adapter | [npm/README.md](npm/README.md) · [#536](https://github.com/ulises-jeremias/agent-toolkit/issues/536) · ADR [#487](https://github.com/ulises-jeremias/agent-toolkit/issues/487) |
 | Docker | this repo (`.github/workflows/docker.yml`) | [docker/README.md](docker/README.md) · [#537](https://github.com/ulises-jeremias/agent-toolkit/issues/537) |
+| Workstation (L1) | `ulises-jeremias/agentic-workstation` | [workstation/README.md](workstation/README.md) · [#469](https://github.com/ulises-jeremias/agent-toolkit/issues/469) |
 
 ## Verification
 

--- a/distribution/workstation/README.md
+++ b/distribution/workstation/README.md
@@ -1,0 +1,59 @@
+# Agentic Workstation adapter
+
+**Epic:** [#469](https://github.com/ulises-jeremias/agent-toolkit/issues/469)  
+**Consumer issue:** [agentic-workstation#206](https://github.com/ulises-jeremias/agentic-workstation/issues/206)  
+**Consumer docs:** [agentic-workstation/docs/AGENT_TOOLKIT.md](https://github.com/ulises-jeremias/agentic-workstation/blob/main/docs/AGENT_TOOLKIT.md)
+
+agentic-workstation is **L1** (machine provisioning). This repo is **L1.5** (capability distribution). Workstation MUST treat Agent Toolkit as a **CLI**, never as a Python library.
+
+## MUST NOT
+
+- `import agent_toolkit` (or any `agent_toolkit.*` module) from workstation code, chezmoi templates, or `dots-*` wrappers.
+- Vendor skills/agents/loops into workstation (`home/dot_local/share/.../skills`). Catalog comes from `agent-toolkit install`.
+- Assume PyInstaller, `python -m agent_toolkit`, or `agent-toolkit-py` is the product.
+
+## Install channel preference
+
+Bootstrap **prefers a platform-native adapter**, then falls back. Every path MUST end with the same CLI contract (`agent-toolkit install`, `doctor`, `inventory`).
+
+| Order | Platform | Channel | Gate |
+|------:|----------|---------|------|
+| 1 | macOS | Homebrew `ulises-jeremias/homebrew-tap` `agent-toolkit` | Formula merged **and** a GitHub Release has V sha256 (homebrew-tap#5) |
+| 1 | Arch Linux | AUR `agent-toolkit-bin` | PKGBUILD merged; Release has `agent-toolkit-linux-*` |
+| 2 | Linux/macOS/Windows | GitHub Release floating binary + `SHA256SUMS` | Tag with ADR-018 assets |
+| 3 | Any (chicken/egg) | `uv tool install --force agent-toolkit-cli` then `agent-toolkit install` | PyPI wheel that **execs the bundled V binary** (ADR-021), not Python as the product |
+| 3 | Node environments | `npm i -g agent-toolkit-cli` | OIDC `publish-npm.yml` + platform optionalDependencies |
+
+Until Homebrew/AUR consume a **real** V sha256, `uv tool install` remains the documented workstation default. That is still **canonical binary behavior** once ADR-021 wheels ship; it is not a Python-impl dependency.
+
+## chezmoi / dots-* contract
+
+Workstation owns these files (do not copy them here):
+
+| Script / command | Allowed after cutover |
+|------------------|------------------------|
+| `run_once_after_50-install-agent-toolkit.sh.tmpl` | Install via the preference table, then `agent-toolkit install` |
+| `run_onchange_45-install-ai-agents.sh.tmpl` | Same two steps + `dots-skills sync` |
+| `dots-skills install-toolkit` | Channel install + `agent-toolkit install` |
+| `dots-skills sync` | `agent-toolkit install` |
+| `dots-skills list` | `agent-toolkit skills list` |
+| `dots-skills check` / `dots-doctor` | `agent-toolkit doctor` (+ workstation-only tmux/herdr checks) |
+| `dots-loop *` | `agent-toolkit loop *` |
+
+LLM policy stays in workstation. Toolkit remains vendor-neutral.
+
+## Rollback
+
+Pin the previous `agent-toolkit-cli` version in the chezmoi script (`uv tool install agent-toolkit-cli==<ver>`) or pin the Homebrew/AUR package. Do not roll back by importing Python modules.
+
+## Testing
+
+Fresh VM/container: install via the highest available channel, then:
+
+```bash
+agent-toolkit --version
+agent-toolkit doctor
+agent-toolkit install
+```
+
+Implementation of the preference table lives in **agentic-workstation#206**, not this repo.

--- a/docs/v/README.md
+++ b/docs/v/README.md
@@ -27,6 +27,7 @@ Canonical artifacts: **GitHub Releases** ([ADR-018](../adrs/ADR-018-release-arti
 | Homebrew | [distribution/homebrew](../../distribution/homebrew/README.md) · ADR-023 | `ulises-jeremias/homebrew-tap` |
 | AUR `agent-toolkit-bin` | [distribution/aur](../../distribution/aur/README.md) · ADR-024 | `ulises-jeremias/aur-packages` |
 | Docker | [distribution/docker](../../distribution/docker/README.md) | debian-slim + glibc V binary |
+| Workstation | [distribution/workstation](../../distribution/workstation/README.md) | L1 CLI-only bootstrap (#469) |
 
 Checksums **MUST**. Attestations/SBOM prove provenance only ([code-signing-policy.md](code-signing-policy.md)).
 


### PR DESCRIPTION
## Summary
- Add \`distribution/workstation/README.md\`: L1 must call the Agent Toolkit **CLI** only (no \`import agent_toolkit\`), with Homebrew/AUR/GitHub then uv/npm fallback (Refs #469).
- Links consumer work to [agentic-workstation#206](https://github.com/ulises-jeremias/agentic-workstation/issues/206). Epic stays open until that workstation PR lands.

## Test plan
- [ ] Markdown lint
- [ ] Do not merge Homebrew tap until V sha256 exists


Made with [Cursor](https://cursor.com)