### PR TITLE
docs: replace ai-workspace brand with agentic-harness (D15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Replace remaining ai-workspace brand with agentic-harness in skills/packs (Fixes #681)
 - **Tests** — Parity harness V_SEMANTIC disposition fixtures for insights/release; widen docs/v paths (Fixes #691)
 - **Docs** — Teach `agent-toolkit loop` instead of obsolete `bin/loop` in skills/packs/loop.yaml (Fixes #680)
 - **Tests** — Stop treating `insights` as a normal ADVANCED_COMMANDS harness entry (DEPRECATE #526)

--- a/catalogs/skill-catalog.yaml
+++ b/catalogs/skill-catalog.yaml
@@ -80,7 +80,7 @@ skills:
   - id: core/workspace-knowledge-sync
     name: workspace-knowledge-sync
     domain: core
-    description: 'Syncs knowledge to the ai-workspace knowledge base. Use when the assistant discovers new patterns, learns user preferences, or identifies information worth preserving for future sessions. Integrates w'
+    description: 'Syncs knowledge to the agentic-harness knowledge base. Use when the assistant discovers new patterns, learns user preferences, or identifies information worth preserving for future sessions. Integrate'
     stability: stable
   - id: data/dbt-validation
     name: dbt-validation

--- a/plugins/agent-toolkit-complete/.github/copilot-instructions.md
+++ b/plugins/agent-toolkit-complete/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ Full stable skill catalog coverage for consumers who want everything (#50)
 - **onboarding**: Getting started guide for new users. Walks through setup validation, the skill/a
 - **output-handshake**: WHAT — Default gate for any deliverable: confirm where the final artifact will b
 - **pr-fallback**: WHAT — When the repo has no GitHub PR template, structure the pull-request body 
-- **workspace-knowledge-sync**: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant disco
+- **workspace-knowledge-sync**: Syncs knowledge to the agentic-harness knowledge base. Use when the assistant disco
 - **dbt-validation**: HOW — Run dbt checks as documented in the target repo (parse, compile, test, sel
 - **snowflake-validation**: HOW — Read-only Snowflake validation patterns: use repo-documented CLI (snowflak
 - **adr**: WHAT — Create and maintain Architecture Decision Records (ADRs) per the process.

--- a/plugins/agent-toolkit-complete/.github/skills/dev-companion/SKILL.md
+++ b/plugins/agent-toolkit-complete/.github/skills/dev-companion/SKILL.md
@@ -51,7 +51,7 @@ Do **not** paste forge or ticket CLI sequences here.
 - **Interactive (default):** IDE session; user steers each step.
 - **Queued job (optional):** only when a local runner is configured; see `~/.local/share//dev-companion/README.md` (installed from chezmoi) and **references/LOOP_GUARDRAILS.md**.
 
-The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
+The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/.ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
 
 ### LLM policy gate (client engagements)
 

--- a/plugins/agent-toolkit-complete/.github/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-complete/.github/skills/onboarding/SKILL.md
@@ -92,7 +92,7 @@ doctor
 # → ask the orchestrator: "what skill should I use for X?"
 
 # Load client/project context
-./bin/workspace-context load packs/<client>.yaml   # if in ai-workspace
+./bin/workspace-context load packs/<client>.yaml   # if in an agentic-harness workspace
 ```
 
 ## Key concepts in 60 seconds

--- a/plugins/agent-toolkit-complete/.github/skills/workspace-knowledge-sync/SKILL.md
+++ b/plugins/agent-toolkit-complete/.github/skills/workspace-knowledge-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workspace-knowledge-sync
 description: >-
-  Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
+  Syncs knowledge to the agentic-harness knowledge base. Use when the assistant
   discovers new patterns, learns user preferences, or identifies information worth
   preserving for future sessions. Integrates with tech-assistant for automatic
   trigger points.
@@ -9,7 +9,7 @@ description: >-
 
 # Workspace Knowledge Sync
 
-Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.
+Automatically syncs valuable discoveries, patterns, and decisions to the agentic-harness knowledge base.
 
 ---
 
@@ -134,7 +134,7 @@ The skill uses these environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KNOWLEDGE_BASE_PATH` | `~/ai-workspace/knowledge` | Knowledge base root |
+| `KNOWLEDGE_BASE_PATH` | `~/.ai-workspace/knowledge` | Knowledge base root |
 
 ---
 

--- a/plugins/agent-toolkit-complete/.opencode/skills/dev-companion/SKILL.md
+++ b/plugins/agent-toolkit-complete/.opencode/skills/dev-companion/SKILL.md
@@ -51,7 +51,7 @@ Do **not** paste forge or ticket CLI sequences here.
 - **Interactive (default):** IDE session; user steers each step.
 - **Queued job (optional):** only when a local runner is configured; see `~/.local/share//dev-companion/README.md` (installed from chezmoi) and **references/LOOP_GUARDRAILS.md**.
 
-The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
+The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/.ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
 
 ### LLM policy gate (client engagements)
 

--- a/plugins/agent-toolkit-complete/.opencode/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-complete/.opencode/skills/onboarding/SKILL.md
@@ -92,7 +92,7 @@ doctor
 # → ask the orchestrator: "what skill should I use for X?"
 
 # Load client/project context
-./bin/workspace-context load packs/<client>.yaml   # if in ai-workspace
+./bin/workspace-context load packs/<client>.yaml   # if in an agentic-harness workspace
 ```
 
 ## Key concepts in 60 seconds

--- a/plugins/agent-toolkit-complete/.opencode/skills/workspace-knowledge-sync/SKILL.md
+++ b/plugins/agent-toolkit-complete/.opencode/skills/workspace-knowledge-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workspace-knowledge-sync
 description: >-
-  Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
+  Syncs knowledge to the agentic-harness knowledge base. Use when the assistant
   discovers new patterns, learns user preferences, or identifies information worth
   preserving for future sessions. Integrates with tech-assistant for automatic
   trigger points.
@@ -9,7 +9,7 @@ description: >-
 
 # Workspace Knowledge Sync
 
-Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.
+Automatically syncs valuable discoveries, patterns, and decisions to the agentic-harness knowledge base.
 
 ---
 
@@ -134,7 +134,7 @@ The skill uses these environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KNOWLEDGE_BASE_PATH` | `~/ai-workspace/knowledge` | Knowledge base root |
+| `KNOWLEDGE_BASE_PATH` | `~/.ai-workspace/knowledge` | Knowledge base root |
 
 ---
 

--- a/plugins/agent-toolkit-complete/AGENTS.md
+++ b/plugins/agent-toolkit-complete/AGENTS.md
@@ -9,7 +9,7 @@ Full stable skill catalog coverage for consumers who want everything (#50)
 - **onboarding**: Getting started guide for new users. Walks through setup validation, the skill/a
 - **output-handshake**: WHAT — Default gate for any deliverable: confirm where the final artifact will b
 - **pr-fallback**: WHAT — When the repo has no GitHub PR template, structure the pull-request body 
-- **workspace-knowledge-sync**: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant disco
+- **workspace-knowledge-sync**: Syncs knowledge to the agentic-harness knowledge base. Use when the assistant disco
 - **dbt-validation**: HOW — Run dbt checks as documented in the target repo (parse, compile, test, sel
 - **snowflake-validation**: HOW — Read-only Snowflake validation patterns: use repo-documented CLI (snowflak
 - **adr**: WHAT — Create and maintain Architecture Decision Records (ADRs) per the process.

--- a/plugins/agent-toolkit-complete/commands.toml
+++ b/plugins/agent-toolkit-complete/commands.toml
@@ -45,7 +45,7 @@ Follow the `pr-fallback` skill instructions for {{args}}.
 
 [[commands]]
 name = "workspace_knowledge_sync"
-description = "Syncs knowledge to the ai-workspace knowledge base. Use when the assistant discovers new patterns, learns user preferenc"
+description = "Syncs knowledge to the agentic-harness knowledge base. Use when the assistant discovers new patterns, learns user preferenc"
 prompt = """
 Follow the `workspace-knowledge-sync` skill instructions for {{args}}.
 

--- a/plugins/agent-toolkit-complete/skills/dev-companion/SKILL.md
+++ b/plugins/agent-toolkit-complete/skills/dev-companion/SKILL.md
@@ -51,7 +51,7 @@ Do **not** paste forge or ticket CLI sequences here.
 - **Interactive (default):** IDE session; user steers each step.
 - **Queued job (optional):** only when a local runner is configured; see `~/.local/share//dev-companion/README.md` (installed from chezmoi) and **references/LOOP_GUARDRAILS.md**.
 
-The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
+The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/.ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
 
 ### LLM policy gate (client engagements)
 

--- a/plugins/agent-toolkit-complete/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-complete/skills/onboarding/SKILL.md
@@ -92,7 +92,7 @@ doctor
 # → ask the orchestrator: "what skill should I use for X?"
 
 # Load client/project context
-./bin/workspace-context load packs/<client>.yaml   # if in ai-workspace
+./bin/workspace-context load packs/<client>.yaml   # if in an agentic-harness workspace
 ```
 
 ## Key concepts in 60 seconds

--- a/plugins/agent-toolkit-complete/skills/workspace-knowledge-sync/SKILL.md
+++ b/plugins/agent-toolkit-complete/skills/workspace-knowledge-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workspace-knowledge-sync
 description: >-
-  Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
+  Syncs knowledge to the agentic-harness knowledge base. Use when the assistant
   discovers new patterns, learns user preferences, or identifies information worth
   preserving for future sessions. Integrates with tech-assistant for automatic
   trigger points.
@@ -9,7 +9,7 @@ description: >-
 
 # Workspace Knowledge Sync
 
-Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.
+Automatically syncs valuable discoveries, patterns, and decisions to the agentic-harness knowledge base.
 
 ---
 
@@ -134,7 +134,7 @@ The skill uses these environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KNOWLEDGE_BASE_PATH` | `~/ai-workspace/knowledge` | Knowledge base root |
+| `KNOWLEDGE_BASE_PATH` | `~/.ai-workspace/knowledge` | Knowledge base root |
 
 ---
 

--- a/plugins/agent-toolkit-core/.github/copilot-instructions.md
+++ b/plugins/agent-toolkit-core/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ Core orchestration skills, dev companion, output handshake, PR fallback, and cod
 - **dev-companion**: WHAT — Dev Companion (general): layered companion for client delivery; modes, ga
 - **output-handshake**: WHAT — Default gate for any deliverable: confirm where the final artifact will b
 - **pr-fallback**: WHAT — When the repo has no GitHub PR template, structure the pull-request body 
-- **workspace-knowledge-sync**: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant disco
+- **workspace-knowledge-sync**: Syncs knowledge to the agentic-harness knowledge base. Use when the assistant disco
 - **onboarding**: Getting started guide for new users. Walks through setup validation, the skill/a
 
 ## Available agents

--- a/plugins/agent-toolkit-core/.github/skills/dev-companion/SKILL.md
+++ b/plugins/agent-toolkit-core/.github/skills/dev-companion/SKILL.md
@@ -51,7 +51,7 @@ Do **not** paste forge or ticket CLI sequences here.
 - **Interactive (default):** IDE session; user steers each step.
 - **Queued job (optional):** only when a local runner is configured; see `~/.local/share//dev-companion/README.md` (installed from chezmoi) and **references/LOOP_GUARDRAILS.md**.
 
-The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
+The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/.ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
 
 ### LLM policy gate (client engagements)
 

--- a/plugins/agent-toolkit-core/.github/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-core/.github/skills/onboarding/SKILL.md
@@ -92,7 +92,7 @@ doctor
 # → ask the orchestrator: "what skill should I use for X?"
 
 # Load client/project context
-./bin/workspace-context load packs/<client>.yaml   # if in ai-workspace
+./bin/workspace-context load packs/<client>.yaml   # if in an agentic-harness workspace
 ```
 
 ## Key concepts in 60 seconds

--- a/plugins/agent-toolkit-core/.github/skills/workspace-knowledge-sync/SKILL.md
+++ b/plugins/agent-toolkit-core/.github/skills/workspace-knowledge-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workspace-knowledge-sync
 description: >-
-  Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
+  Syncs knowledge to the agentic-harness knowledge base. Use when the assistant
   discovers new patterns, learns user preferences, or identifies information worth
   preserving for future sessions. Integrates with tech-assistant for automatic
   trigger points.
@@ -9,7 +9,7 @@ description: >-
 
 # Workspace Knowledge Sync
 
-Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.
+Automatically syncs valuable discoveries, patterns, and decisions to the agentic-harness knowledge base.
 
 ---
 
@@ -134,7 +134,7 @@ The skill uses these environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KNOWLEDGE_BASE_PATH` | `~/ai-workspace/knowledge` | Knowledge base root |
+| `KNOWLEDGE_BASE_PATH` | `~/.ai-workspace/knowledge` | Knowledge base root |
 
 ---
 

--- a/plugins/agent-toolkit-core/.opencode/skills/dev-companion/SKILL.md
+++ b/plugins/agent-toolkit-core/.opencode/skills/dev-companion/SKILL.md
@@ -51,7 +51,7 @@ Do **not** paste forge or ticket CLI sequences here.
 - **Interactive (default):** IDE session; user steers each step.
 - **Queued job (optional):** only when a local runner is configured; see `~/.local/share//dev-companion/README.md` (installed from chezmoi) and **references/LOOP_GUARDRAILS.md**.
 
-The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
+The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/.ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
 
 ### LLM policy gate (client engagements)
 

--- a/plugins/agent-toolkit-core/.opencode/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-core/.opencode/skills/onboarding/SKILL.md
@@ -92,7 +92,7 @@ doctor
 # → ask the orchestrator: "what skill should I use for X?"
 
 # Load client/project context
-./bin/workspace-context load packs/<client>.yaml   # if in ai-workspace
+./bin/workspace-context load packs/<client>.yaml   # if in an agentic-harness workspace
 ```
 
 ## Key concepts in 60 seconds

--- a/plugins/agent-toolkit-core/.opencode/skills/workspace-knowledge-sync/SKILL.md
+++ b/plugins/agent-toolkit-core/.opencode/skills/workspace-knowledge-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workspace-knowledge-sync
 description: >-
-  Syncs knowledge to the ai-workspace knowledge base. Use when the assistant
+  Syncs knowledge to the agentic-harness knowledge base. Use when the assistant
   discovers new patterns, learns user preferences, or identifies information worth
   preserving for future sessions. Integrates with tech-assistant for automatic
   trigger points.
@@ -9,7 +9,7 @@ description: >-
 
 # Workspace Knowledge Sync
 
-Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.
+Automatically syncs valuable discoveries, patterns, and decisions to the agentic-harness knowledge base.
 
 ---
 
@@ -134,7 +134,7 @@ The skill uses these environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KNOWLEDGE_BASE_PATH` | `~/ai-workspace/knowledge` | Knowledge base root |
+| `KNOWLEDGE_BASE_PATH` | `~/.ai-workspace/knowledge` | Knowledge base root |
 
 ---
 

--- a/plugins/agent-toolkit-core/AGENTS.md
+++ b/plugins/agent-toolkit-core/AGENTS.md
@@ -8,7 +8,7 @@ Core orchestration skills, dev companion, output handshake, PR fallback, and cod
 - **dev-companion**: WHAT — Dev Companion (general): layered companion for client delivery; modes, ga
 - **output-handshake**: WHAT — Default gate for any deliverable: confirm where the final artifact will b
 - **pr-fallback**: WHAT — When the repo has no GitHub PR template, structure the pull-request body 
-- **workspace-knowledge-sync**: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant disco
+- **workspace-knowledge-sync**: Syncs knowledge to the agentic-harness knowledge base. Use when the assistant disco
 - **onboarding**: Getting started guide for new users. Walks through setup validation, the skill/a
 
 ## Available Agents

--- a/plugins/agent-toolkit-core/commands.toml
+++ b/plugins/agent-toolkit-core/commands.toml
@@ -36,7 +36,7 @@ Follow the `pr-fallback` skill instructions for {{args}}.
 
 [[commands]]
 name = "workspace_knowledge_sync"
-description = "Syncs knowledge to the ai-workspace knowledge base. Use when the assistant discovers new patterns, learns user preferenc"
+description = "Syncs knowledge to the agentic-harness knowledge base. Use when the assistant discovers new patterns, learns user preferenc"
 prompt = """
 Follow the `workspace-knowledge-sync` skill instructions for {{args}}.
 

--- a/plugins/agent-toolkit-core/skills/dev-companion/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/dev-companion/SKILL.md
@@ -51,7 +51,7 @@ Do **not** paste forge or ticket CLI sequences here.
 - **Interactive (default):** IDE session; user steers each step.
 - **Queued job (optional):** only when a local runner is configured; see `~/.local/share//dev-companion/README.md` (installed from chezmoi) and **references/LOOP_GUARDRAILS.md**.
 
-The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
+The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/.ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
 
 ### LLM policy gate (client engagements)
 

--- a/plugins/agent-toolkit-core/skills/onboarding/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/onboarding/SKILL.md
@@ -95,7 +95,7 @@ doctor
 # → ask the orchestrator: "what skill should I use for X?"
 
 # Load client/project context
-./bin/workspace-context load packs/<client>.yaml   # if in ai-workspace
+./bin/workspace-context load packs/<client>.yaml   # if in an agentic-harness workspace
 ```
 
 ## Key concepts in 60 seconds

--- a/plugins/agent-toolkit-core/skills/workspace-knowledge-sync/SKILL.md
+++ b/plugins/agent-toolkit-core/skills/workspace-knowledge-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-knowledge-sync
-description: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant discovers new
+description: Syncs knowledge to the agentic-harness knowledge base. Use when the assistant discovers new
   patterns, learns user preferences, or identifies information worth preserving for future sessions. Integrates
   with tech-assistant for automatic trigger points.
 origin:
@@ -8,7 +8,7 @@ origin:
 ---
 # Workspace Knowledge Sync
 
-Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.
+Automatically syncs valuable discoveries, patterns, and decisions to the agentic-harness knowledge base.
 
 ---
 
@@ -133,7 +133,7 @@ The skill uses these environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KNOWLEDGE_BASE_PATH` | `~/ai-workspace/knowledge` | Knowledge base root |
+| `KNOWLEDGE_BASE_PATH` | `~/.ai-workspace/knowledge` | Knowledge base root |
 
 ---
 

--- a/skills/core/dev-companion/SKILL.md
+++ b/skills/core/dev-companion/SKILL.md
@@ -51,7 +51,7 @@ Do **not** paste forge or ticket CLI sequences here.
 - **Interactive (default):** IDE session; user steers each step.
 - **Queued job (optional):** only when a local runner is configured; see `~/.local/share//dev-companion/README.md` (installed from chezmoi) and **references/LOOP_GUARDRAILS.md**.
 
-The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
+The queue worker is **mandatory infrastructure** (installed by workstation). The **workspace** (`~/.ai-workspace`) is optional — it provides project-aware wrappers, job templates, and knowledge base integration. When both are present, the runner automatically enriches LLM prompts with workspace context (`projects.yaml`, `projects/`, `knowledge/todos/`).
 
 ### LLM policy gate (client engagements)
 

--- a/skills/core/onboarding/SKILL.md
+++ b/skills/core/onboarding/SKILL.md
@@ -95,7 +95,7 @@ doctor
 # → ask the orchestrator: "what skill should I use for X?"
 
 # Load client/project context
-./bin/workspace-context load packs/<client>.yaml   # if in ai-workspace
+./bin/workspace-context load packs/<client>.yaml   # if in an agentic-harness workspace
 ```
 
 ## Key concepts in 60 seconds

--- a/skills/core/workspace-knowledge-sync/SKILL.md
+++ b/skills/core/workspace-knowledge-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-knowledge-sync
-description: Syncs knowledge to the ai-workspace knowledge base. Use when the assistant discovers new
+description: Syncs knowledge to the agentic-harness knowledge base. Use when the assistant discovers new
   patterns, learns user preferences, or identifies information worth preserving for future sessions. Integrates
   with tech-assistant for automatic trigger points.
 origin:
@@ -8,7 +8,7 @@ origin:
 ---
 # Workspace Knowledge Sync
 
-Automatically syncs valuable discoveries, patterns, and decisions to the ai-workspace knowledge base.
+Automatically syncs valuable discoveries, patterns, and decisions to the agentic-harness knowledge base.
 
 ---
 
@@ -133,7 +133,7 @@ The skill uses these environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KNOWLEDGE_BASE_PATH` | `~/ai-workspace/knowledge` | Knowledge base root |
+| `KNOWLEDGE_BASE_PATH` | `~/.ai-workspace/knowledge` | Knowledge base root |
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace remaining user-facing `ai-workspace` brand references with `agentic-harness` in skills/packs.
- Leave real filesystem paths like `~/.ai-workspace` intact.

Fixes #681

## Test plan
- [ ] Brand grep clean aside from path literals
- [ ] `python3 scripts/validate-skills.py`

Made with [Cursor](https://cursor.com)