### PR TITLE
fix(ci): collapse validate.yml blank lines for yamllint

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -173,7 +173,6 @@ jobs:
         run: v run scripts/gen-surfaces.vsh --check
 
 
-
   # ── ADR-003 dual-run: compiler build --check alongside gen-surfaces ─────────
   check-build:
     name: Check Build (compiler)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **CI** — Fix validate.yml yamllint empty-lines after check-build insert
 - **CI** — ADR-003 dual-run: add `check-build` (`build --check`) alongside gen-surfaces (Fixes #678)
 - **Products** — Include `agentic-security-reviewer` in `agent-toolkit-agents` (Fixes #689)
 - **CI** — Drop stale `packaging` path from MegaLinter FILTER_REGEX_EXCLUDE


### PR DESCRIPTION
## Summary
- Collapses a 3-blank-line run in `.github/workflows/validate.yml` introduced with the ADR-003 `check-build` job insert, which fails yamllint `empty-lines`.

## Test plan
- [ ] YAML Lint job green
- [ ] Required CI green