### PR TITLE
docs: polish published npm/PyPI package READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
 
 ## [1.12.1] — 2026-08-13

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,0 +1,16 @@
+# packages/npm
+
+npm adapter sources. PyPI equivalent: [`packages/pypi/`](../pypi/).
+
+| Directory | npm name | Role |
+|-----------|----------|------|
+| `agent-toolkit-cli/` | `agent-toolkit-cli` | Thin Node launcher (`bin/agent-toolkit.js`) over GitHub Release V binaries (ADR-025) |
+| `agent-toolkit-cli-linux-x64/` | `agent-toolkit-cli-linux-x64` | glibc ELF (`optionalDependency`) |
+| `agent-toolkit-cli-linux-arm64/` | `agent-toolkit-cli-linux-arm64` | glibc ELF (`optionalDependency`) |
+| `agent-toolkit-cli-darwin-arm64/` | `agent-toolkit-cli-darwin-arm64` | macOS arm64 Mach-O |
+| `agent-toolkit-cli-darwin-x64/` | `agent-toolkit-cli-darwin-x64` | macOS x64 Mach-O |
+| `agent-toolkit-cli-win32-x64/` | `agent-toolkit-cli-win32-x64` | Windows x64 PE |
+
+Pack at release time: `scripts/pack_npm.py` (copies Release assets into `bin/`). Publish: `.github/workflows/publish-npm.yml` (OIDC trusted publishing).
+
+Each published package has a polished `README.md`. Platform packages are shorter than the meta-package but document platform, install path, and when *not* to install them directly.

