### PR TITLE
chore(cli): quarantine Python CLI as named fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Quarantine Python CLI as named `agent-toolkit-py` fallback (ADR-021 launcher stays; #540/#470). Product path remains V.
 - **Docs** — Contributor how-tos are V-first: `docs/HOW_TO_DEVELOP_V.md` (V 0.5.2, `import json`, Makefile), install matrix GitHub/brew/AUR/PyPI/npm, GitHub Release adapter no longer claims PyInstaller, `uv run agent-toolkit` removed from HOW_TO/certification docs
 - **Docs** — Install/release docs match V-first channels: GitHub Release, PyPI launcher, Homebrew, AUR `agent-toolkit-bin`, npm `agent-toolkit-cli` + platform packages, Docker `debian:trixie-slim`
 - **Feat** — V CLI `completion` emits bash/zsh/fish/PowerShell scripts (Closes #544)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,12 +340,12 @@ This project follows the [Contributor Covenant Code of Conduct](https://www.cont
 
 ## V modules (canonical consumer CLI)
 
-The in-repo canonical `agent-toolkit` implementation is the V binary ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555), [`docs/v/cutover.md`](docs/v/cutover.md)). PyPI is a thin launcher over GitHub Release binaries ([ADR-021](docs/adrs/ADR-021-pypi-binary.md)); `agent-toolkit-py` remains as fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540).
+The in-repo canonical `agent-toolkit` implementation is the V binary ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555), [`docs/v/cutover.md`](docs/v/cutover.md)). PyPI is a thin launcher over GitHub Release binaries ([ADR-021](docs/adrs/ADR-021-pypi-binary.md)); `agent-toolkit-py` is a quarantined fallback ([`docs/v/python-fallback.md`](docs/v/python-fallback.md)).
 
 - Pin: root [`.v-version`](.v-version) — see [`docs/v/upgrade-policy.md`](docs/v/upgrade-policy.md)
 - Layout: `modules/agent_toolkit_core` + `modules/agent_toolkit_cli` ([ADR-009](docs/adrs/ADR-009-v-module-architecture.md))
 - Local toolchain: install V matching `.v-version`, then `make test`, `make fmt-check`, `make build-cli` → `build/agent-toolkit`
-- Unfinished advanced commands: Python package fallback ([ADR-012](docs/adrs/ADR-012-python-v-coexistence.md); no mixed-engine binary)
+- DEPRECATE/REMOVE advanced commands (`insights`, `release`): quarantined `agent-toolkit-py` ([ADR-012](docs/adrs/ADR-012-python-v-coexistence.md); no mixed-engine binary)
 
 ## Getting Help
 
@@ -373,9 +373,10 @@ AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --direc
 
 ## Adding a new compiler target
 
-1. Create `packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/targets/<target>.py` extending `TargetAdapter`
-2. Register the adapter in `packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/build.py`
-3. Add contract tests under `tests/compiler/`
-4. Add `distributions/targets/<target>.yaml` with capability declarations
-5. Write contract tests in `tests/compiler/test_<target>_adapter.py`
-6. Ensure `CompilationResult` always reports unsupported capabilities explicitly
+Canonical emitters live in V (`modules/agent_toolkit_core`). The Python `compiler/targets/` tree is quarantined fallback for pytest only ([`docs/v/python-fallback.md`](docs/v/python-fallback.md)).
+
+1. Add `distributions/targets/<target>.yaml` with capability declarations
+2. Implement the V emitter next to existing targets in `modules/agent_toolkit_core`
+3. Add contract tests under `tests/compiler/` (and V tests under `modules/`)
+4. Optionally mirror a Python adapter in `packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/targets/<target>.py` for parity tests — not the product path
+5. Ensure unsupported capabilities are reported explicitly (`build --check`)

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -7,7 +7,7 @@ This directory is **documentation-only contracts** for packaging adapters. It is
 
 ## Canonical source
 
-**GitHub Releases** on `ulises-jeremias/agent-toolkit` are the canonical binary source ([ADR-018](../docs/adrs/ADR-018-release-artifacts.md)). PyPI, Homebrew, AUR, npm, and Docker are **adapters** that fetch or wrap those V artifacts. Python remains a launcher/tooling layer (`packages/pypi/agent-toolkit-cli`, `agent-toolkit-py` fallback) — not the product CLI.
+**GitHub Releases** on `ulises-jeremias/agent-toolkit` are the canonical binary source ([ADR-018](../docs/adrs/ADR-018-release-artifacts.md)). PyPI, Homebrew, AUR, npm, and Docker are **adapters** that fetch or wrap those V artifacts. Python remains a launcher/tooling layer (`packages/pypi/agent-toolkit-cli`, quarantined `agent-toolkit-py`) — not the product CLI.
 
 Do **not** duplicate Formula/PKGBUILD/npm `package.json` here. Those live in their owner repos:
 

--- a/distribution/pypi/README.md
+++ b/distribution/pypi/README.md
@@ -6,7 +6,7 @@
 
 | Path | Role |
 |------|------|
-| `packages/pypi/agent-toolkit-cli/` | Hatchling project **`agent-toolkit-cli`**: thin launcher + `agent-toolkit-py` fallback |
+| `packages/pypi/agent-toolkit-cli/` | Hatchling project **`agent-toolkit-cli`**: thin launcher + quarantined `agent-toolkit-py` fallback |
 | `packages/pypi/agent-toolkit-cli/platforms.json` | GitHub Release asset → PEP 425/600 wheel tag |
 | `scripts/pack_pypi.py` | Copies Release V binaries into the wheel at CI time (like `scripts/pack_npm.py`) |
 | `scripts/prepare-native-bin.sh` | Local/PR helper: copy `build/agent-toolkit` into `src/agent_toolkit/bin/` |
