### PR TITLE
ci: ADR-003 dual-run build --check job (D13)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -154,6 +154,39 @@ jobs:
       - name: Assert plugin surfaces are in sync with canonical sources
         run: python3 scripts/gen-surfaces.py --check
 
+
+  # ADR-003 dual-run: V compiler drift check (parallel with gen-surfaces)
+  check-build:
+    name: Check Build (agent-toolkit build --check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pinned V from GitHub Release
+        run: |
+          set -euo pipefail
+          PIN="$(tr -d '[:space:]' < .v-version)"
+          curl -fsSL -o /tmp/v.zip "https://github.com/vlang/v/releases/download/${PIN}/v_linux.zip"
+          sudo rm -rf /usr/local/v
+          sudo unzip -q /tmp/v.zip -d /usr/local
+          if [ -x /usr/local/v/v ]; then
+            echo "/usr/local/v" >> "$GITHUB_PATH"
+          elif [ -x /usr/local/v_linux/v ]; then
+            echo "/usr/local/v_linux" >> "$GITHUB_PATH"
+          else
+            echo "Unexpected V zip layout" >&2
+            exit 1
+          fi
+
+      - name: Build V CLI and run build --check
+        env:
+          VMODULES: ${{ github.workspace }}/modules
+          AGENT_TOOLKIT_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          make build-cli
+          ./build/agent-toolkit build --check
+
   check-skill-matrix:
     name: Check Skill→Product Matrix
     runs-on: ubuntu-latest
@@ -728,6 +761,7 @@ jobs:
       - validate-manifests
       - validate-agent-plugins
       - validate-upstream
+      - check-build
       - check-skill-matrix
       - validate-loops
       - validate-products
@@ -750,6 +784,7 @@ jobs:
           if [[ "${{ needs.validate-manifests.result }}" != "success" ]]; then echo "validate-manifests failed: ${{ needs.validate-manifests.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-agent-plugins.result }}" != "success" ]]; then echo "validate-agent-plugins failed: ${{ needs.validate-agent-plugins.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-upstream.result }}" != "success" ]]; then echo "validate-upstream failed: ${{ needs.validate-upstream.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-build.result }}" != "success" ]]; then echo "check-build failed: ${{ needs.check-build.result }}"; failed="true"; fi
           if [[ "${{ needs.check-skill-matrix.result }}" != "success" ]]; then echo "check-skill-matrix failed: ${{ needs.check-skill-matrix.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-loops.result }}" != "success" ]]; then echo "validate-loops failed: ${{ needs.validate-loops.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-products.result }}" != "success" ]]; then echo "validate-products failed: ${{ needs.validate-products.result }}"; failed="true"; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,8 @@ for f in sorted(Path("loops").rglob("loop.yaml")):
     print(f"  OK: {f}")
 PYEOF
 python3 scripts/generate-catalogs.py   # Regenerates and checks catalogs
-python3 scripts/gen-surfaces.py --check  # Asserts plugin surfaces are in sync
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check  # ADR-003 primary
+python3 scripts/gen-surfaces.py --check  # dual-run legacy until v1.6.0+
 make test && make build-cli
 AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
 AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **CI** — ADR-003 dual-run: add `check-build` (`agent-toolkit build --check`) alongside gen-surfaces
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
-- **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
 - **CI** — Build/push the Docker image from `release.yml` after V assets exist (`GITHUB_TOKEN` cannot trigger `on: release`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,8 @@ PY
 python3 scripts/validate-manifests.py
 
 # Detect plugin surface drift
-python3 scripts/gen-surfaces.py --check
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
+python3 scripts/gen-surfaces.py --check  # dual-run legacy
 
 # Regenerate catalogs and verify they match source files
 python3 scripts/generate-catalogs.py

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,7 +23,8 @@ AGENT_TOOLKIT_ROOT="$PWD" uv run --project packages/pypi/agent-toolkit-cli --dir
 python3 scripts/validate-skills.py
 python3 scripts/validate-agents.py
 python3 scripts/generate-catalogs.py
-python3 scripts/gen-surfaces.py --check
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
+python3 scripts/gen-surfaces.py --check  # dual-run legacy until v1.6.0+
 
 # 3. Commit + tag
 git add -A && git commit -m "chore(release): bump to v1.3.0"

--- a/docs/adrs/ADR-003-retire-gen-surfaces.md
+++ b/docs/adrs/ADR-003-retire-gen-surfaces.md
@@ -29,9 +29,9 @@ This ADR does **not** delete code; it records the decision and migration plan.
 ### CI job swap
 
 - [x] Current `validate.yml` job `check-surfaces` runs `python3 scripts/gen-surfaces.py --check`
-- [ ] Add parallel job `check-build` that runs `make build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check` (keep both during dual-run)
+- [x] Add parallel job `check-build` that runs `make build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check` (keep both during dual-run)
 - [ ] After dual-run green for 30 days, flip `check-surfaces` to advisory (`continue-on-error: true`) or remove, making `check-build` the required check
-- [ ] Update `RELEASING.md` bump → validate → tag checklist to use `build --check` instead of `gen-surfaces.py --check`
+- [x] Update `RELEASING.md` bump → validate → tag checklist to prefer `build --check` (gen-surfaces dual-run)
 
 ### Contributor docs
 

--- a/scripts/gen-surfaces.py
+++ b/scripts/gen-surfaces.py
@@ -4,8 +4,9 @@ Sync canonical agents/ and skills/ into plugin bundle surfaces.
 Run with --check to fail on drift (used in CI).
 
 .. deprecated::
-   Use `agent-toolkit build --check` (see ADR-003). This script is kept for
-   backward compatibility during the dual-run period and will be removed in v1.6.0.
+   Primary gate is `agent-toolkit build --check` (ADR-003). This script remains
+   for dual-run CI (`check-surfaces`) until removal at v1.6.0+ after `check-build`
+   has been required on main.
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- Add `check-build` CI job (`make build-cli` + `./build/agent-toolkit build --check`)
- Keep gen-surfaces dual-run; refresh deprecation header toward v1.6.0+ removal
- Flip CONTRIBUTING / AGENTS / RELEASING to prefer `build --check`

Fixes #678

## Test plan
- [ ] Validate workflow shows Check Build job
- [ ] Required CI depends on `check-build`
- [ ] Docs describe dual-run clearly

Made with [Cursor](https://cursor.com)