### PR TITLE
chore(docker): bump Dockerfile ARG VERSION to 1.12.1 (D08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
+- **Packaging** — Bump Dockerfile default `ARG VERSION` to match `VERSION` (1.12.1)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
+- **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
 
 
 ## [1.12.1] — 2026-08-13

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 # A default of amd64 installs the x86_64 ELF into the linux/arm64 image; exec
 # then fails with "not found" (missing amd64 dynamic linker).
 ARG TARGETARCH
-ARG VERSION=1.11.0
+ARG VERSION=1.12.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git curl ca-certificates \


### PR DESCRIPTION
## Summary
- Align Dockerfile default `ARG VERSION` with repo `VERSION` file (1.12.1)

Fixes #687

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #687
- [ ] Required CI green

Made with [Cursor](https://cursor.com)