### PR TITLE
test(cli): stop treating insights as normal advanced cmd (T01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Tests** — Stop treating `insights` as a normal ADVANCED_COMMANDS harness entry (DEPRECATE #526)
 - **CI** — Fix validate.yml yamllint empty-lines after check-build insert
 - **CI** — ADR-003 dual-run: add `check-build` (`build --check`) alongside gen-surfaces (Fixes #678)
 - **Products** — Include `agentic-security-reviewer` in `agent-toolkit-agents` (Fixes #689)

--- a/tests/test_cli_surfaces.py
+++ b/tests/test_cli_surfaces.py
@@ -12,5 +12,16 @@ def test_help_lists_advanced_section() -> None:
 
 
 def test_advanced_commands_include_harness() -> None:
-    for cmd in ("loop", "workspace", "memory", "project", "devcompanion", "insights"):
+    """Active advanced harness commands (excludes DEPRECATE/REMOVE dispositions)."""
+    for cmd in ("loop", "workspace", "memory", "project", "devcompanion", "swarm"):
         assert cmd in main_mod.ADVANCED_COMMANDS
+
+
+def test_insights_deprecated_not_primary_advanced() -> None:
+    """insights remains wired for back-compat but is DEPRECATE (#526/#560), not a normal advanced cmd."""
+    assert "insights" in main_mod.ADVANCED_COMMANDS  # still registered
+    # Consumer help advanced blurb should not present insights as a featured harness command
+    # in the same breath as loop/workspace (disposition: DEPRECATE — no V requirement).
+    advanced_help = main_mod._CONSUMER_HELP
+    # Prefer explicit disposition docs over help-table membership; ensure release REMOVE (#527)
+    assert "release" in main_mod.ADVANCED_COMMANDS

--- a/tests/test_cli_surfaces.py
+++ b/tests/test_cli_surfaces.py
@@ -1,6 +1,18 @@
 """CLI surface grouping tests (#84)."""
 
+from pathlib import Path
+
 from agent_toolkit.cli import main as main_mod
+
+# Required advanced harness surfaces (PORT/REDESIGN per #560). Not DEPRECATE/REMOVE.
+REQUIRED_ADVANCED = (
+    "loop",
+    "workspace",
+    "memory",
+    "project",
+    "devcompanion",
+    "swarm",
+)
 
 
 def test_help_lists_advanced_section() -> None:
@@ -12,16 +24,19 @@ def test_help_lists_advanced_section() -> None:
 
 
 def test_advanced_commands_include_harness() -> None:
-    """Active advanced harness commands (excludes DEPRECATE/REMOVE dispositions)."""
-    for cmd in ("loop", "workspace", "memory", "project", "devcompanion", "swarm"):
+    for cmd in REQUIRED_ADVANCED:
         assert cmd in main_mod.ADVANCED_COMMANDS
 
 
-def test_insights_deprecated_not_primary_advanced() -> None:
-    """insights remains wired for back-compat but is DEPRECATE (#526/#560), not a normal advanced cmd."""
-    assert "insights" in main_mod.ADVANCED_COMMANDS  # still registered
-    # Consumer help advanced blurb should not present insights as a featured harness command
-    # in the same breath as loop/workspace (disposition: DEPRECATE — no V requirement).
-    advanced_help = main_mod._CONSUMER_HELP
-    # Prefer explicit disposition docs over help-table membership; ensure release REMOVE (#527)
-    assert "release" in main_mod.ADVANCED_COMMANDS
+def test_insights_release_not_required_advanced() -> None:
+    """insights is DEPRECATE (#526); release is REMOVE (#527) — not required ADVANCED_COMMANDS.
+
+    Quarantined Python may still register the names for compatibility; tests must not
+    treat them as members of the required advanced harness set (T01 / #692).
+    """
+    assert "insights" not in REQUIRED_ADVANCED
+    assert "release" not in REQUIRED_ADVANCED
+
+    surfaces = Path("docs/CLI_SURFACES.md").read_text()
+    assert "DEPRECATE" in surfaces and "#526" in surfaces
+    assert "REMOVE" in surfaces and "#527" in surfaces


### PR DESCRIPTION
## Summary
- Split harness assertions from `insights`/`release` disposition (DEPRECATE #526 / REMOVE #527)

Fixes #692

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #692
- [ ] Required CI green

Made with [Cursor](https://cursor.com)