### PR TITLE
chore(ci): remove gone packaging from MegaLinter exclude (C04)

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -18,7 +18,7 @@ DISABLE_ERRORS_LINTERS:
 # Only lint changed files on PR, all files on main
 VALIDATE_ALL_CODEBASE: false
 
-FILTER_REGEX_EXCLUDE: '(\.git|node_modules|\.venv|megalinter-reports|skills/.*/data/.*\.csv|profiles/claude-code/settings\.json|packaging)'
+FILTER_REGEX_EXCLUDE: '(\.git|node_modules|\.venv|megalinter-reports|skills/.*/data/.*\.csv|profiles/claude-code/settings\.json)'
 
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yaml
 YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **CI** — Drop stale `packaging` path from MegaLinter FILTER_REGEX_EXCLUDE
 - **Chore** — Migrate repo tooling scripts from Python to V (`.vsh`); add `make.vsh` with thin Makefile forwarder; keep `provenance.py` / `validate-upstream.py` and PyPI launcher Python; host skills use CLI / Grep (repo-root `scripts/` is checkout/CI only)
 - **Docs** — Clarify experimental-v.yml header (ADR-018; drop PyInstaller channel wording)
 - **Packaging** — PyPI classifier Development Status Beta → Production/Stable


### PR DESCRIPTION
## Summary
- Remove obsolete `packaging` directory from `FILTER_REGEX_EXCLUDE`

Fixes #695

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #695
- [ ] Required CI green

Made with [Cursor](https://cursor.com)