### PR TITLE
docs(skills): replace bin/loop with agent-toolkit loop (D01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Teach `agent-toolkit loop` instead of obsolete `bin/loop` in skills/packs/loop.yaml (Fixes #680)
 - **Tests** — Stop treating `insights` as a normal ADVANCED_COMMANDS harness entry (DEPRECATE #526)
 - **CI** — Fix validate.yml yamllint empty-lines after check-build insert
 - **CI** — ADR-003 dual-run: add `check-build` (`build --check`) alongside gen-surfaces (Fixes #678)

--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -315,7 +315,7 @@ skills:
   - id: loops/loop-runner
     name: loop-runner
     domain: loops
-    description: 'Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via bin/loop CLI.'
+    description: 'Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via the agent-toolkit loop CLI.'
     stability: stable
   - id: ops/docs-generator
     name: docs-generator

--- a/loops/daily-triage/loop.yaml
+++ b/loops/daily-triage/loop.yaml
@@ -3,8 +3,8 @@
 # Cadence: once per day. Cost: low. Tier: L1 (report-only).
 #
 # Usage:
-#   ./bin/loop init daily-triage --repo owner/repo
-#   ./bin/loop run daily-triage
+#   agent-toolkit loop init daily-triage --repo owner/repo
+#   agent-toolkit loop run daily-triage
 
 name: daily-triage
 description: "Triage new issues and propose labels (report-only)"

--- a/loops/oss-pr-monitor/loop.yaml
+++ b/loops/oss-pr-monitor/loop.yaml
@@ -5,7 +5,7 @@
 # Tier L3 is required: merge/close are forbidden at L2 by loop-gh-gate.
 #
 # Usage:
-#   ./bin/loop init oss-pr-monitor --pack packs/my-ecosystem.yaml
+#   agent-toolkit loop init oss-pr-monitor --pack packs/my-ecosystem.yaml
 
 name: oss-pr-monitor
 description: "Monitor open PRs across OSS ecosystem repos and take action (L3, daily)"

--- a/loops/pr-babysitter/loop.yaml
+++ b/loops/pr-babysitter/loop.yaml
@@ -3,7 +3,7 @@
 # Cadence: 15 minutes. Cost: high. Tier: L2 (PR-gated).
 #
 # Usage:
-#   ./bin/loop init pr-babysitter --repo owner/repo
+#   agent-toolkit loop init pr-babysitter --repo owner/repo
 
 name: pr-babysitter
 description: "Monitor open PRs and post review comments (L2, PR-gated)"

--- a/packs/oss-maintenance/README.md
+++ b/packs/oss-maintenance/README.md
@@ -23,7 +23,7 @@ Automate PR review, issue triage, and daily briefings across a multi-repo OSS ec
   gh auth status
   gh auth login   # if not authenticated
   ```
-- A loop runner available. The loops are designed for use with the `bin/loop` runner from [ai-workspace](https://github.com/ulises-jeremias/ai-workspace), but the `request` prompt in each `loop.yaml` can be run manually or with any compatible runner.
+- A loop runner available. The loops are designed for use with the `agent-toolkit loop` runner from [agentic-harness](https://github.com/ulises-jeremias/agentic-harness), but the `request` prompt in each `loop.yaml` can be run manually or with any compatible runner.
 - Token budget: see [Budget Sizing](#budget-sizing) below.
 
 ---
@@ -71,13 +71,13 @@ Start read-only. Graduate to each tier only after confirming the previous tier r
 
 ```bash
 # Tier 1: Daily briefing (read-only, lowest cost)
-./bin/loop run oss-daily-briefing
+agent-toolkit loop run oss-daily-briefing
 
 # Tier 1: Issue triage (label + comment, medium cost)
-./bin/loop run oss-triage
+agent-toolkit loop run oss-triage
 
 # Tier 2: PR monitor (merge + close, highest cost — REVIEW THE REPORT FIRST)
-./bin/loop run oss-pr-monitor
+agent-toolkit loop run oss-pr-monitor
 ```
 
 ---

--- a/packs/oss-maintenance/config.yaml
+++ b/packs/oss-maintenance/config.yaml
@@ -4,7 +4,7 @@
 # Usage:
 #   cp packs/oss-maintenance/config.yaml ~/.ai-workspace/packs/oss-maintenance.yaml
 #   # Edit repos list, then run:
-#   ./bin/loop run oss-daily-briefing --pack ~/.ai-workspace/packs/oss-maintenance.yaml
+#   agent-toolkit loop run oss-daily-briefing --pack ~/.ai-workspace/packs/oss-maintenance.yaml
 #
 # See packs/oss-maintenance/README.md for full setup instructions.
 

--- a/plugins/agent-toolkit-complete/.github/skills/loop-runner/SKILL.md
+++ b/plugins/agent-toolkit-complete/.github/skills/loop-runner/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: loop-runner
-description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via bin/loop CLI.
+description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding
+  session via the agent-toolkit loop CLI.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
+  version: '1.1'
 ---
-
 # loop-runner
 
 > Execute and manage loop engineering primitives from an AI coding session.
@@ -14,8 +16,7 @@ metadata:
 
 ## What this skill does
 
-This skill wraps the `bin/loop` CLI from
-[ai-workspace](https://github.com/ulises-jeremias/ai-workspace), exposing loop
+This skill wraps the **`agent-toolkit loop`** CLI (V product command), exposing loop
 operations to AI coding agents without requiring the user to remember CLI flags.
 
 **Loop engineering** is the practice of designing recursive, autonomous processes
@@ -32,31 +33,34 @@ rollout tiers (L1 report-only → L2 PR-gated → L3 unattended).
 | `loop status` | Show all loops: tier, cadence, last run |
 | `loop audit [loop]` | Summarize past run success/cost |
 | `loop cost <loop>` | Estimate per-run token cost |
+| `loop schedule <loop>` | Install systemd/launchd timer |
 | `loop sync` | Push escalations to knowledge/todos |
 
 ## How to invoke
 
 ```bash
-# Check if ai-workspace loop CLI is available
-loop status
-
-# Or invoke directly
-~/.ai-workspace/bin/loop status
+# Preferred — agent-toolkit V CLI
+agent-toolkit loop status
+agent-toolkit loop run daily-triage
+agent-toolkit loop init oss-pr-monitor
 ```
+
+Historical note: older docs referred to `./bin/loop` or `~/.ai-workspace/bin/loop`.
+Those entrypoints are obsolete; use `agent-toolkit loop` after installing via
+brew / AUR `agent-toolkit-bin` / GitHub Release / `uv tool install agent-toolkit-cli`.
 
 ## Routing
 
-1. Check if `~/.ai-workspace/bin/loop` exists → use it
-2. Otherwise check `AI_WORKSPACE_LOOP_BIN` env var
-3. Otherwise: guide the user to install ai-workspace
+1. Prefer `agent-toolkit loop …` on PATH (V binary or PyPI launcher)
+2. Otherwise guide the user to install per `docs/INSTALLATION.md`
 
-## Runner hierarchy (inside bin/loop)
+## Runner hierarchy
 
-When `./bin/loop run` dispatches a loop, it tries runners in this order:
+When `agent-toolkit loop run` dispatches a loop, it tries runners in this order:
 
 | Priority | Runner | How to enable |
 |----------|--------|---------------|
-| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share//dev-companion/runner"` |
+| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share/agentic-workstation/dev-companion/runner"` |
 | 2 | **`claude --print`** (Claude Code CLI) | `claude` in PATH — zero setup for Claude Code users |
 | 3 | Skeleton plan | Always available |
 

--- a/plugins/agent-toolkit-complete/.github/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-complete/.github/skills/onboarding/SKILL.md
@@ -116,4 +116,4 @@ doctor
 
 - Load a project pack: `./bin/workspace-context load packs/<project>.yaml`
 - Run your first task: `/workflow-generic-project`
-- Set up daily loop: `./bin/loop init daily-triage`
+- Set up daily loop: `agent-toolkit loop init daily-triage`

--- a/plugins/agent-toolkit-complete/.opencode/skills/loop-runner/SKILL.md
+++ b/plugins/agent-toolkit-complete/.opencode/skills/loop-runner/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: loop-runner
-description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via bin/loop CLI.
+description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding
+  session via the agent-toolkit loop CLI.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
+  version: '1.1'
 ---
-
 # loop-runner
 
 > Execute and manage loop engineering primitives from an AI coding session.
@@ -14,8 +16,7 @@ metadata:
 
 ## What this skill does
 
-This skill wraps the `bin/loop` CLI from
-[ai-workspace](https://github.com/ulises-jeremias/ai-workspace), exposing loop
+This skill wraps the **`agent-toolkit loop`** CLI (V product command), exposing loop
 operations to AI coding agents without requiring the user to remember CLI flags.
 
 **Loop engineering** is the practice of designing recursive, autonomous processes
@@ -32,31 +33,34 @@ rollout tiers (L1 report-only → L2 PR-gated → L3 unattended).
 | `loop status` | Show all loops: tier, cadence, last run |
 | `loop audit [loop]` | Summarize past run success/cost |
 | `loop cost <loop>` | Estimate per-run token cost |
+| `loop schedule <loop>` | Install systemd/launchd timer |
 | `loop sync` | Push escalations to knowledge/todos |
 
 ## How to invoke
 
 ```bash
-# Check if ai-workspace loop CLI is available
-loop status
-
-# Or invoke directly
-~/.ai-workspace/bin/loop status
+# Preferred — agent-toolkit V CLI
+agent-toolkit loop status
+agent-toolkit loop run daily-triage
+agent-toolkit loop init oss-pr-monitor
 ```
+
+Historical note: older docs referred to `./bin/loop` or `~/.ai-workspace/bin/loop`.
+Those entrypoints are obsolete; use `agent-toolkit loop` after installing via
+brew / AUR `agent-toolkit-bin` / GitHub Release / `uv tool install agent-toolkit-cli`.
 
 ## Routing
 
-1. Check if `~/.ai-workspace/bin/loop` exists → use it
-2. Otherwise check `AI_WORKSPACE_LOOP_BIN` env var
-3. Otherwise: guide the user to install ai-workspace
+1. Prefer `agent-toolkit loop …` on PATH (V binary or PyPI launcher)
+2. Otherwise guide the user to install per `docs/INSTALLATION.md`
 
-## Runner hierarchy (inside bin/loop)
+## Runner hierarchy
 
-When `./bin/loop run` dispatches a loop, it tries runners in this order:
+When `agent-toolkit loop run` dispatches a loop, it tries runners in this order:
 
 | Priority | Runner | How to enable |
 |----------|--------|---------------|
-| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share//dev-companion/runner"` |
+| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share/agentic-workstation/dev-companion/runner"` |
 | 2 | **`claude --print`** (Claude Code CLI) | `claude` in PATH — zero setup for Claude Code users |
 | 3 | Skeleton plan | Always available |
 

--- a/plugins/agent-toolkit-complete/.opencode/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-complete/.opencode/skills/onboarding/SKILL.md
@@ -116,4 +116,4 @@ doctor
 
 - Load a project pack: `./bin/workspace-context load packs/<project>.yaml`
 - Run your first task: `/workflow-generic-project`
-- Set up daily loop: `./bin/loop init daily-triage`
+- Set up daily loop: `agent-toolkit loop init daily-triage`

--- a/plugins/agent-toolkit-complete/commands.toml
+++ b/plugins/agent-toolkit-complete/commands.toml
@@ -405,7 +405,7 @@ Follow the `slack-cli` skill instructions for {{args}}.
 
 [[commands]]
 name = "loop_runner"
-description = "Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via bin/loop CLI."
+description = "Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via the agent-toolkit loop CLI."
 prompt = """
 Follow the `loop-runner` skill instructions for {{args}}.
 

--- a/plugins/agent-toolkit-complete/skills/loop-runner/SKILL.md
+++ b/plugins/agent-toolkit-complete/skills/loop-runner/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: loop-runner
-description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding session via bin/loop CLI.
+description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding
+  session via the agent-toolkit loop CLI.
+origin:
+  type: first-party
 metadata:
   author: ulises-jeremias
-  version: "1.0"
+  version: '1.1'
 ---
-
 # loop-runner
 
 > Execute and manage loop engineering primitives from an AI coding session.
@@ -14,8 +16,7 @@ metadata:
 
 ## What this skill does
 
-This skill wraps the `bin/loop` CLI from
-[ai-workspace](https://github.com/ulises-jeremias/ai-workspace), exposing loop
+This skill wraps the **`agent-toolkit loop`** CLI (V product command), exposing loop
 operations to AI coding agents without requiring the user to remember CLI flags.
 
 **Loop engineering** is the practice of designing recursive, autonomous processes
@@ -32,31 +33,34 @@ rollout tiers (L1 report-only → L2 PR-gated → L3 unattended).
 | `loop status` | Show all loops: tier, cadence, last run |
 | `loop audit [loop]` | Summarize past run success/cost |
 | `loop cost <loop>` | Estimate per-run token cost |
+| `loop schedule <loop>` | Install systemd/launchd timer |
 | `loop sync` | Push escalations to knowledge/todos |
 
 ## How to invoke
 
 ```bash
-# Check if ai-workspace loop CLI is available
-loop status
-
-# Or invoke directly
-~/.ai-workspace/bin/loop status
+# Preferred — agent-toolkit V CLI
+agent-toolkit loop status
+agent-toolkit loop run daily-triage
+agent-toolkit loop init oss-pr-monitor
 ```
+
+Historical note: older docs referred to `./bin/loop` or `~/.ai-workspace/bin/loop`.
+Those entrypoints are obsolete; use `agent-toolkit loop` after installing via
+brew / AUR `agent-toolkit-bin` / GitHub Release / `uv tool install agent-toolkit-cli`.
 
 ## Routing
 
-1. Check if `~/.ai-workspace/bin/loop` exists → use it
-2. Otherwise check `AI_WORKSPACE_LOOP_BIN` env var
-3. Otherwise: guide the user to install ai-workspace
+1. Prefer `agent-toolkit loop …` on PATH (V binary or PyPI launcher)
+2. Otherwise guide the user to install per `docs/INSTALLATION.md`
 
-## Runner hierarchy (inside bin/loop)
+## Runner hierarchy
 
-When `./bin/loop run` dispatches a loop, it tries runners in this order:
+When `agent-toolkit loop run` dispatches a loop, it tries runners in this order:
 
 | Priority | Runner | How to enable |
 |----------|--------|---------------|
-| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share//dev-companion/runner"` |
+| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share/agentic-workstation/dev-companion/runner"` |
 | 2 | **`claude --print`** (Claude Code CLI) | `claude` in PATH — zero setup for Claude Code users |
 | 3 | Skeleton plan | Always available |
 

--- a/plugins/agent-toolkit-complete/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-complete/skills/onboarding/SKILL.md
@@ -116,4 +116,4 @@ doctor
 
 - Load a project pack: `./bin/workspace-context load packs/<project>.yaml`
 - Run your first task: `/workflow-generic-project`
-- Set up daily loop: `./bin/loop init daily-triage`
+- Set up daily loop: `agent-toolkit loop init daily-triage`

--- a/plugins/agent-toolkit-core/.github/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-core/.github/skills/onboarding/SKILL.md
@@ -116,4 +116,4 @@ doctor
 
 - Load a project pack: `./bin/workspace-context load packs/<project>.yaml`
 - Run your first task: `/workflow-generic-project`
-- Set up daily loop: `./bin/loop init daily-triage`
+- Set up daily loop: `agent-toolkit loop init daily-triage`

--- a/plugins/agent-toolkit-core/.opencode/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-core/.opencode/skills/onboarding/SKILL.md
@@ -116,4 +116,4 @@ doctor
 
 - Load a project pack: `./bin/workspace-context load packs/<project>.yaml`
 - Run your first task: `/workflow-generic-project`
-- Set up daily loop: `./bin/loop init daily-triage`
+- Set up daily loop: `agent-toolkit loop init daily-triage`

--- a/plugins/agent-toolkit-core/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/onboarding/SKILL.md
@@ -119,4 +119,4 @@ doctor
 
 - Load a project pack: `./bin/workspace-context load packs/<project>.yaml`
 - Run your first task: `/workflow-generic-project`
-- Set up daily loop: `./bin/loop init daily-triage`
+- Set up daily loop: `agent-toolkit loop init daily-triage`

--- a/skills/core/onboarding/SKILL.md
+++ b/skills/core/onboarding/SKILL.md
@@ -119,4 +119,4 @@ doctor
 
 - Load a project pack: `./bin/workspace-context load packs/<project>.yaml`
 - Run your first task: `/workflow-generic-project`
-- Set up daily loop: `./bin/loop init daily-triage`
+- Set up daily loop: `agent-toolkit loop init daily-triage`

--- a/skills/loops/loop-runner/SKILL.md
+++ b/skills/loops/loop-runner/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: loop-runner
 description: Execute and manage loop engineering primitives (init, run, status, audit) from an AI coding
-  session via bin/loop CLI.
+  session via the agent-toolkit loop CLI.
 origin:
   type: first-party
 metadata:
   author: ulises-jeremias
-  version: '1.0'
+  version: '1.1'
 ---
 # loop-runner
 
@@ -16,8 +16,7 @@ metadata:
 
 ## What this skill does
 
-This skill wraps the `bin/loop` CLI from
-[ai-workspace](https://github.com/ulises-jeremias/ai-workspace), exposing loop
+This skill wraps the **`agent-toolkit loop`** CLI (V product command), exposing loop
 operations to AI coding agents without requiring the user to remember CLI flags.
 
 **Loop engineering** is the practice of designing recursive, autonomous processes
@@ -34,31 +33,34 @@ rollout tiers (L1 report-only → L2 PR-gated → L3 unattended).
 | `loop status` | Show all loops: tier, cadence, last run |
 | `loop audit [loop]` | Summarize past run success/cost |
 | `loop cost <loop>` | Estimate per-run token cost |
+| `loop schedule <loop>` | Install systemd/launchd timer |
 | `loop sync` | Push escalations to knowledge/todos |
 
 ## How to invoke
 
 ```bash
-# Check if ai-workspace loop CLI is available
-loop status
-
-# Or invoke directly
-~/.ai-workspace/bin/loop status
+# Preferred — agent-toolkit V CLI
+agent-toolkit loop status
+agent-toolkit loop run daily-triage
+agent-toolkit loop init oss-pr-monitor
 ```
+
+Historical note: older docs referred to `./bin/loop` or `~/.ai-workspace/bin/loop`.
+Those entrypoints are obsolete; use `agent-toolkit loop` after installing via
+brew / AUR `agent-toolkit-bin` / GitHub Release / `uv tool install agent-toolkit-cli`.
 
 ## Routing
 
-1. Check if `~/.ai-workspace/bin/loop` exists → use it
-2. Otherwise check `AI_WORKSPACE_LOOP_BIN` env var
-3. Otherwise: guide the user to install ai-workspace
+1. Prefer `agent-toolkit loop …` on PATH (V binary or PyPI launcher)
+2. Otherwise guide the user to install per `docs/INSTALLATION.md`
 
-## Runner hierarchy (inside bin/loop)
+## Runner hierarchy
 
-When `./bin/loop run` dispatches a loop, it tries runners in this order:
+When `agent-toolkit loop run` dispatches a loop, it tries runners in this order:
 
 | Priority | Runner | How to enable |
 |----------|--------|---------------|
-| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share//dev-companion/runner"` |
+| 1 | **runner** | `export HARNESS_RUNNER_DIR="$HOME/.local/share/agentic-workstation/dev-companion/runner"` |
 | 2 | **`claude --print`** (Claude Code CLI) | `claude` in PATH — zero setup for Claude Code users |
 | 3 | Skeleton plan | Always available |
 


### PR DESCRIPTION
## Summary
- Rewrite loop-runner / onboarding / oss-maintenance / loop.yaml comments off `bin/loop`.
- Document `agent-toolkit loop` as the supported entrypoint.

Fixes #680

## Test plan
- [ ] `rg bin/loop skills packs loops` clean (or historical-only notes)
- [ ] `python3 scripts/validate-skills.py`

Made with [Cursor](https://cursor.com)