### PR TITLE
ci: require check-surfaces in required-ci (C01)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -728,6 +728,7 @@ jobs:
       - validate-manifests
       - validate-agent-plugins
       - validate-upstream
+      - check-surfaces
       - check-skill-matrix
       - validate-loops
       - validate-products
@@ -750,6 +751,7 @@ jobs:
           if [[ "${{ needs.validate-manifests.result }}" != "success" ]]; then echo "validate-manifests failed: ${{ needs.validate-manifests.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-agent-plugins.result }}" != "success" ]]; then echo "validate-agent-plugins failed: ${{ needs.validate-agent-plugins.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-upstream.result }}" != "success" ]]; then echo "validate-upstream failed: ${{ needs.validate-upstream.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-surfaces.result }}" != "success" ]]; then echo "check-surfaces failed: ${{ needs.check-surfaces.result }}"; failed="true"; fi
           if [[ "${{ needs.check-skill-matrix.result }}" != "success" ]]; then echo "check-skill-matrix failed: ${{ needs.check-skill-matrix.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-loops.result }}" != "success" ]]; then echo "validate-loops failed: ${{ needs.validate-loops.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-products.result }}" != "success" ]]; then echo "validate-products failed: ${{ needs.validate-products.result }}"; failed="true"; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Chore** — scripts/install.sh and doctor.sh are thin wrappers around the V CLI (Fixes #683)
-- **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
-- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
+- **CI** — Include `check-surfaces` in `required-ci` needs so surface drift cannot merge (Fixes #677)
+- **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
+- **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
 - **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
 - **Packaging** — Bump Dockerfile default `ARG VERSION` to match `VERSION` (1.12.1)
 - **Docs** — Note that wiki-style `[[Page]]` links in docs/wiki are intentional for wiki-sync
-- **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
 - **CI** — Docker push-to-main is smoke-only; registry push requires Release assets (Fixes #679)
+- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
+- **Chore** — scripts/install.sh and doctor.sh are thin wrappers around the V CLI (Fixes #683)
 
 
 ## [1.12.1] — 2026-08-13


### PR DESCRIPTION
## Summary
- Add `check-surfaces` to `required-ci` `needs` and the aggregate result checks in `.github/workflows/validate.yml`.

Fixes #677

## Test plan
- [ ] Required CI depends on Check Plugin Bundle Sync
- [ ] validate.yml still parses; PR CI green


Made with [Cursor](https://cursor.com)