### PR TITLE
docs: V-first contributor how-tos (Python is launcher only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,10 +296,12 @@ for f in sorted(Path("loops").rglob("loop.yaml")):
 PYEOF
 python3 scripts/generate-catalogs.py   # Regenerates and checks catalogs
 python3 scripts/gen-surfaces.py --check  # Asserts plugin surfaces are in sync
+make test && make build-cli
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
 AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v
 ```
 
-All checks must exit 0. Run `uv sync --project packages/pypi/agent-toolkit-cli --all-extras` first for pytest (the repo is not a uv workspace; V is the product CLI).
+All checks must exit 0. V is the product CLI (pin `.v-version` / 0.5.2, `import json` not json2 — [`docs/HOW_TO_DEVELOP_V.md`](docs/HOW_TO_DEVELOP_V.md)). Run `uv sync --project packages/pypi/agent-toolkit-cli --all-extras` first for pytest only (the repo is not a uv workspace).
 
 ---
 
@@ -312,14 +314,14 @@ L1  │ agentic-workstation  │ Machine provisioning (chezmoi, shell, packages,
     │                      │ https://github.com/ulises-jeremias/agentic-workstation
 ────┼──────────────────────┼─────────────────────────────────────────────────────────────
 L1.5│ agent-toolkit        │ THIS REPO — Capability distribution (skills, loops, profiles)
-    │ (this repo)          │ uv tool install agent-toolkit-cli / uvx agent-toolkit-cli
+    │ (this repo)          │ V binary: brew / AUR agent-toolkit-bin / GitHub / uv launcher / npm
 ────┼──────────────────────┼─────────────────────────────────────────────────────────────
 L3  │ agentic-harness      │ AI workspace scaffold for multi-repo orchestration
     │                      │ https://github.com/ulises-jeremias/agentic-harness
 ```
 
 **Integration flow:**
-1. `agentic-workstation` installs `agent-toolkit-cli` automatically during `chezmoi apply`
+1. `agentic-workstation` installs the V CLI during `chezmoi apply` (brew / AUR `agent-toolkit-bin` / GitHub / `uv tool install 'agent-toolkit-cli>=1.11.0'`)
 2. `agent-toolkit install` deploys profiles to detected AI tools (Claude Code, Cursor, etc.)
 3. `agentic-harness` workspaces call `agent-toolkit loop`, `agent-toolkit memory`, etc.
 
@@ -330,9 +332,11 @@ L3  │ agentic-harness      │ AI workspace scaffold for multi-repo orchestrat
 When working in a workspace that has `agent-toolkit` installed, use these commands:
 
 ```bash
-# Installation
-uvx agent-toolkit-cli                          # run without installing
-uv tool install agent-toolkit-cli                  # permanent install
+# Installation (V binary — pick one channel; see docs/INSTALLATION.md)
+# brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
+# yay -S agent-toolkit-bin
+# GitHub Release: agent-toolkit-<os>-<arch> from /releases/latest
+uv tool install 'agent-toolkit-cli>=1.11.0'    # PyPI launcher over bundled V
 agent-toolkit install [--force]                # deploy profiles to detected AI tools
 agent-toolkit doctor                           # verify installation health
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Contributor how-tos are V-first: `docs/HOW_TO_DEVELOP_V.md` (V 0.5.2, `import json`, Makefile), install matrix GitHub/brew/AUR/PyPI/npm, GitHub Release adapter no longer claims PyInstaller, `uv run agent-toolkit` removed from HOW_TO/certification docs
 - **Docs** — Install/release docs match V-first channels: GitHub Release, PyPI launcher, Homebrew, AUR `agent-toolkit-bin`, npm `agent-toolkit-cli` + platform packages, Docker `debian:trixie-slim`
 - **Feat** — V CLI `completion` emits bash/zsh/fish/PowerShell scripts (Closes #544)
 - **Fixed** — Docker multi-arch image honors BuildKit `TARGETARCH` (no amd64 default) so linux/arm64 installs `agent-toolkit-linux-arm64`; skip exec during QEMU cross-build and smoke `version` on a native load

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,20 +7,26 @@ Thank you for your interest in contributing. This document covers everything you
 ## Prerequisites
 
 - **Git** 2.30 or later
-- **Python** 3.10 or later (validation scripts, PyPI launcher tests)
-- **uv** (recommended for the PyPI adapter under `packages/pypi/`) — see https://docs.astral.sh/uv/getting-started/installation/
-- **V** matching [`.v-version`](.v-version) for the canonical CLI (`make test`, `make build-cli`)
+- **V** matching [`.v-version`](.v-version) (**0.5.2**) for the canonical CLI — `import json`, not `json2`. See [`docs/HOW_TO_DEVELOP_V.md`](docs/HOW_TO_DEVELOP_V.md)
+- **Python** 3.10 or later (validation scripts, PyPI launcher tests, pre-commit)
+- **uv** for the PyPI adapter under `packages/pypi/` only — see https://docs.astral.sh/uv/getting-started/installation/
 - A GitHub account and a fork of this repository
+
+The repo is **not** a uv workspace. The product CLI is `make build-cli` → `build/agent-toolkit`.
 
 Verify your setup:
 
 ```bash
 git --version
+v version                 # must match .v-version
 python3 --version
 uv --version
+make test
+make build-cli
+./build/agent-toolkit --version
 ```
 
-Install Python adapter + test tools (not a repo-root uv workspace):
+Install Python adapter + test tools (launcher/pytest only):
 
 ```bash
 uv sync --project packages/pypi/agent-toolkit-cli --all-extras
@@ -89,7 +95,12 @@ python3 scripts/gen-surfaces.py --check
 # Regenerate catalogs and verify they match source files
 python3 scripts/generate-catalogs.py
 
-# Full test suite (CI parity)
+# Canonical V CLI
+make test
+make build-cli
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
+
+# Python launcher / parity tests (CI parity; not the product)
 AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v
 ```
 
@@ -347,22 +358,16 @@ The in-repo canonical `agent-toolkit` implementation is the V binary ([#555](htt
 When adding a new skill, agent, or loop, verify the compiler pipeline:
 
 ```bash
-# Sync the PyPI adapter (launcher + Python fallback tests)
-uv sync --project packages/pypi/agent-toolkit-cli --all-extras
-
-# Validate your changes
+# Canonical V CLI (see docs/HOW_TO_DEVELOP_V.md)
+make build-cli
 python3 scripts/validate-skills.py
 python3 scripts/validate-agents.py
 python3 scripts/validate-manifests.py
 python3 scripts/gen-surfaces.py --check
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
 
-# Run the compiler in check mode (Python fallback)
-uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit-py build --check
-
-# Check for drift vs installed bundles
-uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit-py diff
-
-# Run all tests including contract tests
+# Python adapter tests (launcher + fallback; not the product)
+uv sync --project packages/pypi/agent-toolkit-cli --all-extras
 AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@
 One toolkit. Any coding assistant. Zero duplication.
 
 ```bash
-# Primary install — auto-detects your AI tools
-uvx --from agent-toolkit-cli agent-toolkit install
+# Native V CLI (any channel below), then:
+agent-toolkit install
 agent-toolkit doctor
 ```
 
@@ -111,13 +111,20 @@ agent-toolkit doctor
 **Recommended:** the product CLI is the **native V binary**. PyPI/`uv` is a thin launcher over that binary ([ADR-021](docs/adrs/ADR-021-pypi-binary.md)).
 
 ```bash
-# PyPI launcher (uv) — preferred when you already use Python tooling
-uvx --from agent-toolkit-cli agent-toolkit install
-uv tool install agent-toolkit-cli
+# GitHub Release — native V binary + SHA256SUMS (v1.11.0+)
+# https://github.com/ulises-jeremias/agent-toolkit/releases/latest
 
-# Homebrew / AUR / npm / GitHub Release — same V binary
+# Homebrew
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
+
+# AUR (Arch) — native V binary; not the Python AUR package
 yay -S agent-toolkit-bin
+
+# PyPI launcher (execs bundled V; ADR-021)
+uv tool install 'agent-toolkit-cli>=1.11.0'
+uvx --from 'agent-toolkit-cli>=1.11.0' agent-toolkit install
+
+# npm
 npm i -g agent-toolkit-cli
 
 agent-toolkit install    # auto-detects Claude, Cursor, OpenCode, Windsurf, Pi, Copilot

--- a/distribution/github-release/README.md
+++ b/distribution/github-release/README.md
@@ -3,12 +3,14 @@
 **Owner:** this repository (`.github/workflows/release.yml`).  
 **Names:** [ADR-018](../../docs/adrs/ADR-018-release-artifacts.md).
 
-Stable floating assets (today PyInstaller until V promotion):
+Stable floating assets are **native V binaries** (since `v1.11.0`). Do not treat PyInstaller as the product. Do **not retag** `v1.10.0` (empty asset list).
 
-- `agent-toolkit-linux-x86_64`
-- `agent-toolkit-macos-arm64`
+- `agent-toolkit-linux-x86_64` / `agent-toolkit-linux-arm64`
+- `agent-toolkit-macos-arm64` / `agent-toolkit-macos-x86_64`
 - `agent-toolkit-windows-x86_64.exe`
+- Versioned archives `agent-toolkit-<semver>-<os>-<arch>.tar.gz` (Windows `.zip`)
+- `SHA256SUMS`, `manifest.json`, `sbom.cyclonedx.json`
 
-Experimental V assets use the `agent-toolkit-v-experimental-` prefix only ([#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562)).
+Experimental V CI artifacts use the `agent-toolkit-v-experimental-` prefix only and MUST NOT overwrite stable names ([#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562)).
 
-Checksums, attestations, SBOM: [#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530). Manifest: [#488](https://github.com/ulises-jeremias/agent-toolkit/issues/488).
+Checksums are MUST. Attestations/SBOM: [#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530). Manifest: [ADR-022](../../docs/adrs/ADR-022-release-manifest.md). Runbook: [`docs/RELEASING.md`](../../docs/RELEASING.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 agent-toolkit is organized around three layers that compose to form a complete AI capability stack for any project or team.
 
+**Canonical CLI:** native **V 0.5.2** (`import json`, not json2). Build with `make build-cli` → `build/agent-toolkit`. PyPI/`uv`/`npm` are distribution adapters over that binary. See [`docs/HOW_TO_DEVELOP_V.md`](HOW_TO_DEVELOP_V.md) and [`docs/v/README.md`](v/README.md).
+
 ---
 
 ## Three-Layer Model

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,14 +2,23 @@
 
 The fastest path from install to your first successful skill use.
 
-## 1. Install (one primary method)
+## 1. Install (pick one channel — all end on the same V CLI)
 
 ```bash
-uv tool install agent-toolkit-cli
+# GitHub Release binary (native V) — see docs/INSTALLATION.md
+# Homebrew
+brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
+# AUR
+yay -S agent-toolkit-bin
+# PyPI launcher (execs bundled V; ADR-021)
+uv tool install 'agent-toolkit-cli>=1.11.0'
+# npm
+npm i -g agent-toolkit-cli
+
 agent-toolkit install
 ```
 
-From a git checkout, the **canonical CLI implementation is V** ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)):
+From a git checkout, build the canonical V binary ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555), [HOW_TO_DEVELOP_V.md](HOW_TO_DEVELOP_V.md)):
 
 ```bash
 make install-cli    # ~/.local/bin/agent-toolkit
@@ -17,8 +26,6 @@ agent-toolkit doctor --json
 ```
 
 PyPI/`uvx` is a thin launcher over the bundled V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)). Unfinished advanced commands fall back to `agent-toolkit-py` (see [docs/v/cutover.md](v/cutover.md)). Rollback: [docs/v/rollback.md](v/rollback.md).
-
-Alternatives: `uvx --from agent-toolkit-cli agent-toolkit install` (one-shot), `brew install agent-toolkit`, `yay -S agent-toolkit-bin`, or `npm i -g agent-toolkit-cli`.
 
 See [docs/INSTALLATION.md](INSTALLATION.md) for full options.
 

--- a/docs/HOW_TO_ADD_SKILL.md
+++ b/docs/HOW_TO_ADD_SKILL.md
@@ -135,17 +135,15 @@ Fix any reported errors before proceeding.
 
 If your skill should appear in a plugin bundle (most skills should), it must be listed in `distributions/products.yaml` (see ADR-001 and ADR-003).
 
-The compiler is the source of truth. Run the canonical build check:
+The compiler is the source of truth. Run the canonical **V** build check (not `uv run agent-toolkit` — there is no product uv workspace):
 
 ```bash
-AGENT_TOOLKIT_ROOT="$PWD" uv run agent-toolkit build --check
-```
-
-Legacy fallback (deprecated, see ADR-003):
-
-```bash
+make build-cli
+AGENT_TOOLKIT_ROOT="$PWD" ./build/agent-toolkit build --check
 python3 scripts/gen-surfaces.py --check
 ```
+
+See [`docs/HOW_TO_DEVELOP_V.md`](HOW_TO_DEVELOP_V.md).
 
 ---
 
@@ -180,7 +178,8 @@ Use the standard PR workflow. Include this checklist in your PR description:
 - [ ] `python3 scripts/validate-skills.py` passes with no errors
 - [ ] Registered in `catalogs/skills-layout.json` (correct group)
 - [ ] Registered in `catalogs/skill-catalog.yaml` (with triggers)
-- [ ] `AGENT_TOOLKIT_ROOT="$PWD" uv run agent-toolkit build --check` passes (or `python3 scripts/gen-surfaces.py --check` during dual-run, see ADR-003)
+- [ ] `make build-cli && AGENT_TOOLKIT_ROOT="$PWD" ./build/agent-toolkit build --check` passes
+- [ ] `python3 scripts/gen-surfaces.py --check` passes
 - [ ] No secrets or hardcoded tokens in skill body
 - [ ] `references/` documents linked from skill body (if present)
 ```

--- a/docs/HOW_TO_DEVELOP_V.md
+++ b/docs/HOW_TO_DEVELOP_V.md
@@ -1,0 +1,77 @@
+# How to develop the V CLI
+
+The **product** is a native V binary. Python is a thin PyPI launcher (`packages/pypi/agent-toolkit-cli`) plus `agent-toolkit-py` fallback, scripts, tests, and pre-commit. Do not treat `uv run agent-toolkit` or a repo-root uv workspace as the product.
+
+Index: [`docs/v/README.md`](v/README.md) · packaging adapters: [`distribution/README.md`](../distribution/README.md)
+
+## Toolchain
+
+| Item | Value |
+|------|--------|
+| V pin | [`.v-version`](../.v-version) — currently **0.5.2** |
+| JSON | `import json` (stdlib). Do **not** `import json2` or run `v fmt` in a way that rewrites `json` → `json2` |
+| Layout | `modules/agent_toolkit_core`, `modules/agent_toolkit_cli`, `cmd/agent-toolkit` ([ADR-009](adrs/ADR-009-v-module-architecture.md)) |
+| Output | `make build-cli` → `build/agent-toolkit` |
+
+```bash
+v version          # second field must match .v-version
+make fmt-check
+make vet
+make test
+make build-cli
+./build/agent-toolkit --version
+./build/agent-toolkit doctor
+```
+
+`VMODULES` is set by the Makefile (`$PWD/modules`). For a raw `v` invocation:
+
+```bash
+export VMODULES="$PWD/modules"
+v -o build/agent-toolkit cmd/agent-toolkit
+```
+
+## Python adapter (not the product)
+
+Used for pytest parity, the PyPI launcher, and `agent-toolkit-py` fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). **Do not delete the launcher.**
+
+```bash
+uv sync --project packages/pypi/agent-toolkit-cli --all-extras
+AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v
+```
+
+Never `uv run agent-toolkit` from repo root (there is no product uv workspace). To exercise the launcher:
+
+```bash
+uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit --version
+# fallback implementation (Python business logic, not the product):
+uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit-py --help
+```
+
+## Build check (skills / plugins)
+
+After changing `skills/`, `agents/`, `loops/`, or `distributions/`:
+
+```bash
+python3 scripts/validate-skills.py
+python3 scripts/validate-agents.py
+python3 scripts/generate-catalogs.py
+python3 scripts/gen-surfaces.py --check
+make build-cli
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
+```
+
+## Packaging (do not copy Formula/PKGBUILD here)
+
+| Channel | Where |
+|---------|--------|
+| GitHub Release V binaries + `SHA256SUMS` | `.github/workflows/release.yml` · [`distribution/github-release`](../distribution/github-release/README.md) |
+| PyPI launcher wheels | `packages/pypi/agent-toolkit-cli` · ADR-021 |
+| npm + platform optionalDeps | `packages/npm/` · ADR-025 · OIDC `publish-npm.yml` |
+| Homebrew Formula | [`ulises-jeremias/homebrew-tap`](https://github.com/ulises-jeremias/homebrew-tap) |
+| AUR `agent-toolkit-bin` | [`ulises-jeremias/aur-packages`](https://github.com/ulises-jeremias/aur-packages) |
+
+Release runbook: [`docs/RELEASING.md`](RELEASING.md). **Do not retag** empty historical tags (`v1.10.0` has no assets).
+
+## Out of scope
+
+P3 server/TUI and Bobatea ([#492](https://github.com/ulises-jeremias/agent-toolkit/issues/492)–[#494](https://github.com/ulises-jeremias/agent-toolkit/issues/494)) — do not invent APIs.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,9 +8,9 @@ manual file copies.
 
 ## Prerequisites
 
-The product CLI is the **native V binary** (GitHub Releases). `uvx agent-toolkit-cli` / PyPI still wrap that binary ([ADR-021](adrs/ADR-021-pypi-binary.md)). Index: [`docs/v/README.md`](v/README.md).
+The product CLI is the **native V binary** (GitHub Releases). `uvx agent-toolkit-cli` / PyPI still wrap that binary ([ADR-021](adrs/ADR-021-pypi-binary.md)). Index: [`docs/v/README.md`](v/README.md). Contributor build: [`docs/HOW_TO_DEVELOP_V.md`](HOW_TO_DEVELOP_V.md).
 
-- **Python** 3.10 or later — for the PyPI launcher and `agent-toolkit-py` fallback (`uv` / `uvx` recommended)
+- **Python** 3.10 or later — **optional** unless you use the PyPI launcher / `agent-toolkit-py` fallback (`uv` / `uvx`)
 - At least one supported AI coding assistant:
   - [Claude Code](https://claude.ai/code) (Anthropic)
   - [Cursor](https://cursor.sh)
@@ -54,33 +54,32 @@ agent-toolkit swarm runners --json
 
 ## Primary install (recommended)
 
-One command auto-detects your AI tools and deploys the right profiles.
+One command auto-detects your AI tools and deploys the right profiles. Pick **one** channel — all install the same V CLI.
 
-**Canonical implementation (from git checkout)** is the V binary ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)):
+```bash
+# Homebrew
+brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
+# AUR (native V; not the Python AUR package)
+yay -S agent-toolkit-bin
+# GitHub Release — download agent-toolkit-<os>-<arch> + SHA256SUMS from
+# https://github.com/ulises-jeremias/agent-toolkit/releases/latest
+# PyPI launcher (execs bundled V)
+uv tool install 'agent-toolkit-cli>=1.11.0'
+# npm
+npm i -g agent-toolkit-cli
+
+agent-toolkit install
+agent-toolkit doctor
+```
+
+**From a git checkout** the canonical implementation is the V binary ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555), [HOW_TO_DEVELOP_V.md](HOW_TO_DEVELOP_V.md)):
 
 ```bash
 make install-cli    # PREFIX/bin/agent-toolkit, default ~/.local/bin
 agent-toolkit doctor --json
 ```
 
-See [docs/v/cutover.md](v/cutover.md) and [docs/v/rollback.md](v/rollback.md). PyPI/`uvx` ships a thin Python launcher over the V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)); `agent-toolkit-py` remains as fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540).
-
-```bash
-# Run without installing the CLI (preferred for PyPI)
-uvx --from agent-toolkit-cli agent-toolkit install
-
-# Verify
-uvx --from agent-toolkit-cli agent-toolkit doctor
-```
-
-### Persistent CLI install
-
-```bash
-uv tool install agent-toolkit-cli
-
-agent-toolkit install                # auto-detect all tools
-agent-toolkit doctor                 # verify setup
-```
+See [docs/v/cutover.md](v/cutover.md) and [docs/v/rollback.md](v/rollback.md). PyPI/`uvx` ships a thin Python launcher over the V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)); `agent-toolkit-py` remains as fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). Do not retag empty `v1.10.0`.
 
 ### Install options
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 | Audience | Canonical docs | Notes |
 |----------|----------------|-------|
 | Consumers | `README.md`, `docs/INSTALLATION.md`, `docs/UNINSTALL.md`, `docs/MIGRATION.md`, `docs/TRUST_BOUNDARIES.md` | Prefer these over wiki mirrors |
