### PR TITLE
ci(docker): build image from Release after V assets exist

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: Docker
 
 on:
+  # GITHUB_TOKEN creating a GitHub Release does not fire `release: published`
+  # for other workflows. Release.yml calls this after upload-assets instead.
+  workflow_call:
   release:
     types: [published]
   push:
@@ -81,9 +84,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Smoke published amd64 image
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}
         run: |
           docker pull --platform linux/amd64 "$IMAGE"
           docker run --rm --platform linux/amd64 "$IMAGE" version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ name: Release
 # file — PyPI Trusted Publishing is registered for release.yml, not publish.yml.
 #
 # Job graph:
-#   create-release ─┬─► build-binaries ─► upload-assets ─► publish-pypi (platform wheels from Release assets)
+#   create-release ─┬─► build-binaries ─► upload-assets ─┬─► publish-pypi (platform wheels from Release assets)
+#                   │                                    └─► docker (reusable workflow; GITHUB_TOKEN cannot trigger on: release)
 #                   └─► sbom (SHOULD CycloneDX; does not prove “secure software”)
 
 on:
@@ -357,3 +358,12 @@ jobs:
             sleep 15
           done
           echo "::warning::PyPI verification timed out — publish step succeeded; CDN may lag"
+
+  docker:
+    name: Docker image
+    if: github.event_name == 'push'
+    needs: [upload-assets]
+    uses: ./.github/workflows/docker.yml
+    permissions:
+      contents: read
+      packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
+
 ## [1.12.1] — 2026-08-13
 
 - **Fixed** — V CLI help matches or exceeds Python: real command blurbs, inventory/matrix usage, doctor `--provenance`, examples, and honest #526/#527 insights/release dispositions

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -33,7 +33,10 @@ git push origin main --follow-tags
 # 4. Watch Release + downstream
 gh run list --repo ulises-jeremias/agent-toolkit --limit 5  # Release v1.3.0 should be completed success
 gh release view v1.3.0 --repo ulises-jeremias/agent-toolkit
-# Homebrew/AUR notifies run after Release create-release; check their repos
+# Docker is a reusable job on Release after upload-assets (do not rely on `on: release`;
+# GITHUB_TOKEN-created releases do not start sibling workflows). Manual fallback:
+#   gh workflow run Docker --ref v1.3.0
+# Homebrew/AUR notifies wait for V binaries then repository_dispatch; check their repos
 gh run list --repo ulises-jeremias/homebrew-tap --limit 3
 gh run list --repo ulises-jeremias/aur-packages --limit 3
 


### PR DESCRIPTION
## Summary
- Call `docker.yml` from `release.yml` after `upload-assets` so GHCR is published on every tag.
- `GITHUB_TOKEN` creating a GitHub Release does not fire `on: release` for sibling workflows (v1.12.1 required a manual `workflow_dispatch`).
- Smoke the published image by VERSION tag, not only `main`.

## Test plan
- [x] No local V
- [ ] Required CI green
- [ ] Docker workflow on this PR smoke-builds (path filter)
- [ ] Next tag: Release graph includes Docker image job after assets


Made with [Cursor](https://cursor.com)