### PR TITLE
feat(cli): emit bash/zsh/fish/PowerShell completions from V CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — V CLI `completion` emits bash/zsh/fish/PowerShell scripts (Closes #544)
 - **Fixed** — Docker multi-arch image honors BuildKit `TARGETARCH` (no amd64 default) so linux/arm64 installs `agent-toolkit-linux-arm64`; skip exec during QEMU cross-build and smoke `version` on a native load
 - **Fixed** — Install `types-PyYAML` in the PyPI adapter dev extra so incremental mypy can type `yaml` imports
 - **Fixed** — PyPI launcher exports wheel `data/` as `AGENT_TOOLKIT_ROOT`; V `doctor` uses `find_toolkit_root` (wheel `bin/../data`) and `embedded_version` instead of a hardcoded 1.10.0; uvx CI checks out the repo so published wheels can resolve skills/loops

--- a/docs/CLI_SURFACES.md
+++ b/docs/CLI_SURFACES.md
@@ -21,7 +21,7 @@ Install, verify, and sync toolkit content for coding assistants:
 | `mcp` | MCP provider setup, health, doctor, uninstall |
 | `plugin` | Plugin bundle sync and check |
 
-Also: `version`, `help`.
+Also: `version`, `help`, `completion` (bash/zsh/fish/PowerShell).
 
 ## Advanced commands
 
@@ -67,6 +67,7 @@ Wave/complexity/risk in the YAML `migration:` block.
 |---------|---------|-------|-------------|
 | `help` | meta | — | keep |
 | `version` | meta | [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555) | PORT (V canonical) |
+| `completion` | consumer | [#544](https://github.com/ulises-jeremias/agent-toolkit/issues/544) | PORT |
 | `install` | consumer | [#607](https://github.com/ulises-jeremias/agent-toolkit/issues/607) | PORT |
 | `update` | consumer | [ADR-017](adrs/ADR-017-update-ownership.md) | PORT (capability-only) |
 | `uninstall` | consumer | [#461](https://github.com/ulises-jeremias/agent-toolkit/issues/461) | PORT |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -104,6 +104,8 @@ After the primary install:
 
 ```bash
 agent-toolkit doctor
+# Optional: shell completions (bash / zsh / fish / PowerShell)
+agent-toolkit completion bash >> ~/.bashrc
 ```
 
 Open your AI tool and ask: *"What skills do you have available?"* — responses should

--- a/modules/agent_toolkit_cli/completion.v
+++ b/modules/agent_toolkit_cli/completion.v
@@ -1,0 +1,188 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+import os
+
+const completion_shells = ['bash', 'zsh', 'fish', 'powershell']
+
+const completion_commands = 'install update uninstall doctor diff skills mcp plugin loop workspace memory project devcompanion dc insights build inventory matrix release swarm completion help version'
+
+const completion_loop_cmds = 'init run status audit cost schedule sync templates help'
+
+const completion_install_tools = 'claude-code cursor opencode copilot windsurf pi muse-code'
+
+fn completion_help_text() string {
+	return 'Usage: agent-toolkit completion <bash|zsh|fish|powershell>
+
+Emit a shell completion script for the V CLI. Install examples:
+
+  agent-toolkit completion bash >> ~/.bashrc
+  agent-toolkit completion zsh  >> ~/.zshrc
+  agent-toolkit completion fish > ~/.config/fish/completions/agent-toolkit.fish
+  agent-toolkit completion powershell >> \$PROFILE
+'
+}
+
+fn run_completion(args []string) int {
+	if args.len == 0 || args[0] in ['-h', '--help', 'help'] {
+		print(completion_help_text())
+		return 0
+	}
+	shell := args[0].to_lower()
+	script := completion_script(shell) or {
+		eprintln('Unknown shell: ${shell}')
+		eprintln('Supported: ${completion_shells.join(', ')}')
+		return 2
+	}
+	print(script)
+	if !script.ends_with('\n') {
+		print('\n')
+	}
+	return 0
+}
+
+fn completion_script(shell string) !string {
+	return match shell {
+		'bash' { completion_bash() }
+		'zsh' { completion_zsh() }
+		'fish' { completion_fish() }
+		'powershell', 'pwsh' { completion_powershell() }
+		else { error('unknown shell') }
+	}
+}
+
+fn completion_loop_names() string {
+	root := agent_toolkit_core.find_toolkit_root() or { return '' }
+	loops_dir := os.join_path(root.path, 'loops')
+	if !os.is_dir(loops_dir) {
+		return ''
+	}
+	entries := os.ls(loops_dir) or { return '' }
+	mut names := []string{}
+	for e in entries {
+		dir := os.join_path(loops_dir, e)
+		if os.is_dir(dir) && (os.is_file(os.join_path(dir, 'loop.yaml'))
+			|| os.is_file(os.join_path(dir, 'LOOP.md'))) {
+			names << e
+		}
+	}
+	names.sort()
+	return names.join(' ')
+}
+
+fn completion_bash() string {
+	loops := completion_loop_names()
+	return
+		'# agent-toolkit bash completion
+_agent_toolkit_completions() {
+    local cur prev words cword
+    _init_completion || return
+    local commands="' +
+		completion_commands + '"
+    local loop_cmds="' + completion_loop_cmds +
+		'"
+    local loop_names="' + loops + '"
+    local install_tools="' +
+		completion_install_tools +
+		'"
+    if [[ \$cword -eq 1 ]]; then
+        COMPREPLY=( \$(compgen -W "\$commands" -- "\$cur") )
+        return
+    fi
+    case "\${words[1]}" in
+        install|update)
+            COMPREPLY=( \$(compgen -W "--tools --dry-run --force --offline --check --pin --help \$install_tools" -- "\$cur") )
+            ;;
+        loop)
+            if [[ \$cword -eq 2 ]]; then
+                COMPREPLY=( \$(compgen -W "\$loop_cmds" -- "\$cur") )
+            elif [[ "\${words[2]}" == "run" || "\${words[2]}" == "init" ]] && [[ \$cword -eq 3 ]]; then
+                COMPREPLY=( \$(compgen -W "\$loop_names" -- "\$cur") )
+            fi
+            ;;
+        completion)
+            COMPREPLY=( \$(compgen -W "bash zsh fish powershell" -- "\$cur") )
+            ;;
+        *)
+            COMPREPLY=( \$(compgen -W "--help --json --quiet" -- "\$cur") )
+            ;;
+    esac
+}
+complete -F _agent_toolkit_completions agent-toolkit
+complete -F _agent_toolkit_completions agent-toolkit-cli
+'
+}
+
+fn completion_zsh() string {
+	loops := completion_loop_names()
+	return
+		'#compdef agent-toolkit agent-toolkit-cli
+_agent_toolkit() {
+    local -a commands loop_cmds loop_names install_tools
+    commands=(' +
+		completion_commands + ')
+    loop_cmds=(' + completion_loop_cmds + ')
+    loop_names=(' +
+		loops + ')
+    install_tools=(' + completion_install_tools +
+		')
+    _arguments -C "1:command:->command" "*::arg:->args"
+    case \$state in
+        command)
+            _describe "command" commands
+            ;;
+        args)
+            case \$words[1] in
+                loop)
+                    _arguments "1:loop subcommand:(\$loop_cmds)" "2:loop name:(\$loop_names)"
+                    ;;
+                completion)
+                    _arguments "1:shell:(bash zsh fish powershell)"
+                    ;;
+                install|update)
+                    _arguments "--tools[Tools]:tool:(\$install_tools)" "--dry-run" "--force" "--help"
+                    ;;
+            esac
+            ;;
+    esac
+}
+_agent_toolkit "\$@"
+'
+}
+
+fn completion_fish() string {
+	loops := completion_loop_names()
+	mut lines := []string{}
+	lines << '# agent-toolkit fish completion'
+	lines << 'complete -c agent-toolkit -f'
+	lines << 'complete -c agent-toolkit-cli -f'
+	lines << "complete -c agent-toolkit -n '__fish_use_subcommand' -a '${completion_commands}'"
+	lines << "complete -c agent-toolkit-cli -n '__fish_use_subcommand' -a '${completion_commands}'"
+	lines << "complete -c agent-toolkit -n '__fish_seen_subcommand_from loop' -a '${completion_loop_cmds}'"
+	if loops.len > 0 {
+		lines << "complete -c agent-toolkit -n '__fish_seen_subcommand_from loop; and __fish_seen_subcommand_from run init' -a '${loops}'"
+	}
+	lines << "complete -c agent-toolkit -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish powershell'"
+	return lines.join('\n') + '\n'
+}
+
+fn completion_powershell() string {
+	return 'Register-ArgumentCompleter -Native -CommandName agent-toolkit,agent-toolkit-cli -ScriptBlock {
+    param(\$wordToComplete, \$commandAst, \$cursorPosition)
+    \$cmds = @(\'install\',\'update\',\'uninstall\',\'doctor\',\'diff\',\'skills\',\'mcp\',\'plugin\',\'loop\',\'workspace\',\'memory\',\'project\',\'devcompanion\',\'dc\',\'insights\',\'build\',\'inventory\',\'matrix\',\'release\',\'swarm\',\'completion\',\'help\',\'version\')
+    \$shells = @(\'bash\',\'zsh\',\'fish\',\'powershell\')
+    \$tokens = \$commandAst.CommandElements | ForEach-Object { \$_.ToString() }
+    if (\$tokens.Count -le 2) {
+        \$cmds | Where-Object { \$_ -like "\$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(\$_, \$_, \'ParameterValue\', \$_)
+        }
+        return
+    }
+    if (\$tokens[1] -eq \'completion\') {
+        \$shells | Where-Object { \$_ -like "\$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new(\$_, \$_, \'ParameterValue\', \$_)
+        }
+    }
+}
+'
+}

--- a/modules/agent_toolkit_cli/completion_test.v
+++ b/modules/agent_toolkit_cli/completion_test.v
@@ -1,0 +1,49 @@
+module agent_toolkit_cli
+
+fn test_completion_bash_registers_complete() {
+	script := completion_bash()
+	assert script.contains('complete -F _agent_toolkit_completions agent-toolkit')
+	assert script.contains('install')
+	assert script.len > 100
+}
+
+fn test_completion_zsh_compdef() {
+	script := completion_zsh()
+	assert script.contains('#compdef agent-toolkit')
+	assert script.contains('install')
+}
+
+fn test_completion_fish_complete_c() {
+	script := completion_fish()
+	assert script.contains('complete -c agent-toolkit')
+	assert script.contains('install')
+}
+
+fn test_completion_powershell_register() {
+	script := completion_powershell()
+	assert script.contains('Register-ArgumentCompleter')
+	assert script.contains('agent-toolkit')
+}
+
+fn test_run_completion_help() {
+	assert run_completion(['--help']) == 0
+	assert run_completion([]) == 0
+}
+
+fn test_run_completion_unknown_shell() {
+	assert run_completion(['csh']) == 2
+}
+
+fn test_run_completion_each_shell() {
+	for shell in completion_shells {
+		assert run_completion([shell]) == 0
+	}
+}
+
+fn test_dispatch_completion_help() {
+	assert dispatch(['agent-toolkit', 'completion', '--help']) == 0
+}
+
+fn test_dispatch_completion_bash() {
+	assert dispatch(['agent-toolkit', 'completion', 'bash']) == 0
+}

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -163,6 +163,9 @@ pub fn dispatch(args []string) int {
 		report := agent_toolkit_core.run_swarm(opts)
 		return render(agent_toolkit_core.swarm_result(report), mode)
 	}
+	if cmd_name == 'completion' {
+		return run_completion(argv[1..])
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
@@ -1198,8 +1201,7 @@ fn allowed_flag(cmd string, a string) bool {
 		}
 	}
 	if cmd == 'swarm' {
-		if a in ['--dry-run', '--force', '--recipe', '--backend', '--ui', '--workspace',
-			'--reason'] {
+		if a in ['--dry-run', '--force', '--recipe', '--backend', '--ui', '--workspace', '--reason'] {
 			return true
 		}
 		if a.starts_with('--recipe') || a.starts_with('--backend') || a.starts_with('--ui')
@@ -1233,7 +1235,8 @@ fn is_known_command(name string) bool {
 }
 
 fn consumer_commands() []string {
-	return ['install', 'update', 'uninstall', 'doctor', 'diff', 'skills', 'mcp', 'plugin']
+	return ['install', 'update', 'uninstall', 'doctor', 'diff', 'skills', 'mcp', 'plugin',
+		'completion']
 }
 
 fn advanced_commands() []string {
@@ -1388,6 +1391,9 @@ Read-only health checks by default. --fix allowlists profile refresh only.
 	}
 	if name == 'swarm' {
 		return agent_toolkit_core.swarm_help_text()
+	}
+	if name == 'completion' {
+		return completion_help_text()
 	}
 	mut c := cli.Command{
 		name:        name


### PR DESCRIPTION
## Summary

- Add `agent-toolkit completion <bash|zsh|fish|powershell>` to the canonical V CLI (Closes #544).
- Scripts cover consumer/advanced commands plus loop names from the toolkit tree.

## Type

- [x] Other

## Changes

- `modules/agent_toolkit_cli/completion.v` (+ tests)
- `dispatch.v` wires the `completion` consumer command
- `docs/CLI_SURFACES.md`, `docs/INSTALLATION.md`

## Testing

- [x] `v test modules/agent_toolkit_cli` (5 passed)

## Checklist

- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes
- [x] Commit messages are in English and follow conventional commits format


Made with [Cursor](https://cursor.com)