-| Contributors | `CONTRIBUTING.md`, `AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/HOW_TO_ADD_SKILL.md` | |
+| Contributors | `CONTRIBUTING.md`, `AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/HOW_TO_DEVELOP_V.md`, `docs/HOW_TO_ADD_SKILL.md` | V CLI first; Python is launcher/tests |
 | V migration | [`docs/v/README.md`](v/README.md), [`docs/RELEASING.md`](RELEASING.md), [`distribution/`](../distribution/README.md) | Native binary is canonical; Python is launcher/fallback |
 | Target matrix | `docs/TARGETS.md`, `docs/targets/*-certification.md` | |
 | Research / historical | `docs/research/`, `docs/wiki/` | Wiki pages may lag; treat as mirrors until sync |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,6 +2,12 @@
 
 Runbook for cutting a versioned release.
 
+**Do not retag empty historical releases.** `v1.10.0` has **no** GitHub Release assets — leave it. The first V-binary tag is `v1.11.0` (ADR-018 names + `SHA256SUMS` + `manifest.json`).
+
+Trusted Publishing: PyPI OIDC is registered for **`release.yml`** (environment `pypi`), not `publish.yml`. npm OIDC is `publish-npm.yml` on tag `v*`.
+
+Canonical artifacts are **native V binaries**. PyPI `packages/pypi/agent-toolkit-cli` is a launcher wheel. npm lives under `packages/npm/`. Homebrew Formula and AUR PKGBUILD are **not** in this repo (`ulises-jeremias/homebrew-tap`, `ulises-jeremias/aur-packages`).
+
 ## Bump → validate → tag → watch → verify
 
 ```bash
@@ -10,6 +16,8 @@ python3 scripts/bump-version.py 1.3.0
 git diff --stat  # VERSION, packages/pypi/agent-toolkit-cli/src/agent_toolkit/__init__.py, package.json, packages/npm/*/package.json, .claude-plugin/marketplace.json, .cursor-plugin/marketplace.json
 
 # 2. Validate (CI parity)
+make test && make build-cli
+AGENT_TOOLKIT_ROOT="$PWD" ./build/agent-toolkit --version
 uv sync --project packages/pypi/agent-toolkit-cli --all-extras
 AGENT_TOOLKIT_ROOT="$PWD" uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v
 python3 scripts/validate-skills.py

--- a/docs/adrs/ADR-003-retire-gen-surfaces.md
+++ b/docs/adrs/ADR-003-retire-gen-surfaces.md
@@ -18,7 +18,7 @@ This ADR does **not** delete code; it records the decision and migration plan.
 
 ## Decision
 
-`gen-surfaces.py` is deprecated. The canonical check is `agent-toolkit build --check` (equivalently: `uv run agent-toolkit build --check` from a checkout).
+`gen-surfaces.py` is deprecated. The canonical check is `agent-toolkit build --check` (from a checkout: `make build-cli && ./build/agent-toolkit build --check`). There is no product uv workspace — do not `uv run agent-toolkit`.
 
 - **Source of truth:** `distributions/products.yaml` + `skills/` + `agents/` + `compiler/targets/`
 - **Build command:** `agent-toolkit build` (writes to `plugins/`), `agent-toolkit build --check` (drift detection, exit 1 on drift)
@@ -29,7 +29,7 @@ This ADR does **not** delete code; it records the decision and migration plan.
 ### CI job swap
 
 - [x] Current `validate.yml` job `check-surfaces` runs `python3 scripts/gen-surfaces.py --check`
-- [ ] Add parallel job `check-build` that runs `AGENT_TOOLKIT_ROOT=$PWD uv run agent-toolkit build --check` (keep both during dual-run)
+- [ ] Add parallel job `check-build` that runs `make build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check` (keep both during dual-run)
 - [ ] After dual-run green for 30 days, flip `check-surfaces` to advisory (`continue-on-error: true`) or remove, making `check-build` the required check
 - [ ] Update `RELEASING.md` bump → validate → tag checklist to use `build --check` instead of `gen-surfaces.py --check`
 
@@ -42,7 +42,7 @@ This ADR does **not** delete code; it records the decision and migration plan.
 
 ### How-tos
 
-- Contributors (after ADR merge): `uv sync --all-extras && AGENT_TOOLKIT_ROOT=$PWD uv run agent-toolkit build --check`
+- Contributors (after ADR merge): `make build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check`
 - Maintainers: `agent-toolkit build` to regenerate `plugins/` before tagging a release
 - CI debugging: compare `build --check --json` output (per-target emit/omit/unsupported) vs legacy drift lines
 

--- a/docs/adrs/ADR-004-profiles-vs-plugins.md
+++ b/docs/adrs/ADR-004-profiles-vs-plugins.md
@@ -51,7 +51,7 @@ Immediate deletion of `profiles/` is out of scope for this ADR (explicit non-goa
 
 ## Guidance for Contributors
 
-- **Do:** edit `skills/`, `agents/`, `loops/`, and `distributions/products.yaml`, then run `AGENT_TOOLKIT_ROOT=$PWD uv run agent-toolkit build --check`.
+- **Do:** edit `skills/`, `agents/`, `loops/`, and `distributions/products.yaml`, then run `make build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check`.
 - **Do not hand-edit** `plugins/` — it is overwritten by `agent-toolkit build`. CI fails on drift.
 - **Profiles status:** `profiles/` is legacy. Do not add new skills/agents only in `profiles/`; add them canonically and let the compiler emit them.
 - **Plugins status:** generated, validated in CI via `build --check` (see ADR-003).

--- a/docs/adrs/ADR-011-resource-packaging.md
+++ b/docs/adrs/ADR-011-resource-packaging.md
@@ -40,7 +40,7 @@ Adopt **option C (Hybrid)**.
 
 - ADR-005 (`docs/adrs/ADR-005-data-packaging.md`)
 - `scripts/prepare-package-data.sh`
-- `.github/workflows/release.yml` (PyInstaller `--add-data` — transitional)
+- `.github/workflows/release.yml` (native V binaries on ADR-018 names since v1.11.0)
 - Issues [#481](https://github.com/ulises-jeremias/agent-toolkit/issues/481), [#547](https://github.com/ulises-jeremias/agent-toolkit/issues/547)
 
 **Verified:** 2026-08-12

--- a/docs/adrs/ADR-023-homebrew.md
+++ b/docs/adrs/ADR-023-homebrew.md
@@ -37,7 +37,7 @@ Adopt **A**.
 ## Consequences
 
 - **Positive:** Same bytes as GitHub Releases / PyPI wheels (ADR-021 A); one implementation.
-- **Negative:** `brew install` is blocked until a tag attaches V assets (v1.10.0 currently has an empty asset list). Release.yml must upload V binaries ([#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530)), not PyInstaller, onto stable names after promotion.
+- **Negative (at decision):** `brew install` was blocked while `v1.10.0` had an empty asset list. **Update (`v1.11.0`):** GitHub Release attaches native V binaries (not PyInstaller); the tap Formula `agent-toolkit` installs that CLI. Do not retag `v1.10.0`.
 - **Follow-on:** [#538](https://github.com/ulises-jeremias/agent-toolkit/issues/538) contract README; notify workflow waits for darwin/linux **binary** assets, not only the source tarball.
 
 ## Validation plan

--- a/docs/cli/doctor-inventory-improvements.md
+++ b/docs/cli/doctor-inventory-improvements.md
@@ -37,7 +37,7 @@
 ## Tests
 
 * `tests/test_doctor_provenance.py` — isolated `HOME=$(mktemp -d)` + `toolkit_root` override: lock exists/version/entries/SHA immutability/staleness, `--provenance` flag, `--json` category presence, packs/mcp registry counts, `complete` coverage — hermetic, no mutation of ci HOME.
-* `uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/test_doctor*.py -v` green, `uv run agent-toolkit doctor --json | jq '.checks[] | select(.category=="provenance")'` shows `lock version`/`lock entries`/`doctor --provenance`.
+* `uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/test_doctor*.py -v` green; `./build/agent-toolkit doctor --json` (after `make build-cli`) shows provenance checks.
 
 ## Verification
 

--- a/docs/targets/claude-code-certification.md
+++ b/docs/targets/claude-code-certification.md
@@ -36,9 +36,10 @@
 ## Validation
 
 ```bash
