### PR TITLE
docs: mark insights/release DEPRECATE/REMOVE in SCOPE surfaces (D04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Docs** — Note that wiki-style `[[Page]]` links in docs/wiki are intentional for wiki-sync
+- **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
 - **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
 - **Packaging** — Bump Dockerfile default `ARG VERSION` to match `VERSION` (1.12.1)
+- **Docs** — Note that wiki-style `[[Page]]` links in docs/wiki are intentional for wiki-sync
 
 
 ## [1.12.1] — 2026-08-13

--- a/docs/CLI_SURFACES.md
+++ b/docs/CLI_SURFACES.md
@@ -35,11 +35,11 @@ Still available on the same binary — de-emphasized in top-level help:
 | `memory` | Knowledge base: add, search, inject, review, todo |
 | `project` | Project index: clone, list, add, remove, scan |
 | `devcompanion` | Background job queue (`dc` alias) |
-| `insights` | Local usage analytics (OpenCode, Cursor, Claude) |
+| `insights` | **DEPRECATE** — local usage analytics (OpenCode, Cursor, Claude); [#526](https://github.com/ulises-jeremias/agent-toolkit/issues/526) |
 | `build` | Compile canonical capabilities into target artifacts |
 | `inventory` | List skills, agents, and products |
 | `matrix` | Platform capability matrix |
-| `release` | Generate release artifacts (maintainer / CI) |
+| `release` | **REMOVE** — release artifacts (CI / `docs/RELEASING.md`); [#527](https://github.com/ulises-jeremias/agent-toolkit/issues/527) |
 | `swarm` | Multi-agent swarm orchestration (pair/team/full, Herdr/tmux, budgets, handoffs) |
 
 Swarm details: `docs/SWARMS.md`, `docs/SWARM_ARCHITECTURE.md`.

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -30,12 +30,19 @@ marketplace consumer path:
 | `memory` | Local knowledge base CRUD |
 | `project` | Project index / clone helpers |
 | `devcompanion` | Background LLM job queue |
-| `insights` | Usage analytics from local tool stores |
 | `swarm` | Multi-agent swarm orchestration (pair/team/full, Herdr/tmux) |
 
 These commands remain available without a separate binary; help text lists
 them under **Advanced commands** so new users are not overwhelmed.
 
-Maintainer-only: `release` (hidden from primary help; wired for CI).
+### Disposition (not primary advanced UX)
+
+| Command | Disposition | Tracking |
+|---------|-------------|----------|
+| `insights` | **DEPRECATE** (no V port requirement) | [#526](https://github.com/ulises-jeremias/agent-toolkit/issues/526), [#560](https://github.com/ulises-jeremias/agent-toolkit/issues/560) |
+| `release` | **REMOVE** (CI / `docs/RELEASING.md`) | [#527](https://github.com/ulises-jeremias/agent-toolkit/issues/527) |
+
+`insights` may still be wired for back-compat; do not present it as a recommended harness command.
+`release` is maintainer/CI-only and is being removed from the product CLI surface.
 
 See also: [`CLI_SURFACES.md`](CLI_SURFACES.md), `docs/CONCEPTS.md`, `docs/INSTALLATION.md`.


### PR DESCRIPTION
## Summary
- Call out insights DEPRECATE (#526) and release REMOVE (#527) in SCOPE.md and CLI_SURFACES.md advanced tables

Fixes #684

## Test plan
- [ ] Spot-check changed files match acceptance criteria for #684
- [ ] Required CI green

Made with [Cursor](https://cursor.com)