### PR TITLE
fix(products): correct version_source path after pypi move (D07)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Docs** — Homebrew README links in-repo ADR-023 path (keep #490 as discussion)
+- **Fixed** — `distributions/products.yaml` `version_source` points at packages/pypi layout
 - **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Chore** — scripts/install.sh and doctor.sh are thin wrappers around the V CLI (Fixes #683)
 - **CI** — Include `check-surfaces` in `required-ci` needs so surface drift cannot merge (Fixes #677)
 - **Docs** — ADR-007 / install messaging aligned V-first (thin wrappers to agent-toolkit) (Fixes #682)
+- **Docs** — Homebrew README links in-repo ADR-023 path (keep #490 as discussion)
 
 
 ## [1.12.1] — 2026-08-13

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -4,7 +4,7 @@ products:
   - id: agent-toolkit-core
     name: Agent Toolkit Core
     description: Core orchestration skills, dev companion, output handshake, PR fallback, and code-reviewer agent. The baseline install for any project.
-    version_source: src/agent_toolkit/__init__.py
+    version_source: packages/pypi/agent-toolkit-cli/src/agent_toolkit/__init__.py
     stability: stable
     includes:
       skills:
@@ -38,7 +38,7 @@ products:
   - id: agent-toolkit-agents
     name: Agent Toolkit Agents
     description: 'Full set of 16 AI agent personas: architect, code-reviewer, security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.'
-    version_source: src/agent_toolkit/__init__.py
+    version_source: packages/pypi/agent-toolkit-cli/src/agent_toolkit/__init__.py
     stability: stable
     includes:
       skills: []
@@ -71,7 +71,7 @@ products:
   - id: agent-toolkit-forge
     name: Agent Toolkit Forge
     description: 'GitHub and GitLab automation skills: PR workflows, CI fixes, comment resolution, and contribution planning.'
-    version_source: src/agent_toolkit/__init__.py
+    version_source: packages/pypi/agent-toolkit-cli/src/agent_toolkit/__init__.py
     stability: stable
     includes:
       skills:

--- a/tests/test_packs_390.py
+++ b/tests/test_packs_390.py
@@ -41,8 +41,11 @@ def test_packs_coherent_workflow_not_everything():
 def test_packs_are_docs_only_not_compiler_wired():
     # Ensure packs not referenced in distributions/products.yaml as composition layer
     prod = yaml.safe_load((ROOT / "distributions/products.yaml").read_text())
-    # products.yaml should not have pack field
-    assert not any("pack" in str(p) for p in prod.get("products", []))
+    # products.yaml should not have pack/packs composition fields
+    # (do not substring-search product dicts — version_source may contain "packages/")
+    for p in prod.get("products", []):
+        assert "pack" not in p
+        assert "packs" not in p
 
 
 def test_inventory_and_context_budget_surface():


### PR DESCRIPTION
## Summary
- Update `version_source` to `packages/pypi/agent-toolkit-cli/src/agent_toolkit/__init__.py`

Fixes #690

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #690
- [ ] Required CI green

Made with [Cursor](https://cursor.com)