--- a/packages/npm/agent-toolkit-cli-darwin-arm64/README.md
+++ b/packages/npm/agent-toolkit-cli-darwin-arm64/README.md
@@ -1,0 +1,70 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
+# agent-toolkit-cli-darwin-arm64
+
+**Native V binary** for macOS Apple Silicon — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli-darwin-arm64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-arm64)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+
+[Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
+[GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
+
+## What is this package?
+
+This package ships **only** the floating GitHub Release asset `agent-toolkit-macos-arm64` as `bin/agent-toolkit`. It is **not** a second CLI and is **not** meant to be installed directly.
+
+Install the meta-package instead:
+
+```bash
+npm install -g agent-toolkit-cli
+agent-toolkit --help
+```
+
+npm selects this package via `optionalDependencies` when `os=darwin` and `cpu=arm64`.
+
+| Field | Value |
+|-------|-------|
+| npm name | `agent-toolkit-cli-darwin-arm64` |
+| Release asset | `agent-toolkit-macos-arm64` |
+| Binary path | `bin/agent-toolkit` |
+| Parent | [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli) |
+
+---
+
+## Requirements
+
+- macOS on **Apple Silicon** (arm64)
+- Prefer installing via the meta-package so the Node launcher can resolve this binary
+- Gatekeeper / code-signing notes: [docs](https://github.com/ulises-jeremias/agent-toolkit/tree/main/docs) (see code-signing policy in the monorepo)
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
+| [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
+
+---
+
+<div align="center">
+
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli-darwin-arm64) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+
+</div>

--- a/packages/npm/agent-toolkit-cli-darwin-arm64/README.md
+++ b/packages/npm/agent-toolkit-cli-darwin-arm64/README.md
@@ -10,12 +10,12 @@
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-darwin-arm64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-arm64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
-[![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
-[![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
+[![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 
 [Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
 [GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
-[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) ·
 [Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
 
 </div>
@@ -57,7 +57,7 @@ npm selects this package via `optionalDependencies` when `os=darwin` and `cpu=ar
 | Guide | Description |
 |-------|-------------|
 | [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
-| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) | npm topology |
 | [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
 | [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
 

--- a/packages/npm/agent-toolkit-cli-darwin-arm64/package.json
+++ b/packages/npm/agent-toolkit-cli-darwin-arm64/package.json
@@ -10,8 +10,13 @@
     "arm64"
   ],
   "files": [
+    "README.md",
     "bin/agent-toolkit"
   ],
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "bugs": {
+    "url": "https://github.com/ulises-jeremias/agent-toolkit/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ulises-jeremias/agent-toolkit.git",

--- a/packages/npm/agent-toolkit-cli-darwin-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-darwin-x64/README.md
@@ -1,0 +1,70 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
+# agent-toolkit-cli-darwin-x64
+
+**Native V binary** for macOS Intel — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli-darwin-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-x64)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+
+[Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
+[GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
+
+## What is this package?
+
+This package ships **only** the floating GitHub Release asset `agent-toolkit-macos-x86_64` as `bin/agent-toolkit`. It is **not** a second CLI and is **not** meant to be installed directly.
+
+Install the meta-package instead:
+
+```bash
+npm install -g agent-toolkit-cli
+agent-toolkit --help
+```
+
+npm selects this package via `optionalDependencies` when `os=darwin` and `cpu=x64`.
+
+| Field | Value |
+|-------|-------|
+| npm name | `agent-toolkit-cli-darwin-x64` |
+| Release asset | `agent-toolkit-macos-x86_64` |
+| Binary path | `bin/agent-toolkit` |
+| Parent | [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli) |
+
+---
+
+## Requirements
+
+- macOS on **Intel** (x86_64)
+- Prefer installing via the meta-package so the Node launcher can resolve this binary
+- Gatekeeper / code-signing notes: [docs](https://github.com/ulises-jeremias/agent-toolkit/tree/main/docs) (see code-signing policy in the monorepo)
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
+| [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
+
+---
+
+<div align="center">
+
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli-darwin-x64) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+
+</div>

--- a/packages/npm/agent-toolkit-cli-darwin-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-darwin-x64/README.md
@@ -10,12 +10,12 @@
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-darwin-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-x64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
-[![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
-[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
+[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 
 [Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
 [GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
-[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) ·
 [Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
 
 </div>
@@ -57,7 +57,7 @@ npm selects this package via `optionalDependencies` when `os=darwin` and `cpu=x6
 | Guide | Description |
 |-------|-------------|
 | [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
-| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) | npm topology |
 | [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
 | [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
 

--- a/packages/npm/agent-toolkit-cli-darwin-x64/package.json
+++ b/packages/npm/agent-toolkit-cli-darwin-x64/package.json
@@ -10,8 +10,13 @@
     "x64"
   ],
   "files": [
+    "README.md",
     "bin/agent-toolkit"
   ],
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "bugs": {
+    "url": "https://github.com/ulises-jeremias/agent-toolkit/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ulises-jeremias/agent-toolkit.git",

--- a/packages/npm/agent-toolkit-cli-linux-arm64/README.md
+++ b/packages/npm/agent-toolkit-cli-linux-arm64/README.md
@@ -1,0 +1,70 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
+# agent-toolkit-cli-linux-arm64
+
+**Native V binary** for Linux arm64 (glibc) — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli-linux-arm64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-linux-arm64)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![libc](https://img.shields.io/badge/libc-glibc-16a34a?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md)
+
+[Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
+[GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
+
+## What is this package?
+
+This package ships **only** the floating GitHub Release asset `agent-toolkit-linux-arm64` as `bin/agent-toolkit`. It is **not** a second CLI and is **not** meant to be installed directly.
+
+Install the meta-package instead:
+
+```bash
+npm install -g agent-toolkit-cli
+agent-toolkit --help
+```
+
+npm selects this package via `optionalDependencies` when `os=linux`, `cpu=arm64`, and `libc=glibc` ([ADR-019](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md) — musl/Alpine is not a MUST tag).
+
+| Field | Value |
+|-------|-------|
+| npm name | `agent-toolkit-cli-linux-arm64` |
+| Release asset | `agent-toolkit-linux-arm64` |
+| Binary path | `bin/agent-toolkit` |
+| Parent | [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli) |
+
+---
+
+## Requirements
+
+- Linux **arm64** with **glibc** (typically 2.38+ for current Release builds)
+- Prefer installing via the meta-package so the Node launcher can resolve this binary
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
+| [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
+
+---
+
+<div align="center">
+
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli-linux-arm64) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+
+</div>

--- a/packages/npm/agent-toolkit-cli-linux-arm64/README.md
+++ b/packages/npm/agent-toolkit-cli-linux-arm64/README.md
@@ -10,13 +10,13 @@
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-linux-arm64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-linux-arm64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
-[![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
-[![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
+[![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![libc](https://img.shields.io/badge/libc-glibc-16a34a?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md)
 
 [Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
 [GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
-[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) ·
 [Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
 
 </div>
@@ -57,7 +57,7 @@ npm selects this package via `optionalDependencies` when `os=linux`, `cpu=arm64`
 | Guide | Description |
 |-------|-------------|
 | [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
-| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) | npm topology |
 | [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
 | [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
 

--- a/packages/npm/agent-toolkit-cli-linux-arm64/package.json
+++ b/packages/npm/agent-toolkit-cli-linux-arm64/package.json
@@ -10,8 +10,13 @@
     "arm64"
   ],
   "files": [
+    "README.md",
     "bin/agent-toolkit"
   ],
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "bugs": {
+    "url": "https://github.com/ulises-jeremias/agent-toolkit/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ulises-jeremias/agent-toolkit.git",

--- a/packages/npm/agent-toolkit-cli-linux-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-linux-x64/README.md
@@ -10,13 +10,13 @@
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-linux-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-linux-x64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
-[![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
-[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
+[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![libc](https://img.shields.io/badge/libc-glibc-16a34a?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md)
 
 [Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
 [GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
-[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) ·
 [Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
 
 </div>
@@ -57,7 +57,7 @@ npm selects this package via `optionalDependencies` when `os=linux`, `cpu=x64`, 
 | Guide | Description |
 |-------|-------------|
 | [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
-| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) | npm topology |
 | [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
 | [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
 

--- a/packages/npm/agent-toolkit-cli-linux-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-linux-x64/README.md
@@ -1,0 +1,70 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
+# agent-toolkit-cli-linux-x64
+
+**Native V binary** for Linux x86_64 (glibc) — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli-linux-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-linux-x64)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![libc](https://img.shields.io/badge/libc-glibc-16a34a?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md)
+
+[Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
+[GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
+
+## What is this package?
+
+This package ships **only** the floating GitHub Release asset `agent-toolkit-linux-x86_64` as `bin/agent-toolkit`. It is **not** a second CLI and is **not** meant to be installed directly.
+
+Install the meta-package instead:
+
+```bash
+npm install -g agent-toolkit-cli
+agent-toolkit --help
+```
+
+npm selects this package via `optionalDependencies` when `os=linux`, `cpu=x64`, and `libc=glibc` ([ADR-019](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md) — musl/Alpine is not a MUST tag).
+
+| Field | Value |
+|-------|-------|
+| npm name | `agent-toolkit-cli-linux-x64` |
+| Release asset | `agent-toolkit-linux-x86_64` |
+| Binary path | `bin/agent-toolkit` |
+| Parent | [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli) |
+
+---
+
+## Requirements
+
+- Linux **x86_64** with **glibc** (typically 2.38+ for current Release builds)
+- Prefer installing via the meta-package so the Node launcher can resolve this binary
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
+| [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
+
+---
+
+<div align="center">
+
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli-linux-x64) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+
+</div>

--- a/packages/npm/agent-toolkit-cli-linux-x64/package.json
+++ b/packages/npm/agent-toolkit-cli-linux-x64/package.json
@@ -10,8 +10,13 @@
     "x64"
   ],
   "files": [
+    "README.md",
     "bin/agent-toolkit"
   ],
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "bugs": {
+    "url": "https://github.com/ulises-jeremias/agent-toolkit/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ulises-jeremias/agent-toolkit.git",

--- a/packages/npm/agent-toolkit-cli-win32-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-win32-x64/README.md
@@ -1,0 +1,70 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
+# agent-toolkit-cli-win32-x64
+
+**Native V binary** for Windows x64 — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli-win32-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-win32-x64)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![os](https://img.shields.io/badge/os-win32-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+
+[Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
+[GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
+
+## What is this package?
+
+This package ships **only** the floating GitHub Release asset `agent-toolkit-windows-x86_64.exe` as `bin/agent-toolkit.exe`. It is **not** a second CLI and is **not** meant to be installed directly.
+
+Install the meta-package instead:
+
+```bash
+npm install -g agent-toolkit-cli
+agent-toolkit --help
+```
+
+npm selects this package via `optionalDependencies` when `os=win32` and `cpu=x64`.
+
+| Field | Value |
+|-------|-------|
+| npm name | `agent-toolkit-cli-win32-x64` |
+| Release asset | `agent-toolkit-windows-x86_64.exe` |
+| Binary path | `bin/agent-toolkit.exe` |
+| Parent | [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli) |
+
+---
+
+## Requirements
+
+- Windows **x64**
+- Prefer installing via the meta-package so the Node launcher can resolve this binary
+- SmartScreen / code-signing notes: [docs](https://github.com/ulises-jeremias/agent-toolkit/tree/main/docs) (see code-signing policy in the monorepo)
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
+| [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
+
+---
+
+<div align="center">
+
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli-win32-x64) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+
+</div>

--- a/packages/npm/agent-toolkit-cli-win32-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-win32-x64/README.md
@@ -10,12 +10,12 @@
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-win32-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-win32-x64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
-[![os](https://img.shields.io/badge/os-win32-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
-[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)
+[![os](https://img.shields.io/badge/os-win32-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
+[![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 
 [Meta-package](https://www.npmjs.com/package/agent-toolkit-cli) ·
 [GitHub Release](https://github.com/ulises-jeremias/agent-toolkit/releases/latest) ·
-[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) ·
+[ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) ·
 [Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
 
 </div>
@@ -57,7 +57,7 @@ npm selects this package via `optionalDependencies` when `os=win32` and `cpu=x64
 | Guide | Description |
 |-------|-------------|
 | [agent-toolkit-cli (npm)](https://www.npmjs.com/package/agent-toolkit-cli) | Meta-package README — install, commands, tools |
-| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) | npm topology |
 | [ADR-018](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-018-release-artifacts.md) | Canonical Release asset names |
 | [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) | Source of truth |
 

--- a/packages/npm/agent-toolkit-cli-win32-x64/package.json
+++ b/packages/npm/agent-toolkit-cli-win32-x64/package.json
@@ -10,8 +10,13 @@
     "x64"
   ],
   "files": [
+    "README.md",
     "bin/agent-toolkit.exe"
   ],
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "bugs": {
+    "url": "https://github.com/ulises-jeremias/agent-toolkit/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ulises-jeremias/agent-toolkit.git",

--- a/packages/npm/agent-toolkit-cli/README.md
+++ b/packages/npm/agent-toolkit-cli/README.md
@@ -36,7 +36,7 @@
 
 ## What is this package?
 
-`agent-toolkit-cli` on npm is the **Node adapter** for the agent-toolkit monorepo ([ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)). It is a **thin launcher** — no JavaScript business logic. The real CLI is the native **V** binary from [GitHub Releases](https://github.com/ulises-jeremias/agent-toolkit/releases/latest).
+`agent-toolkit-cli` on npm is the **Node adapter** for the agent-toolkit monorepo ([ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)). It is a **thin launcher** — no JavaScript business logic. The real CLI is the native **V** binary from [GitHub Releases](https://github.com/ulises-jeremias/agent-toolkit/releases/latest).
 
 Same product name as [PyPI](https://pypi.org/project/agent-toolkit-cli/). Same binary. Different install channel.
 
@@ -244,7 +244,7 @@ npm uninstall -g agent-toolkit-cli
 | [README (monorepo)](https://github.com/ulises-jeremias/agent-toolkit#readme) | Full product overview, skills, agents, packs |
 | [INSTALLATION.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md) | Install paths per tool |
 | [CLI_SURFACES.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/CLI_SURFACES.md) | Consumer vs advanced commands |
-| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology (meta + optionalDeps) |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md) | npm topology (meta + optionalDeps) |
 | [TRUST.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/TRUST.md) | Trust boundaries and supply chain |
 | [Wiki](https://github.com/ulises-jeremias/agent-toolkit/wiki) | Extended reference |
 

--- a/packages/npm/agent-toolkit-cli/README.md
+++ b/packages/npm/agent-toolkit-cli/README.md
@@ -1,14 +1,285 @@
-# agent-toolkit-cli (npm)
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
 
-Thin Node launcher for the **native V** `agent-toolkit` binary. Same product name as PyPI: **`agent-toolkit-cli`**.
+<div align="center">
+
+# agent-toolkit-cli
+
+**The official CLI for [agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit)** — install skills, agents, loops, and MCP configs across every major AI coding assistant.
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![Node](https://img.shields.io/node/v/agent-toolkit-cli?style=flat&labelColor=1f2937)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Validate](https://img.shields.io/github/actions/workflow/status/ulises-jeremias/agent-toolkit/validate.yml?branch=main&label=validate&style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/actions/workflows/validate.yml)
+
+![skills](https://img.shields.io/badge/skills-77-7c3aed?style=flat&labelColor=1f2937)
+![agents](https://img.shields.io/badge/agents-17-0891b2?style=flat&labelColor=1f2937)
+![loops](https://img.shields.io/badge/loops-10-ea580c?style=flat&labelColor=1f2937)
+
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-7c3aed?style=flat&labelColor=1f2937&logo=anthropic&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/claude-code)
+[![Cursor](https://img.shields.io/badge/Cursor-rules-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/cursor)
+[![OpenCode](https://img.shields.io/badge/OpenCode-agents-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/opencode)
+[![Copilot](https://img.shields.io/badge/GitHub%20Copilot-instructions-16a34a?style=flat&labelColor=1f2937&logo=github&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/copilot)
+[![Windsurf](https://img.shields.io/badge/Windsurf-rules-2563eb?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/windsurf)
+[![Pi](https://img.shields.io/badge/Pi%20Agent-skills-db2777?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/pi)
+
+[Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
+[Docs](https://github.com/ulises-jeremias/agent-toolkit/tree/main/docs) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md) ·
+[CLI surfaces](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/CLI_SURFACES.md) ·
+[Changelog](https://github.com/ulises-jeremias/agent-toolkit/blob/main/CHANGELOG.md)
+
+</div>
+
+---
+
+## What is this package?
+
+`agent-toolkit-cli` on npm is the **Node adapter** for the agent-toolkit monorepo ([ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md)). It is a **thin launcher** — no JavaScript business logic. The real CLI is the native **V** binary from [GitHub Releases](https://github.com/ulises-jeremias/agent-toolkit/releases/latest).
+
+Same product name as [PyPI](https://pypi.org/project/agent-toolkit-cli/). Same binary. Different install channel.
 
 ```bash
 npm install -g agent-toolkit-cli
-agent-toolkit --help
+agent-toolkit install
+agent-toolkit doctor
 ```
 
-The installer pulls a platform package via `optionalDependencies` (`agent-toolkit-cli-<os>-<cpu>`). Those packages contain GitHub Release V binaries (ADR-018 / ADR-025), not a second CLI.
+<div align="center">
+<img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/architecture.svg?raw=true" width="88%" alt="agent-toolkit architecture">
+</div>
 
-Dev override: `AGENT_TOOLKIT_BIN=/path/to/agent-toolkit`.
+---
 
-Publish: GitHub Actions OIDC trusted publishing (`.github/workflows/publish-npm.yml`). No long-lived `NPM_TOKEN`.
+## How the binary arrives
+
+npm cannot ship one ELF for every OS the way pip ships platform-tagged wheels. Instead:
+
+| Package | Role |
+|---------|------|
+| **`agent-toolkit-cli`** (this package) | Meta-package: `bin/agent-toolkit` → thin Node launcher |
+| `agent-toolkit-cli-linux-x64` | glibc ELF (optionalDependency) |
+| `agent-toolkit-cli-linux-arm64` | glibc ELF (optionalDependency) |
+| `agent-toolkit-cli-darwin-arm64` | macOS arm64 Mach-O |
+| `agent-toolkit-cli-darwin-x64` | macOS x86_64 Mach-O |
+| `agent-toolkit-cli-win32-x64` | Windows PE |
+
+On install, npm pulls the matching platform package via `optionalDependencies`. The launcher resolves that binary and spawns it with forwarded argv, stdio, signals, and exit code.
+
+**Platform notes**
+
+- Linux packages require **glibc** (ADR-019). Alpine/musl is not a MUST npm tag.
+- Node **≥ 18**
+- Dev override: `AGENT_TOOLKIT_BIN=/path/to/agent-toolkit`
+
+---
+
+## Quick start
+
+```bash
+# Global install (recommended for shells)
+npm install -g agent-toolkit-cli
+agent-toolkit install    # auto-detects Claude, Cursor, OpenCode, Windsurf, Pi, Copilot
+agent-toolkit doctor
+
+# Or project-local
+npx agent-toolkit-cli doctor
+```
+
+### Other installers
+
+```bash
+# PyPI (same CLI name, platform wheels)
+uvx --from agent-toolkit-cli agent-toolkit install
+uv tool install agent-toolkit-cli
+
+# System packages (release notify → dedicated taps)
+brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
+yay -S agent-toolkit-bin   # Arch Linux (AUR)
+
+# Direct binary
+# https://github.com/ulises-jeremias/agent-toolkit/releases/latest
+```
+
+Full walkthrough: [docs/INSTALLATION.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+---
+
+## Key concepts
+
+<table>
+  <tr>
+    <td width="50%" valign="top">
+      <h3>🛠️ Skills</h3>
+      <sub>Reusable capability units (<code>SKILL.md</code>) that teach an agent how to do a job — delivery, forge CLIs, design, data, ops.</sub>
+      <br><br>
+      <sub>77 skills across domains. Browse with <code>agent-toolkit inventory</code> or <code>agent-toolkit skills list</code>.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <h3>🤖 Agents</h3>
+      <sub>Personas that constrain <em>how</em> the AI works — review, plan, architect, fix CI — without rewriting prompts each time.</sub>
+      <br><br>
+      <sub>17 personas, compiled into each target's native format via <code>install</code>.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h3>🔄 Loops</h3>
+      <sub>Recurring agentic workflows with mutation-safety tiers (L1 observe → L2 controlled → L3 high autonomy).</sub>
+      <br><br>
+      <sub><code>agent-toolkit loop run daily-triage</code> · 10 bundled templates</sub>
+    </td>
+    <td width="50%" valign="top">
+      <h3>🔗 MCP</h3>
+      <sub>Provider registry + ready templates (GitHub, Slack, Notion, Linear, Figma, ClickUp) emitted into target-native configs.</sub>
+      <br><br>
+      <sub><code>agent-toolkit mcp list</code> · <code>mcp setup &lt;provider&gt;</code> · <code>mcp doctor</code></sub>
+    </td>
+  </tr>
+</table>
+
+---
+
+## Supported tools
+
+<div align="center">
+<img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/tools-grid.svg?raw=true" width="96%" alt="Supported AI tools grid">
+</div>
+
+| Tool | What `install` deploys |
+|------|------------------------|
+| **Claude Code** | Plugin manifest, skill references, settings |
+| **Cursor** | Marketplace plugins + `.mdc` rules (IDE + Agent CLI) |
+| **OpenCode** | System prompt overlays, agent configs |
+| **GitHub Copilot** | `copilot-instructions.md` with domain selection |
+| **Windsurf** | Rules and memory files via Cascade (`~/.codeium/windsurf/`) |
+| **Pi Agent** | Skills and loop templates in Pi's native format |
+
+```bash
+agent-toolkit install --tools claude-code,cursor
+agent-toolkit install --dry-run
+agent-toolkit install --force
+```
+
+---
+
+## Command reference
+
+Everyday **consumer** commands vs **advanced** workstation / harness commands.
+Details: [docs/CLI_SURFACES.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/CLI_SURFACES.md)
+
+### Consumer
+
+| Command | Purpose |
+|---------|---------|
+| `install` | Install profiles for detected or selected AI tools |
+| `update` | Refresh installed profiles from latest toolkit data |
+| `uninstall` | Remove toolkit-owned files using install receipts |
+| `doctor` | Check toolkit data and tool availability |
+| `diff` | Show changes vs currently installed plugin bundles |
+| `skills` | Sync, list, and validate skills |
+| `mcp` | MCP provider setup, health, doctor, uninstall |
+| `plugin` | Plugin bundle sync and check |
+
+```bash
+agent-toolkit skills list
+agent-toolkit skills sync --tools claude-code,cursor
+agent-toolkit mcp setup github
+agent-toolkit doctor --fix
+```
+
+### Advanced
+
+Still on the same binary — start here when running an [agentic-harness](https://github.com/ulises-jeremias/agentic-harness)-style workspace:
+
+| Command | Purpose |
+|---------|---------|
+| `loop` | Loop engineering: init, run, status, audit, cost, schedule, sync |
+| `workspace` | Workspace scaffolding: init, context, personas, packs |
+| `memory` | Knowledge base: add, search, inject, review, todo |
+| `project` | Project index: clone, list, add, remove, scan |
+| `devcompanion` | Background job queue (`dc` alias) |
+| `insights` | Local usage analytics (OpenCode, Cursor, Claude) |
+| `inventory` | List skills, agents, and products |
+| `matrix` | Platform capability matrix |
+| `build` / `release` | Compile / release artifacts (maintainer) |
+
+<div align="center">
+<img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/loop-tiers.svg?raw=true" width="88%" alt="Loop autonomy tiers">
+</div>
+
+---
+
+## Upgrade & uninstall
+
+```bash
+npm update -g agent-toolkit-cli
+agent-toolkit update          # refresh deployed profiles
+agent-toolkit uninstall       # remove toolkit-owned files via receipts
+
+npm uninstall -g agent-toolkit-cli
+```
+
+→ [docs/UNINSTALL.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/UNINSTALL.md)
+
+---
+
+## Ecosystem
+
+`agent-toolkit` is the **capability distribution layer (L1.5)** in a personal DX stack:
+
+| Layer | Repo | Role |
+|-------|------|------|
+| **L1** | [agentic-workstation](https://github.com/ulises-jeremias/agentic-workstation) | Machine provisioning — chezmoi, shell, packages, LLM policy |
+| **L1.5** | **agent-toolkit** (this CLI) | Skills, loops, profiles, MCP |
+| **L3** | [agentic-harness](https://github.com/ulises-jeremias/agentic-harness) | AI workspace scaffold — memory, personas, multi-repo orchestration |
+
+---
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [README (monorepo)](https://github.com/ulises-jeremias/agent-toolkit#readme) | Full product overview, skills, agents, packs |
+| [INSTALLATION.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md) | Install paths per tool |
+| [CLI_SURFACES.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/CLI_SURFACES.md) | Consumer vs advanced commands |
+| [ADR-025](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm.md) | npm topology (meta + optionalDeps) |
+| [TRUST.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/TRUST.md) | Trust boundaries and supply chain |
+| [Wiki](https://github.com/ulises-jeremias/agent-toolkit/wiki) | Extended reference |
+
+Publish uses GitHub Actions OIDC trusted publishing (`.github/workflows/publish-npm.yml`) — no long-lived `NPM_TOKEN`.
+
+Canonical sources live in the [agent-toolkit monorepo](https://github.com/ulises-jeremias/agent-toolkit). This package is the installable npm distribution of that source of truth.
+
+---
+
+## Requirements
+
+- **Node.js** 18+
+- Matching platform optionalDependency (installed automatically on supported OS/arch)
+- At least one supported AI coding assistant (for `install` to deploy profiles)
+
+---
+
+## Contributing
+
+Issues and PRs welcome on the monorepo:
+
+- [Contributing guide](https://github.com/ulises-jeremias/agent-toolkit/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.gg/bR5VyATgka)
+
+```bash
+git clone https://github.com/ulises-jeremias/agent-toolkit
+cd agent-toolkit
+node packages/npm/agent-toolkit-cli/bin/agent-toolkit.js --help
+# Dev: AGENT_TOOLKIT_BIN=/path/to/native/agent-toolkit
+```
+
+---
+
+<div align="center">
+
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+
+</div>

--- a/packages/pypi/README.md
+++ b/packages/pypi/README.md
@@ -7,3 +7,20 @@ PyPI adapter sources. npm equivalent: [`packages/npm/`](../npm/).
 | `agent-toolkit-cli/` | `agent-toolkit-cli` | Thin launcher + quarantined Python fallback (`agent-toolkit-py`). CI stamps **platform-tagged wheels** of this single project. |
 
 There are **no** `agent-toolkit-cli-linux-*` Python packages. npm uses `optionalDependencies` per OS; pip consumes PEP 425/600 tags on one distribution (see [`distribution/pypi/README.md`](../../distribution/pypi/README.md)).
+
+## Published README
+
+Consumers see [`agent-toolkit-cli/README.md`](agent-toolkit-cli/README.md) on PyPI (banner / install channels / CLI surfaces). Keep that file in sync with the npm meta-package tone.
+
+## Why `src/` stays
+
+`packages/pypi/agent-toolkit-cli/src/` is **required** — not obsolete after the V cutover ([ADR-021](../../docs/adrs/ADR-021-pypi-binary.md), [python-fallback.md](../../docs/v/python-fallback.md)):
+
+| Path | Role |
+|------|------|
+| `src/agent_toolkit/launcher.py` | Product console scripts `agent-toolkit` / `agent-toolkit-cli` → `exec` the bundled V binary |
+| `src/agent_toolkit/cli/` (+ compiler, installer, …) | Quarantined `agent-toolkit-py` fallback + pytest |
+| `src/agent_toolkit/bin/` | Wheel-time home for the Release V binary (`scripts/pack_pypi.py`) |
+| `src/agent_toolkit/data/` | Capability trees copied by `scripts/prepare-package-data.sh` before pack |
+
+Hatchling builds from this `src` layout (`pyproject.toml` → `packages = ["src/agent_toolkit"]`). Deleting `src/` would break `uv tool install agent-toolkit-cli` and the thin-launcher product path (#540 closed with the launcher kept).

--- a/packages/pypi/agent-toolkit-cli/README.md
+++ b/packages/pypi/agent-toolkit-cli/README.md
@@ -13,8 +13,8 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
 [![Validate](https://img.shields.io/github/actions/workflow/status/ulises-jeremias/agent-toolkit/validate.yml?branch=main&label=validate&style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/actions/workflows/validate.yml)
 
-![skills](https://img.shields.io/badge/skills-61-7c3aed?style=flat&labelColor=1f2937)
-![agents](https://img.shields.io/badge/agents-16-0891b2?style=flat&labelColor=1f2937)
+![skills](https://img.shields.io/badge/skills-77-7c3aed?style=flat&labelColor=1f2937)
+![agents](https://img.shields.io/badge/agents-17-0891b2?style=flat&labelColor=1f2937)
 ![loops](https://img.shields.io/badge/loops-10-ea580c?style=flat&labelColor=1f2937)
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-7c3aed?style=flat&labelColor=1f2937&logo=anthropic&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/claude-code)
@@ -94,13 +94,13 @@ Full walkthrough: [docs/INSTALLATION.md](https://github.com/ulises-jeremias/agen
       <h3>🛠️ Skills</h3>
       <sub>Reusable capability units (<code>SKILL.md</code>) that teach an agent how to do a job — delivery, forge CLIs, design, data, ops.</sub>
       <br><br>
-      <sub>61 skills across 9 domains. Browse with <code>agent-toolkit inventory</code> or <code>agent-toolkit skills list</code>.</sub>
+      <sub>77 skills across domains. Browse with <code>agent-toolkit inventory</code> or <code>agent-toolkit skills list</code>.</sub>
     </td>
     <td width="50%" valign="top">
       <h3>🤖 Agents</h3>
       <sub>Personas that constrain <em>how</em> the AI works — review, plan, architect, fix CI — without rewriting prompts each time.</sub>
       <br><br>
-      <sub>16 personas, compiled into each target's native format via <code>install</code>.</sub>
+      <sub>17 personas, compiled into each target's native format via <code>install</code>.</sub>
     </td>
   </tr>
   <tr>

--- a/scripts/pack_npm.py
+++ b/scripts/pack_npm.py
@@ -33,7 +33,11 @@ def write_platform_package(spec: dict, ver: str, src_bin: Path | None) -> Path:
         "license": "MIT",
         "os": [spec["os"]],
         "cpu": [spec["cpu"]],
-        "files": [f"bin/{spec['bin']}"],
+        "files": ["README.md", f"bin/{spec['bin']}"],
+        "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+        "bugs": {
+            "url": "https://github.com/ulises-jeremias/agent-toolkit/issues",
+        },
         "repository": {
             "type": "git",
             "url": "git+https://github.com/ulises-jeremias/agent-toolkit.git",

--- a/tests/test_pack_npm.py
+++ b/tests/test_pack_npm.py
@@ -35,6 +35,7 @@ def test_pack_npm_copies_floating_linux_binary(tmp_path: Path) -> None:
             (REPO / "packages/npm/agent-toolkit-cli-linux-x64/package.json").read_text()
         )
         assert pkg["version"] == "9.9.9"
+        assert "README.md" in pkg["files"]
         meta = json.loads((REPO / "packages/npm/agent-toolkit-cli/package.json").read_text())
         assert meta["version"] == "9.9.9"
     finally:


### PR DESCRIPTION
## Summary
- Bring every published npm package README up to the quality bar of `packages/pypi/agent-toolkit-cli/README.md` (banner, badges, install channels, platform notes, docs links)
- Add polished shorter READMEs for platform packages (`agent-toolkit-cli-linux-x64`, etc.) and keep `scripts/pack_npm.py` shipping `README.md` in `files`
- Document why `packages/pypi/agent-toolkit-cli/src/` **stays** (thin V launcher + quarantined `agent-toolkit-py`; hatchling `src` layout) — not obsolete after ADR-021
- Refresh PyPI adapter inventory badges (77 skills / 17 agents) to match the monorepo

## `src/` decision
**Keep.** Investigation (ADR-021, `python-fallback.md`, `pyproject.toml` scripts):
- `launcher.py` / `__main__.py` are the product entrypoints that `exec` the bundled V binary
- `cli/` + friends remain as `agent-toolkit-py` fallback + pytest parity (#540 closed with launcher kept)
- Removing `src/` would break Hatch packaging and console scripts

## Test plan
- [x] `node --test packages/npm/agent-toolkit-cli/test/launcher.test.js`
- [x] `pytest tests/test_pack_npm.py`
- [x] Assert every `packages/npm/*/README.md` exists and is non-trivial
- [ ] Required CI green on this PR
- [ ] No retag / no release — lands on main for the next publish


Made with [Cursor](https://cursor.com)