### PR TITLE
ci(docker): smoke-only on main; gate push on assets (C02)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,8 +71,41 @@ jobs:
         if: github.event_name == 'pull_request'
         run: docker run --rm agent-toolkit:ci version
 
+      # Push only when Release assets exist (workflow_call from release.yml),
+      # a published release, or an explicit workflow_dispatch. Push-to-main is
+      # smoke-only so VERSION bumps cannot publish before GitHub Release assets.
+      - name: Build native image (main smoke)
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          build-args: |
+            VERSION=${{ steps.ver.outputs.version }}
+          tags: agent-toolkit:ci
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Smoke native image (main)
+        if: github.event_name == 'push'
+        run: docker run --rm agent-toolkit:ci version
+
+      - name: Require Release assets before push
+        if: github.event_name == 'workflow_call' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ steps.ver.outputs.version }}"
+          echo "Checking Release assets for $TAG"
+          assets=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets -q '.assets[].name' || true)
+          echo "$assets"
+          echo "$assets" | grep -q 'agent-toolkit-linux-x86_64' || {
+            echo "::error::Missing agent-toolkit-linux-x86_64 on $TAG — refuse Docker push"
+            exit 1
+          }
+
       - name: Build and push
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_call' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -84,7 +117,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Smoke published amd64 image
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_call' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
-- **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
-- **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
+- **CI** — Docker push-to-main is smoke-only; registry push requires Release assets (Fixes #679)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
+- **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
+- **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
 - **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
 - **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
 - **Packaging** — Bump Dockerfile default `ARG VERSION` to match `VERSION` (1.12.1)
 - **Docs** — Note that wiki-style `[[Page]]` links in docs/wiki are intentional for wiki-sync
+- **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
 
 
 ## [1.12.1] — 2026-08-13

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -42,3 +42,15 @@ The Dockerfile MUST NOT `exec` the V binary during `RUN` (QEMU user-mode for the
 - Multi-arch: `linux/amd64` + `linux/arm64` (glibc), matching ADR-018.
 
 Owner of the Dockerfile remains this repo (unlike Homebrew/AUR).
+
+## CI triggers
+
+| Event | Behavior |
+|-------|----------|
+| `pull_request` (Dockerfile paths) | Native smoke build (`load`); no registry push |
+| `push` to `main` (Dockerfile paths) | Native smoke build only — **no push** (avoids racing ahead of Release assets) |
+| `workflow_call` from `release.yml` after `upload-assets` | Multi-arch build **and push** (preferred path) |
+| `release: published` / `workflow_dispatch` | Multi-arch build **and push**, after verifying `v$(VERSION)` Release has linux assets |
+
+`GITHUB_TOKEN`-created Releases do not start sibling `on: release` workflows; prefer `workflow_call` from `release.yml`.
+


### PR DESCRIPTION
## Summary
- `push` to `main` builds a native smoke image only (no registry push).
- Registry push runs on `workflow_call` / `release` / `workflow_dispatch` after verifying `v$(VERSION)` has `agent-toolkit-linux-x86_64`.
- Document trigger matrix in `distribution/docker/README.md`.

Fixes #679

## Test plan
- [ ] PR path still smokes
- [ ] Main path does not push
- [ ] release.yml workflow_call still pushes after assets

Made with [Cursor](https://cursor.com)