+make build-cli
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target claude-code --check
 uv sync --project packages/pypi/agent-toolkit-cli --all-extras
 uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/compiler/test_claude_code_adapter.py tests/test_install_claude_settings.py -q
-uv run agent-toolkit build --target claude-code --check
 ```
 
 ## References

--- a/docs/targets/copilot-certification.md
+++ b/docs/targets/copilot-certification.md
@@ -44,10 +44,11 @@
 ## Validation
 
 ```bash
+make build-cli
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target copilot-cli --check
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target copilot-repository --check
 uv sync --project packages/pypi/agent-toolkit-cli --all-extras
 uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/compiler/test_copilot_adapter.py -q
-uv run agent-toolkit build --target copilot-cli --check
-uv run agent-toolkit build --target copilot-repository --check
 ```
 
 ## References

--- a/docs/targets/cursor-certification.md
+++ b/docs/targets/cursor-certification.md
@@ -36,9 +36,10 @@
 ## Validation
 
 ```bash
+make build-cli
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target cursor --check
 uv sync --project packages/pypi/agent-toolkit-cli --all-extras
 uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/compiler/test_cursor_adapter.py tests/test_cursor_profile_rules.py -q
-uv run agent-toolkit build --target cursor --check
 ```
 
 ## References

--- a/docs/targets/opencode-certification.md
+++ b/docs/targets/opencode-certification.md
@@ -33,9 +33,10 @@
 ## Validation
 
 ```bash
