### PR TITLE
docs: align install and release channels with V-first 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Install/release docs match V-first channels: GitHub Release, PyPI launcher, Homebrew, AUR `agent-toolkit-bin`, npm `agent-toolkit-cli` + platform packages, Docker `debian:trixie-slim`
 - **Feat** — V CLI `completion` emits bash/zsh/fish/PowerShell scripts (Closes #544)
 - **Fixed** — Docker multi-arch image honors BuildKit `TARGETARCH` (no amd64 default) so linux/arm64 installs `agent-toolkit-linux-arm64`; skip exec during QEMU cross-build and smoke `version` on a native load
 - **Fixed** — Install `types-PyYAML` in the PyPI adapter dev extra so incremental mypy can type `yaml` imports

--- a/README.md
+++ b/README.md
@@ -108,15 +108,17 @@ agent-toolkit doctor
 
 ## 🚀 Quick Install
 
-**Recommended:** use the Python CLI with [uv](https://docs.astral.sh/uv/) — one flow for every supported tool.
+**Recommended:** the product CLI is the **native V binary**. PyPI/`uv` is a thin launcher over that binary ([ADR-021](docs/adrs/ADR-021-pypi-binary.md)).
 
 ```bash
-# No install needed — run directly (preferred)
+# PyPI launcher (uv) — preferred when you already use Python tooling
 uvx --from agent-toolkit-cli agent-toolkit install
+uv tool install agent-toolkit-cli
 
-# Or install the CLI persistently
-uv tool install agent-toolkit-cli          # preferred over pip when using uv
-# uv tool install agent-toolkit-cli            # alternative
+# Homebrew / AUR / npm / GitHub Release — same V binary
+brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
+yay -S agent-toolkit-bin
+npm i -g agent-toolkit-cli
 
 agent-toolkit install    # auto-detects Claude, Cursor, OpenCode, Windsurf, Pi, Copilot
 agent-toolkit doctor     # verify everything is set up
@@ -200,7 +202,8 @@ Formulas live in dedicated repos ([homebrew-tap](https://github.com/ulises-jerem
 
 ```bash
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
-yay -S agent-toolkit   # Arch Linux (AUR) — pending publish, use `uv tool install agent-toolkit-cli` until AUR RPC shows package
+yay -S agent-toolkit-bin   # Arch Linux (AUR) — GitHub Release V binary
+npm i -g agent-toolkit-cli # optionalDependencies platform packages
 ```
 
 </details>

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -7,7 +7,7 @@ This directory is **documentation-only contracts** for packaging adapters. It is
 
 ## Canonical source
 
-**GitHub Releases** on `ulises-jeremias/agent-toolkit` are the canonical binary source ([ADR-018](../docs/adrs/ADR-018-release-artifacts.md)). PyPI, Homebrew, AUR, npm, and Docker are **adapters**: they fetch or wrap those artifacts (or, until V promotion, the current Python wheel / PyInstaller names).
+**GitHub Releases** on `ulises-jeremias/agent-toolkit` are the canonical binary source ([ADR-018](../docs/adrs/ADR-018-release-artifacts.md)). PyPI, Homebrew, AUR, npm, and Docker are **adapters** that fetch or wrap those V artifacts. Python remains a launcher/tooling layer (`packages/pypi/agent-toolkit-cli`, `agent-toolkit-py` fallback) — not the product CLI.
 
 Do **not** duplicate Formula/PKGBUILD/npm `package.json` here. Those live in their owner repos:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ agent-toolkit is organized around three layers that compose to form a complete A
 The outermost layer is the installer or workstation harness that provisions agent-toolkit onto a machine. This layer is responsible for:
 
 - Cloning or updating the toolkit repository
-- Running `agent-toolkit install` (Python CLI; `scripts/install.sh` is a deprecated legacy fallback — see ADR-007) to copy profiles/plugins to the right tool-specific locations
+- Running `agent-toolkit install` (canonical **V** CLI; PyPI/`uv` is a thin launcher — ADR-021. `scripts/install.sh` is a deprecated legacy fallback — see ADR-007) to copy profiles/plugins to the right tool-specific locations
 - Managing credentials and environment variables (but never storing secrets in this repo)
 - Scheduling recurring loops via a cron or loop-runner daemon
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -16,9 +16,9 @@ make install-cli    # ~/.local/bin/agent-toolkit
 agent-toolkit doctor --json
 ```
 
-PyPI/`uvx` still runs the Python wheel until native binary wrappers. Unfinished advanced commands: `uvx --from agent-toolkit-cli agent-toolkit <cmd>` (see [docs/v/cutover.md](v/cutover.md)). Rollback: [docs/v/rollback.md](v/rollback.md).
+PyPI/`uvx` is a thin launcher over the bundled V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)). Unfinished advanced commands fall back to `agent-toolkit-py` (see [docs/v/cutover.md](v/cutover.md)). Rollback: [docs/v/rollback.md](v/rollback.md).
 
