### PR TITLE
chore(products): include agentic-security-reviewer (D12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Docs** — Homebrew README links in-repo ADR-023 path (keep #490 as discussion)
-- **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
+- **Packaging** — Include agentic-security-reviewer in agent-toolkit-agents product (Fixes #689)
+- **Providers** — capability provider abstraction WHAT vs HOW (Closes #386), audit 8 candidates + 5 ADOPT via hierarchy (Refs #393), curated agentic-security/code-quality/architecture/design-engineering packs (Closes #390)
+- **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
+- **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
+- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
-- **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
-- **Docs** — PyPI republish guidance uses `release.yml` OIDC (not Publish manual)
 - **Docs** — Fix broken `docs/SWARMS.md` link to missing `CLI_REFERENCE.md` → `CLI_SURFACES.md`
 - **Packaging** — Bump Dockerfile default `ARG VERSION` to match `VERSION` (1.12.1)
 - **Docs** — Note that wiki-style `[[Page]]` links in docs/wiki are intentional for wiki-sync
+- **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
 - **CI** — Docker push-to-main is smoke-only; registry push requires Release assets (Fixes #679)
-- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Chore** — scripts/install.sh and doctor.sh are thin wrappers around the V CLI (Fixes #683)
 - **CI** — Include `check-surfaces` in `required-ci` needs so surface drift cannot merge (Fixes #677)
 - **Docs** — ADR-007 / install messaging aligned V-first (thin wrappers to agent-toolkit) (Fixes #682)
+- **Docs** — Homebrew README links in-repo ADR-023 path (keep #490 as discussion)
 
 
 ## [1.12.1] — 2026-08-13

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -43,6 +43,7 @@ products:
     includes:
       skills: []
       agents:
+        - agentic-security-reviewer
         - architect
         - assistant
         - build-error-resolver

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -37,7 +37,7 @@ products:
       rationale: Core skills are read-only instruction files with no side effects.
   - id: agent-toolkit-agents
     name: Agent Toolkit Agents
-    description: 'Full set of 16 AI agent personas: architect, code-reviewer, security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.'
+    description: 'Full set of 17 AI agent personas: architect, code-reviewer, security-reviewer, agentic-security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.'
     version_source: src/agent_toolkit/__init__.py
     stability: stable
     includes:

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -9,7 +9,7 @@ _Generated from 4 products × 77 skills × 17 agents._
 | Product | Stability | Targets | Skills | Agents |
 |---------|-----------|---------|--------|--------|
 | `agent-toolkit-core` | stable | claude-code, cursor | 6 | 1 |
-| `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 16 |
+| `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 17 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
 | `agent-toolkit-complete` | experimental | — | 77 | 0 |
 
@@ -99,7 +99,7 @@ _Generated from 4 products × 77 skills × 17 agents._
 
 | Agent | Products | Targets (via products) |
 |-------|----------|------------------------|
-| `agentic-security-reviewer` | _uncovered_ | — |
+| `agentic-security-reviewer` | `agent-toolkit-agents` | claude-code, cursor |
 | `architect` | `agent-toolkit-agents` | claude-code, cursor |
 | `assistant` | `agent-toolkit-agents` | claude-code, cursor |
 | `build-error-resolver` | `agent-toolkit-agents` | claude-code, cursor |


### PR DESCRIPTION
## Summary
- Add `agentic-security-reviewer` to `agent-toolkit-agents` `includes.agents` in `distributions/products.yaml`.
- Update product description count 16 → 17.

Fixes #689

## Test plan
- [ ] Agent listed under agent-toolkit-agents includes
- [ ] validate-products / surfaces still green

Made with [Cursor](https://cursor.com)