### PR TITLE
ci: ADR-003 dual-run check-build job (D13)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -154,6 +154,42 @@ jobs:
       - name: Assert plugin surfaces are in sync with canonical sources
         run: python3 scripts/gen-surfaces.py --check
 
+
+  # ── ADR-003 dual-run: compiler build --check alongside gen-surfaces ─────────
+  check-build:
+    name: Check Build (compiler)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install pinned V from GitHub Release
+        run: |
+          set -euo pipefail
+          PIN="$(tr -d '[:space:]' < .v-version)"
+          curl -fsSL -o /tmp/v.zip "https://github.com/vlang/v/releases/download/${PIN}/v_linux.zip"
+          sudo rm -rf /usr/local/v
+          sudo unzip -q /tmp/v.zip -d /usr/local
+          if [ -x /usr/local/v/v ]; then
+            echo "/usr/local/v" >> "$GITHUB_PATH"
+          elif [ -x /usr/local/v_linux/v ]; then
+            echo "/usr/local/v_linux" >> "$GITHUB_PATH"
+          else
+            echo "Unexpected V zip layout" >&2
+            exit 1
+          fi
+
+      - name: Build V CLI
+        env:
+          VMODULES: ${{ github.workspace }}/modules
+        run: make build-cli
+
+      - name: agent-toolkit build --check
+        env:
+          AGENT_TOOLKIT_ROOT: ${{ github.workspace }}
+          VMODULES: ${{ github.workspace }}/modules
+        run: ./build/agent-toolkit build --check
+
   check-skill-matrix:
     name: Check Skill→Product Matrix
     runs-on: ubuntu-latest
@@ -728,6 +764,7 @@ jobs:
       - validate-manifests
       - validate-agent-plugins
       - validate-upstream
+      - check-build
       - check-skill-matrix
       - validate-loops
       - validate-products
@@ -750,6 +787,7 @@ jobs:
           if [[ "${{ needs.validate-manifests.result }}" != "success" ]]; then echo "validate-manifests failed: ${{ needs.validate-manifests.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-agent-plugins.result }}" != "success" ]]; then echo "validate-agent-plugins failed: ${{ needs.validate-agent-plugins.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-upstream.result }}" != "success" ]]; then echo "validate-upstream failed: ${{ needs.validate-upstream.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-build.result }}" != "success" ]]; then echo "check-build failed: ${{ needs.check-build.result }}"; failed="true"; fi
           if [[ "${{ needs.check-skill-matrix.result }}" != "success" ]]; then echo "check-skill-matrix failed: ${{ needs.check-skill-matrix.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-loops.result }}" != "success" ]]; then echo "validate-loops failed: ${{ needs.validate-loops.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-products.result }}" != "success" ]]; then echo "validate-products failed: ${{ needs.validate-products.result }}"; failed="true"; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,8 @@ for f in sorted(Path("loops").rglob("loop.yaml")):
     print(f"  OK: {f}")
 PYEOF
 python3 scripts/generate-catalogs.py   # Regenerates and checks catalogs
-python3 scripts/gen-surfaces.py --check  # Asserts plugin surfaces are in sync
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check  # primary surface check (ADR-003)
+python3 scripts/gen-surfaces.py --check  # legacy dual-run until removed
 make test && make build-cli
 AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
 AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