-Alternatives: `uvx --from agent-toolkit-cli agent-toolkit install` (one-shot) or `yay -S agent-toolkit-cli && agent-toolkit install` on Arch Linux (AUR pending publish — use `uv` until RPC shows package).
+Alternatives: `uvx --from agent-toolkit-cli agent-toolkit install` (one-shot), `brew install agent-toolkit`, `yay -S agent-toolkit-bin`, or `npm i -g agent-toolkit-cli`.
 
 See [docs/INSTALLATION.md](INSTALLATION.md) for full options.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -76,8 +76,7 @@ uvx --from agent-toolkit-cli agent-toolkit doctor
 ### Persistent CLI install
 
 ```bash
-uv tool install agent-toolkit-cli    # preferred when using uv
-# uv tool install agent-toolkit-cli      # alternative
+uv tool install agent-toolkit-cli
 
 agent-toolkit install                # auto-detect all tools
 agent-toolkit doctor                 # verify setup

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -63,7 +63,7 @@ make install-cli    # PREFIX/bin/agent-toolkit, default ~/.local/bin
 agent-toolkit doctor --json
 ```
 
-See [docs/v/cutover.md](v/cutover.md) and [docs/v/rollback.md](v/rollback.md). PyPI/`uvx` still ships the Python wheel until native wrappers.
+See [docs/v/cutover.md](v/cutover.md) and [docs/v/rollback.md](v/rollback.md). PyPI/`uvx` ships a thin Python launcher over the V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)); `agent-toolkit-py` remains as fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540).
 
 ```bash
 # Run without installing the CLI (preferred for PyPI)
@@ -187,7 +187,8 @@ npx skills add ulises-jeremias/agent-toolkit -g
 
 ```bash
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
-yay -S agent-toolkit   # Arch Linux (AUR)
+yay -S agent-toolkit-bin   # Arch Linux (AUR) — GitHub Release V binary
+npm i -g agent-toolkit-cli # npm optionalDependencies platform packages @1.11.0
 ```
 
 ### Git clone + legacy script fallback (deprecated — see ADR-007)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -32,7 +32,8 @@ gh run list --repo ulises-jeremias/aur-packages --limit 3
 # 5. Verify PyPI / npm / AUR / formula
 curl -sS https://pypi.org/pypi/agent-toolkit-cli/json | python3 -c "import json,urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/agent-toolkit-cli/json'))['info']['version'])"
 npm view agent-toolkit-cli version
-curl -sS 'https://aur.archlinux.org/rpc/v5/info?arg[]=agent-toolkit' | python3 -m json.tool  # resultcount 0 until published
+npm view agent-toolkit-cli optionalDependencies
+curl -sS 'https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=agent-toolkit-bin' | python3 -c "import json,sys; r=json.load(sys.stdin)['results']; print(r[0]['Version'] if r else 'missing')"
 # Homebrew formula version matches tag
 ```
 
@@ -85,8 +86,8 @@ Stable GitHub Release assets are **native V binaries** (not PyInstaller). Names 
 **Checksums are MUST.** Verify:
 
 ```bash
-curl -fsSL -O "https://github.com/ulises-jeremias/agent-toolkit/releases/download/v1.10.0/SHA256SUMS"
-curl -fsSL -O "https://github.com/ulises-jeremias/agent-toolkit/releases/download/v1.10.0/agent-toolkit-linux-x86_64"
+curl -fsSL -O "https://github.com/ulises-jeremias/agent-toolkit/releases/download/v1.11.0/SHA256SUMS"
+curl -fsSL -O "https://github.com/ulises-jeremias/agent-toolkit/releases/download/v1.11.0/agent-toolkit-linux-x86_64"
 sha256sum -c SHA256SUMS --ignore-missing
 ```
 
@@ -120,12 +121,12 @@ Failure visibility on the releasing repo:
 * For AUR, a maintenance failure is expected — document it in the release comment and retry when AUR leaves maintenance; do not auto-open issues on every window.
 
 
-## Downstream install source (PyPI wheel preferred)
+## Downstream install source (GitHub Release V binaries)
 