+make build-cli
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target opencode --check
 uv sync --project packages/pypi/agent-toolkit-cli --all-extras
 uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/compiler/test_opencode_adapter.py tests/test_install_opencode_profile.py tests/security/test_secret_redaction.py -q
-uv run agent-toolkit build --target opencode --check
 ```
 
 ## References

--- a/docs/v/README.md
+++ b/docs/v/README.md
@@ -3,7 +3,7 @@
 **Issue:** [#545](https://github.com/ulises-jeremias/agent-toolkit/issues/545)  
 **Program:** [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456)
 
-The product CLI is a **native V 0.5.2** binary (`import json`, not json2). Python is a launcher (`agent-toolkit` → V) plus `agent-toolkit-py` fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540).
+The product CLI is a **native V 0.5.2** binary (`import json`, not json2). Python is a launcher (`agent-toolkit` → V) plus `agent-toolkit-py` fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). Contributor how-to: [`docs/HOW_TO_DEVELOP_V.md`](../HOW_TO_DEVELOP_V.md).
 
 ## Build from source
 

--- a/docs/v/migration-risk-register.md
+++ b/docs/v/migration-risk-register.md
@@ -11,11 +11,11 @@ Living register. Likelihood (L) / Impact (I): H/M/L. Update when an ADR closes a
 | JSON Schema validation gap | M | H | Python `jsonschema` remains in harness until V validator exists | Schema tests | Keep Python validator | Open |
 | Cross-platform FS/symlinks | H | H | Filesystem service; no assume POSIX symlink | Win/mac parity jobs | Per-OS quarantine | Open |
 | macOS cross-compile unsupported | H | H | Native `macos-latest` + `macos-15-intel` in `release.yml` | Release matrix | N/A | **Mitigated** [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529) |
-| PyInstaller→native cutover gaps | M | H | V assets on GitHub Release ([#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530)); Python wheel still publishes | Release smoke | Keep wheel + `agent-toolkit-py` | **Mitigated** pending first V tag |
+| PyInstaller→native cutover gaps | M | H | V assets on GitHub Release since `v1.11.0` ([#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530)); Python wheel still publishes as launcher | Release smoke | Keep wheel + `agent-toolkit-py` | **Mitigated** `v1.11.0` |
 | Dual-engine drift | H | H | Golden `tests/parity/`; short dual period; ADR-012 | Parity CI | Single engine sooner | Open until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) |
 | PyPI wheel tag complexity | M | M | ADR-021 A; `py3-none-{plat}` hatch tag | Install smoke | Do not default to download-B ([#563](https://github.com/ulises-jeremias/agent-toolkit/issues/563)) | **Mitigated** ADR-021/#535 |
 | npm optionalDeps failures | M | M | Exit 127 + message; glibc-only (ADR-019) | Matrix smoke | GitHub binary / `AGENT_TOOLKIT_BIN` | **Mitigated** ADR-025/#536 |
-| Homebrew/AUR empty sha256 | H | H | Fail-closed until Release assets exist; do not merge Formula with all-zero sha256 | Tap CI / brew fetch | Keep Python formula | **Open** — needs `v*` tag after #530 |
+| Homebrew/AUR empty sha256 | H | H | Fail-closed until Release assets exist; do not merge Formula with all-zero sha256 | Tap CI / brew fetch | GitHub binary / uv launcher | **Mitigated** `v1.11.0` (Homebrew Formula + AUR `agent-toolkit-bin`) |
 | Unsigned macOS/Windows prompts | H | M | Checksums MUST; notarization/Authenticode FUTURE | Manual UX | Document Gatekeeper steps | See [#543](https://github.com/ulises-jeremias/agent-toolkit/issues/543) |
 | Runtime download of binaries | M | H | Reject as product default ([#563](https://github.com/ulises-jeremias/agent-toolkit/issues/563)) | Threat model review | Bundle-at-build | **Mitigated** |
 | Attestations ≠ secure software | L | M | SBOM/attestations SHOULD prove provenance only | Docs | Checksums MUST | **Mitigated** [#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530) |


### PR DESCRIPTION
## Summary
- Add `docs/HOW_TO_DEVELOP_V.md`: V 0.5.2, `import json` (not json2), `make test` / `make build-cli`, packaging adapter table, do not retag empty `v1.10.0`, skip Bobatea.
- Contributor-facing docs (`CONTRIBUTING`, `AGENTS.md`, `INSTALLATION`, `RELEASING`, `ARCHITECTURE`, HOW_TO_ADD_SKILL, certification) no longer treat `uv run agent-toolkit`, a repo-root uv workspace, or PyInstaller as the product.
- Install matrix leads with GitHub Release / Homebrew / AUR `agent-toolkit-bin`, then PyPI `agent-toolkit-cli>=1.11.0` launcher and npm. The PyPI launcher is **kept** (#540).

## Test plan
- [ ] `docs/HOW_TO_DEVELOP_V.md` matches `.v-version` (0.5.2)
- [ ] README / INSTALLATION / GETTING_STARTED install order: GitHub, brew, AUR `-bin`, PyPI launcher, npm
- [ ] `CONTRIBUTING` / `AGENTS.md` validation uses `make build-cli` + `./build/agent-toolkit build --check`
- [ ] GitHub Release adapter README does not claim PyInstaller
- [ ] No new `uv run agent-toolkit` (without `--project`) in HOW_TO / certification docs


Made with [Cursor](https://cursor.com)