### PR TITLE
docs(pypi): republish via release.yml OIDC (D11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays

--- a/distribution/pypi/README.md
+++ b/distribution/pypi/README.md
@@ -36,7 +36,13 @@ bash scripts/prepare-package-data.sh
 python3 scripts/pack_pypi.py   # sdist + one wheel per present asset → dist/
 ```
 
-- Tag releases: `.github/workflows/release.yml` `publish-pypi` (after `upload-assets`).
-- Manual republish (e.g. v1.11.0 after the manylinux fix): workflow **Publish (manual)** — downloads `v$(cat VERSION)` Release assets and packs the same way.
+- Tag releases: `.github/workflows/release.yml` `publish-pypi` (after `upload-assets`) via **OIDC Trusted Publishing** (environment `pypi`). See [docs/RELEASING.md](../../docs/RELEASING.md).
+- Manual republish of an existing `VERSION` (no retag): re-run **Release** (`release.yml`) with `workflow_dispatch` — Trusted Publishing is registered for that workflow, not `publish.yml`:
+
+  ```bash
+  gh workflow run Release --ref main -f environment=pypi
+  ```
+
+  Historical note: `Publish (manual)` (`publish.yml`) can still pack wheels but OIDC fails until that filename is also registered on PyPI — prefer `release.yml`.
 
 Console scripts: `agent-toolkit` / `agent-toolkit-cli` → `agent_toolkit.launcher:main` (exec V). `agent-toolkit-py` is a quarantined fallback ([docs/v/python-fallback.md](../../docs/v/python-fallback.md)).


### PR DESCRIPTION
## Summary
- Update `distribution/pypi/README.md` republish guidance to match `docs/RELEASING.md` / `release.yml` OIDC.
- Mark `Publish (manual)` (`publish.yml`) as historical-only (OIDC not registered).

Fixes #676

## Test plan
- [ ] README republish steps match RELEASING.md `gh workflow run Release …`
- [ ] Manual Publish path labeled historical-only


Made with [Cursor](https://cursor.com)