### PR TITLE
docs(scripts): V-first install/doctor messaging (D03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Align install/doctor ADR-007 messaging with V-first channels (not Python-era primary)
 - **Docs** — AUR playbook and release replay use `agent-toolkit-bin`; warn off legacy `agent-toolkit` AUR (Fixes #675)
 - **Docs** — Align AUR playbook with canonical `agent-toolkit-bin` (warn on legacy `agent-toolkit` AUR name)
 - **Docs** — Polish published npm/PyPI package READMEs to the cozy banner/badge style of `packages/pypi/agent-toolkit-cli/README.md`; document why the PyPI `src/` launcher tree stays

--- a/docs/adrs/ADR-007-install-sh-deprecation.md
+++ b/docs/adrs/ADR-007-install-sh-deprecation.md
@@ -1,6 +1,6 @@
 # ADR-007: Deprecate scripts/install.sh Behind Python CLI (Thin Wrapper)
 
-**Status:** Accepted  
+**Status:** Accepted (amended: V-first primary install — brew / AUR `agent-toolkit-bin` / GitHub Release / `uv tool install agent-toolkit-cli`)  
 **Date:** 2026-08-06  
 **Deciders:** maintainers (Wave 3 #270, parent #263)
 
@@ -16,9 +16,9 @@ The goal is one consumer install path to reduce support load.
 
 - `scripts/install.sh` remains but prints a deprecation notice on every invocation:
   ```
-  [warn] scripts/install.sh is deprecated — use `uvx --from agent-toolkit-cli agent-toolkit install` (or `agent-toolkit install` after `uv tool install`). See docs/INSTALLATION.md and docs/adrs/ADR-007-install-sh-deprecation.md
+  [warn] scripts/install.sh is deprecated — prefer `agent-toolkit install` from brew/AUR/GitHub/uv (V CLI). See docs/INSTALLATION.md and docs/adrs/ADR-007-install-sh-deprecation.md
   ```
-- **Primary install** is the Python CLI (`uvx` one-liner or `uv tool install`):
+- **Primary install** is the **V CLI** via brew / AUR `agent-toolkit-bin` / GitHub Release, or the PyPI launcher (`uvx` / `uv tool install agent-toolkit-cli`) which execs V (ADR-021):
   ```bash
   uvx --from agent-toolkit-cli agent-toolkit install
   uvx --from agent-toolkit-cli agent-toolkit install --dry-run

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -40,5 +40,6 @@ check_profile "Windsurf rules" "$HOME/.codeium/windsurf/rules/"
 check_profile "Pi skills" "$HOME/.pi/agent/skills/"
 
 echo ""
-echo "Run 'bash scripts/install.sh' to install missing profiles."
+echo "Install profiles with: agent-toolkit install  (brew/AUR/GitHub/uv — see docs/INSTALLATION.md)"
+echo "Legacy: bash scripts/install.sh (deprecated; wraps agent-toolkit install when available)."
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,11 +19,11 @@
 set -euo pipefail
 
 # --- Deprecation notice (ADR-007) ---
-# Primary install is now the Python CLI: `uvx --from agent-toolkit-cli agent-toolkit install`
+# Primary install is the V CLI: brew / AUR agent-toolkit-bin / GitHub Release / `uv tool install agent-toolkit-cli` then `agent-toolkit install`
 # This script is kept as a legacy/offline fallback and will be removed in v2.0.
 # It may delegate to `agent-toolkit install` when available (thin wrapper).
 if [[ -z "${AGENT_TOOLKIT_NO_DEPRECATION_WARNING:-}" ]]; then
-  printf '  [warn]  scripts/install.sh is deprecated — use `uvx --from agent-toolkit-cli agent-toolkit install` (see docs/INSTALLATION.md and docs/adrs/ADR-007-install-sh-deprecation.md)\n' >&2
+  printf '  [warn]  scripts/install.sh is deprecated — use `agent-toolkit install` (V CLI via brew/AUR/GitHub/uv; see docs/INSTALLATION.md and ADR-007)\n' >&2
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Amend ADR-007 messaging toward V-first install channels
- Update `doctor.sh` / `install.sh` deprecation warnings accordingly
- Thin wrappers remain P01 (#683)

Fixes #682

## Test plan
- [ ] ADR-007 / script warnings mention brew/AUR/GitHub/uv
- [ ] No longer present Python CLI as sole primary

Made with [Cursor](https://cursor.com)