### PR TITLE
docs(ci): align experimental-v.yml header with ADR-018 (D10)

### DIFF
--- a/.github/workflows/experimental-v.yml
+++ b/.github/workflows/experimental-v.yml
@@ -1,7 +1,8 @@
 name: Experimental V binaries
 
 # Native V MUST matrix (#529) with experimental artifact names (#562 / ADR-018).
-# MUST NOT upload over stable PyInstaller channel names. Promotion is a later release decision.
+# Uploads use ADR-018 experimental names only — never overwrite stable GitHub Release
+# channel assets (agent-toolkit-<os>-<arch>). Promotion to stable is a later release decision.
 
 on:
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Clarify experimental-v.yml header (ADR-018; drop PyInstaller channel wording)
 - **Packaging** — PyPI classifier Development Status Beta → Production/Stable
 - **Docs** — ADR-007 / install messaging aligned V-first (thin wrappers to agent-toolkit) (Fixes #682)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)


### PR DESCRIPTION
## Summary
- Rewrite workflow header to describe ADR-018 experimental artifact names (no PyInstaller channel wording)

Fixes #693

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #693
- [ ] Required CI green

Made with [Cursor](https://cursor.com)