### PR TITLE
fix(ci): add types-PyYAML so incremental mypy can type yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Fixed** — Install `types-PyYAML` in the PyPI adapter dev extra so incremental mypy can type `yaml` imports
 - **Fixed** — PyPI launcher exports wheel `data/` as `AGENT_TOOLKIT_ROOT`; V `doctor` uses `find_toolkit_root` (wheel `bin/../data`) and `embedded_version` instead of a hardcoded 1.10.0; uvx CI checks out the repo so published wheels can resolve skills/loops
 - **CI** — Republish PyPI via `workflow_dispatch` on `release.yml` (Trusted Publishing is registered for that workflow, not `publish.yml`)
 - **Packaging** — Move PyPI adapter to `packages/pypi/` (npm-parallel layout; platform-tagged wheels, not fake optionalDeps packages), drop the root uv workspace, tag Linux wheels `manylinux_2_38_*` after PyPI rejected `linux_x86_64` on 1.11.0, and ship a V-first Docker image from GitHub Release binaries

--- a/packages/pypi/agent-toolkit-cli/pyproject.toml
+++ b/packages/pypi/agent-toolkit-cli/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "jsonschema>=4.26.0",
     "pytest-cov>=7.1.0",
     "mypy>=2.3.0",
+    "types-PyYAML>=6.0.12",
 ]
 yaml = ["pyyaml>=6.0"]
 all = ["pyyaml>=6.0"]


### PR DESCRIPTION
## Summary

- Incremental mypy failed on main with `Library stubs not installed for "yaml"` because PyYAML is present but untyped.
- Add `types-PyYAML` to the PyPI adapter `dev` extra.

## Type

- [x] Bug fix

## Changes

- `packages/pypi/agent-toolkit-cli/pyproject.toml`

## Testing

- [x] `uv run --project packages/pypi/agent-toolkit-cli --directory . mypy packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler packages/pypi/agent-toolkit-cli/src/agent_toolkit/installer` — Success: no issues found in 25 source files

## Checklist

- [x] No secrets, tokens, API keys, or credentials committed
- [x] Commit messages are in English and follow conventional commits format


Made with [Cursor](https://cursor.com)