### PR TITLE
docs(aur): fix AUR playbook to agent-toolkit-bin (D02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
+- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
 

--- a/docs/AUR_PLAYBOOK.md
+++ b/docs/AUR_PLAYBOOK.md
@@ -2,9 +2,15 @@
 
 Manual re-dispatch for `aur-packages` when the AUR leaves maintenance or a publish is missed.
 
+## Canonical package
+
+* **Product package:** `agent-toolkit-bin` — V binaries from GitHub Releases (ADR-024 / [distribution/aur/README.md](../distribution/aur/README.md)).
+* Notify workflow: `.github/workflows/notify-aur.yml` dispatches `package_name=agent-toolkit-bin`.
+* **Legacy:** An older Python-oriented AUR package named `agent-toolkit` may still exist. Do **not** update it for V releases; consumers should use `yay -S agent-toolkit-bin` (or `uv tool install agent-toolkit-cli`).
+
 ## When to use
 
-* README advertises `yay -S agent-toolkit` but `https://aur.archlinux.org/rpc/v5/info?arg[]=agent-toolkit` returns `resultcount: 0`
+* README advertises `yay -S agent-toolkit-bin` but `https://aur.archlinux.org/rpc/v5/info?arg[]=agent-toolkit-bin` returns `resultcount: 0`
 * A new tag `vX.Y.Z` was pushed and downstream `aur-packages` did not publish (retry window exhausted)
 * Maintainer intentionally wants to replay a release to AUR without re-tagging
 
@@ -12,15 +18,15 @@ Manual re-dispatch for `aur-packages` when the AUR leaves maintenance or a publi
 
 * `gh` CLI authenticated (`gh auth status`)
 * Maintainer access to `ulises-jeremias/aur-packages` (repo admin or dispatch permission)
-* Version matches a published tag and PyPI `agent-toolkit-cli` version
+* Version matches a published tag and GitHub Release assets for that tag
 
 ## Re-dispatch (one command)
 
 ```bash
-VERSION=v1.3.0  # or latest tag, without leading spaces
+VERSION=v1.12.1  # or latest tag, without leading spaces
 gh api repos/ulises-jeremias/aur-packages/dispatches \
   -f event_type=new-release \
-  -f 'client_payload[package_name]=agent-toolkit' \
+  -f 'client_payload[package_name]=agent-toolkit-bin' \
   -f "client_payload[version]=$VERSION"
 ```
 
@@ -34,7 +40,7 @@ gh run list --repo ulises-jeremias/aur-packages --limit 5
 
 ```bash
 # AUR RPC should show pkgver matching latest release
-curl -sS 'https://aur.archlinux.org/rpc/v5/info?arg[]=agent-toolkit' | python3 -m json.tool
+curl -sS 'https://aur.archlinux.org/rpc/v5/info?arg[]=agent-toolkit-bin' | python3 -m json.tool
 
 # Update README AUR section to full install instructions only after RPC shows pkgver
 ```
@@ -50,4 +56,4 @@ agent-toolkit install
 uvx --from agent-toolkit-cli agent-toolkit install
 ```
 
-Do not advertise `yay -S agent-toolkit` as working until verified per above.
+Do not advertise `yay -S agent-toolkit-bin` as working until verified per above. Do not advertise legacy `yay -S agent-toolkit` for the V product.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,7 +81,7 @@ python3 scripts/bump-version.py 1.3.0         # writes files
 * **GitHub Release:** delete tag locally + remote + release, fix, re-tag. Prefer `gh release delete v1.3.0 --yes && git tag -d v1.3.0 && git push origin :v1.3.0`.
 * **Homebrew/AUR:** downstream repos are notified via `repository_dispatch` from `release.yml` `create-release`. If they missed, replay per `docs/AUR_PLAYBOOK.md`:
   ```bash
-  gh api repos/ulises-jeremias/aur-packages/dispatches -f event_type=new-release -f 'client_payload[package_name]=agent-toolkit' -f 'client_payload[version]=v1.3.0'
+  gh api repos/ulises-jeremias/aur-packages/dispatches -f event_type=new-release -f 'client_payload[package_name]=agent-toolkit-bin' -f 'client_payload[version]=v1.3.0'
   ```
 
 ## Asset naming
@@ -148,6 +148,6 @@ See `docs/AUR_PLAYBOOK.md` for re-dispatch when AUR leaves maintenance.
 Re-dispatch example:
 
 ```bash
-gh api repos/ulises-jeremias/aur-packages/dispatches -f event_type=new-release -f 'client_payload[package_name]=agent-toolkit' -f 'client_payload[version]=v1.3.0'
+gh api repos/ulises-jeremias/aur-packages/dispatches -f event_type=new-release -f 'client_payload[package_name]=agent-toolkit-bin' -f 'client_payload[version]=v1.3.0'
 gh api repos/ulises-jeremias/homebrew-tap/dispatches -f event_type=new-release -f 'client_payload[formula_name]=agent-toolkit' -f 'client_payload[version]=1.3.0'
 ```


### PR DESCRIPTION
## Summary
- Point `docs/AUR_PLAYBOOK.md` (and RELEASING AUR replay examples) at **`agent-toolkit-bin`**, matching `.github/workflows/notify-aur.yml` and ADR-024.
- Document that legacy AUR package `agent-toolkit` is not the V product path.

Fixes #675

## Test plan
- [ ] Playbook package_name matches notify-aur.yml (`agent-toolkit-bin`)
- [ ] Verify section uses AUR RPC for `agent-toolkit-bin`
- [ ] Legacy `agent-toolkit` called out as non-product


Made with [Cursor](https://cursor.com)