### PR TITLE
test(npm): trampoline suite + Python 3.14 / Node 24 CI

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: tools/danger/package.json
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,6 +54,27 @@ jobs:
         run: uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v --tb=short
         env:
           AGENT_TOOLKIT_ROOT: ${{ github.workspace }}
+
+  # ── Job 1b: npm trampoline (node --test; ADR-025) ─────────────────────────
+  test-npm:
+    name: Test npm launcher (Node ${{ matrix.node-version }} / ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # 22 = Active LTS; 24 = Current (matches publish-npm.yml)
+        node-version: ["22", "24"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run npm trampoline tests
+        working-directory: packages/npm/agent-toolkit-cli
+        run: npm test
 
   # ── Job 2a: Mechanical smoke for skills/ and agents/ ─────────────────────
   # Fast mechanical integrity check: frontmatter, name-directory match,
@@ -382,7 +403,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli@0.44.0
@@ -431,7 +452,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Sync PyPI adapter
         run: uv sync --project packages/pypi/agent-toolkit-cli --all-extras
       - name: Ruff check
@@ -448,7 +469,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: Sync PyPI adapter
         run: uv sync --project packages/pypi/agent-toolkit-cli --all-extras
       - name: Run launcher coverage (fail_under=70)
@@ -469,7 +490,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install pinned V from GitHub Release
         run: |
@@ -545,7 +566,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Download built wheel
         uses: actions/download-artifact@v8
@@ -793,6 +814,7 @@ jobs:
     if: always()
     needs:
       - test-package
+      - test-npm
       - smoke-test-skills
       - validate-skills
       - validate-manifests
@@ -818,6 +840,7 @@ jobs:
           failed="false"
           # Use GitHub's needs context to check each job result
           if [[ "${{ needs.test-package.result }}" != "success" && "${{ needs.test-package.result }}" != "skipped" ]]; then echo "test-package failed: ${{ needs.test-package.result }}"; failed="true"; fi
+          if [[ "${{ needs.test-npm.result }}" != "success" ]]; then echo "test-npm failed: ${{ needs.test-npm.result }}"; failed="true"; fi
           if [[ "${{ needs.smoke-test-skills.result }}" != "success" && "${{ needs.smoke-test-skills.result }}" != "skipped" ]]; then echo "smoke-test-skills failed: ${{ needs.smoke-test-skills.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-skills.result }}" != "success" ]]; then echo "validate-skills failed: ${{ needs.validate-skills.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-manifests.result }}" != "success" ]]; then echo "validate-manifests failed: ${{ needs.validate-manifests.result }}"; failed="true"; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,7 +309,7 @@ AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
 AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v
 ```
 
-All checks must exit 0. V is the product CLI (pin `.v-version` / 0.5.2, `import json` not json2 — [`docs/HOW_TO_DEVELOP_V.md`](docs/HOW_TO_DEVELOP_V.md)). Run `uv sync --project packages/pypi/agent-toolkit-cli --all-extras` first for pytest only (the repo is not a uv workspace).
+All checks must exit 0. V is the product CLI (pin `.v-version` / 0.5.2, `import json` not json2 — [`docs/HOW_TO_DEVELOP_V.md`](docs/HOW_TO_DEVELOP_V.md)). Run `uv sync --project packages/pypi/agent-toolkit-cli --all-extras` first for pytest only (the repo is not a uv workspace). For the npm trampoline: `npm test --prefix packages/npm/agent-toolkit-cli` (CI: Node 22/24).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Tests** — Expand npm trampoline suite (`node --test`) to mirror PyPI launcher coverage; add dedicated `test-npm` CI job (Node 22/24 × ubuntu/macOS/Windows)
+- **CI** — Bump primary Python to **3.14** (matrix still covers 3.10–3.14); Node jobs use **24** (markdownlint / Danger; npm tests also cover 22 LTS)
+
 ## [1.13.0] — 2026-08-14
 
 - **Breaking** — Remove quarantined Python CLI (`agent-toolkit-py` and `src/agent_toolkit/{cli,compiler,installer,…}`). PyPI is an npm-style trampoline over the V binary; CLI tests live in V (`modules/**/*_test.v`) and CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ as a drive-by fix.
 
 - **Git** 2.30 or later
 - **V** matching [`.v-version`](.v-version) (**0.5.2**) for the canonical CLI — `import json`, not `json2`. See [`docs/HOW_TO_DEVELOP_V.md`](docs/HOW_TO_DEVELOP_V.md)
-- **Python** 3.10 or later (validation scripts, PyPI launcher tests, pre-commit)
+- **Python** 3.10 or later (validation scripts, PyPI launcher tests, pre-commit); CI primary is **3.14**
+- **Node.js** 18+ for the npm trampoline tests (`packages/npm/agent-toolkit-cli`); CI uses **22** (LTS) and **24** (Current)
 - **uv** for the PyPI adapter under `packages/pypi/` only — see https://docs.astral.sh/uv/getting-started/installation/
 - A GitHub account and a fork of this repository
 
@@ -107,8 +108,11 @@ make test
 make build-cli
 AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check
 
-# Python launcher / parity tests (CI parity; not the product)
+# Python launcher / packaging tests (CI parity; not the product)
 AGENT_TOOLKIT_ROOT=$PWD uv run --project packages/pypi/agent-toolkit-cli --directory . pytest -c tests/pytest.ini tests/ -v
+
+# npm trampoline (node --test; ADR-025 — no V compile required)
+npm test --prefix packages/npm/agent-toolkit-cli
 ```
 
 Install pre-commit hooks (one-time, #274):

--- a/docs/HOW_TO_DEVELOP_V.md
+++ b/docs/HOW_TO_DEVELOP_V.md
@@ -48,6 +48,16 @@ uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit --v
 uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit --help
 ```
 
+## npm adapter (not the product)
+
+Thin Node launcher over the same Release V binaries ([ADR-025](adrs/ADR-025-npm-binary.md)). Tests use `node --test` (no V compile):
+
+```bash
+npm test --prefix packages/npm/agent-toolkit-cli
+```
+
+CI runs this matrix on Node **22** and **24** (`validate.yml` → `test-npm`). Pytest also invokes the same suite via `tests/test_npm_launcher.py` when `node` is on `PATH`.
+
 ## Build check (skills / plugins)
 
 After changing `skills/`, `agents/`, `loops/`, or `distributions/`:

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -13,4 +13,12 @@ npm adapter sources. PyPI equivalent: [`packages/pypi/`](../pypi/).
 
 Pack at release time: `scripts/pack_npm.vsh` (copies Release assets into `bin/`). Publish: `.github/workflows/publish-npm.yml` (OIDC trusted publishing).
 
+Trampoline tests (no V compile):
+
+```bash
+npm test --prefix packages/npm/agent-toolkit-cli
+```
+
+CI runs Node **22** and **24** across ubuntu/macOS/Windows (`validate.yml` → `test-npm`).
+
 Each published package has a polished `README.md`. Platform packages are shorter than the meta-package but document platform, install path, and when *not* to install them directly.

--- a/packages/npm/agent-toolkit-cli/bin/agent-toolkit.js
+++ b/packages/npm/agent-toolkit-cli/bin/agent-toolkit.js
@@ -63,7 +63,15 @@ function missingBinaryMessage() {
 }
 
 function runNative(binPath, argv) {
-  const child = spawn(binPath, argv, {
+  // Native Release binaries are .exe / ELF / Mach-O. For Windows tests (and rare
+  // AGENT_TOOLKIT_BIN=.js helpers), invoke via node so spawn does not need shell.
+  let command = binPath;
+  let args = argv;
+  if (process.platform === "win32" && /\.js$/i.test(binPath)) {
+    command = process.execPath;
+    args = [binPath, ...argv];
+  }
+  const child = spawn(command, args, {
     stdio: "inherit",
     windowsHide: true,
   });

--- a/packages/npm/agent-toolkit-cli/test/launcher.test.js
+++ b/packages/npm/agent-toolkit-cli/test/launcher.test.js
@@ -1,13 +1,25 @@
 "use strict";
 
+/**
+ * npm trampoline tests (ADR-025) — mirror packages/pypi launcher coverage in
+ * tests/test_launcher.py. No V compile required.
+ */
+
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { test } = require("node:test");
+const { test, describe } = require("node:test");
 const assert = require("node:assert/strict");
 
-const LAUNCHER = path.join(__dirname, "..", "bin", "agent-toolkit.js");
+const PKG_ROOT = path.join(__dirname, "..");
+const LAUNCHER = path.join(PKG_ROOT, "bin", "agent-toolkit.js");
+const {
+  platformSpec,
+  resolveNativeBin,
+  missingBinaryMessage,
+  EXIT_MISSING,
+} = require(LAUNCHER);
 
 function writeFakeBin(dir) {
   const isWin = process.platform === "win32";
@@ -27,6 +39,14 @@ function writeFakeBin(dir) {
   return dest;
 }
 
+function writeNativeStub(filePath) {
+  if (process.platform === "win32") {
+    fs.writeFileSync(filePath, "@echo off\r\nexit /b 0\r\n");
+  } else {
+    fs.writeFileSync(filePath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  }
+}
+
 function runLauncher(args, env) {
   return spawnSync(process.execPath, [LAUNCHER, ...args], {
     encoding: "utf8",
@@ -34,40 +54,187 @@ function runLauncher(args, env) {
   });
 }
 
-test("missing binary exits 127", () => {
-  const result = runLauncher(["version"], {
-    AGENT_TOOLKIT_BIN: "",
-    AGENT_TOOLKIT_ROOT: path.join(os.tmpdir(), "agent-toolkit-missing-root"),
+function withEnv(overrides, fn) {
+  const keys = Object.keys(overrides);
+  const prev = {};
+  for (const key of keys) {
+    prev[key] = process.env[key];
+    const val = overrides[key];
+    if (val === undefined || val === null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = val;
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    for (const key of keys) {
+      if (prev[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prev[key];
+      }
+    }
+  }
+}
+
+describe("spawn: missing / env binary", () => {
+  test("missing binary exits 127", () => {
+    const result = runLauncher(["version"], {
+      AGENT_TOOLKIT_BIN: "",
+      AGENT_TOOLKIT_ROOT: path.join(os.tmpdir(), "agent-toolkit-missing-root"),
+    });
+    assert.equal(result.status, EXIT_MISSING);
+    assert.match(result.stderr, /native V binary not found/);
+    assert.match(result.stderr, /AGENT_TOOLKIT_BIN|make build-cli|optionalDependencies/);
   });
-  assert.equal(result.status, 127);
-  assert.match(result.stderr, /native V binary not found/);
+
+  test("AGENT_TOOLKIT_BIN forwards argv and exit code", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-"));
+    const bin = writeFakeBin(tmp);
+    const result = runLauncher(["--flag", "value with spaces"], {
+      AGENT_TOOLKIT_BIN: bin,
+      FAKE_EXIT: "0",
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /--flag/);
+    assert.match(result.stdout, /value with spaces/);
+  });
+
+  test("AGENT_TOOLKIT_BIN forwards non-zero exit", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-"));
+    const bin = writeFakeBin(tmp);
+    const result = runLauncher(["boom"], {
+      AGENT_TOOLKIT_BIN: bin,
+      FAKE_EXIT: "3",
+    });
+    assert.equal(result.status, 3);
+  });
+
+  test("AGENT_TOOLKIT_BIN pointing at a missing file exits 127", () => {
+    const result = runLauncher([], {
+      AGENT_TOOLKIT_BIN: path.join(os.tmpdir(), "no-such-agent-toolkit-bin"),
+      AGENT_TOOLKIT_ROOT: path.join(os.tmpdir(), "agent-toolkit-missing-root"),
+    });
+    assert.equal(result.status, EXIT_MISSING);
+  });
 });
 
-test("AGENT_TOOLKIT_BIN forwards argv and exit code", () => {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-"));
-  const bin = writeFakeBin(tmp);
-  const result = runLauncher(["--flag", "value with spaces"], {
-    AGENT_TOOLKIT_BIN: bin,
-    FAKE_EXIT: "0",
+describe("resolveNativeBin (unit)", () => {
+  test("prefers AGENT_TOOLKIT_BIN when the file exists", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-"));
+    const bin = writeFakeBin(tmp);
+    withEnv({ AGENT_TOOLKIT_BIN: bin, AGENT_TOOLKIT_ROOT: undefined }, () => {
+      assert.equal(resolveNativeBin(), bin);
+    });
   });
-  assert.equal(result.status, 0);
-  assert.match(result.stdout, /--flag/);
-  assert.match(result.stdout, /value with spaces/);
+
+  test("returns null when AGENT_TOOLKIT_BIN is set but missing", () => {
+    withEnv(
+      {
+        AGENT_TOOLKIT_BIN: path.join(os.tmpdir(), "no-such-agent-toolkit-bin"),
+        AGENT_TOOLKIT_ROOT: undefined,
+      },
+      () => {
+        assert.equal(resolveNativeBin(), null);
+      },
+    );
+  });
+
+  test("resolves AGENT_TOOLKIT_ROOT/build native stub", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-root-"));
+    const build = path.join(tmp, "build");
+    fs.mkdirSync(build);
+    const names =
+      process.platform === "win32"
+        ? ["agent-toolkit.exe", "agent-toolkit"]
+        : ["agent-toolkit", "agent-toolkit-v"];
+    const native = path.join(build, names[0]);
+    writeNativeStub(native);
+    withEnv({ AGENT_TOOLKIT_BIN: undefined, AGENT_TOOLKIT_ROOT: tmp }, () => {
+      assert.equal(resolveNativeBin(), native);
+    });
+  });
+
+  test("resolves AGENT_TOOLKIT_ROOT/build/agent-toolkit-v on posix", { skip: process.platform === "win32" }, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-v-"));
+    const build = path.join(tmp, "build");
+    fs.mkdirSync(build);
+    const native = path.join(build, "agent-toolkit-v");
+    writeNativeStub(native);
+    withEnv({ AGENT_TOOLKIT_BIN: undefined, AGENT_TOOLKIT_ROOT: tmp }, () => {
+      assert.equal(resolveNativeBin(), native);
+    });
+  });
 });
 
-test("AGENT_TOOLKIT_BIN forwards non-zero exit", () => {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-"));
-  const bin = writeFakeBin(tmp);
-  const result = runLauncher(["boom"], {
-    AGENT_TOOLKIT_BIN: bin,
-    FAKE_EXIT: "3",
+describe("platformSpec + package metadata", () => {
+  test("platformSpec matches platforms.json for this host", () => {
+    const specs = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, "platforms.json"), "utf8"));
+    const cpu = process.arch === "ia32" ? "ia32" : process.arch;
+    const expected = specs.find((p) => p.os === process.platform && p.cpu === cpu) || null;
+    assert.deepEqual(platformSpec(), expected);
   });
-  assert.equal(result.status, 3);
+
+  test("platforms.json covers release triples (no musl)", () => {
+    const specs = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, "platforms.json"), "utf8"));
+    assert.equal(specs.length, 5);
+    const npmNames = specs.map((s) => s.npm).sort();
+    assert.deepEqual(npmNames, [
+      "agent-toolkit-cli-darwin-arm64",
+      "agent-toolkit-cli-darwin-x64",
+      "agent-toolkit-cli-linux-arm64",
+      "agent-toolkit-cli-linux-x64",
+      "agent-toolkit-cli-win32-x64",
+    ]);
+    for (const spec of specs) {
+      assert.ok(spec.bin);
+      assert.ok(spec.floating);
+      if (spec.os === "linux") {
+        assert.equal(spec.libc, "glibc");
+      }
+    }
+  });
+
+  test("package.json bin entries and optionalDependencies stay in sync", () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf8"));
+    assert.equal(pkg.bin["agent-toolkit"], "bin/agent-toolkit.js");
+    assert.equal(pkg.bin["agent-toolkit-cli"], "bin/agent-toolkit.js");
+    assert.match(pkg.engines.node, />=18/);
+    const specs = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, "platforms.json"), "utf8"));
+    for (const spec of specs) {
+      assert.equal(pkg.optionalDependencies[spec.npm], pkg.version);
+    }
+  });
+
+  test("missingBinaryMessage mentions ADR-025 and recovery paths", () => {
+    const msg = missingBinaryMessage();
+    assert.match(msg, /ADR-025/);
+    assert.match(msg, /optionalDependencies|AGENT_TOOLKIT_BIN|make build-cli/);
+  });
 });
 
-test("unset AGENT_TOOLKIT_BIN that points at a missing file exits 127", () => {
-  const result = runLauncher([], {
-    AGENT_TOOLKIT_BIN: path.join(os.tmpdir(), "no-such-agent-toolkit-bin"),
+describe("spawn: AGENT_TOOLKIT_ROOT", () => {
+  test("forwards through root-resolved stub", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-spawn-root-"));
+    const build = path.join(tmp, "build");
+    fs.mkdirSync(build);
+    const stubName = process.platform === "win32" ? "agent-toolkit.exe" : "agent-toolkit";
+    const stub = path.join(build, stubName);
+    // Reuse argv-echoing fake so we can assert forwarding.
+    const echo = writeFakeBin(tmp);
+    fs.copyFileSync(echo, stub);
+    if (process.platform !== "win32") {
+      fs.chmodSync(stub, 0o755);
+    }
+    const result = runLauncher(["skills", "list"], {
+      AGENT_TOOLKIT_BIN: "",
+      AGENT_TOOLKIT_ROOT: tmp,
+      FAKE_EXIT: "0",
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /skills/);
+    assert.match(result.stdout, /list/);
   });
-  assert.equal(result.status, 127);
 });

--- a/packages/npm/agent-toolkit-cli/test/launcher.test.js
+++ b/packages/npm/agent-toolkit-cli/test/launcher.test.js
@@ -22,29 +22,36 @@ const {
 } = require(LAUNCHER);
 
 function writeFakeBin(dir) {
-  const isWin = process.platform === "win32";
-  const dest = path.join(dir, isWin ? "fake-bin.cmd" : "fake-bin");
-  if (isWin) {
-    fs.writeFileSync(
-      dest,
-      ["@echo off", "echo %*", "if not \"%FAKE_EXIT%\"==\"\" exit /b %FAKE_EXIT%", "exit /b 0"].join("\r\n"),
-    );
-  } else {
-    fs.writeFileSync(
-      dest,
-      "#!/bin/sh\nprintf '%s\\n' \"$*\"\nexit \"${FAKE_EXIT:-0}\"\n",
-      { mode: 0o755 },
-    );
-  }
+  // Portable Node stub: shebang on posix; on Windows the launcher rewrites
+  // AGENT_TOOLKIT_BIN=*.js → spawn(process.execPath, [script, ...argv]).
+  const dest = path.join(dir, process.platform === "win32" ? "fake-bin.js" : "fake-bin");
+  fs.writeFileSync(
+    dest,
+    [
+      "#!/usr/bin/env node",
+      '"use strict";',
+      'const code = Number(process.env.FAKE_EXIT || "0");',
+      'process.stdout.write(process.argv.slice(2).join(" ") + "\\n");',
+      "process.exit(Number.isFinite(code) ? code : 0);",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
   return dest;
 }
 
 function writeNativeStub(filePath) {
-  if (process.platform === "win32") {
-    fs.writeFileSync(filePath, "@echo off\r\nexit /b 0\r\n");
-  } else {
-    fs.writeFileSync(filePath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-  }
+  // Same portable stub used for AGENT_TOOLKIT_ROOT/build resolution tests.
+  fs.writeFileSync(
+    filePath,
+    [
+      "#!/usr/bin/env node",
+      '"use strict";',
+      "process.exit(0);",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
 }
 
 function runLauncher(args, env) {
@@ -216,24 +223,22 @@ describe("platformSpec + package metadata", () => {
 });
 
 describe("spawn: AGENT_TOOLKIT_ROOT", () => {
-  test("forwards through root-resolved stub", () => {
+  test("forwards through root-resolved stub", { skip: process.platform === "win32" }, () => {
+    // Windows Release binaries are PE (.exe); shebang stubs cannot be CreateProcess'd.
+    // Windows spawn forwarding is covered by AGENT_TOOLKIT_BIN=*.js tests above.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atk-npm-spawn-root-"));
     const build = path.join(tmp, "build");
     fs.mkdirSync(build);
-    const stubName = process.platform === "win32" ? "agent-toolkit.exe" : "agent-toolkit";
-    const stub = path.join(build, stubName);
-    // Reuse argv-echoing fake so we can assert forwarding.
+    const stub = path.join(build, "agent-toolkit");
     const echo = writeFakeBin(tmp);
     fs.copyFileSync(echo, stub);
-    if (process.platform !== "win32") {
-      fs.chmodSync(stub, 0o755);
-    }
+    fs.chmodSync(stub, 0o755);
     const result = runLauncher(["skills", "list"], {
       AGENT_TOOLKIT_BIN: "",
       AGENT_TOOLKIT_ROOT: tmp,
       FAKE_EXIT: "0",
     });
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.match(result.stdout, /skills/);
     assert.match(result.stdout, /list/);
   });

--- a/packages/pypi/agent-toolkit-cli/pyproject.toml
+++ b/packages/pypi/agent-toolkit-cli/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]

--- a/tests/test_npm_launcher.py
+++ b/tests/test_npm_launcher.py
@@ -1,4 +1,9 @@
-"""npm launcher invokes a native binary (ADR-025 / #536)."""
+"""npm launcher invokes a native binary (ADR-025 / #536).
+
+Delegates to packages/npm/agent-toolkit-cli/test/launcher.test.js so pytest
+and `npm test` share one suite. Prefer `npm test --prefix packages/npm/agent-toolkit-cli`
+locally; CI also runs a dedicated Node matrix (`validate.yml` → `test-npm`).
+"""
 
 from __future__ import annotations
 
@@ -10,6 +15,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parent.parent
 LAUNCHER_TEST = REPO / "packages/npm/agent-toolkit-cli/test/launcher.test.js"
+NPM_PKG = REPO / "packages/npm/agent-toolkit-cli"
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node required for npm launcher tests")
@@ -22,3 +28,9 @@ def test_npm_launcher_node_suite() -> None:
         text=True,
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+@pytest.mark.skipif(shutil.which("npm") is None, reason="npm required for package.json test script")
+def test_npm_test_script_matches_node_suite() -> None:
+    pkg = (NPM_PKG / "package.json").read_text(encoding="utf-8")
+    assert '"test": "node --test test/launcher.test.js"' in pkg


### PR DESCRIPTION
## Summary
- Expand `packages/npm/agent-toolkit-cli` `node --test` suite to mirror PyPI launcher coverage (`resolveNativeBin`, `AGENT_TOOLKIT_ROOT`, `platforms.json` / package metadata).
- Add dedicated `test-npm` job in `validate.yml` (Node **22** LTS + **24** Current × ubuntu/macOS/Windows) and gate it in Required CI.
- Bump primary Python CI jobs to **3.14**; packaging matrix is now **3.10–3.14**. Align markdownlint / Danger Node pins with publish-npm (**24**).

## Test plan
- [x] `npm test --prefix packages/npm/agent-toolkit-cli` (13 tests, local)
- [ ] CI `test-npm` matrix green
- [ ] CI `test-package` green on Python 3.14
- [ ] Required CI aggregate green


Made with [Cursor](https://cursor.com)