@@ -39,4 +39,4 @@ python3 scripts/pack_pypi.py   # sdist + one wheel per present asset → dist/
 - Tag releases: `.github/workflows/release.yml` `publish-pypi` (after `upload-assets`).
 - Manual republish (e.g. v1.11.0 after the manylinux fix): workflow **Publish (manual)** — downloads `v$(cat VERSION)` Release assets and packs the same way.
 
-Console scripts: `agent-toolkit` / `agent-toolkit-cli` → `agent_toolkit.launcher:main` (exec V). `agent-toolkit-py` remains until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540).
+Console scripts: `agent-toolkit` / `agent-toolkit-cli` → `agent_toolkit.launcher:main` (exec V). `agent-toolkit-py` is a quarantined fallback ([docs/v/python-fallback.md](../../docs/v/python-fallback.md)).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -25,7 +25,7 @@ make install-cli    # ~/.local/bin/agent-toolkit
 agent-toolkit doctor --json
 ```
 
-PyPI/`uvx` is a thin launcher over the bundled V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)). Unfinished advanced commands fall back to `agent-toolkit-py` (see [docs/v/cutover.md](v/cutover.md)). Rollback: [docs/v/rollback.md](v/rollback.md).
+PyPI/`uvx` is a thin launcher over the bundled V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)). `insights` / `release` stay on quarantined `agent-toolkit-py` ([python-fallback.md](v/python-fallback.md)). Rollback: [docs/v/rollback.md](v/rollback.md).
 
 See [docs/INSTALLATION.md](INSTALLATION.md) for full options.
 

--- a/docs/HOW_TO_DEVELOP_V.md
+++ b/docs/HOW_TO_DEVELOP_V.md
@@ -1,6 +1,6 @@
 # How to develop the V CLI
 
-The **product** is a native V binary. Python is a thin PyPI launcher (`packages/pypi/agent-toolkit-cli`) plus `agent-toolkit-py` fallback, scripts, tests, and pre-commit. Do not treat `uv run agent-toolkit` or a repo-root uv workspace as the product.
+The **product** is a native V binary. Python is a thin PyPI launcher (`packages/pypi/agent-toolkit-cli`) plus a **quarantined** `agent-toolkit-py` fallback ([python-fallback.md](v/python-fallback.md)), scripts, tests, and pre-commit. Do not treat `uv run agent-toolkit` or a repo-root uv workspace as the product.
 
 Index: [`docs/v/README.md`](v/README.md) · packaging adapters: [`distribution/README.md`](../distribution/README.md)
 
@@ -32,7 +32,7 @@ v -o build/agent-toolkit cmd/agent-toolkit
 
 ## Python adapter (not the product)
 
-Used for pytest parity, the PyPI launcher, and `agent-toolkit-py` fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). **Do not delete the launcher.**
+Used for pytest parity, the PyPI launcher, and quarantined `agent-toolkit-py` ([#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) / ADR-021). **Do not delete the launcher.**
 
 ```bash
 uv sync --project packages/pypi/agent-toolkit-cli --all-extras
@@ -43,7 +43,7 @@ Never `uv run agent-toolkit` from repo root (there is no product uv workspace). 
 
 ```bash
 uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit --version
-# fallback implementation (Python business logic, not the product):
+# quarantined fallback (Python business logic, not the product):
 uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit-py --help
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -79,7 +79,7 @@ make install-cli    # PREFIX/bin/agent-toolkit, default ~/.local/bin
 agent-toolkit doctor --json
 ```
 
-See [docs/v/cutover.md](v/cutover.md) and [docs/v/rollback.md](v/rollback.md). PyPI/`uvx` ships a thin Python launcher over the V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)); `agent-toolkit-py` remains as fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). Do not retag empty `v1.10.0`.
+See [docs/v/cutover.md](v/cutover.md) and [docs/v/rollback.md](v/rollback.md). PyPI/`uvx` ships a thin Python launcher over the V binary ([ADR-021](adrs/ADR-021-pypi-binary.md)); `agent-toolkit-py` is a quarantined fallback ([python-fallback.md](v/python-fallback.md)). Do not retag empty `v1.10.0`.
 
 ### Install options
 

