### PR TITLE
docs(swarms): fix broken CLI_REFERENCE link (D05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
-- **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
-- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
+- **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
+- **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
+- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
+- **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
+
 
 ## [1.12.1] — 2026-08-13
 

--- a/docs/SWARMS.md
+++ b/docs/SWARMS.md
@@ -171,7 +171,7 @@ Related: [SWARM_RECIPES.md](SWARM_RECIPES.md) · [SWARM_HANDOFFS.md](SWARM_HANDO
 
 Missing tools produce actionable installation guidance. Run `agent-toolkit doctor` for a
 complete installation health picture that includes swarm prerequisites alongside system,
-AI tool, profile, loop, LLM, MCP, and scheduled-loops checks. See [CLI_REFERENCE.md](CLI_REFERENCE.md)
+AI tool, profile, loop, LLM, MCP, and scheduled-loops checks. See [CLI_SURFACES.md](CLI_SURFACES.md)
 for the full list.
 
 ## No Cloud Required


### PR DESCRIPTION
## Summary
- Point SWARMS.md doctor section at `docs/CLI_SURFACES.md` (CLI_REFERENCE.md does not exist)

Fixes #685

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #685
- [ ] Required CI green

Made with [Cursor](https://cursor.com)