### PR TITLE
fix(cli): V --help matches or exceeds Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Fixed** — V CLI help matches or exceeds Python: real command blurbs, inventory/matrix usage, doctor `--provenance`, examples, and honest #526/#527 insights/release dispositions
+
 ## [1.12.0] — 2026-08-13
 
 Inventory-honest docs and V-first install/upgrade paths. Ships Unreleased work since `v1.11.0` (completions, Docker `TARGETARCH`, PyPI launcher/`doctor` root, Python CLI quarantine as `agent-toolkit-py`).

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -166,18 +166,35 @@ pub fn dispatch(args []string) int {
 	if cmd_name == 'completion' {
 		return run_completion(argv[1..])
 	}
+	if cmd_name == 'insights' {
+		print(insights_help_text())
+		if insights_subcommand(argv[1..]).len > 0 {
+			eprintln('insights is deprecated in V (#526). Use: agent-toolkit-py insights <opencode|cursor|claude>')
+			return 1
+		}
+		return 0
+	}
+	if cmd_name == 'release' {
+		print(release_help_text())
+		return 1
+	}
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
 fn parse_doctor_options(args []string) agent_toolkit_core.DoctorOptions {
 	mut fix := false
+	mut provenance := false
 	for a in args {
 		if a == '--fix' {
 			fix = true
 		}
+		if a == '--provenance' {
+			provenance = true
+		}
 	}
 	return agent_toolkit_core.DoctorOptions{
-		fix: fix
+		fix:        fix
+		provenance: provenance
 	}
 }
 
@@ -1257,44 +1274,46 @@ fn mode_from_argv(argv []string) agent_toolkit_core.RenderMode {
 }
 
 fn grouped_help() string {
-	mut root := cli.Command{
-		name:        'agent-toolkit'
-		description: 'Composable AI agent toolkit CLI\n\nSee docs/CLI_SURFACES.md for consumer vs advanced commands.'
-		version:     agent_toolkit_core.resolve_toolkit_version()
-		commands:    help_commands()
-	}
-	root.setup()
-	return root.help_message()
-}
+	ver := agent_toolkit_core.resolve_toolkit_version()
+	return 'agent-toolkit — Composable AI agent toolkit CLI (${ver})
 
-fn help_commands() []cli.Command {
-	mut cmds := []cli.Command{}
-	cmds << cli.Command{
-		name:        'version'
-		description: 'Print agent-toolkit version'
-	}
-	for name in consumer_commands() {
-		cmds << cli.Command{
-			name:        name
-			description: '${name} (consumer)'
-			group:       'Consumer'
-		}
-	}
-	for name in advanced_commands() {
-		mut c := cli.Command{
-			name:        name
-			description: '${name} (advanced)'
-			group:       'Advanced'
-		}
-		if name == 'devcompanion' {
-			c.alias = 'dc'
-		}
-		if name == 'uninstall' {
-			c.description = 'uninstall / rollback (consumer alias rollback)'
-		}
-		cmds << c
-	}
-	return cmds
+Usage:
+    agent-toolkit <command> [args...]
+    agent-toolkit [-h|--help|help]
+    agent-toolkit [-V|--version|version]
+
+Global options:
+    -h, --help       Show this help
+    -V, --version    Print version
+    --json           Structured CommandResult JSON (most commands)
+    --quiet          Suppress human output
+
+Consumer commands:
+    install       Install profiles for detected AI tools
+    update        Refresh installed profiles from latest toolkit data
+    uninstall     Remove toolkit-owned files using install receipts (alias: rollback)
+    doctor        Check system health and tool availability
+    diff          Show changes vs currently installed plugin bundles
+    skills        Skill management: sync, list, validate
+    mcp           MCP provider management: setup, list, doctor
+    plugin        Plugin bundle management: sync, check
+    completion    Emit bash/zsh/fish/PowerShell completion scripts
+
+Advanced commands (workstation / power-user — docs/CLI_SURFACES.md):
+    loop          Loop engineering: init, run, status, audit, cost, schedule, sync
+    workspace     Workspace scaffolding: init, context, sync
+    memory        Knowledge base: add, search, inject, review, todo
+    project       Project management: clone, list, add, remove, scan
+    devcompanion  Background job queue: queue, run-once, status, done, sync-todos (alias: dc)
+    insights      AI tool usage insights (deprecated in V; use agent-toolkit-py)
+    build         Compile canonical capabilities into target-native artifacts
+    inventory     List all canonical skills, agents, and products
+    matrix        Show platform capability matrix
+    release       Not in V — maintainer artifacts live in CI / docs/RELEASING.md
+    swarm         Multi-agent swarm orchestration (pair/team/full, Herdr/tmux)
+
+Run \'agent-toolkit <command> --help\' for details.
+'
 }
 
 fn subcommand_help(name string) string {
@@ -1307,7 +1326,12 @@ Compile canonical capabilities into target artifacts (Tier-1 + remaining emitter
   --target TARGET    Target id (default: all implemented emitters)
   --product PRODUCT  Product id (default: all products)
   --output DIR       Output directory (default: <repo>/plugins)
-	--json             Structured CommandResult JSON
+  --json             Structured CommandResult JSON
+
+Examples:
+  agent-toolkit build --check
+  agent-toolkit build --target cursor --product agent-toolkit-core
+  AGENT_TOOLKIT_ROOT=/path/to/checkout agent-toolkit build --check
 '
 	}
 	if name == 'install' {
@@ -1321,6 +1345,10 @@ Install profiles for detected or selected AI tools.
   --force        Overwrite existing files without prompting
   --offline      Use only bundled/cached data (skip GitHub Release refresh)
   --json         Structured CommandResult JSON
+
+Examples:
+  agent-toolkit install --dry-run --offline
+  agent-toolkit install --tools cursor,opencode --offline
 '
 	}
 	if name == 'uninstall' {
@@ -1343,6 +1371,10 @@ Show what would change between freshly compiled output and plugins/.
   --target TARGET    Target platform (default: Tier-1 cursor/claude-code/opencode)
   --product PRODUCT  Product ID to diff (default: all products)
   --json             Structured CommandResult JSON
+
+Examples:
+  agent-toolkit diff --target cursor
+  agent-toolkit diff --target claude-code --product agent-toolkit-core
 '
 	}
 	if name == 'update' {
@@ -1354,16 +1386,51 @@ Refresh installed profiles from toolkit capability data (not binary self-update)
   --check        Dry-run — show what would change without writing
   --pin VERSION  Download capability data for a release before updating
   --json         Structured CommandResult JSON
+
+Examples:
+  agent-toolkit update --check
+  agent-toolkit update --tools cursor,opencode
 '
 	}
 	if name == 'doctor' {
-		return 'Usage: agent-toolkit doctor [--fix] [--json]
+		return 'Usage: agent-toolkit doctor [--fix] [--provenance] [--json]
 
 Read-only health checks by default. --fix allowlists profile refresh only.
 
-  --fix   Attempt auto-repair for missing profiles (runs capability update)
-  --json  Structured CommandResult JSON
+  --fix          Attempt auto-repair for missing profiles (runs capability update)
+  --provenance   Report capabilities/upstream.lock presence (full SHA/expiry: agent-toolkit-py)
+  --json         Structured CommandResult JSON
+
+Exit codes:
+  0  no errors detected
+  1  one or more errors detected
 '
+	}
+	if name == 'inventory' {
+		return 'Usage: agent-toolkit inventory [--json]
+
+List canonical skills, agents, and products from the toolkit tree.
+
+  --json  Structured CommandResult JSON (counts in data)
+
+Set AGENT_TOOLKIT_ROOT to the checkout or wheel data directory if auto-detect fails.
+'
+	}
+	if name == 'matrix' {
+		return 'Usage: agent-toolkit matrix [--json]
+
+Print docs/research/platform-capability-matrix.md from the toolkit tree.
+
+  --json  Structured CommandResult JSON
+
+If the matrix file is missing, prints where it is expected (research pipeline).
+'
+	}
+	if name == 'insights' {
+		return insights_help_text()
+	}
+	if name == 'release' {
+		return release_help_text()
 	}
 	if name == 'skills' {
 		return agent_toolkit_core.skills_help_text()
@@ -1397,8 +1464,43 @@ Read-only health checks by default. --fix allowlists profile refresh only.
 	}
 	mut c := cli.Command{
 		name:        name
-		description: '${name} — not yet implemented in V; use the Python package for unfinished advanced commands (docs/v/cutover.md)'
+		description: '${name} — not yet implemented in V; use agent-toolkit-py for unfinished commands (docs/v/python-fallback.md)'
 	}
 	c.setup()
 	return c.help_message()
+}
+
+fn insights_subcommand(args []string) string {
+	for a in args {
+		if !a.starts_with('-') {
+			return a
+		}
+	}
+	return ''
+}
+
+fn insights_help_text() string {
+	return 'insights — AI tool usage analytics (deprecated in V; #526).
+
+Not ported to the V CLI. The quarantined Python fallback still implements it:
+
+  agent-toolkit-py insights opencode [--days N] [--output PATH]
+  agent-toolkit-py insights cursor   [--output PATH]
+  agent-toolkit-py insights claude   [--days N] [--output PATH]
+
+See docs/v/advanced-command-disposition.md and docs/v/python-fallback.md.
+'
+}
+
+fn release_help_text() string {
+	return 'release — Generate release artifacts (removed from V; #527).
+
+Maintainer artifact generation belongs in GitHub Actions / docs/RELEASING.md, not the runtime CLI.
+
+The quarantined Python fallback still has a --dry-run generator:
+
+  agent-toolkit-py release --dry-run [--output DIR] [--target TARGET] [--json]
+
+See docs/v/advanced-command-disposition.md.
+'
 }

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -151,4 +151,65 @@ fn test_grouped_help_mentions_consumer_and_advanced() {
 	h := grouped_help()
 	assert h.contains('Consumer') || h.to_lower().contains('install')
 	assert h.contains('Advanced') || h.to_lower().contains('inventory')
+	assert h.contains('Install profiles for detected AI tools')
+	assert h.contains('completion')
+	assert h.contains('alias: rollback')
+	assert h.contains('alias: dc')
+	assert !h.contains('install (consumer)')
+}
+
+fn test_inventory_help_is_implemented() {
+	h := subcommand_help('inventory')
+	assert h.contains('agent-toolkit inventory')
+	assert h.contains('--json')
+	assert !h.contains('not yet implemented')
+}
+
+fn test_matrix_help_is_implemented() {
+	h := subcommand_help('matrix')
+	assert h.contains('agent-toolkit matrix')
+	assert h.contains('--json')
+	assert !h.contains('not yet implemented')
+}
+
+fn test_doctor_help_mentions_provenance() {
+	h := subcommand_help('doctor')
+	assert h.contains('--provenance')
+	assert h.contains('--fix')
+	assert h.contains('Exit codes')
+}
+
+fn test_insights_help_is_deprecate_disposition() {
+	h := subcommand_help('insights')
+	assert h.contains('agent-toolkit-py')
+	assert h.contains('#526') || h.to_lower().contains('deprecat')
+	assert !h.contains('not yet implemented')
+}
+
+fn test_release_help_is_remove_disposition() {
+	h := subcommand_help('release')
+	assert h.contains('docs/RELEASING.md')
+	assert h.contains('#527') || h.to_lower().contains('removed')
+	assert !h.contains('not yet implemented')
+}
+
+fn test_insights_no_args_exits_zero() {
+	code := dispatch(['agent-toolkit', 'insights'])
+	assert code == 0
+}
+
+fn test_insights_subcommand_exits_one() {
+	code := dispatch(['agent-toolkit', 'insights', 'opencode'])
+	assert code == 1
+}
+
+fn test_release_exits_one() {
+	code := dispatch(['agent-toolkit', 'release'])
+	assert code == 1
+}
+
+fn test_update_help_has_examples() {
+	h := subcommand_help('update')
+	assert h.contains('Examples:')
+	assert h.contains('--check')
 }

--- a/modules/agent_toolkit_core/devcompanion.v
+++ b/modules/agent_toolkit_core/devcompanion.v
@@ -151,7 +151,8 @@ Alias:
 }
 
 pub fn dc_help_text() string {
-	return devcompanion_help_text(DcConfig{})
+	ws := find_devcompanion_workspace('')
+	return devcompanion_help_text(get_dc_config(ws))
 }
 
 fn find_devcompanion_workspace(override string) string {

--- a/modules/agent_toolkit_core/doctor.v
+++ b/modules/agent_toolkit_core/doctor.v
@@ -6,6 +6,7 @@ import os
 pub struct DoctorOptions {
 pub:
 	fix               bool
+	provenance        bool // --provenance: extra lock reporting (Python flag parity)
 	home_dir          string // empty → os.home_dir()
 	data_root         string // empty → resolve via update/find_toolkit_root
 	skip_data_refresh bool
@@ -66,6 +67,9 @@ pub fn run_doctor(opts DoctorOptions) DoctorSnapshot {
 		checks << DoctorCheck{'root', 'offline', 'warn', 'AGENT_TOOLKIT_OFFLINE set'}
 	}
 	checks << collect_profile_checks(home)
+	if opts.provenance {
+		checks << collect_provenance_checks(root)
+	}
 
 	mut ok := true
 	for c in checks {
@@ -96,6 +100,14 @@ pub fn run_doctor(opts DoctorOptions) DoctorSnapshot {
 		lines << ''
 		lines << '── Profiles ──'
 		for c in profile_checks {
+			lines << doctor_format_check(c)
+		}
+	}
+	prov_checks := checks.filter(it.category == 'provenance')
+	if prov_checks.len > 0 {
+		lines << ''
+		lines << '── Provenance ──'
+		for c in prov_checks {
 			lines << doctor_format_check(c)
 		}
 	}
@@ -189,6 +201,23 @@ pub fn doctor_result(snap DoctorSnapshot) CommandResult {
 			'errors':      '${err_n}'
 		}
 	}
+}
+
+fn collect_provenance_checks(root string) []DoctorCheck {
+	mut out := []DoctorCheck{}
+	if root.len == 0 {
+		out << DoctorCheck{'provenance', 'upstream.lock exists', 'warn', 'no toolkit root'}
+		return out
+	}
+	lock_path := os.join_path(root, 'capabilities', 'upstream.lock')
+	if os.is_file(lock_path) {
+		out << DoctorCheck{'provenance', 'upstream.lock exists', 'ok', lock_path}
+		out << DoctorCheck{'provenance', 'provenance: doctor --provenance', 'ok', 'lock present; SHA/expiry detail: agent-toolkit-py doctor --provenance'}
+	} else {
+		// Warn (not err): wheel/data installs often omit capabilities/upstream.lock
+		out << DoctorCheck{'provenance', 'upstream.lock exists', 'warn', 'not found under toolkit root (checkout only)'}
+	}
+	return out
 }
 
 fn doctor_format_check(c DoctorCheck) string {

--- a/modules/agent_toolkit_core/doctor_test.v
+++ b/modules/agent_toolkit_core/doctor_test.v
@@ -75,3 +75,14 @@ fn test_doctor_fix_noop_when_profiles_ok() {
 	assert !snap.fix_applied
 	assert snap.message.contains('No profile issues')
 }
+
+fn test_doctor_includes_provenance_category() {
+	snap := run_doctor(DoctorOptions{ provenance: true })
+	assert snap.checks.any(it.category == 'provenance')
+	assert snap.message.contains('Provenance') || snap.checks.any(it.name.contains('upstream.lock'))
+}
+
+fn test_doctor_skips_provenance_without_flag() {
+	snap := run_doctor_readonly()
+	assert !snap.checks.any(it.category == 'provenance')
+}

--- a/modules/agent_toolkit_core/loop.v
+++ b/modules/agent_toolkit_core/loop.v
@@ -116,20 +116,24 @@ pub fn loop_help_text() string {
 
 Usage:
     agent-toolkit loop init <pattern> [--name NAME]
-    agent-toolkit loop run <loop> [--force] [--runner NAME] [--no-llm]
+    agent-toolkit loop run <loop> [--force] [--runner NAME] [--no-llm] [--quiet] [--pack PATH]
     agent-toolkit loop list
     agent-toolkit loop status [loop]
     agent-toolkit loop audit [loop]
     agent-toolkit loop cost <loop>
-    agent-toolkit loop schedule <loop> [--dry-run]
+    agent-toolkit loop schedule <loop> [--dry-run] [--cron EXPR] [--list] [--remove]
     agent-toolkit loop sync
     agent-toolkit loop templates
     agent-toolkit loop help
 
 loop run options:
     --force       Bypass max_runs_per_day only (not wall/token budgets)
+    --quiet       Suppress live runner output
+    --pack PATH   Apply loop overrides from pack YAML
+    --workspace PATH  Workspace root override
     --runner NAME auto|skeleton (LLM PATH runners fail closed to skeleton without stdin)
     --no-llm      Alias for --runner skeleton (no network)
+    --json        Structured CommandResult JSON
 
 Concurrency: one OS process per iteration via ProcessService; no Python threads / no `go` workers.
 Schedule: systemd/launchd on Unix; not supported on Windows.

--- a/modules/agent_toolkit_core/mcp.v
+++ b/modules/agent_toolkit_core/mcp.v
@@ -77,7 +77,9 @@ pub fn mcp_result(report McpReport) CommandResult {
 }
 
 pub fn mcp_help_text() string {
-	return 'Usage: agent-toolkit mcp <subcommand> [args]
+	return 'mcp — MCP (Model Context Protocol) provider management.
+
+Usage: agent-toolkit mcp <subcommand> [args]
 
 Subcommands:
     list                   List available MCP providers

--- a/modules/agent_toolkit_core/memory.v
+++ b/modules/agent_toolkit_core/memory.v
@@ -93,7 +93,7 @@ Subcommands:
     inject             Output full knowledge base for AI session injection
     review [--fix] [--stale-after N]
                        Detect duplicates, stale/orphan refs, and contradictions
-    todo               List unchecked todos
+    todo [--done]       List unchecked todos (--done includes completed)
 
 Types for add:
     learning   Factual session learning (knowledge/learnings/general.md)
@@ -102,6 +102,7 @@ Types for add:
 
 Options:
     --workspace PATH   Override workspace root
+    --json             Structured CommandResult JSON
     --help             Show this help message
 '
 }

--- a/modules/agent_toolkit_core/plugin.v
+++ b/modules/agent_toolkit_core/plugin.v
@@ -56,11 +56,16 @@ pub fn plugin_result(report PluginReport) CommandResult {
 }
 
 pub fn plugin_help_text() string {
-	return 'Usage: agent-toolkit plugin <subcommand>
+	return 'plugin — Plugin bundle management for agent-toolkit.
+
+Usage: agent-toolkit plugin <subcommand> [--json]
 
 Subcommands:
     sync     Sync canonical agents/skills into plugin bundles
     check    Verify plugin bundles are in sync (exit 1 if drift)
+
+Options:
+    --json   Structured CommandResult JSON
 
 This is gen-surfaces copy/compare (core/agents/forge). Compiler emit drift is `build --check`.
 '

--- a/modules/agent_toolkit_core/skills.v
+++ b/modules/agent_toolkit_core/skills.v
@@ -81,7 +81,9 @@ pub fn skills_result(report SkillsReport) CommandResult {
 }
 
 pub fn skills_help_text() string {
-	return 'Usage: agent-toolkit skills <subcommand> [options]
+	return 'skills — Skill management for agent-toolkit.
+
+Usage: agent-toolkit skills <subcommand> [options]
 
 Subcommands:
     list [--domain DOMAIN]     List skills grouped by domain


### PR DESCRIPTION
## Summary
- Replace V root/subcommand `--help` placeholders (`install (consumer)`) with real blurbs, examples, and `inventory`/`matrix` usage.
- Honor Python `doctor --provenance` (lock presence only; SHA/expiry still `agent-toolkit-py`).
- Document #526/#527: `insights` deprecated, `release` removed from V (point at `agent-toolkit-py` / `docs/RELEASING.md`).

## Type
- [x] Bug fix

## Testing
- [x] V tests added in `dispatch_test.v` / `doctor_test.v` (run in CI — not compiled locally)
- [ ] Confirmed `validate` CI workflow passes

## Checklist
- [x] No secrets committed
- [x] Commit messages are in English and follow conventional commits format
- [x] CHANGELOG Unreleased bullet for this PR only


Made with [Cursor](https://cursor.com)