### PR TITLE
docs(wiki): document intentional wiki-style links (D14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Packaging** — Bump Dockerfile default `ARG VERSION` to match `VERSION` (1.12.1)
+- **Docs** — Note that wiki-style `[[Page]]` links in docs/wiki are intentional for wiki-sync
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
 - **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
+- **Packaging** — Bump Dockerfile default `ARG VERSION` to match `VERSION` (1.12.1)
 
 
 ## [1.12.1] — 2026-08-13

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,12 @@ Thank you for your interest in contributing. This document covers everything you
 
 ---
 
+## Wiki mirror links
+
+The `docs/wiki/` tree is a mirror for GitHub Wiki sync. Wiki-style `[[Page]]` links there
+are intentional — see `docs/wiki/Contributing.md`. Do not rewrite them to relative markdown
+as a drive-by fix.
+
 ## Prerequisites
 
 - **Git** 2.30 or later

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -7,3 +7,12 @@ Canonical contributor docs:
 - [`docs/HOW_TO_DEVELOP_V.md`](../HOW_TO_DEVELOP_V.md) — V CLI (product). Python is the PyPI launcher + tests only.
 
 The repo is **not** a uv workspace and **not** installed with `pip install -e .`. Build the CLI with `make build-cli` → `build/agent-toolkit`.
+
+## Wiki-style links (intentional)
+
+Pages under `docs/wiki/` may use GitHub wiki-style links such as `[[Installation]]` or
+wiki-relative targets. These look broken when browsing the git tree, but **wiki-sync**
+(`.github/workflows/wiki-sync.yml`) publishes this mirror to the GitHub Wiki where those
+links resolve. Do **not** mass-convert them to relative markdown without checking the
+wiki-sync pipeline.
+


### PR DESCRIPTION
## Summary
- Add short note in CONTRIBUTING and docs/wiki/Contributing.md that wiki-style links are intentional for wiki-sync (do not blind-rewrite)

Fixes #694

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #694
- [ ] Required CI green

Made with [Cursor](https://cursor.com)