--- a/docs/adrs/ADR-021-pypi-binary.md
+++ b/docs/adrs/ADR-021-pypi-binary.md
@@ -28,7 +28,7 @@ Adopt **A**.
 1. **Product path is the V binary.** The commands `agent-toolkit` and `agent-toolkit-cli` MUST `exec` (or equivalent spawn+wait with signal/stdio/exit forwarding) a native V binary. They MUST NOT run Python business logic.
 2. **Bundle at wheel-build time.** CI downloads the matching GitHub Release asset (stable floating name after promotion; `agent-toolkit-v-experimental-<os>-<arch>` until then) into the wheel. Runtime download (option B) is **not** the default and is blocked on the distribution threat model ([#563](https://github.com/ulises-jeremias/agent-toolkit/issues/563)).
 3. **Thin Python process is allowed.** `uv tool install` may start a tiny Python entrypoint whose only job is locate-binary + `os.execv` / `subprocess` with forwarded argv, env, cwd, stdio, signals, and exit code. **Zero Python implementation**, not zero Python process.
-4. **Python CLI remains a named fallback.** Console script `agent-toolkit-py` keeps the Python implementation until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). It is not the product command.
+4. **Python CLI remains a named fallback.** Console script `agent-toolkit-py` keeps the quarantined Python implementation ([python-fallback.md](../v/python-fallback.md)). It is not the product command. [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) does **not** require deleting this script or the thin launcher.
 
 ### Name continuity
 
@@ -36,7 +36,7 @@ Adopt **A**.
 |------|----------|
 | PyPI **distribution** name | Keep **`agent-toolkit-cli`**. Do not require acquiring the unused `agent-toolkit` name on PyPI. |
 | Console **command** name | **`agent-toolkit`** (and alias `agent-toolkit-cli`) → V launcher. |
-| Python **import** name | `agent_toolkit` stays for the thin launcher and, until #540/#561, the Python modules. Importing `agent_toolkit.cli.main` is advanced/fallback, not the product path. |
+| Python **import** name | `agent_toolkit` stays for the thin launcher and quarantined modules. Importing `agent_toolkit.cli.main` is advanced/fallback, not the product path. |
 
 ### Platform tags (glibc MUST)
 
@@ -82,6 +82,10 @@ Sources live under **`packages/pypi/agent-toolkit-cli/`**, parallel to **`packag
 CI copies GitHub Release V binaries into the wheel (`scripts/pack_pypi.py` + `scripts/prepare-native-bin.sh`). The repo root is not a uv workspace; `uv.lock` belongs next to the adapter if present. Pre-commit Ruff uses `language: python` (`ruff-pre-commit`) with root `ruff.toml` — no product uv workspace.
 
 Contract: [`distribution/pypi/README.md`](../../distribution/pypi/README.md).
+
+## Retirement follow-up (2026-08-13)
+
+[#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) / [#470](https://github.com/ulises-jeremias/agent-toolkit/issues/470) close with this ADR still in force: the PyPI **product** path is the bundled V binary + thin launcher. `agent-toolkit-py` stays as a quarantined fallback for DEPRECATE/REMOVE commands and pytest. Deleting `packages/pypi` would break `uv tool install agent-toolkit-cli`.
 
 ## Validation plan
 

--- a/docs/adrs/ADR-024-aur.md
+++ b/docs/adrs/ADR-024-aur.md
@@ -24,7 +24,7 @@ Adopt **A** as the **MUST** migration outcome. Source `agent-toolkit` is **OPTIO
 
 1. Package **`agent-toolkit-bin`**: download `agent-toolkit-linux-x86_64` / `agent-toolkit-linux-arm64` (ADR-018), verify sha256, install `/usr/bin/agent-toolkit`.
 2. `provides=('agent-toolkit')` and `conflicts=('agent-toolkit')`.
-3. Existing Python `agent-toolkit` PKGBUILD may remain as an optional source/wheel package until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540); it is **not** canonical.
+3. Existing Python `agent-toolkit` PKGBUILD may remain as an optional source/wheel package; it is **not** canonical. Product install is `agent-toolkit-bin`.
 4. Automation prefers GitHub-mirror commits plus AUR publish; first AUR push needs an empty `aur.archlinux.org/agent-toolkit-bin.git`. `notify-aur.yml` should dispatch `package_name=agent-toolkit-bin` (and may still bump the optional source package).
 5. `pacman -Syu` / AUR helpers own the binary ([ADR-017](ADR-017-update-ownership.md)).
 

--- a/docs/v/README.md
+++ b/docs/v/README.md
@@ -3,7 +3,7 @@
 **Issue:** [#545](https://github.com/ulises-jeremias/agent-toolkit/issues/545)  
 **Program:** [#456](https://github.com/ulises-jeremias/agent-toolkit/issues/456)
 
-The product CLI is a **native V 0.5.2** binary (`import json`, not json2). Python is a launcher (`agent-toolkit` → V) plus `agent-toolkit-py` fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540). Contributor how-to: [`docs/HOW_TO_DEVELOP_V.md`](../HOW_TO_DEVELOP_V.md).
+The product CLI is a **native V 0.5.2** binary (`import json`, not json2). Python is a launcher (`agent-toolkit` → V) plus quarantined `agent-toolkit-py` ([python-fallback.md](python-fallback.md)). Contributor how-to: [`docs/HOW_TO_DEVELOP_V.md`](../HOW_TO_DEVELOP_V.md).
 
 ## Build from source
 
@@ -40,7 +40,8 @@ Checksums **MUST**. Attestations/SBOM prove provenance only ([code-signing-polic
 | [advanced-command-disposition.md](advanced-command-disposition.md) | PORT/REDESIGN/DEPRECATE/REMOVE (#560) |
 | [../compatibility/cli-contract.yaml](../compatibility/cli-contract.yaml) | Machine-readable flags/IO (#549) |
 | [cutover.md](cutover.md) | Engine cutover |
-| [python-api-consumers.md](python-api-consumers.md) | Python import audit (#561); #540 must cite this |
+| [python-fallback.md](python-fallback.md) | Quarantined `agent-toolkit-py` (not the product) |
+| [python-api-consumers.md](python-api-consumers.md) | Python import audit (#561) |
 | [migration-risk-register.md](migration-risk-register.md) | Risks (#478) |
 | [performance-baseline.md](performance-baseline.md) | Startup/help/inventory/doctor timings (#533) |
 

--- a/docs/v/advanced-command-disposition.md
+++ b/docs/v/advanced-command-disposition.md
@@ -15,7 +15,7 @@ Legend: **PORT** 1:1 V rewrite · **REDESIGN** V rewrite with a different shape 
 | `loop` | [#523](https://github.com/ulises-jeremias/agent-toolkit/issues/523) | **REDESIGN** | Yes | Product differentiator; do not clone Python threads — follow [#528](https://github.com/ulises-jeremias/agent-toolkit/issues/528) + process service. |
 | `swarm` | [#524](https://github.com/ulises-jeremias/agent-toolkit/issues/524) | **REDESIGN** | Yes | Keep surface; backends (Herdr/tmux) behind interfaces (ADR-008). Concurrency via #528. |
 | `devcompanion` | [#525](https://github.com/ulises-jeremias/agent-toolkit/issues/525) | **PORT** | Yes | Filesystem job queue used by AGENTS.md. Keep **`dc` alias** (already in V dispatcher). |
-| `insights` | [#526](https://github.com/ulises-jeremias/agent-toolkit/issues/526) | **DEPRECATE** | **No** | Local DB/path parsers churn with Cursor/OpenCode; privacy-sensitive; not required for consumer cutover or Python removal. Python may keep it until #540; V need not port. |
+| `insights` | [#526](https://github.com/ulises-jeremias/agent-toolkit/issues/526) | **DEPRECATE** | **No** | Local DB/path parsers churn with Cursor/OpenCode; privacy-sensitive; not required for consumer cutover or Python removal. Quarantined `agent-toolkit-py` may keep it; V need not port. |
 | `release` | [#527](https://github.com/ulises-jeremias/agent-toolkit/issues/527) | **REMOVE** | **No** | Maintainer artifact generation belongs in GitHub Actions / `docs/RELEASING.md`, not the runtime CLI. V help may list it as unsupported; do not port. |
 
 ## Alias policy
@@ -37,4 +37,4 @@ Legend: **PORT** 1:1 V rewrite · **REDESIGN** V rewrite with a different shape 
 4. REDESIGN `swarm` after loop/process patterns exist (`docs/v/swarm.md`).
 5. Close #526/#527 as dispositioned without V implementations.
 
-Python remains available for DEPRECATE/REMOVE commands until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540), matching [ADR-012](../adrs/ADR-012-python-v-coexistence.md) (no per-command mixed engine).
+Quarantined `agent-toolkit-py` remains available for DEPRECATE/REMOVE commands ([python-fallback.md](python-fallback.md)), matching [ADR-012](../adrs/ADR-012-python-v-coexistence.md) (no per-command mixed engine).

--- a/docs/v/ci-cost-tiers.md
+++ b/docs/v/ci-cost-tiers.md
@@ -24,13 +24,9 @@ Experimental native V artifacts stay on the **experimental** channel ([ADR-018](
 
 ## Python lane retirement trigger
 
-Remove the `test-package` OS × CPython matrix from `.github/workflows/validate.yml` **only when all of**:
+[#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) gates are met (V is the product; PyPI is a launcher). **Keep** the `test-package` OS × CPython matrix while quarantined `agent-toolkit-py` and pytest still exercise Python modules ([python-fallback.md](python-fallback.md)). Drop that lane only when `agent-toolkit-py` itself is deleted — optional cleanup, not a V CLI GA blocker.
 
-1. [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) gates are actually met (not merely “V is default in-repo”).
-2. [#561](https://github.com/ulises-jeremias/agent-toolkit/issues/561) consumer audit is closed with no remaining in-tree Python API dependents (or they are documented exceptions).
-3. PyPI/Homebrew/AUR no longer require the Python CLI as the shipped runtime ([#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535) / [#486](https://github.com/ulises-jeremias/agent-toolkit/issues/486)).
-
-Until then, Python tests stay on **PR** and **main**. Do not drop them to save CI minutes while Python is still the stable distribution.
+Do not drop Python tests to save CI minutes while the wheel still ships those modules.
 
 ## Timeouts (recorded)
 

--- a/docs/v/cutover.md
+++ b/docs/v/cutover.md
@@ -3,7 +3,7 @@
 **Issue:** [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)  
 **ADR:** [ADR-012](../adrs/ADR-012-python-v-coexistence.md)
 
-V is the **canonical implementation** of consumer `agent-toolkit` (install lifecycle + skills/mcp/plugin). Python remains a **fallback** via `agent-toolkit-py` for unfinished advanced commands. PyPI/`uvx` runs a **thin launcher** over the bundled V binary ([ADR-021](../adrs/ADR-021-pypi-binary.md) / [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535)).
+V is the **canonical implementation** of `agent-toolkit`. PyPI/`uvx` runs a **thin launcher** over the bundled V binary ([ADR-021](../adrs/ADR-021-pypi-binary.md) / [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535)). Python business logic is quarantined behind `agent-toolkit-py` ([python-fallback.md](python-fallback.md)).
 
 ## What changed
 
@@ -11,17 +11,14 @@ V is the **canonical implementation** of consumer `agent-toolkit` (install lifec
 |---------|-----------|--------|
 | From-source CLI | V (`make build-cli` / `make install-cli`) | Installs `PREFIX/bin/agent-toolkit` (default `~/.local/bin`) |
 | `doctor --json` / `version --json` | engine=`v`, version, commit | Human stdout unchanged (no engine/commit pollution) |
-| Unfinished advanced commands | `not_implemented` in V | Use `agent-toolkit-py` (Python extra script); **no** in-process Python exec (ADR-012 rejected C) |
-| PyPI `uvx` / `uv tool install` | V binary via thin launcher (ADR-021) | `agent-toolkit-py` is the Python fallback; not a dual-engine switch |
-| GitHub Release binaries | Experimental until MUST-platform promotion | See [rollback](rollback.md) |
+| Consumer + PORT/REDESIGN advanced | V | install lifecycle, skills/mcp/plugin, workspace/memory/project/loop/swarm/devcompanion |
+| `insights` (DEPRECATE) / `release` (REMOVE) | `not_implemented` in V | Use `agent-toolkit-py` if needed; **no** in-process Python exec (ADR-012 rejected C) |
+| PyPI `uvx` / `uv tool install` | V binary via thin launcher (ADR-021) | `agent-toolkit-py` is the quarantined fallback; not a dual-engine switch |
+| GitHub Release binaries | Stable native V since `v1.11.0` | See [rollback](rollback.md). Do not retag empty `v1.10.0`. |
 
-## Experimental → stable promotion
+## Python fallback (quarantined)
 
-Native artifacts stay **experimental** until [#562](https://github.com/ulises-jeremias/agent-toolkit/issues/562) / [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529) MUST platforms have green smoke ([#531](https://github.com/ulises-jeremias/agent-toolkit/issues/531)). Promotion is an explicit release decision — experimental assets must not overwrite stable channel names without that gate.
-
-## Python fallback (advanced commands)
-
-EPIC 5 remaining commands (`insights`, `release`) may still be `not_implemented` in V. `workspace` (#520), `memory` (#521), `project` (#522), `devcompanion`/`dc` (#525), `loop` (#523, ADR-020 process-per-run), and `swarm` (#524, ADR-008 filesystem SoT) are implemented in V. Run the Python CLI explicitly for unfinished advanced commands:
+[#560](https://github.com/ulises-jeremias/agent-toolkit/issues/560) left `insights` as **DEPRECATE** and `release` as **REMOVE** — V need not port them. Run the Python CLI explicitly:
 
 ```bash
 agent-toolkit-py insights opencode

--- a/docs/v/migration-risk-register.md
+++ b/docs/v/migration-risk-register.md
@@ -12,7 +12,7 @@ Living register. Likelihood (L) / Impact (I): H/M/L. Update when an ADR closes a
 | Cross-platform FS/symlinks | H | H | Filesystem service; no assume POSIX symlink | Win/mac parity jobs | Per-OS quarantine | Open |
 | macOS cross-compile unsupported | H | H | Native `macos-latest` + `macos-15-intel` in `release.yml` | Release matrix | N/A | **Mitigated** [#529](https://github.com/ulises-jeremias/agent-toolkit/issues/529) |
 | PyInstaller→native cutover gaps | M | H | V assets on GitHub Release since `v1.11.0` ([#530](https://github.com/ulises-jeremias/agent-toolkit/issues/530)); Python wheel still publishes as launcher | Release smoke | Keep wheel + `agent-toolkit-py` | **Mitigated** `v1.11.0` |
-| Dual-engine drift | H | H | Golden `tests/parity/`; short dual period; ADR-012 | Parity CI | Single engine sooner | Open until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) |
+| Dual-engine drift | H | H | Golden `tests/parity/`; short dual period; ADR-012 | Parity CI | Product path is V-only; `agent-toolkit-py` quarantined | **Mitigated** [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) |
 | PyPI wheel tag complexity | M | M | ADR-021 A; `py3-none-{plat}` hatch tag | Install smoke | Do not default to download-B ([#563](https://github.com/ulises-jeremias/agent-toolkit/issues/563)) | **Mitigated** ADR-021/#535 |
 | npm optionalDeps failures | M | M | Exit 127 + message; glibc-only (ADR-019) | Matrix smoke | GitHub binary / `AGENT_TOOLKIT_BIN` | **Mitigated** ADR-025/#536 |
 | Homebrew/AUR empty sha256 | H | H | Fail-closed until Release assets exist; do not merge Formula with all-zero sha256 | Tap CI / brew fetch | GitHub binary / uv launcher | **Mitigated** `v1.11.0` (Homebrew Formula + AUR `agent-toolkit-bin`) |

--- a/docs/v/pypi-launcher.md
+++ b/docs/v/pypi-launcher.md
@@ -9,7 +9,7 @@
 |--------|----------------|
 | `agent-toolkit` | V launcher |
 | `agent-toolkit-cli` | V launcher (alias) |
-| `agent-toolkit-py` | Python CLI (fallback until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540)) |
+| `agent-toolkit-py` | Quarantined Python CLI ([python-fallback.md](python-fallback.md)) |
 
 Resolution order: `AGENT_TOOLKIT_BIN` → `agent_toolkit/bin/agent-toolkit` inside the wheel → `AGENT_TOOLKIT_ROOT/build/agent-toolkit{,-v}`.
 

--- a/docs/v/python-api-consumers.md
+++ b/docs/v/python-api-consumers.md
@@ -1,7 +1,7 @@
 # Python module API consumer audit
 
 **Issue:** [#561](https://github.com/ulises-jeremias/agent-toolkit/issues/561)  
-**Required by:** [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) (do not open #540 until other gates land)
+**Required by:** [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) (gates met; Python remains quarantined fallback, not a library API)
 
 The published PyPI/npm **product** is the CLI. `import agent_toolkit` is not a supported library API. This audit lists who would break if the Python package were removed or reduced to a launcher-only wheel.
 
@@ -36,10 +36,10 @@ Public import surface today:
 | Audience | Plan |
 |----------|------|
 | CLI users (`uvx`, brew, AUR, npm) | Stay on the V binary / launcher. No Python import migration. |
-| In-repo tests | Keep calling `agent-toolkit-py` / `-m agent_toolkit.cli` until #540 deletes the Python CLI. |
-| Hypothetical external `import agent_toolkit.compiler` | Unsupported. If discovered later: treat as a bug, add a shim issue, do not block #540 on unknown third parties. |
-| `#540` checklist | **MUST** include: “#561 audit: no first-party library consumers; workstation/harness are CLI-only.” |
+| In-repo tests | Keep calling `agent-toolkit-py` / `-m agent_toolkit.cli` (quarantined fallback; [python-fallback.md](python-fallback.md)). |
+| Hypothetical external `import agent_toolkit.compiler` | Unsupported. If discovered later: treat as a bug, add a shim issue. |
+| `#540` checklist | Cited: “#561 audit: no first-party library consumers; workstation/harness are CLI-only.” |
 
 ## Residual risk
 
-PyPI package name `agent-toolkit-cli` install still ships Python modules until #540. Someone *could* `from agent_toolkit.compiler.loader import load_graph` without us knowing (no telemetry). That is not a supported contract; removal may proceed after #540’s other gates.
+PyPI `agent-toolkit-cli` still ships quarantined Python modules in the same wheel as the launcher. Someone *could* `from agent_toolkit.compiler.loader import load_graph` without us knowing (no telemetry). That is not a supported contract.

--- a/docs/v/python-architecture-map.md
+++ b/docs/v/python-architecture-map.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#477](https://github.com/ulises-jeremias/agent-toolkit/issues/477)  
 **Parent:** [#457](https://github.com/ulises-jeremias/agent-toolkit/issues/457) (EPIC 0)  
-**Product runtime:** native V binary is canonical ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)). Python remains a fallback CLI (`agent-toolkit-py`) and the PyPI/npm launcher host until [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540).
+**Product runtime:** native V binary is canonical ([#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)). Python is a quarantined fallback CLI (`agent-toolkit-py`) plus the PyPI launcher host ([python-fallback.md](python-fallback.md) / [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540)).
 
 Tree: `packages/pypi/agent-toolkit-cli/src/agent_toolkit/`.
 

--- a/docs/v/python-fallback.md
+++ b/docs/v/python-fallback.md
@@ -1,0 +1,31 @@
+# Python CLI quarantine (named fallback)
+
+**Gate:** [#540](https://github.com/ulises-jeremias/agent-toolkit/issues/540) · **ADR:** [ADR-021](../adrs/ADR-021-pypi-binary.md)
+
+The product command is the **native V binary**. `agent-toolkit` / `agent-toolkit-cli` are a thin PyPI launcher that `exec`s that binary. Python business logic is **quarantined** behind `agent-toolkit-py` and is not the product.
+
+## What stays
+
+| Surface | Role |
+|---------|------|
+| `packages/pypi/agent-toolkit-cli` launcher | Permanent PyPI adapter (`uv tool install agent-toolkit-cli`). **Do not delete.** |
+| `agent-toolkit-py` | Named fallback for [#560](https://github.com/ulises-jeremias/agent-toolkit/issues/560) **DEPRECATE** `insights` and **REMOVE** `release`, plus first-party pytest |
+| `scripts/` + pytest + pre-commit | Tooling, not the product CLI |
+
+## What is not the product
+
+- `agent_toolkit.cli`, `compiler/`, `installer/`, `loop/`, `swarm/` — in-tree Python implementation, unsupported as a library API ([python-api-consumers.md](python-api-consumers.md))
+- `python -m agent_toolkit.cli` — same quarantined entry as `agent-toolkit-py`
+- `python -m agent_toolkit` — launcher (V), not Python business logic
+
+Interactive `agent-toolkit-py` prints a stderr notice (silence with `AGENT_TOOLKIT_PY_QUIET=1`). Non-TTY / CI captures are quiet by default.
+
+## Why the modules are not deleted
+
+EPIC 13 ([#470](https://github.com/ulises-jeremias/agent-toolkit/issues/470)) retires Python as the **product** runtime. ADR-021 keeps a thin Python **process** on PyPI. Deleting `cli/` would break pytest parity and the documented `insights` fallback. That is not required to close #540.
+
+Future deletion of `agent-toolkit-py` is optional cleanup after `insights` is dropped; it is **not** a V CLI GA blocker.
+
+## See also
+
+- [cutover.md](cutover.md) · [rollback.md](rollback.md) · [pypi-launcher.md](pypi-launcher.md) · [HOW_TO_DEVELOP_V.md](../HOW_TO_DEVELOP_V.md)

--- a/docs/v/rollback.md
+++ b/docs/v/rollback.md
@@ -2,47 +2,60 @@
 
 **Issue:** [#555](https://github.com/ulises-jeremias/agent-toolkit/issues/555)
 
-Rollback restores a **Python** `agent-toolkit` (or a previous V binary). Channels are independent — pick the one you installed from.
+The product is a **native V** binary on every channel. Rollback means pin a previous **V** release on the same channel — not switch back to Python as `agent-toolkit`.
 
-## GitHub (from-source / experimental binary)
+`agent-toolkit-py` is a quarantined Python entry in the same PyPI wheel ([python-fallback.md](python-fallback.md)). It is not a channel rollback.
+
+## GitHub Release
+
+Download `agent-toolkit-<os>-<arch>` + `SHA256SUMS` from a previous tag (do **not** retag empty `v1.10.0`):
+
+https://github.com/ulises-jeremias/agent-toolkit/releases
+
+From a git checkout:
 
 ```bash
-# Remove V binary installed by make install-cli
-rm -f ~/.local/bin/agent-toolkit
-
-# Restore Python CLI on PATH
-uv tool install agent-toolkit-cli
-# or pin a previous release:
-uv tool install agent-toolkit-cli==1.10.0
+git checkout v1.11.0
+make build-cli
+make install-cli
 ```
 
-To run a previous V build: check out that git tag, `make build-cli`, `make install-cli`.
+To undo `make install-cli` only: `rm -f ~/.local/bin/agent-toolkit` (do not overwrite a brew/AUR/npm-managed binary — [ADR-017](../adrs/ADR-017-update-ownership.md)).
 
 ## PyPI
 
-PyPI still publishes the Python wheel until binary wrappers ([#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535)):
+Wheels since `1.11.0` bundle V and exec it via the thin launcher ([ADR-021](../adrs/ADR-021-pypi-binary.md)):
 
 ```bash
-uv tool install agent-toolkit-cli==<previous>
+uv tool install 'agent-toolkit-cli==1.11.0'
 # or
-pip install 'agent-toolkit-cli==<previous>'
+pip install 'agent-toolkit-cli==1.11.0'
 ```
 
-`agent-toolkit-py` is the explicit Python entry after cutover (same package).
+The console script `agent-toolkit-py` remains in the wheel as the quarantined fallback.
 
 ## Homebrew
 
-Formulae live in the Homebrew tap (not this repo). Until the Homebrew epic ([#467](https://github.com/ulises-jeremias/agent-toolkit/issues/467) / [#538](https://github.com/ulises-jeremias/agent-toolkit/issues/538)), `brew` installs remain the Python formula. Rollback: `brew reinstall agent-toolkit` from the last known Python bottle, or `brew uninstall` and use `uv tool install`.
+Formulae live in [`ulises-jeremias/homebrew-tap`](https://github.com/ulises-jeremias/homebrew-tap) and install GitHub Release V binaries ([ADR-023](../adrs/ADR-023-homebrew.md)).
 
-Do not overwrite a brew-managed binary with `make install-cli` (ADR-017 / [#489](https://github.com/ulises-jeremias/agent-toolkit/issues/489)).
+```bash
+brew reinstall agent-toolkit
+# or pin a tap revision / previous formula version
+```
 
 ## AUR
 
-Until the AUR epic ([#468](https://github.com/ulises-jeremias/agent-toolkit/issues/468) / [#539](https://github.com/ulises-jeremias/agent-toolkit/issues/539)), Arch users install via `uv` or a Python PKGBUILD. Rollback: reinstall the previous `agent-toolkit-cli` package or `uv tool install agent-toolkit-cli==<previous>`.
+Canonical package is **`agent-toolkit-bin`** ([ADR-024](../adrs/ADR-024-aur.md)):
+
+```bash
+yay -S agent-toolkit-bin
+```
+
+Optional Python `agent-toolkit` PKGBUILD is not the product.
 
 ## Verify engine
 
 ```bash
-agent-toolkit doctor --json   # "engine": "v" or Python doctor without that key
+agent-toolkit doctor --json   # "engine": "v"
 agent-toolkit version --json  # V: engine + commit in data; human line unchanged
 ```

--- a/docs/v/threat-model-distribution.md
+++ b/docs/v/threat-model-distribution.md
@@ -53,7 +53,7 @@ CI copies a GitHub Release (or just-built) binary into the wheel at **publish** 
 | Malicious PyPI wheel (account/token theft, dependency confusion) | Critical | Keep dist name `agent-toolkit-cli`; Trusted Publishing; users pin version+hash when they can | PyPI is still a second host of the bytes |
 | Wheel tag mismatch (macOS installs a Linux binary) | High | Platform tags (`infer_tag`); hatch `pure_python=False` when a native bin is present; missing/wrong bin → exit 127, **no** Python CLI fallback | sdist has no binary — must not silently become the product |
 | `AGENT_TOOLKIT_BIN` / writable `agent_toolkit/bin/` TOCTOU | Medium | Document as trusted-operator; do not search `PATH` for a random `agent-toolkit` | Local privilege already implies PATH hijack |
-| Launcher reimplements CLI in Python | High | Product scripts call launcher only; `agent-toolkit-py` is explicit fallback (#535) | Until #540, Python still ships in the same dist |
+| Launcher reimplements CLI in Python | High | Product scripts call launcher only; `agent-toolkit-py` is explicit quarantined fallback (#535 / [python-fallback.md](python-fallback.md)) | Same wheel still ships Python modules; they are not the product path |
 | Offline install | Info | A is **offline-capable** after the wheel is fetched | — |
 
 **npm/Homebrew/AUR** using A-equivalent (Formula/PKGBUILD copies Release bytes at *package build* or install-from-URL with checksum) inherit the same row for “compromised Release.”

--- a/packages/pypi/README.md
+++ b/packages/pypi/README.md
@@ -4,6 +4,6 @@ PyPI adapter sources. npm equivalent: [`packages/npm/`](../npm/).
 
 | Directory | PyPI name | Role |
 |-----------|-----------|------|
-| `agent-toolkit-cli/` | `agent-toolkit-cli` | Thin launcher + Python fallback (`agent-toolkit-py`). CI stamps **platform-tagged wheels** of this single project. |
+| `agent-toolkit-cli/` | `agent-toolkit-cli` | Thin launcher + quarantined Python fallback (`agent-toolkit-py`). CI stamps **platform-tagged wheels** of this single project. |
 
 There are **no** `agent-toolkit-cli-linux-*` Python packages. npm uses `optionalDependencies` per OS; pip consumes PEP 425/600 tags on one distribution (see [`distribution/pypi/README.md`](../../distribution/pypi/README.md)).

--- a/packages/pypi/agent-toolkit-cli/README.md
+++ b/packages/pypi/agent-toolkit-cli/README.md
@@ -36,7 +36,7 @@
 
 ## What is this package?
 
-`agent-toolkit-cli` is the **PyPI adapter** for the agent-toolkit monorepo ([ADR-021](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-021-pypi-binary.md)). Platform wheels bundle the native V binary; `agent-toolkit` / `agent-toolkit-cli` are a thin launcher. The Python implementation remains as `agent-toolkit-py` until retirement.
+`agent-toolkit-cli` is the **PyPI adapter** for the agent-toolkit monorepo ([ADR-021](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-021-pypi-binary.md)). Platform wheels bundle the native V binary; `agent-toolkit` / `agent-toolkit-cli` are a thin launcher. The Python implementation is a quarantined `agent-toolkit-py` fallback ([python-fallback.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/v/python-fallback.md)).
 
 It also ships:
 

--- a/packages/pypi/agent-toolkit-cli/pyproject.toml
+++ b/packages/pypi/agent-toolkit-cli/pyproject.toml
@@ -44,6 +44,7 @@ all = ["pyyaml>=6.0"]
 [project.scripts]
 agent-toolkit = "agent_toolkit.launcher:main"
 agent-toolkit-cli = "agent_toolkit.launcher:main"
+# Quarantined fallback (insights/release + pytest). Not the product. docs/v/python-fallback.md
 agent-toolkit-py = "agent_toolkit.cli.main:main"
 
 [project.urls]

--- a/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/README.md
+++ b/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/README.md
@@ -1,0 +1,10 @@
+# Quarantined Python CLI (`agent-toolkit-py`)
+
+This package tree is **not** the product CLI.
+
+- Product: native V binary via `agent_toolkit.launcher` (`agent-toolkit` / `agent-toolkit-cli`).
+- This directory: Python business logic behind the `agent-toolkit-py` console script.
+
+Kept for pytest parity and for [#560](https://github.com/ulises-jeremias/agent-toolkit/issues/560) DEPRECATE/REMOVE commands (`insights`, `release`). Do not add new product features here.
+
+Canonical note: `docs/v/python-fallback.md` in the monorepo.

--- a/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/__main__.py
+++ b/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/__main__.py
@@ -1,4 +1,4 @@
-"""Python CLI fallback — python -m agent_toolkit.cli (ADR-021)."""
+"""Quarantined Python CLI — python -m agent_toolkit.cli (docs/v/python-fallback.md)."""
 
 from agent_toolkit.cli.main import main
 

--- a/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -28,6 +28,7 @@ def emit_quarantine_notice() -> None:
         "Use `agent-toolkit` (native V). See docs/v/python-fallback.md\n"
     )
 
+
 CONSUMER_COMMANDS: tuple[str, ...] = (
     "install",
     "update",

--- a/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/main.py
+++ b/packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/main.py
@@ -1,9 +1,32 @@
 #!/usr/bin/env python3
-"""agent-toolkit CLI entrypoint — see docs/CLI_SURFACES.md."""
+"""Quarantined Python CLI (`agent-toolkit-py`) — not the product.
+
+Product commands are `agent-toolkit` / `agent-toolkit-cli` (V launcher).
+See docs/v/python-fallback.md.
+"""
 
 from __future__ import annotations
 
+import os
 import sys
+
+_QUIET_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def emit_quarantine_notice() -> None:
+    """Warn interactive users; stay quiet in CI / captured pytest."""
+    raw = os.environ.get("AGENT_TOOLKIT_PY_QUIET", "").strip().lower()
+    if raw in _QUIET_VALUES:
+        return
+    try:
+        if not sys.stderr.isatty():
+            return
+    except OSError:
+        return
+    sys.stderr.write(
+        "agent-toolkit-py: quarantined Python fallback (not the product CLI). "
+        "Use `agent-toolkit` (native V). See docs/v/python-fallback.md\n"
+    )
 
 CONSUMER_COMMANDS: tuple[str, ...] = (
     "install",
@@ -64,6 +87,7 @@ Run 'agent-toolkit <command> --help' for details.
 
 
 def main() -> None:
+    emit_quarantine_notice()
     argv = sys.argv[1:]
     if not argv or argv[0] in ("-h", "--help", "help"):
         print(_CONSUMER_HELP)

--- a/packages/pypi/agent-toolkit-cli/src/agent_toolkit/launcher.py
+++ b/packages/pypi/agent-toolkit-cli/src/agent_toolkit/launcher.py
@@ -66,7 +66,7 @@ def missing_binary_message() -> str:
         "agent-toolkit: native V binary not found (ADR-021).\n"
         "  Packaged wheels bundle the binary under agent_toolkit/bin/.\n"
         "  Dev: make build-cli, or set AGENT_TOOLKIT_BIN to that executable.\n"
-        "  Python implementation (fallback): agent-toolkit-py\n"
+        "  Quarantined Python fallback: agent-toolkit-py\n"
     )
 
 

--- a/tests/test_cli_quarantine.py
+++ b/tests/test_cli_quarantine.py
@@ -1,0 +1,27 @@
+"""Quarantined Python CLI notice (docs/v/python-fallback.md)."""
+
+from __future__ import annotations
+
+from agent_toolkit.cli.main import emit_quarantine_notice
+
+
+def test_quarantine_notice_quiet_env(monkeypatch, capsys):
+    monkeypatch.setenv("AGENT_TOOLKIT_PY_QUIET", "1")
+    emit_quarantine_notice()
+    assert capsys.readouterr().err == ""
+
+
+def test_quarantine_notice_non_tty(monkeypatch, capsys):
+    monkeypatch.delenv("AGENT_TOOLKIT_PY_QUIET", raising=False)
+    monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+    emit_quarantine_notice()
+    assert capsys.readouterr().err == ""
+
+
+def test_quarantine_notice_tty(monkeypatch, capsys):
+    monkeypatch.delenv("AGENT_TOOLKIT_PY_QUIET", raising=False)
+    monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+    emit_quarantine_notice()
+    err = capsys.readouterr().err
+    assert "quarantined Python fallback" in err
+    assert "docs/v/python-fallback.md" in err


### PR DESCRIPTION
## Summary
- Quarantine Python business logic behind `agent-toolkit-py` (interactive stderr notice; quiet in CI). Product commands stay the ADR-021 V launcher — `uv tool install agent-toolkit-cli` is unchanged.
- Document the fallback contract in `docs/v/python-fallback.md` and stop treating #540 as a future deletion of the launcher.
- Refresh cutover/rollback/install how-tos so Homebrew, AUR `-bin`, and PyPI are V channels.

Closes #540
Closes #470

## Test plan
- [ ] `uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/test_cli_quarantine.py tests/test_launcher.py tests/test_cli.py`
- [ ] `agent-toolkit` / `agent-toolkit-cli` still map to `agent_toolkit.launcher:main` in `pyproject.toml`
- [ ] `docs/v/python-fallback.md` states the launcher must stay
- [ ] Rollback doc no longer claims Homebrew/AUR still ship a Python product CLI


Made with [Cursor](https://cursor.com)