### PR TITLE
fix(ci): republish PyPI via workflow_dispatch on release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 # Sole automated PyPI publish path for version tags (v*).
-# Manual TestPyPI/PyPI republish: workflow "Publish (manual)" only.
+# Manual republish of an already-tagged VERSION (no retag): workflow_dispatch this
+# file — PyPI Trusted Publishing is registered for release.yml, not publish.yml.
 #
 # Job graph:
 #   create-release ─┬─► build-binaries ─► upload-assets ─► publish-pypi (platform wheels from Release assets)
@@ -11,6 +12,14 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy target (Trusted Publishing is registered for release.yml)"
+        required: true
+        default: "pypi"
+        type: choice
+        options: [pypi, testpypi]
 
 permissions:
   contents: write
@@ -23,6 +32,7 @@ concurrency:
 jobs:
   create-release:
     name: Create GitHub Release
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -56,6 +66,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
+    if: github.event_name == 'push'
     needs: [create-release, upload-assets]
     runs-on: ubuntu-latest
     environment: pypi
@@ -120,6 +131,7 @@ jobs:
 
   build-binaries:
     name: Build ${{ matrix.artifact }}
+    if: github.event_name == 'push'
     needs: create-release
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -207,6 +219,7 @@ jobs:
 
   upload-assets:
     name: Attach V binaries, archives, SHA256SUMS, manifest
+    if: github.event_name == 'push'
     needs: [create-release, build-binaries]
     runs-on: ubuntu-latest
     environment: release
@@ -247,6 +260,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
+    if: github.event_name == 'push'
     needs: create-release
     runs-on: ubuntu-latest
     permissions:
@@ -283,3 +297,63 @@ jobs:
           done
           echo "::error::Failed to attach SBOM after retries"
           exit 1
+
+  republish-pypi:
+    name: Republish to PyPI (manual)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Download GitHub Release V binaries for VERSION
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION="$(tr -d '[:space:]' < VERSION)"
+          mkdir -p binaries
+          gh release download "v${VERSION}" -D binaries -p 'agent-toolkit-*'
+          ls -lh binaries/
+      - name: Pack sdist + platform wheels (manylinux_2_38)
+        run: |
+          set -euo pipefail
+          bash scripts/prepare-package-data.sh
+          export RELEASE_BIN_DIR=binaries
+          export RELEASE_VERSION="$(tr -d '[:space:]' < VERSION)"
+          export RELEASE_OUT_DIR=dist
+          python3 scripts/pack_pypi.py
+          ls -lh dist/
+          python3 - <<'PY'
+          from pathlib import Path
+          wheels = [p.name for p in Path("dist").glob("*.whl")]
+          print(wheels)
+          bad = [n for n in wheels if "linux_x86_64" in n and "manylinux" not in n]
+          if bad:
+              raise SystemExit(f"raw linux_x86_64 tag (PyPI will reject): {bad}")
+          if not any("manylinux_2_38_x86_64" in n for n in wheels):
+              raise SystemExit("missing manylinux_2_38_x86_64 wheel")
+          PY
+      - name: Publish (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          repository-url: ${{ inputs.environment == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}
+      - name: Verify PyPI shows this version
+        if: inputs.environment == 'pypi'
+        run: |
+          VERSION="$(tr -d '[:space:]' < VERSION)"
+          for attempt in $(seq 1 24); do
+            if curl -fsSL "https://pypi.org/pypi/agent-toolkit-cli/${VERSION}/json" >/dev/null 2>&1; then
+              echo "✓ PyPI has agent-toolkit-cli==$VERSION"
+              exit 0
+            fi
+            echo "Attempt $attempt/24: waiting for PyPI..."
+            sleep 15
+          done
+          echo "::warning::PyPI verification timed out — publish step succeeded; CDN may lag"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **CI** — Republish PyPI via `workflow_dispatch` on `release.yml` (Trusted Publishing is registered for that workflow, not `publish.yml`)
 - **Packaging** — Move PyPI adapter to `packages/pypi/` (npm-parallel layout; platform-tagged wheels, not fake optionalDeps packages), drop the root uv workspace, tag Linux wheels `manylinux_2_38_*` after PyPI rejected `linux_x86_64` on 1.11.0, and ship a V-first Docker image from GitHub Release binaries
 - **Docs** — Agentic Workstation adapter: CLI-only bootstrap, channel preference, no `import agent_toolkit` (#469)
 - **Docs** — V vs Python CLI performance baseline (startup/help/inventory/doctor) (Closes #533)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -57,7 +57,11 @@ python3 scripts/bump-version.py 1.3.0         # writes files
 
 ## Rollback / republish
 
-* **PyPI:** Trusted Publishing via `release.yml` `publish-pypi` after Release assets are attached (`scripts/pack_pypi.py` stamps `manylinux_2_38_*` wheels). Manual republish: workflow `Publish (manual)` (`.github/workflows/publish.yml`) with `TestPyPI`/`PyPI` — it downloads `v$(cat VERSION)` GitHub Release binaries (do not rebuild a different glibc).
+* **PyPI:** Trusted Publishing is registered for **`release.yml`** (environment `pypi`), not `publish.yml`. Tag path: `publish-pypi` after Release assets (`scripts/pack_pypi.py` stamps `manylinux_2_38_*`). Manual republish of an existing `VERSION` (no retag):
+  ```bash
+  gh workflow run Release --ref main -f environment=pypi
+  ```
+  `Publish (manual)` (`publish.yml`) can still pack wheels but OIDC will fail until that filename is also registered on PyPI.
 * **npm:** OIDC trusted publishing via `publish-npm.yml` on tag `v*` (npm CLI ≥ 11.5.1, `id-token: write`, no `NPM_TOKEN`). First publish of a new package name is local (`npm login` then `npm publish`). Then pin GitHub:
   ```bash
   npm trust github agent-toolkit-cli --file publish-npm.yml --repository ulises-jeremias/agent-toolkit --allow-publish -y


### PR DESCRIPTION
## Summary

- PyPI Trusted Publishing is registered for `release.yml`, not `publish.yml`. `Publish (manual)` on main failed OIDC (`invalid-publisher`) after packing manylinux_2_38 wheels.
- Add `workflow_dispatch` on `Release` with a `republish-pypi` job that downloads existing `v$(VERSION)` GitHub Release binaries and publishes (no retag). Tag jobs stay `if: github.event_name == 'push'`.

## Test plan

- [ ] Required CI green
- [ ] After merge: `gh workflow run Release --ref main -f environment=pypi`
- [ ] `https://pypi.org/pypi/agent-toolkit-cli/1.11.0/json` returns 200 with `manylinux_2_38_*` wheels
- [ ] Dispatch does **not** create a GitHub Release named `main`


Made with [Cursor](https://cursor.com)