-- **Chore** — scripts/install.sh and doctor.sh are thin wrappers around the V CLI (Fixes #683)
+- **CI** — ADR-003 dual-run: add check-build (`agent-toolkit build --check`) alongside gen-surfaces (Fixes #678)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs** — Note that wiki-style `[[Page]]` links in docs/wiki are intentional for wiki-sync
 - **Docs** — Mark `insights` DEPRECATE (#526) and `release` REMOVE (#527) in SCOPE.md / CLI_SURFACES.md
 - **CI** — Docker push-to-main is smoke-only; registry push requires Release assets (Fixes #679)
+- **Chore** — scripts/install.sh and doctor.sh are thin wrappers around the V CLI (Fixes #683)
 
 
 ## [1.12.1] — 2026-08-13

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,8 @@ PY
 python3 scripts/validate-manifests.py
 
 # Detect plugin surface drift
-python3 scripts/gen-surfaces.py --check
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check  # primary (ADR-003)
+python3 scripts/gen-surfaces.py --check  # legacy dual-run
 
 # Regenerate catalogs and verify they match source files
 python3 scripts/generate-catalogs.py

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,7 +23,8 @@ AGENT_TOOLKIT_ROOT="$PWD" uv run --project packages/pypi/agent-toolkit-cli --dir
 python3 scripts/validate-skills.py
 python3 scripts/validate-agents.py
 python3 scripts/generate-catalogs.py
-python3 scripts/gen-surfaces.py --check
+AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
+python3 scripts/gen-surfaces.py --check  # legacy dual-run until v1.14+
 
 # 3. Commit + tag
 git add -A && git commit -m "chore(release): bump to v1.3.0"

--- a/docs/adrs/ADR-003-retire-gen-surfaces.md
+++ b/docs/adrs/ADR-003-retire-gen-surfaces.md
@@ -29,7 +29,7 @@ This ADR does **not** delete code; it records the decision and migration plan.
 ### CI job swap
 
 - [x] Current `validate.yml` job `check-surfaces` runs `python3 scripts/gen-surfaces.py --check`
-- [ ] Add parallel job `check-build` that runs `make build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check` (keep both during dual-run)
+- [x] Add parallel job `check-build` that runs `make build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check` (keep both during dual-run) — see #678
 - [ ] After dual-run green for 30 days, flip `check-surfaces` to advisory (`continue-on-error: true`) or remove, making `check-build` the required check
 - [ ] Update `RELEASING.md` bump → validate → tag checklist to use `build --check` instead of `gen-surfaces.py --check`
 
@@ -52,7 +52,7 @@ This ADR does **not** delete code; it records the decision and migration plan.
 |-------|--------|------|--------|
 | **Deprecate** | v1.3.x (now) | ADR-003 accepted | Add deprecation header to `scripts/gen-surfaces.py`, keep CI required |
 | **Dual-run** | v1.4.x – v1.5.x | Both checks pass on main for 30 days | Run `gen-surfaces --check` + `build --check` in parallel; document legacy fallback |
-| **Remove** | v1.6.0+ | Maintainer vote after RELEASING checklist updated | Delete `scripts/gen-surfaces.py` and `check-surfaces` job; `build --check` is sole gate |
+| **Remove** | v1.14.0+ | Maintainer vote after RELEASING checklist updated | Delete `scripts/gen-surfaces.py` and `check-surfaces` job; `build --check` is sole gate (v1.6.0 target superseded; dual-run completed later) |
 
 No file deletion occurs in the ADR PR itself. Deletion is deferred to the **Remove** milestone and requires a follow-up PR referencing this ADR.
 

--- a/scripts/gen-surfaces.py
+++ b/scripts/gen-surfaces.py
@@ -4,8 +4,9 @@ Sync canonical agents/ and skills/ into plugin bundle surfaces.
 Run with --check to fail on drift (used in CI).
 
 .. deprecated::
-   Use `agent-toolkit build --check` (see ADR-003). This script is kept for
-   backward compatibility during the dual-run period and will be removed in v1.6.0.
+   Prefer `agent-toolkit build --check` (see ADR-003). This script remains for
+   dual-run CI compatibility and will be removed once `build --check` is the sole
+   required gate (target: v1.14.0+; timeline updated — v1.6.0 was superseded).
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- Add `check-build` CI job: install pinned V, `make build-cli`, `./build/agent-toolkit build --check`.
- Include it in `required-ci`.
- Update gen-surfaces deprecation header / ADR-003 remove target to v1.14.0+.
- Prefer `build --check` in CONTRIBUTING / AGENTS / RELEASING.

Fixes #678

## Test plan
- [ ] check-build job green on PR
- [ ] required-ci depends on check-build

Made with [Cursor](https://cursor.com)