### PR TITLE
chore(products): include agentic-security-reviewer (D12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — Include `agentic-security-reviewer` in agent-toolkit-agents product
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -37,12 +37,13 @@ products:
       rationale: Core skills are read-only instruction files with no side effects.
   - id: agent-toolkit-agents
     name: Agent Toolkit Agents
-    description: 'Full set of 16 AI agent personas: architect, code-reviewer, security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.'
+    description: 'Full set of 17 AI agent personas: architect, code-reviewer, security-reviewer, agentic-security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.'
     version_source: src/agent_toolkit/__init__.py
     stability: stable
     includes:
       skills: []
       agents:
+        - agentic-security-reviewer
         - architect
         - assistant
         - build-error-resolver


### PR DESCRIPTION
## Summary
- Add `agentic-security-reviewer` to `agent-toolkit-agents` includes
- Update product description count 16 → 17

Fixes #689

## Test plan
- [ ] products.yaml lists the agent
- [ ] validate-products CI green

Made with [Cursor](https://cursor.com)