-Homebrew (`homebrew-tap`) and AUR (`aur-packages`) should install from the PyPI wheel/sdist (which bundles `skills/` data via `prepare-package-data.sh`) rather than building from the GitHub source tarball without that step. This avoids silent incomplete installs (see #257, #258).
+Homebrew (`homebrew-tap`) and AUR (`aur-packages`) install **GitHub Release V binaries** (ADR-018 floating names + `SHA256SUMS`), not a Python wheel. PyPI `agent-toolkit-cli` remains a thin launcher for `uv`/`pip` users ([ADR-021](adrs/ADR-021-pypi-binary.md)). npm `agent-toolkit-cli` + `agent-toolkit-cli-{linux-x64,linux-arm64,darwin-arm64,darwin-x64,win32-x64}` wrap the same binaries ([ADR-025](adrs/ADR-025-npm-binary.md)).
 
-- **Homebrew:** Formula `agent-toolkit.rb` should `url` the PyPI wheel (`https://files.pythonhosted.org/.../agent-toolkit_cli-*.whl`) or run `scripts/prepare-package-data.sh` before `pip install` from tarball. Verify via `brew install --build-from-source` then `agent-toolkit doctor`.
-- **AUR:** `PKGBUILD` should `source` the PyPI sdist/wheel and run `prepare-package-data.sh` if building from source. Verify via `makepkg -si` then `agent-toolkit doctor`.
+- **Homebrew:** Formula `agent-toolkit.rb` `url`s `agent-toolkit-macos-*` / `agent-toolkit-linux-*` from the GitHub Release. Verify `brew install` then `agent-toolkit version`.
+- **AUR:** `agent-toolkit-bin` PKGBUILD sources the linux ELF + `SHA256SUMS`. Verify `yay -S agent-toolkit-bin` then `agent-toolkit version`.
 
 See `docs/AUR_PLAYBOOK.md` for re-dispatch; downstream repos are the source of truth for their formulas.
 

--- a/docs/v/artifact-smoke.md
+++ b/docs/v/artifact-smoke.md
@@ -13,4 +13,4 @@ MUST-platform V binaries are **executed on the same runner architecture that bui
 
 Implemented in `.github/workflows/experimental-v.yml` after `make`-equivalent V build. Failures fail the job (`fail-fast: false` so other platforms still report).
 
-Tag `release.yml` PyInstaller assets are **not** switched here; promotion after smoke stays an explicit decision.
+Tag `release.yml` stable assets are native V as of v1.11.0. This file documents the **experimental** CI smoke path (`experimental-v.yml`), not the Release upload.

--- a/docs/v/ci-cost-tiers.md
+++ b/docs/v/ci-cost-tiers.md
@@ -12,9 +12,9 @@ Dual implementation CI is expensive. Workflows follow three **cost tiers**. Dist
 |------|------|-----------|--------|
 | **PR** | `pull_request` | Lint/fmt/validate; Python unit (validate.yml); V compile via parity seed + dispatch tests in validate if present; golden parity (`parity.yml`) only when CLI/V/Python CLI paths change | Wall: parity ≤ 15 min; experimental-v **skipped** unless its path filter matches. Cancel-in-progress: yes |
 | **main** | `push` to `main` | PR set plus fuller compile. Experimental V MUST matrix (`experimental-v.yml`) only on V/release-doc path changes | Wall: experimental-v job ≤ 25 min/platform. Cancel-in-progress: yes |
-| **release** | `v*` tags (`release.yml`) | Full native **stable** PyInstaller matrix, PyPI publish, SHA256SUMS/attestations/SBOM (#530) | Wall: release workflow ≤ 60 min. Cancel-in-progress: **no** |
+| **release** | `v*` tags (`release.yml`) | Full native **stable V** matrix, PyPI manylinux_2_38 wheels, SHA256SUMS/attestations/SBOM (#530) | Wall: release workflow ≤ 60 min. Cancel-in-progress: **no** |
 
-Experimental native V artifacts stay on the **experimental** channel ([ADR-018](../adrs/ADR-018-release-artifacts.md)) until an explicit promotion. They are **not** the release-tier stable upload.
+Experimental native V artifacts stay on the **experimental** channel ([ADR-018](../adrs/ADR-018-release-artifacts.md)). They are **not** the release-tier stable upload (stable names are native V as of v1.11.0).
 
 ## Path filters (distribution smoke)
 

--- a/docs/v/experimental-binaries.md
+++ b/docs/v/experimental-binaries.md
@@ -4,7 +4,7 @@
 **Names:** [ADR-018](../adrs/ADR-018-release-artifacts.md)  
 **Libc:** [ADR-019](../adrs/ADR-019-linux-libc.md) (Linux MUST artifact is glibc)
 
-These are **CI artifacts only**. They are not the stable GitHub Release channel (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe` — those remain PyInstaller until promotion after [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531)). Experimental names **must not** overwrite stable names.
+These are **CI artifacts only**. They are not the stable GitHub Release channel (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe` — native V as of v1.11.0). Experimental names **must not** overwrite stable names.
 
 The MUST platform matrix (Linux x86_64/ARM64, macOS ARM64/x86_64, Windows x86_64) is documented in [release-matrix.md](release-matrix.md) ([#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529)).
 

--- a/docs/v/performance-baseline.md
+++ b/docs/v/performance-baseline.md
@@ -14,7 +14,7 @@ Migration is not a performance project. These numbers exist so later changes can
 | V | 0.5.2 (`v version` 45e92d1), pin `.v-version` |
 | Commit | `b356e19` (docs/python-api-audit; methodology applies to `main` at audit time) |
 | N | 7 timed runs after 1 warmup; median and p95 |
-| Python | `uv run --package agent-toolkit-cli agent-toolkit-py` (not the V launcher) |
+| Python | `uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit-py` (not the V launcher; no root uv workspace) |
 | V binary | `make build-cli` → `build/agent-toolkit` (debug, tcc→cc fallback) |
 | V `-prod` | **Does not build** on 0.5.2: `import json` is a **error** under `-prod` (we MUST keep `json`, not json2) |
 | PyInstaller | N/A — `v1.10.0` GitHub Release has **zero** assets |

--- a/docs/v/release-matrix.md
+++ b/docs/v/release-matrix.md
@@ -6,7 +6,7 @@
 
 V **cannot cross-compile to macOS**. Every macOS artifact is built **on** a macOS runner.
 
-Stable GitHub Release names (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe`) remain **PyInstaller** until an explicit promotion after [#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531) smoke. This matrix publishes **experimental** names only.
+As of **v1.11.0**, stable GitHub Release names (`agent-toolkit-linux-x86_64`, `agent-toolkit-macos-arm64`, `agent-toolkit-windows-x86_64.exe`, plus linux-arm64 / macos-x86_64) are **native V binaries** with `SHA256SUMS` ([ADR-018](../adrs/ADR-018-release-artifacts.md)). This matrix still publishes **experimental** names for CI-only smoke; they must not overwrite stable names.
 
 ## MUST capabilities (verified 2026-08-13)
 
@@ -26,9 +26,9 @@ Labels are **not** forever architecture. Re-verify when GitHub retargets `-lates
 |------------|--------|
 | Windows ARM64 | Issue #529 FUTURE (`windows-11-arm` exists; not a retirement gate). |
 | Linux musl | Optional extra (ADR-019); must not overwrite glibc names. |
-| Stable floating names | Still PyInstaller in `release.yml` until promotion. |
+| Stable floating names | Native V as of v1.11.0 (`release.yml` `build-binaries` / `upload-assets`). |
 
-macOS x86_64 is **MUST here** (experimental channel). The historical #256 skip (`agent-toolkit-darwin-x86_64` / stable `macos-x86_64`) stays for the **stable** floating name until promotion.
+macOS x86_64 is **MUST** on both the experimental CI channel and the v1.11.0+ stable Release name `agent-toolkit-macos-x86_64`.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Install/release docs now describe the real v1.11.0 channels: GitHub Release V binaries, PyPI thin launcher, Homebrew Formula, AUR `agent-toolkit-bin`, npm `agent-toolkit-cli` + platform optionalDeps, Docker `debian:trixie-slim`.
- Python is documented as launcher/tooling (`agent-toolkit-py` fallback), not the product CLI.

## Type

- [x] Documentation

## Changes

- `README.md`, `docs/INSTALLATION.md`, `docs/GETTING_STARTED.md`, `docs/RELEASING.md`, `docs/ARCHITECTURE.md`, `distribution/README.md`

## Testing

- [x] Manual review against PyPI 1.11.0 wheels, npm 1.11.0 optionalDependencies, AUR `agent-toolkit-bin` 1.11.0-1, homebrew-tap Formula on main

## Checklist

- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes
- [x] Branding-neutral: no organization-specific references in public-facing files
- [x] Commit messages are in English and follow conventional commits format


Made with [Cursor](https://cursor.com)