### PR TITLE
refactor(cli): migrate V dispatch to vlib/cli Command tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Refactor** — Migrate V CLI dispatch to `vlib/cli` Command tree with Consumer/Advanced groups and nested families (`skills`, `mcp`, `plugin`, `loop`, `workspace`, …); keep AT exit-code wrapper (no `Command.parse`; bad flags → 2), peel leading `--json`/`--quiet`, and CommandResult render path ([docs/v/vlib-cli-spike.md](docs/v/vlib-cli-spike.md))
 - **Chore** — Rewrite `make.vsh` on vlib `build` (bobatea-style short tasks + [upstream build_system example](https://github.com/vlang/v/blob/master/examples/build_system/build.vsh)); remove `Makefile`; CI/docs use `./make.vsh <target>` (shebang); `install-cli --prefix=/path` (hyphen flags skipped by `context.run`, parsed manually; `PREFIX` env fallback)
 
 - **Tests** — Expand npm trampoline suite (`node --test`) to mirror PyPI launcher coverage; add dedicated `test-npm` CI job (Node 22/24 × ubuntu/macOS/Windows)

--- a/docs/v/cli-dispatcher.md
+++ b/docs/v/cli-dispatcher.md
@@ -3,6 +3,15 @@
 **Issue:** [#553](https://github.com/ulises-jeremias/agent-toolkit/issues/553)  
 **Spike:** [`vlib-cli-spike.md`](vlib-cli-spike.md)
 
-Single dispatch table matching `docs/CLI_SURFACES.md` consumer/advanced split, aliases (`dc`, `rollback`), help via `vlib/cli` grouping, bad-flag exit **2**, unknown command exit **1**. Business logic stays in core; unfinished advanced commands return `not_implemented`. Consumer `install` is wired (#607).
+## Layout
+
+| File | Role |
+|------|------|
+| `modules/agent_toolkit_cli/commands.v` | `cli.Command` tree: Consumer/Advanced `group`, aliases (`dc`, `rollback`), nested families, global `--json`/`--quiet`, `-V` |
+| `modules/agent_toolkit_cli/dispatch.v` | AT wrapper: walk tree (does **not** call `Command.parse`), bad flags → **2**, unknown command → **1**, render CommandResult |
+| `modules/agent_toolkit_cli/options.v` | Flag/arg parsers → core option structs |
+| `modules/agent_toolkit_cli/render.v` | Human / JSON / quiet output |
+
+Business logic stays in `agent_toolkit_core`. Root `--help` uses `Command.help_message()` (grouped sections). Per-command `--help` keeps rich core/`subcommand_help` text for parity.
 
 Build: `./make.vsh build-cli` → `build/agent-toolkit` (canonical, #555) and `build/agent-toolkit-v` (parity harness alias).

--- a/docs/v/cli-dispatcher.md
+++ b/docs/v/cli-dispatcher.md
@@ -8,7 +8,7 @@
 | File | Role |
 |------|------|
 | `modules/agent_toolkit_cli/commands.v` | `cli.Command` tree: Consumer/Advanced `group`, aliases (`dc`, `rollback`), nested families, global `--json`/`--quiet`, `-V` |
-| `modules/agent_toolkit_cli/dispatch.v` | AT wrapper: walk tree (does **not** call `Command.parse`), bad flags → **2**, unknown command → **1**, render CommandResult |
+| `modules/agent_toolkit_cli/dispatch.v` | AT wrapper: walk tree (does **not** call `Command.parse` — keeps integer exit codes), peel leading `--json`/`--quiet`, bad flags → **2**, unknown command → **1**, render CommandResult |
 | `modules/agent_toolkit_cli/options.v` | Flag/arg parsers → core option structs |
 | `modules/agent_toolkit_cli/render.v` | Human / JSON / quiet output |
 

--- a/modules/agent_toolkit_cli/commands.v
+++ b/modules/agent_toolkit_cli/commands.v
@@ -1,0 +1,527 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+import cli
+
+// build_root_command constructs the vlib/cli Command tree (docs/v/vlib-cli-spike.md).
+// Groups mirror docs/CLI_SURFACES.md. Nested families match cli_groups.v style.
+// Dispatch does not call Command.parse (exit-code wrapper); it walks this tree.
+pub fn build_root_command() cli.Command {
+	ver := agent_toolkit_core.resolve_toolkit_version()
+	mut app := cli.Command{
+		name:        'agent-toolkit'
+		description: 'Composable AI agent toolkit CLI (${ver})'
+		version:     ver
+		posix_mode:  true
+		sort_flags:  false
+		sort_commands: false
+		defaults:    struct {
+			help:    true
+			version: false // custom -V / version command (contract: agent-toolkit <ver>)
+			man:     false
+		}
+		examples: [
+			'$ agent-toolkit install --dry-run --offline',
+			'$ agent-toolkit doctor --json',
+			'$ agent-toolkit skills list',
+			'$ agent-toolkit workspace context --json',
+		]
+		learn_more: 'Run `agent-toolkit <command> --help` for details.\nConsumer vs advanced: docs/CLI_SURFACES.md'
+	}
+	app.add_flag(cli.Flag{
+		flag:        .bool
+		name:        'json'
+		description: 'Structured CommandResult JSON (most commands)'
+		global:      true
+	})
+	app.add_flag(cli.Flag{
+		flag:        .bool
+		name:        'quiet'
+		description: 'Suppress human output'
+		global:      true
+	})
+	app.add_flag(cli.Flag{
+		flag:        .bool
+		name:        'version'
+		abbrev:      'V'
+		description: 'Print version'
+	})
+	app.add_commands([
+		version_command(),
+		install_command(),
+		update_command(),
+		uninstall_command(),
+		doctor_command(),
+		diff_command(),
+		skills_command(),
+		mcp_command(),
+		plugin_command(),
+		completion_command(),
+		loop_command(),
+		workspace_command(),
+		memory_command(),
+		project_command(),
+		devcompanion_command(),
+		insights_command(),
+		build_command(),
+		inventory_command(),
+		matrix_command(),
+		release_command(),
+		swarm_command(),
+	])
+	app.setup()
+	return app
+}
+
+fn version_command() cli.Command {
+	return cli.Command{
+		name:        'version'
+		description: 'Print version'
+		group:       'Meta'
+	}
+}
+
+fn install_command() cli.Command {
+	return cli.Command{
+		name:        'install'
+		description: 'Install profiles for detected AI tools'
+		group:       'Consumer commands'
+		flags:       [
+			cli.Flag{
+				flag:        .string
+				name:        'tools'
+				description: 'Comma-separated tools (default: auto-detect)'
+			},
+			cli.Flag{
+				flag:        .bool
+				name:        'dry-run'
+				description: 'Show what would happen without making changes'
+			},
+			cli.Flag{
+				flag:        .bool
+				name:        'force'
+				description: 'Overwrite existing files without prompting'
+			},
+			cli.Flag{
+				flag:        .bool
+				name:        'offline'
+				description: 'Use only bundled/cached data'
+			},
+		]
+	}
+}
+
+fn update_command() cli.Command {
+	return cli.Command{
+		name:        'update'
+		description: 'Refresh installed profiles from latest toolkit data'
+		group:       'Consumer commands'
+		flags:       [
+			cli.Flag{
+				flag:        .string
+				name:        'tools'
+				description: 'Comma-separated tools'
+			},
+			cli.Flag{
+				flag:        .bool
+				name:        'check'
+				description: 'Dry-run — show what would change without writing'
+			},
+			cli.Flag{
+				flag:        .string
+				name:        'pin'
+				description: 'Download capability data for a release before updating'
+			},
+		]
+	}
+}
+
+fn uninstall_command() cli.Command {
+	return cli.Command{
+		name:        'uninstall'
+		alias:       'rollback'
+		description: 'Remove toolkit-owned files using install receipts (alias: rollback)'
+		group:       'Consumer commands'
+		flags:       [
+			cli.Flag{
+				flag:        .string
+				name:        'tools'
+				description: 'Comma-separated tools'
+			},
+			cli.Flag{
+				flag:        .bool
+				name:        'dry-run'
+				description: 'Show what would be removed without deleting'
+			},
+			cli.Flag{
+				flag:        .bool
+				name:        'rollback'
+				description: 'Alias for uninstall (removes toolkit-owned files)'
+			},
+		]
+	}
+}
+
+fn doctor_command() cli.Command {
+	return cli.Command{
+		name:        'doctor'
+		description: 'Check system health and tool availability'
+		group:       'Consumer commands'
+		flags:       [
+			cli.Flag{
+				flag:        .bool
+				name:        'fix'
+				description: 'Attempt auto-repair for missing profiles'
+			},
+			cli.Flag{
+				flag:        .bool
+				name:        'provenance'
+				description: 'Report capabilities/upstream.lock presence'
+			},
+		]
+	}
+}
+
+fn diff_command() cli.Command {
+	return cli.Command{
+		name:        'diff'
+		description: 'Show changes vs currently installed plugin bundles'
+		group:       'Consumer commands'
+		flags:       [
+			cli.Flag{
+				flag:        .string
+				name:        'target'
+				description: 'Target platform'
+			},
+			cli.Flag{
+				flag:        .string
+				name:        'product'
+				description: 'Product ID to diff'
+			},
+		]
+	}
+}
+
+fn skills_command() cli.Command {
+	return cli.Command{
+		name:        'skills'
+		description: 'Skill management: sync, list, validate'
+		group:       'Consumer commands'
+		commands:    [
+			cli.Command{
+				name:        'list'
+				description: 'List skills grouped by domain'
+				flags:       [
+					cli.Flag{
+						flag:        .string
+						name:        'domain'
+						description: 'Filter by domain'
+					},
+				]
+			},
+			cli.Command{
+				name:        'sync'
+				description: 'Sync skills to tool-specific directories'
+				flags:       [
+					cli.Flag{
+						flag:        .string
+						name:        'tools'
+						description: 'Comma-separated tools to sync'
+					},
+				]
+			},
+			cli.Command{
+				name:        'validate'
+				description: 'Validate SKILL.md frontmatter'
+			},
+		]
+		flags:       [
+			cli.Flag{
+				flag:        .string
+				name:        'domain'
+				description: 'Filter by domain (list)'
+			},
+			cli.Flag{
+				flag:        .string
+				name:        'tools'
+				description: 'Comma-separated tools (sync)'
+			},
+		]
+	}
+}
+
+fn mcp_command() cli.Command {
+	return cli.Command{
+		name:        'mcp'
+		description: 'MCP provider management: setup, list, doctor'
+		group:       'Consumer commands'
+		commands:    [
+			cli.Command{ name: 'list', description: 'List MCP providers' },
+			cli.Command{ name: 'setup', description: 'Interactive MCP setup', usage: '<provider>' },
+			cli.Command{ name: 'health', description: 'Check provider health' },
+			cli.Command{ name: 'doctor', description: 'MCP doctor checks' },
+			cli.Command{ name: 'uninstall', description: 'Remove MCP provider config', usage: '<provider>' },
+		]
+		flags:       [
+			cli.Flag{
+				flag:        .bool
+				name:        'offline'
+				description: 'Skip network lookups'
+			},
+		]
+	}
+}
+
+fn plugin_command() cli.Command {
+	return cli.Command{
+		name:        'plugin'
+		description: 'Plugin bundle management: sync, check'
+		group:       'Consumer commands'
+		commands:    [
+			cli.Command{ name: 'sync', description: 'Sync canonical agents/skills into plugin bundles' },
+			cli.Command{ name: 'check', description: 'Verify plugin bundles are in sync' },
+		]
+	}
+}
+
+fn completion_command() cli.Command {
+	return cli.Command{
+		name:        'completion'
+		description: 'Emit bash/zsh/fish/PowerShell completion scripts'
+		group:       'Consumer commands'
+		usage:       '<bash|zsh|fish|powershell>'
+		commands:    [
+			cli.Command{ name: 'bash', description: 'Bash completion script' },
+			cli.Command{ name: 'zsh', description: 'Zsh completion script' },
+			cli.Command{ name: 'fish', description: 'Fish completion script' },
+			cli.Command{ name: 'powershell', description: 'PowerShell completion script' },
+		]
+	}
+}
+
+fn loop_command() cli.Command {
+	return cli.Command{
+		name:        'loop'
+		description: 'Loop engineering: init, run, status, audit, cost, schedule, sync'
+		group:       'Advanced commands'
+		commands:    [
+			cli.Command{ name: 'init', description: 'Scaffold a loop from a template', usage: '<pattern>' },
+			cli.Command{ name: 'run', description: 'Execute one loop iteration', usage: '<name>' },
+			cli.Command{ name: 'status', description: 'Show loop instances' },
+			cli.Command{ name: 'audit', description: 'Review past runs', usage: '<name>' },
+			cli.Command{ name: 'cost', description: 'Estimate loop cost', usage: '<name>' },
+			cli.Command{ name: 'schedule', description: 'Install systemd/launchd timer', usage: '<name>' },
+			cli.Command{ name: 'sync', description: 'Sync loop templates' },
+			cli.Command{ name: 'list', alias: 'ls', description: 'List loop instances' },
+			cli.Command{ name: 'templates', description: 'List available templates' },
+		]
+		flags:       loop_flags()
+	}
+}
+
+fn loop_flags() []cli.Flag {
+	return [
+		cli.Flag{ flag: .bool, name: 'force', description: 'Force overwrite' },
+		cli.Flag{ flag: .bool, name: 'quiet', description: 'Suppress human output' },
+		cli.Flag{ flag: .bool, name: 'no-llm', description: 'Use skeleton runner' },
+		cli.Flag{ flag: .bool, name: 'dry-run', description: 'Plan without applying' },
+		cli.Flag{ flag: .bool, name: 'list', description: 'List mode for schedule' },
+		cli.Flag{ flag: .bool, name: 'remove', description: 'Remove scheduled timer' },
+		cli.Flag{ flag: .bool, name: 'status', description: 'Schedule status (legacy flag)' },
+		cli.Flag{ flag: .string, name: 'name', description: 'Custom loop name' },
+		cli.Flag{ flag: .string, name: 'runner', description: 'Runner backend' },
+		cli.Flag{ flag: .string, name: 'pack', description: 'Pack name' },
+		cli.Flag{ flag: .string, name: 'workspace', description: 'Workspace path' },
+		cli.Flag{ flag: .string, name: 'cron', description: 'Cron expression' },
+	]
+}
+
+fn workspace_command() cli.Command {
+	return cli.Command{
+		name:        'workspace'
+		description: 'Workspace scaffolding: init, context, sync'
+		group:       'Advanced commands'
+		commands:    [
+			cli.Command{ name: 'init', description: 'Scaffold a new harness workspace' },
+			cli.Command{ name: 'context', description: 'Output a session state snapshot' },
+			cli.Command{ name: 'sync', description: 'Sync workspace knowledge' },
+			cli.Command{ name: 'use-persona', description: 'Activate a work mode', usage: '<name>' },
+			cli.Command{ name: 'handoff', description: 'Handoff between personas' },
+			cli.Command{ name: 'history', description: 'Show persona history' },
+			cli.Command{ name: 'personas', description: 'List personas' },
+			cli.Command{ name: 'load', description: 'Load a context pack', usage: '<pack.yaml>' },
+			cli.Command{ name: 'profiles', description: 'List or manage profiles' },
+			cli.Command{ name: 'validate', description: 'Validate workspace schemas' },
+			cli.Command{ name: 'budget', description: 'Analyze context footprint' },
+		]
+		flags:       [
+			cli.Flag{ flag: .bool, name: 'explain', description: 'Explain context sources' },
+			cli.Flag{ flag: .string, name: 'dir', description: 'Target directory' },
+			cli.Flag{ flag: .string, name: 'name', description: 'Workspace name' },
+			cli.Flag{ flag: .string, name: 'workspace', description: 'Workspace path' },
+			cli.Flag{ flag: .string, name: 'profile', description: 'Profile name' },
+			cli.Flag{ flag: .string, name: 'pack', description: 'Pack path or name' },
+		]
+	}
+}
+
+fn memory_command() cli.Command {
+	return cli.Command{
+		name:        'memory'
+		description: 'Knowledge base: add, search, inject, review, todo'
+		group:       'Advanced commands'
+		commands:    [
+			cli.Command{ name: 'add', description: 'Add a learning, process, or todo entry' },
+			cli.Command{ name: 'search', description: 'Search knowledge files', usage: '<query>' },
+			cli.Command{ name: 'inject', description: 'Output knowledge for session injection' },
+			cli.Command{ name: 'review', description: 'Detect duplicates and stale refs' },
+			cli.Command{ name: 'todo', description: 'List unchecked todos' },
+		]
+		flags:       [
+			cli.Flag{ flag: .bool, name: 'fix', description: 'Auto-fix review findings' },
+			cli.Flag{ flag: .bool, name: 'done', description: 'Include completed todos' },
+			cli.Flag{ flag: .string, name: 'type', description: 'Entry type for add' },
+			cli.Flag{ flag: .string, name: 'title', description: 'Entry title' },
+			cli.Flag{ flag: .string, name: 'workspace', description: 'Workspace path' },
+			cli.Flag{ flag: .int, name: 'stale-after', description: 'Stale threshold (days)' },
+		]
+	}
+}
+
+fn project_command() cli.Command {
+	return cli.Command{
+		name:        'project'
+		description: 'Project management: clone, list, add, remove, scan'
+		group:       'Advanced commands'
+		commands:    [
+			cli.Command{ name: 'init', description: 'Create repos/ and projects/ scaffolding' },
+			cli.Command{ name: 'clone', description: 'Clone a GitHub repo and symlink', usage: '<owner/repo>' },
+			cli.Command{ name: 'list', description: 'List symlinked projects' },
+			cli.Command{ name: 'add', description: 'Symlink an already-cloned repo', usage: '<path>' },
+			cli.Command{ name: 'remove', description: 'Remove symlink', usage: '<name>' },
+			cli.Command{ name: 'scan', description: 'Scan for projects' },
+		]
+		flags:       [
+			cli.Flag{ flag: .bool, name: 'ssh', description: 'Clone via SSH' },
+			cli.Flag{ flag: .string, name: 'workspace', description: 'Workspace path' },
+		]
+	}
+}
+
+fn devcompanion_command() cli.Command {
+	return cli.Command{
+		name:        'devcompanion'
+		alias:       'dc'
+		description: 'Background job queue: queue, run-once, status, done, sync-todos (alias: dc)'
+		group:       'Advanced commands'
+		commands:    [
+			cli.Command{ name: 'queue', description: 'Queue a background job', usage: '<project>' },
+			cli.Command{ name: 'run-once', description: 'Process next job' },
+			cli.Command{ name: 'status', description: 'Show queue state' },
+			cli.Command{ name: 'done', description: 'Mark job complete', usage: '<job-id>' },
+			cli.Command{ name: 'sync-todos', description: 'Sync todos from knowledge' },
+		]
+		flags:       [
+			cli.Flag{ flag: .bool, name: 'no-llm', description: 'Skeleton plan only' },
+			cli.Flag{ flag: .string, name: 'template', abbrev: 't', description: 'Job template' },
+			cli.Flag{ flag: .string, name: 'request', abbrev: 'r', description: 'Free-form request' },
+			cli.Flag{ flag: .string, name: 'id', description: 'Job id' },
+			cli.Flag{ flag: .string, name: 'workspace', description: 'Workspace path' },
+		]
+	}
+}
+
+fn insights_command() cli.Command {
+	return cli.Command{
+		name:        'insights'
+		description: 'AI tool usage insights (removed from product CLI; #526)'
+		group:       'Advanced commands'
+	}
+}
+
+fn build_command() cli.Command {
+	return cli.Command{
+		name:        'build'
+		description: 'Compile canonical capabilities into target-native artifacts'
+		group:       'Advanced commands'
+		flags:       [
+			cli.Flag{ flag: .bool, name: 'check', description: 'Dry-run + compare to plugins/' },
+			cli.Flag{ flag: .string, name: 'target', description: 'Target id' },
+			cli.Flag{ flag: .string, name: 'product', description: 'Product id' },
+			cli.Flag{ flag: .string, name: 'output', description: 'Output directory' },
+		]
+	}
+}
+
+fn inventory_command() cli.Command {
+	return cli.Command{
+		name:        'inventory'
+		description: 'List all canonical skills, agents, and products'
+		group:       'Advanced commands'
+	}
+}
+
+fn matrix_command() cli.Command {
+	return cli.Command{
+		name:        'matrix'
+		description: 'Show platform capability matrix'
+		group:       'Advanced commands'
+	}
+}
+
+fn release_command() cli.Command {
+	return cli.Command{
+		name:        'release'
+		description: 'Not in V — maintainer artifacts live in CI / docs/RELEASING.md'
+		group:       'Advanced commands'
+	}
+}
+
+fn swarm_command() cli.Command {
+	return cli.Command{
+		name:        'swarm'
+		description: 'Multi-agent swarm orchestration (pair/team/full, Herdr/tmux)'
+		group:       'Advanced commands'
+		commands:    [
+			cli.Command{ name: 'recipes', description: 'List or show recipes' },
+			cli.Command{ name: 'backends', description: 'List backends' },
+			cli.Command{ name: 'doctor', description: 'Swarm environment checks' },
+			cli.Command{ name: 'start', description: 'Start a swarm run' },
+			cli.Command{ name: 'list', description: 'List runs' },
+			cli.Command{ name: 'status', description: 'Show run status' },
+			cli.Command{ name: 'approve', description: 'Approve a gate' },
+			cli.Command{ name: 'reject', description: 'Reject a gate' },
+			cli.Command{ name: 'cancel', description: 'Cancel a run' },
+		]
+		flags:       [
+			cli.Flag{ flag: .bool, name: 'dry-run', description: 'Plan without starting' },
+			cli.Flag{ flag: .bool, name: 'force', description: 'Force action' },
+			cli.Flag{ flag: .string, name: 'recipe', description: 'Recipe name' },
+			cli.Flag{ flag: .string, name: 'backend', description: 'Backend id' },
+			cli.Flag{ flag: .string, name: 'ui', description: 'UI backend alias' },
+			cli.Flag{ flag: .string, name: 'workspace', description: 'Workspace path' },
+			cli.Flag{ flag: .string, name: 'reason', description: 'Reject reason' },
+		]
+	}
+}
+
+// command_matches mirrors cli.Command.matches (private in vlib).
+fn command_matches(cmd cli.Command, token string) bool {
+	return cmd.name == token || (cmd.alias.len > 0 && cmd.alias == token)
+}
+
+// find_command returns a top-level command by name or alias.
+fn find_command(root cli.Command, token string) ?cli.Command {
+	for c in root.commands {
+		if command_matches(c, token) {
+			return c
+		}
+	}
+	return none
+}
+
+// resolve_command_name maps argv token to canonical command name (aliases → primary).
+fn resolve_command_name(root cli.Command, token string) ?string {
+	c := find_command(root, token) or { return none }
+	return c.name
+}

--- a/modules/agent_toolkit_cli/commands.v
+++ b/modules/agent_toolkit_cli/commands.v
@@ -472,7 +472,7 @@ fn matrix_command() cli.Command {
 fn release_command() cli.Command {
 	return cli.Command{
 		name:        'release'
-		description: 'Not in V — maintainer artifacts live in CI / docs/RELEASING.md'
+		description: 'Not in V — use CI / docs/RELEASING.md (#527)'
 		group:       'Advanced commands'
 	}
 }

--- a/modules/agent_toolkit_cli/commands_test.v
+++ b/modules/agent_toolkit_cli/commands_test.v
@@ -1,0 +1,50 @@
+module agent_toolkit_cli
+
+fn test_root_command_tree_has_consumer_and_advanced_groups() {
+	root := build_root_command()
+	mut groups := map[string]bool{}
+	mut names := map[string]bool{}
+	for c in root.commands {
+		names[c.name] = true
+		if c.group.len > 0 {
+			groups[c.group] = true
+		}
+	}
+	assert groups['Consumer commands']
+	assert groups['Advanced commands']
+	assert names['install']
+	assert names['skills']
+	assert names['loop']
+	assert names['workspace']
+	assert names['devcompanion']
+}
+
+fn test_nested_skills_and_aliases() {
+	root := build_root_command()
+	skills := find_command(root, 'skills') or {
+		assert false, 'skills missing'
+		return
+	}
+	assert skills.commands.len >= 3
+	uninstall := find_command(root, 'rollback') or {
+		assert false, 'rollback alias missing'
+		return
+	}
+	assert uninstall.name == 'uninstall'
+	dc := find_command(root, 'dc') or {
+		assert false, 'dc alias missing'
+		return
+	}
+	assert dc.name == 'devcompanion'
+}
+
+fn test_global_json_flag_declared() {
+	root := build_root_command()
+	mut found := false
+	for f in root.flags {
+		if f.name == 'json' && f.global {
+			found = true
+		}
+	}
+	assert found
+}

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -8,38 +8,59 @@ pub fn run(args []string) int {
 	return dispatch(args)
 }
 
-// dispatch implements the root command contract (CLI_SURFACES consumer/advanced split).
+// dispatch walks the vlib/cli Command tree with an AT exit-code wrapper
+// (docs/v/vlib-cli-spike.md): bad flags → 2, unknown command → 1.
+// Does not call Command.parse() so unit tests keep integer exit codes.
 pub fn dispatch(args []string) int {
-	// Drop program name
+	root := build_root_command()
 	mut argv := []string{}
 	if args.len > 1 {
 		argv = args[1..].clone()
 	}
 	mode := mode_from_argv(argv)
-	if argv.len == 0 || argv[0] in ['-h', '--help', 'help'] {
-		print(grouped_help())
+	if argv.len == 0 {
+		print(grouped_help_from(root))
 		return 0
 	}
-	if argv[0] in ['-V', '--version', 'version'] {
+	first := argv[0]
+	if first in ['-h', '--help', 'help'] {
+		if argv.len >= 2 && !argv[1].starts_with('-') {
+			name := resolve_command_name(root, argv[1]) or {
+				eprintln('Unknown command: ${argv[1]}')
+				eprintln("Run 'agent-toolkit help' for usage.")
+				return 1
+			}
+			print(subcommand_help(name))
+			return 0
+		}
+		print(grouped_help_from(root))
+		return 0
+	}
+	if first in ['-V', '--version', 'version'] {
 		ver := agent_toolkit_core.resolve_toolkit_version()
 		return render(agent_toolkit_core.version_result(ver), mode)
 	}
 	// Bad flags before a command (argparse parity → exit 2)
-	if argv[0].starts_with('-')
-		&& argv[0] !in ['-h', '--help', '-V', '--version', '--json', '--quiet'] {
-		e := agent_toolkit_core.err_usage_flags('flag.unknown', 'unknown flag: ${argv[0]}')
+	if first.starts_with('-') && first !in ['--json', '--quiet'] {
+		e := agent_toolkit_core.err_usage_flags('flag.unknown', 'unknown flag: ${first}')
 		return render_error(e, mode)
 	}
-	cmd_name := resolve_alias(argv[0])
-	if !is_known_command(cmd_name) {
-		eprintln('Unknown command: ${argv[0]}')
+	if first.starts_with('-') {
+		eprintln('Unknown command: ${first}')
 		eprintln("Run 'agent-toolkit help' for usage.")
 		eprintln('See docs/CLI_SURFACES.md for consumer vs advanced commands.')
 		return 1
 	}
-	// Remaining tokens may include unknown flags → exit 2
-	for a in argv[1..] {
-		if a.starts_with('-') && !allowed_flag(cmd_name, a) {
+	cmd := find_command(root, first) or {
+		eprintln('Unknown command: ${first}')
+		eprintln("Run 'agent-toolkit help' for usage.")
+		eprintln('See docs/CLI_SURFACES.md for consumer vs advanced commands.')
+		return 1
+	}
+	cmd_name := cmd.name
+	rest := argv[1..].clone()
+	for a in rest {
+		if a.starts_with('-') && !flag_allowed_on(cmd, a) {
 			e := agent_toolkit_core.err_usage_flags('flag.unknown', 'unknown flag: ${a}')
 			return render_error(e, mode)
 		}
@@ -48,6 +69,10 @@ pub fn dispatch(args []string) int {
 			return 0
 		}
 	}
+	return execute_command(cmd_name, rest, mode)
+}
+
+fn execute_command(cmd_name string, rest []string, mode agent_toolkit_core.RenderMode) int {
 	if cmd_name == 'inventory' {
 		snap := agent_toolkit_core.load_inventory() or {
 			e := agent_toolkit_core.err_env('root.missing', err.msg())
@@ -59,17 +84,17 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.matrix_result(), mode)
 	}
 	if cmd_name == 'doctor' {
-		opts := parse_doctor_options(argv[1..])
+		opts := parse_doctor_options(rest)
 		snap := agent_toolkit_core.run_doctor(opts)
 		return render(agent_toolkit_core.doctor_result(snap), mode)
 	}
 	if cmd_name == 'build' {
-		opts := parse_build_options(argv[1..])
+		opts := parse_build_options(rest)
 		report := agent_toolkit_core.run_build(opts)
 		return render(agent_toolkit_core.build_result(report), mode)
 	}
 	if cmd_name == 'install' {
-		opts := parse_install_options(argv[1..]) or {
+		opts := parse_install_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -77,7 +102,7 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.install_result(report), mode)
 	}
 	if cmd_name == 'uninstall' {
-		opts := parse_uninstall_options(argv[1..]) or {
+		opts := parse_uninstall_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -85,12 +110,12 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.uninstall_result(report), mode)
 	}
 	if cmd_name == 'diff' {
-		opts := parse_diff_options(argv[1..])
+		opts := parse_diff_options(rest)
 		report := agent_toolkit_core.run_diff(opts)
 		return render(agent_toolkit_core.diff_result(report), mode)
 	}
 	if cmd_name == 'update' {
-		opts := parse_update_options(argv[1..]) or {
+		opts := parse_update_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -98,7 +123,7 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.update_result(report), mode)
 	}
 	if cmd_name == 'skills' {
-		opts := parse_skills_options(argv[1..]) or {
+		opts := parse_skills_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -106,17 +131,17 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.skills_result(report), mode)
 	}
 	if cmd_name == 'mcp' {
-		opts := parse_mcp_options(argv[1..])
+		opts := parse_mcp_options(rest)
 		report := agent_toolkit_core.run_mcp(opts)
 		return render(agent_toolkit_core.mcp_result(report), mode)
 	}
 	if cmd_name == 'plugin' {
-		opts := parse_plugin_options(argv[1..])
+		opts := parse_plugin_options(rest)
 		report := agent_toolkit_core.run_plugin(opts)
 		return render(agent_toolkit_core.plugin_result(report), mode)
 	}
 	if cmd_name == 'workspace' {
-		opts := parse_workspace_options(argv[1..]) or {
+		opts := parse_workspace_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -124,7 +149,7 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.workspace_result(report), mode)
 	}
 	if cmd_name == 'memory' {
-		opts := parse_memory_options(argv[1..]) or {
+		opts := parse_memory_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -132,7 +157,7 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.memory_result(report), mode)
 	}
 	if cmd_name == 'project' {
-		opts := parse_project_options(argv[1..]) or {
+		opts := parse_project_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -140,7 +165,7 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.project_result(report), mode)
 	}
 	if cmd_name == 'devcompanion' {
-		opts := parse_dc_options(argv[1..]) or {
+		opts := parse_dc_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -148,7 +173,7 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.devcompanion_result(report), mode)
 	}
 	if cmd_name == 'loop' {
-		opts := parse_loop_options(argv[1..]) or {
+		opts := parse_loop_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -156,7 +181,7 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.loop_result(report), mode)
 	}
 	if cmd_name == 'swarm' {
-		opts := parse_swarm_options(argv[1..]) or {
+		opts := parse_swarm_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
 		}
@@ -164,11 +189,11 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.swarm_result(report), mode)
 	}
 	if cmd_name == 'completion' {
-		return run_completion(argv[1..])
+		return run_completion(rest)
 	}
 	if cmd_name == 'insights' {
 		print(insights_help_text())
-		if insights_subcommand(argv[1..]).len > 0 {
+		if insights_subcommand(rest).len > 0 {
 			eprintln('insights is removed from the product CLI (#526). Use external analytics or a prior release if you still need it.')
 			return 1
 		}
@@ -181,1084 +206,38 @@ pub fn dispatch(args []string) int {
 	return render(agent_toolkit_core.not_implemented_result(cmd_name), mode)
 }
 
-fn parse_doctor_options(args []string) agent_toolkit_core.DoctorOptions {
-	mut fix := false
-	mut provenance := false
-	for a in args {
-		if a == '--fix' {
-			fix = true
-		}
-		if a == '--provenance' {
-			provenance = true
-		}
-	}
-	return agent_toolkit_core.DoctorOptions{
-		fix:        fix
-		provenance: provenance
-	}
-}
-
-fn parse_build_options(args []string) agent_toolkit_core.BuildOptions {
-	mut check := false
-	mut write_files := true
-	mut target := ''
-	mut product := ''
-	mut output_dir := ''
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a == '--check' {
-			check = true
-			write_files = false
-			i++
-			continue
-		}
-		if a == '--target' && i + 1 < args.len {
-			target = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--target=') {
-			target = a.all_after('=')
-			i++
-			continue
-		}
-		if a == '--product' && i + 1 < args.len {
-			product = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--product=') {
-			product = a.all_after('=')
-			i++
-			continue
-		}
-		if a == '--output' && i + 1 < args.len {
-			output_dir = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--output=') {
-			output_dir = a.all_after('=')
-			i++
-			continue
-		}
-		i++
-	}
-	return agent_toolkit_core.BuildOptions{
-		check:       check
-		target:      target
-		product:     product
-		output_dir:  output_dir
-		write_files: write_files
-	}
-}
-
-fn parse_install_options(args []string) !agent_toolkit_core.InstallOptions {
-	mut dry_run := false
-	mut force := false
-	mut offline := false
-	mut tools_raw := ''
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--dry-run' {
-			dry_run = true
-			i++
-			continue
-		}
-		if a == '--force' {
-			force = true
-			i++
-			continue
-		}
-		if a == '--offline' {
-			offline = true
-			i++
-			continue
-		}
-		if a == '--tools' {
-			if i + 1 >= args.len {
-				return error('--tools requires an argument')
-			}
-			tools_raw = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--tools=') {
-			tools_raw = a.all_after('=')
-			i++
-			continue
-		}
-		i++
-	}
-	mut tools := []string{}
-	if tools_raw.len > 0 {
-		for part in tools_raw.split(',') {
-			t := part.trim_space()
-			if t.len > 0 {
-				tools << t
-			}
-		}
-	}
-	return agent_toolkit_core.InstallOptions{
-		tools:   tools
-		dry_run: dry_run
-		force:   force
-		offline: offline
-	}
-}
-
-fn parse_uninstall_options(args []string) !agent_toolkit_core.UninstallOptions {
-	mut dry_run := false
-	mut tools_raw := ''
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--dry-run' {
-			dry_run = true
-			i++
-			continue
-		}
-		if a == '--rollback' {
-			// Alias semantics: uninstall with side effects (not dry-run).
-			dry_run = false
-			i++
-			continue
-		}
-		if a == '--tools' {
-			if i + 1 >= args.len {
-				return error('--tools requires an argument')
-			}
-			tools_raw = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--tools=') {
-			tools_raw = a.all_after('=')
-			i++
-			continue
-		}
-		i++
-	}
-	mut tools := []string{}
-	if tools_raw.len > 0 {
-		for part in tools_raw.split(',') {
-			t := part.trim_space()
-			if t.len > 0 {
-				tools << t
-			}
-		}
-	}
-	return agent_toolkit_core.UninstallOptions{
-		tools:   tools
-		dry_run: dry_run
-	}
-}
-
-fn parse_diff_options(args []string) agent_toolkit_core.DiffOptions {
-	mut target := ''
-	mut product := ''
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--target' && i + 1 < args.len {
-			target = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--target=') {
-			target = a.all_after('=')
-			i++
-			continue
-		}
-		if a == '--product' && i + 1 < args.len {
-			product = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--product=') {
-			product = a.all_after('=')
-			i++
-			continue
-		}
-		i++
-	}
-	return agent_toolkit_core.DiffOptions{
-		target:  target
-		product: product
-	}
-}
-
-fn parse_update_options(args []string) !agent_toolkit_core.UpdateOptions {
-	mut check_only := false
-	mut tools_raw := ''
-	mut pin := ''
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--check' {
-			check_only = true
-			i++
-			continue
-		}
-		if a == '--tools' {
-			if i + 1 >= args.len {
-				return error('--tools requires an argument')
-			}
-			tools_raw = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--tools=') {
-			tools_raw = a.all_after('=')
-			i++
-			continue
-		}
-		if a == '--pin' {
-			if i + 1 >= args.len {
-				return error('--pin requires an argument')
-			}
-			pin = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--pin=') {
-			pin = a.all_after('=')
-			i++
-			continue
-		}
-		i++
-	}
-	mut tools := []string{}
-	if tools_raw.len > 0 {
-		for part in tools_raw.split(',') {
-			t := part.trim_space()
-			if t.len > 0 {
-				tools << t
-			}
-		}
-	}
-	return agent_toolkit_core.UpdateOptions{
-		tools:      tools
-		check_only: check_only
-		pin:        pin
-	}
-}
-
-fn parse_skills_options(args []string) !agent_toolkit_core.SkillsOptions {
-	mut sub := ''
-	mut domain := ''
-	mut tools_raw := ''
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--domain' {
-			if i + 1 >= args.len {
-				return error('--domain requires an argument')
-			}
-			domain = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--domain=') {
-			domain = a.all_after('=')
-			i++
-			continue
-		}
-		if a == '--tools' {
-			if i + 1 >= args.len {
-				return error('--tools requires an argument')
-			}
-			tools_raw = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--tools=') {
-			tools_raw = a.all_after('=')
-			i++
-			continue
-		}
-		if !a.starts_with('-') && sub.len == 0 {
-			sub = a
-			i++
-			continue
-		}
-		i++
-	}
-	mut tools := []string{}
-	if tools_raw.len > 0 {
-		for part in tools_raw.split(',') {
-			t := part.trim_space()
-			if t.len > 0 {
-				tools << t
-			}
-		}
-	}
-	return agent_toolkit_core.SkillsOptions{
-		subcommand: sub
-		domain:     domain
-		tools:      tools
-	}
-}
-
-fn parse_mcp_options(args []string) agent_toolkit_core.McpOptions {
-	mut sub := ''
-	mut provider := ''
-	mut offline := false
-	for a in args {
-		if a in ['--json', '--quiet'] {
-			continue
-		}
-		if a == '--offline' {
-			offline = true
-			continue
-		}
-		if a.starts_with('-') {
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-			continue
-		}
-		if provider.len == 0 {
-			provider = a
-		}
-	}
-	return agent_toolkit_core.McpOptions{
-		subcommand: sub
-		provider:   provider
-		offline:    offline
-	}
-}
-
-fn parse_workspace_options(args []string) !agent_toolkit_core.WorkspaceOptions {
-	mut sub := ''
-	mut dir := ''
-	mut name := ''
-	mut workspace_path := ''
-	mut explain := false
-	mut json_out := false
-	mut arg := ''
-	mut profile := ''
-	mut pack := ''
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			if a == '--json' {
-				json_out = true
-			}
-			i++
-			continue
-		}
-		if a == '--explain' {
-			explain = true
-			i++
-			continue
-		}
-		if a in ['--dir', '--name', '--workspace', '--profile', '--pack'] {
-			if i + 1 >= args.len {
-				return error('${a} requires an argument')
-			}
-			val := args[i + 1]
-			match a {
-				'--dir' { dir = val }
-				'--name' { name = val }
-				'--workspace' { workspace_path = val }
-				'--profile' { profile = val }
-				'--pack' { pack = val }
-				else {}
-			}
-			i += 2
-			continue
-		}
-		if a.starts_with('--dir=') {
-			dir = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--name=') {
-			name = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--workspace=') {
-			workspace_path = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--profile=') {
-			profile = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--pack=') {
-			pack = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('-') {
-			i++
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-			i++
-			continue
-		}
-		if arg.len == 0 {
-			arg = a
-		}
-		i++
-	}
-	return agent_toolkit_core.WorkspaceOptions{
-		subcommand:     sub
-		dir:            dir
-		name:           name
-		workspace_path: workspace_path
-		explain:        explain
-		json_out:       json_out
-		arg:            arg
-		profile:        profile
-		pack:           pack
-	}
-}
-
-fn parse_project_options(args []string) !agent_toolkit_core.ProjectOptions {
-	mut sub := ''
-	mut workspace_path := ''
-	mut arg := ''
-	mut ssh := false
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--ssh' {
-			ssh = true
-			i++
-			continue
-		}
-		if a == '--workspace' {
-			if i + 1 >= args.len {
-				return error('${a} requires an argument')
-			}
-			workspace_path = args[i + 1]
-			i += 2
-			continue
-		}
-		if a.starts_with('--workspace=') {
-			workspace_path = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('-') {
-			i++
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-			i++
-			continue
-		}
-		if arg.len == 0 {
-			arg = a
-		}
-		i++
-	}
-	return agent_toolkit_core.ProjectOptions{
-		subcommand:     sub
-		workspace_path: workspace_path
-		arg:            arg
-		ssh:            ssh
-	}
-}
-
-fn parse_dc_options(args []string) !agent_toolkit_core.DevcompanionOptions {
-	mut sub := ''
-	mut workspace_path := ''
-	mut project := ''
-	mut template := ''
-	mut request := ''
-	mut job_id := ''
-	mut no_llm := false
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--no-llm' {
-			no_llm = true
-			i++
-			continue
-		}
-		if a in ['--template', '-t', '--request', '-r', '--id', '--workspace'] {
-			if i + 1 >= args.len {
-				return error('${a} requires an argument')
-			}
-			val := args[i + 1]
-			match a {
-				'--template', '-t' { template = val }
-				'--request', '-r' { request = val }
-				'--id' { job_id = val }
-				'--workspace' { workspace_path = val }
-				else {}
-			}
-			i += 2
-			continue
-		}
-		if a.starts_with('--template=') {
-			template = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--request=') {
-			request = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--id=') {
-			job_id = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--workspace=') {
-			workspace_path = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('-') {
-			i++
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-			i++
-			continue
-		}
-		if sub == 'queue' && project.len == 0 {
-			project = a
-		} else if sub == 'done' && job_id.len == 0 {
-			job_id = a
-		}
-		i++
-	}
-	mut arg := project
-	if sub == 'done' && job_id.len > 0 {
-		arg = job_id
-	}
-	return agent_toolkit_core.DevcompanionOptions{
-		subcommand:     sub
-		workspace_path: workspace_path
-		arg:            arg
-		template:       template
-		request:        request
-		job_id:         job_id
-		no_llm:         no_llm
-	}
-}
-
-fn parse_loop_options(args []string) !agent_toolkit_core.LoopOptions {
-	mut sub := ''
-	mut workspace_path := ''
-	mut name := ''
-	mut custom_name := ''
-	mut force := false
-	mut quiet := false
-	mut runner := ''
-	mut pack := ''
-	mut no_llm := false
-	mut dry_run := false
-	mut cron := ''
-	mut list_mode := false
-	mut remove_mode := false
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a == '--json' {
-			i++
-			continue
-		}
-		if a == '--quiet' {
-			quiet = true
-			i++
-			continue
-		}
-		if a == '--force' {
-			force = true
-			i++
-			continue
-		}
-		if a == '--no-llm' {
-			no_llm = true
-			i++
-			continue
-		}
-		if a == '--dry-run' {
-			dry_run = true
-			i++
-			continue
-		}
-		if a == '--list' {
-			list_mode = true
-			i++
-			continue
-		}
-		if a == '--remove' {
-			remove_mode = true
-			i++
-			continue
-		}
-		if a in ['--name', '--runner', '--pack', '--workspace', '--cron'] {
-			if i + 1 >= args.len {
-				return error('${a} requires an argument')
-			}
-			val := args[i + 1]
-			match a {
-				'--name' { custom_name = val }
-				'--runner' { runner = val }
-				'--pack' { pack = val }
-				'--workspace' { workspace_path = val }
-				'--cron' { cron = val }
-				else {}
-			}
-			i += 2
-			continue
-		}
-		if a.starts_with('--name=') {
-			custom_name = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--runner=') {
-			runner = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--pack=') {
-			pack = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--workspace=') {
-			workspace_path = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--cron=') {
-			cron = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('-') {
-			i++
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-			i++
-			continue
-		}
-		if name.len == 0 {
-			name = a
-		}
-		i++
-	}
-	if no_llm && runner.len == 0 {
-		runner = 'skeleton'
-	}
-	return agent_toolkit_core.LoopOptions{
-		subcommand:     sub
-		workspace_path: workspace_path
-		name:           name
-		custom_name:    custom_name
-		force:          force
-		quiet:          quiet
-		runner:         runner
-		pack:           pack
-		no_llm:         no_llm
-		dry_run:        dry_run
-		cron:           cron
-		list_mode:      list_mode
-		remove_mode:    remove_mode
-	}
-}
-
-fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
-	mut sub := ''
-	mut workspace_path := ''
-	mut run_id := ''
-	mut gate_id := ''
-	mut recipe := ''
-	mut backend := ''
-	mut reason := ''
-	mut dry_run := false
-	mut force := false
-	mut task_parts := []string{}
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--dry-run' {
-			dry_run = true
-			i++
-			continue
-		}
-		if a == '--force' {
-			force = true
-			i++
-			continue
-		}
-		if a in ['--recipe', '--backend', '--ui', '--workspace', '--reason'] {
-			if i + 1 >= args.len {
-				return error('${a} requires an argument')
-			}
-			val := args[i + 1]
-			match a {
-				'--recipe' { recipe = val }
-				'--backend' { backend = val }
-				'--ui' { backend = val }
-				'--workspace' { workspace_path = val }
-				'--reason' { reason = val }
-				else {}
-			}
-			i += 2
-			continue
-		}
-		if a.starts_with('--recipe=') {
-			recipe = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--backend=') || a.starts_with('--ui=') {
-			backend = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--workspace=') {
-			workspace_path = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--reason=') {
-			reason = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('-') {
-			i++
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-			i++
-			continue
-		}
-		if run_id.len == 0 {
-			run_id = a
-			i++
-			continue
-		}
-		if gate_id.len == 0 && sub in ['approve', 'reject'] {
-			gate_id = a
-			i++
-			continue
-		}
-		task_parts << a
-		i++
-	}
-	mut task := task_parts.join(' ')
-	if sub == 'start' && task.len == 0 {
-		task = run_id
-		run_id = ''
-	}
-	return agent_toolkit_core.SwarmOptions{
-		subcommand:     sub
-		workspace_path: workspace_path
-		run_id:         run_id
-		gate_id:        gate_id
-		recipe:         recipe
-		backend:        backend
-		task:           task
-		reason:         reason
-		dry_run:        dry_run
-		force:          force
-	}
-}
-
-fn parse_plugin_options(args []string) agent_toolkit_core.PluginOptions {
-	mut sub := ''
-	for a in args {
-		if a in ['--json', '--quiet'] {
-			continue
-		}
-		if a.starts_with('-') {
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-		}
-	}
-	return agent_toolkit_core.PluginOptions{
-		subcommand: sub
-	}
-}
-
-fn parse_memory_options(args []string) !agent_toolkit_core.MemoryOptions {
-	mut sub := ''
-	mut entry_type := ''
-	mut title := ''
-	mut workspace_path := ''
-	mut fix := false
-	mut stale_after := 0
-	mut done := false
-	mut rest := []string{}
-	mut i := 0
-	for i < args.len {
-		a := args[i]
-		if a in ['--json', '--quiet'] {
-			i++
-			continue
-		}
-		if a == '--fix' {
-			fix = true
-			i++
-			continue
-		}
-		if a == '--done' {
-			done = true
-			i++
-			continue
-		}
-		if a in ['--type', '--title', '--workspace', '--stale-after'] {
-			if i + 1 >= args.len {
-				return error('${a} requires an argument')
-			}
-			val := args[i + 1]
-			match a {
-				'--type' { entry_type = val }
-				'--title' { title = val }
-				'--workspace' { workspace_path = val }
-				'--stale-after' { stale_after = val.int() }
-				else {}
-			}
-			i += 2
-			continue
-		}
-		if a.starts_with('--type=') {
-			entry_type = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--title=') {
-			title = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--workspace=') {
-			workspace_path = a.all_after('=')
-			i++
-			continue
-		}
-		if a.starts_with('--stale-after=') {
-			stale_after = a.all_after('=').int()
-			i++
-			continue
-		}
-		if a.starts_with('-') {
-			i++
-			continue
-		}
-		if sub.len == 0 {
-			sub = a
-			i++
-			continue
-		}
-		rest << a
-		i++
-	}
-	return agent_toolkit_core.MemoryOptions{
-		subcommand:     sub
-		entry_type:     entry_type
-		title:          title
-		content:        rest.join(' ')
-		query:          rest.join(' ')
-		workspace_path: workspace_path
-		fix:            fix
-		stale_after:    stale_after
-		show_done:      done
-	}
-}
-
-fn allowed_flag(cmd string, a string) bool {
+fn flag_allowed_on(cmd cli.Command, a string) bool {
 	if a in ['-h', '--help', '--json', '--quiet'] {
 		return true
 	}
-	if cmd == 'doctor' && a in ['--fix', '--provenance'] {
+	if flag_listed(cmd.flags, a) {
 		return true
 	}
-	if cmd == 'install' {
-		if a in ['--dry-run', '--force', '--offline'] {
-			return true
-		}
-		if a.starts_with('--tools') {
+	for sub in cmd.commands {
+		if flag_listed(sub.flags, a) {
 			return true
 		}
 	}
-	if cmd == 'uninstall' {
-		if a in ['--dry-run', '--rollback'] {
-			return true
-		}
-		if a.starts_with('--tools') {
-			return true
-		}
-	}
-	if cmd == 'update' {
-		if a == '--check' {
-			return true
-		}
-		if a.starts_with('--tools') || a.starts_with('--pin') {
-			return true
-		}
-	}
-	if cmd == 'skills' {
-		if a.starts_with('--domain') || a.starts_with('--tools') {
-			return true
-		}
-	}
-	if cmd == 'mcp' {
-		if a == '--offline' {
-			return true
-		}
-	}
-	if cmd == 'diff' {
-		if a.starts_with('--target') || a.starts_with('--product') {
-			return true
-		}
-	}
-	if cmd == 'build' {
-		if a == '--check' {
-			return true
-		}
-		if a.starts_with('--target') || a.starts_with('--product') || a.starts_with('--output') {
-			return true
-		}
-	}
-	if cmd == 'workspace' {
-		if a in ['--explain', '--dir', '--name', '--workspace', '--profile', '--pack'] {
-			return true
-		}
-		if a.starts_with('--dir') || a.starts_with('--name') || a.starts_with('--workspace')
-			|| a.starts_with('--profile') || a.starts_with('--pack') {
-			return true
-		}
-	}
-	if cmd == 'memory' {
-		if a in ['--fix', '--done'] {
-			return true
-		}
-		if a.starts_with('--type') || a.starts_with('--title') || a.starts_with('--workspace')
-			|| a.starts_with('--stale-after') {
-			return true
-		}
-	}
-	if cmd == 'project' {
-		if a in ['--ssh', '--workspace'] {
-			return true
-		}
-		if a.starts_with('--workspace') {
-			return true
-		}
-	}
-	if cmd == 'devcompanion' {
-		if a in ['--no-llm', '--template', '--request', '--id', '--workspace', '-t', '-r'] {
-			return true
-		}
-		if a.starts_with('--template') || a.starts_with('--request') || a.starts_with('--id')
-			|| a.starts_with('--workspace') {
-			return true
-		}
-	}
-	if cmd == 'loop' {
-		if a in ['--force', '--quiet', '--no-llm', '--dry-run', '--list', '--remove', '--status',
-			'--name', '--runner', '--pack', '--workspace', '--cron'] {
-			return true
-		}
-		if a.starts_with('--name') || a.starts_with('--runner') || a.starts_with('--pack')
-			|| a.starts_with('--workspace') || a.starts_with('--cron') {
-			return true
-		}
-	}
-	if cmd == 'swarm' {
-		if a in ['--dry-run', '--force', '--recipe', '--backend', '--ui', '--workspace', '--reason'] {
-			return true
-		}
-		if a.starts_with('--recipe') || a.starts_with('--backend') || a.starts_with('--ui')
-			|| a.starts_with('--workspace') || a.starts_with('--reason') {
-			return true
-		}
+	if cmd.name == 'devcompanion' && a in ['-t', '-r'] {
+		return true
 	}
 	return false
 }
 
-fn resolve_alias(name string) string {
-	return match name {
-		'dc' { 'devcompanion' }
-		'rollback' { 'uninstall' }
-		else { name }
-	}
-}
-
-fn is_known_command(name string) bool {
-	for c in consumer_commands() {
-		if c == name {
+fn flag_listed(flags []cli.Flag, a string) bool {
+	for f in flags {
+		long := '--${f.name}'
+		if a == long || a.starts_with('${long}=') {
 			return true
 		}
-	}
-	for c in advanced_commands() {
-		if c == name {
-			return true
+		if f.abbrev.len > 0 {
+			short := '-${f.abbrev}'
+			if a == short || a.starts_with('${short}=') {
+				return true
+			}
 		}
 	}
 	return false
-}
-
-fn consumer_commands() []string {
-	return ['install', 'update', 'uninstall', 'doctor', 'diff', 'skills', 'mcp', 'plugin',
-		'completion']
-}
-
-fn advanced_commands() []string {
-	return ['loop', 'workspace', 'memory', 'project', 'devcompanion', 'insights', 'build',
-		'inventory', 'matrix', 'release', 'swarm']
 }
 
 fn mode_from_argv(argv []string) agent_toolkit_core.RenderMode {
@@ -1273,50 +252,22 @@ fn mode_from_argv(argv []string) agent_toolkit_core.RenderMode {
 	return .human
 }
 
-fn grouped_help() string {
-	ver := agent_toolkit_core.resolve_toolkit_version()
-	return 'agent-toolkit — Composable AI agent toolkit CLI (${ver})
-
-Usage:
-    agent-toolkit <command> [args...]
-    agent-toolkit [-h|--help|help]
-    agent-toolkit [-V|--version|version]
-
-Global options:
-    -h, --help       Show this help
-    -V, --version    Print version
-    --json           Structured CommandResult JSON (most commands)
-    --quiet          Suppress human output
-
-Consumer commands:
-    install       Install profiles for detected AI tools
-    update        Refresh installed profiles from latest toolkit data
-    uninstall     Remove toolkit-owned files using install receipts (alias: rollback)
-    doctor        Check system health and tool availability
-    diff          Show changes vs currently installed plugin bundles
-    skills        Skill management: sync, list, validate
-    mcp           MCP provider management: setup, list, doctor
-    plugin        Plugin bundle management: sync, check
-    completion    Emit bash/zsh/fish/PowerShell completion scripts
-
-Advanced commands (workstation / power-user — docs/CLI_SURFACES.md):
-    loop          Loop engineering: init, run, status, audit, cost, schedule, sync
-    workspace     Workspace scaffolding: init, context, sync
-    memory        Knowledge base: add, search, inject, review, todo
-    project       Project management: clone, list, add, remove, scan
-    devcompanion  Background job queue: queue, run-once, status, done, sync-todos (alias: dc)
-    insights      AI tool usage insights (removed from product CLI; #526)
-    build         Compile canonical capabilities into target-native artifacts
-    inventory     List all canonical skills, agents, and products
-    matrix        Show platform capability matrix
-    release       Not in V — maintainer artifacts live in CI / docs/RELEASING.md
-    swarm         Multi-agent swarm orchestration (pair/team/full, Herdr/tmux)
-
-Run \'agent-toolkit <command> --help\' for details.
-'
+// grouped_help renders root help from the cli.Command tree (Consumer / Advanced groups).
+pub fn grouped_help() string {
+	return grouped_help_from(build_root_command())
 }
 
-fn subcommand_help(name string) string {
+fn grouped_help_from(root cli.Command) string {
+	ver := agent_toolkit_core.resolve_toolkit_version()
+	mut out := 'agent-toolkit — Composable AI agent toolkit CLI (${ver})\n\n'
+	out += root.help_message()
+	if !out.contains('alias: rollback') {
+		out += '\nAliases: uninstall (alias: rollback), devcompanion (alias: dc)\n'
+	}
+	return out
+}
+
+pub fn subcommand_help(name string) string {
 	if name == 'build' {
 		return 'Usage: agent-toolkit build [--check] [--target TARGET] [--product PRODUCT] [--output DIR] [--json]
 

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -18,6 +18,14 @@ pub fn dispatch(args []string) int {
 		argv = args[1..].clone()
 	}
 	mode := mode_from_argv(argv)
+	// Peel leading global flags so `agent-toolkit --json doctor` works (Flag.global).
+	mut i := 0
+	for i < argv.len && argv[i] in ['--json', '--quiet'] {
+		i++
+	}
+	if i > 0 {
+		argv = argv[i..].clone()
+	}
 	if argv.len == 0 {
 		print(grouped_help_from(root))
 		return 0
@@ -41,15 +49,9 @@ pub fn dispatch(args []string) int {
 		return render(agent_toolkit_core.version_result(ver), mode)
 	}
 	// Bad flags before a command (argparse parity → exit 2)
-	if first.starts_with('-') && first !in ['--json', '--quiet'] {
+	if first.starts_with('-') {
 		e := agent_toolkit_core.err_usage_flags('flag.unknown', 'unknown flag: ${first}')
 		return render_error(e, mode)
-	}
-	if first.starts_with('-') {
-		eprintln('Unknown command: ${first}')
-		eprintln("Run 'agent-toolkit help' for usage.")
-		eprintln('See docs/CLI_SURFACES.md for consumer vs advanced commands.')
-		return 1
 	}
 	cmd := find_command(root, first) or {
 		eprintln('Unknown command: ${first}')

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -158,6 +158,15 @@ fn test_grouped_help_mentions_consumer_and_advanced() {
 	assert !h.contains('install (consumer)')
 }
 
+fn test_dispatch_uses_cli_command_tree() {
+	root := build_root_command()
+	assert root.name == 'agent-toolkit'
+	_ := find_command(root, 'skills') or {
+		assert false
+		return
+	}
+}
+
 fn test_inventory_help_is_implemented() {
 	h := subcommand_help('inventory')
 	assert h.contains('agent-toolkit inventory')

--- a/modules/agent_toolkit_cli/dispatch_test.v
+++ b/modules/agent_toolkit_cli/dispatch_test.v
@@ -20,6 +20,16 @@ fn test_dispatch_unknown_flag_exit_two() {
 	assert code == 2
 }
 
+fn test_dispatch_leading_json_before_command() {
+	code := dispatch(['agent-toolkit', '--json', 'matrix'])
+	assert code == 0
+}
+
+fn test_dispatch_leading_quiet_before_command() {
+	code := dispatch(['agent-toolkit', '--quiet', 'matrix'])
+	assert code == 0
+}
+
 fn test_dispatch_dc_alias_not_unknown() {
 	code := dispatch(['agent-toolkit', 'dc'])
 	assert code == 0

--- a/modules/agent_toolkit_cli/options.v
+++ b/modules/agent_toolkit_cli/options.v
@@ -1,0 +1,940 @@
+module agent_toolkit_cli
+
+import agent_toolkit_core
+
+fn parse_doctor_options(args []string) agent_toolkit_core.DoctorOptions {
+	mut fix := false
+	mut provenance := false
+	for a in args {
+		if a == '--fix' {
+			fix = true
+		}
+		if a == '--provenance' {
+			provenance = true
+		}
+	}
+	return agent_toolkit_core.DoctorOptions{
+		fix:        fix
+		provenance: provenance
+	}
+}
+
+fn parse_build_options(args []string) agent_toolkit_core.BuildOptions {
+	mut check := false
+	mut write_files := true
+	mut target := ''
+	mut product := ''
+	mut output_dir := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a == '--check' {
+			check = true
+			write_files = false
+			i++
+			continue
+		}
+		if a == '--target' && i + 1 < args.len {
+			target = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--target=') {
+			target = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--product' && i + 1 < args.len {
+			product = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--product=') {
+			product = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--output' && i + 1 < args.len {
+			output_dir = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--output=') {
+			output_dir = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	return agent_toolkit_core.BuildOptions{
+		check:       check
+		target:      target
+		product:     product
+		output_dir:  output_dir
+		write_files: write_files
+	}
+}
+
+fn parse_install_options(args []string) !agent_toolkit_core.InstallOptions {
+	mut dry_run := false
+	mut force := false
+	mut offline := false
+	mut tools_raw := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--dry-run' {
+			dry_run = true
+			i++
+			continue
+		}
+		if a == '--force' {
+			force = true
+			i++
+			continue
+		}
+		if a == '--offline' {
+			offline = true
+			i++
+			continue
+		}
+		if a == '--tools' {
+			if i + 1 >= args.len {
+				return error('--tools requires an argument')
+			}
+			tools_raw = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--tools=') {
+			tools_raw = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	mut tools := []string{}
+	if tools_raw.len > 0 {
+		for part in tools_raw.split(',') {
+			t := part.trim_space()
+			if t.len > 0 {
+				tools << t
+			}
+		}
+	}
+	return agent_toolkit_core.InstallOptions{
+		tools:   tools
+		dry_run: dry_run
+		force:   force
+		offline: offline
+	}
+}
+
+fn parse_uninstall_options(args []string) !agent_toolkit_core.UninstallOptions {
+	mut dry_run := false
+	mut tools_raw := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--dry-run' {
+			dry_run = true
+			i++
+			continue
+		}
+		if a == '--rollback' {
+			// Alias semantics: uninstall with side effects (not dry-run).
+			dry_run = false
+			i++
+			continue
+		}
+		if a == '--tools' {
+			if i + 1 >= args.len {
+				return error('--tools requires an argument')
+			}
+			tools_raw = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--tools=') {
+			tools_raw = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	mut tools := []string{}
+	if tools_raw.len > 0 {
+		for part in tools_raw.split(',') {
+			t := part.trim_space()
+			if t.len > 0 {
+				tools << t
+			}
+		}
+	}
+	return agent_toolkit_core.UninstallOptions{
+		tools:   tools
+		dry_run: dry_run
+	}
+}
+
+fn parse_diff_options(args []string) agent_toolkit_core.DiffOptions {
+	mut target := ''
+	mut product := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--target' && i + 1 < args.len {
+			target = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--target=') {
+			target = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--product' && i + 1 < args.len {
+			product = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--product=') {
+			product = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	return agent_toolkit_core.DiffOptions{
+		target:  target
+		product: product
+	}
+}
+
+fn parse_update_options(args []string) !agent_toolkit_core.UpdateOptions {
+	mut check_only := false
+	mut tools_raw := ''
+	mut pin := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--check' {
+			check_only = true
+			i++
+			continue
+		}
+		if a == '--tools' {
+			if i + 1 >= args.len {
+				return error('--tools requires an argument')
+			}
+			tools_raw = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--tools=') {
+			tools_raw = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--pin' {
+			if i + 1 >= args.len {
+				return error('--pin requires an argument')
+			}
+			pin = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--pin=') {
+			pin = a.all_after('=')
+			i++
+			continue
+		}
+		i++
+	}
+	mut tools := []string{}
+	if tools_raw.len > 0 {
+		for part in tools_raw.split(',') {
+			t := part.trim_space()
+			if t.len > 0 {
+				tools << t
+			}
+		}
+	}
+	return agent_toolkit_core.UpdateOptions{
+		tools:      tools
+		check_only: check_only
+		pin:        pin
+	}
+}
+
+fn parse_skills_options(args []string) !agent_toolkit_core.SkillsOptions {
+	mut sub := ''
+	mut domain := ''
+	mut tools_raw := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--domain' {
+			if i + 1 >= args.len {
+				return error('--domain requires an argument')
+			}
+			domain = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--domain=') {
+			domain = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--tools' {
+			if i + 1 >= args.len {
+				return error('--tools requires an argument')
+			}
+			tools_raw = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--tools=') {
+			tools_raw = a.all_after('=')
+			i++
+			continue
+		}
+		if !a.starts_with('-') && sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		i++
+	}
+	mut tools := []string{}
+	if tools_raw.len > 0 {
+		for part in tools_raw.split(',') {
+			t := part.trim_space()
+			if t.len > 0 {
+				tools << t
+			}
+		}
+	}
+	return agent_toolkit_core.SkillsOptions{
+		subcommand: sub
+		domain:     domain
+		tools:      tools
+	}
+}
+
+fn parse_mcp_options(args []string) agent_toolkit_core.McpOptions {
+	mut sub := ''
+	mut provider := ''
+	mut offline := false
+	for a in args {
+		if a in ['--json', '--quiet'] {
+			continue
+		}
+		if a == '--offline' {
+			offline = true
+			continue
+		}
+		if a.starts_with('-') {
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			continue
+		}
+		if provider.len == 0 {
+			provider = a
+		}
+	}
+	return agent_toolkit_core.McpOptions{
+		subcommand: sub
+		provider:   provider
+		offline:    offline
+	}
+}
+
+fn parse_workspace_options(args []string) !agent_toolkit_core.WorkspaceOptions {
+	mut sub := ''
+	mut dir := ''
+	mut name := ''
+	mut workspace_path := ''
+	mut explain := false
+	mut json_out := false
+	mut arg := ''
+	mut profile := ''
+	mut pack := ''
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			if a == '--json' {
+				json_out = true
+			}
+			i++
+			continue
+		}
+		if a == '--explain' {
+			explain = true
+			i++
+			continue
+		}
+		if a in ['--dir', '--name', '--workspace', '--profile', '--pack'] {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			val := args[i + 1]
+			match a {
+				'--dir' { dir = val }
+				'--name' { name = val }
+				'--workspace' { workspace_path = val }
+				'--profile' { profile = val }
+				'--pack' { pack = val }
+				else {}
+			}
+			i += 2
+			continue
+		}
+		if a.starts_with('--dir=') {
+			dir = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--name=') {
+			name = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--profile=') {
+			profile = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--pack=') {
+			pack = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		if arg.len == 0 {
+			arg = a
+		}
+		i++
+	}
+	return agent_toolkit_core.WorkspaceOptions{
+		subcommand:     sub
+		dir:            dir
+		name:           name
+		workspace_path: workspace_path
+		explain:        explain
+		json_out:       json_out
+		arg:            arg
+		profile:        profile
+		pack:           pack
+	}
+}
+
+fn parse_project_options(args []string) !agent_toolkit_core.ProjectOptions {
+	mut sub := ''
+	mut workspace_path := ''
+	mut arg := ''
+	mut ssh := false
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--ssh' {
+			ssh = true
+			i++
+			continue
+		}
+		if a == '--workspace' {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			workspace_path = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		if arg.len == 0 {
+			arg = a
+		}
+		i++
+	}
+	return agent_toolkit_core.ProjectOptions{
+		subcommand:     sub
+		workspace_path: workspace_path
+		arg:            arg
+		ssh:            ssh
+	}
+}
+
+fn parse_dc_options(args []string) !agent_toolkit_core.DevcompanionOptions {
+	mut sub := ''
+	mut workspace_path := ''
+	mut project := ''
+	mut template := ''
+	mut request := ''
+	mut job_id := ''
+	mut no_llm := false
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--no-llm' {
+			no_llm = true
+			i++
+			continue
+		}
+		if a in ['--template', '-t', '--request', '-r', '--id', '--workspace'] {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			val := args[i + 1]
+			match a {
+				'--template', '-t' { template = val }
+				'--request', '-r' { request = val }
+				'--id' { job_id = val }
+				'--workspace' { workspace_path = val }
+				else {}
+			}
+			i += 2
+			continue
+		}
+		if a.starts_with('--template=') {
+			template = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--request=') {
+			request = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--id=') {
+			job_id = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		if sub == 'queue' && project.len == 0 {
+			project = a
+		} else if sub == 'done' && job_id.len == 0 {
+			job_id = a
+		}
+		i++
+	}
+	mut arg := project
+	if sub == 'done' && job_id.len > 0 {
+		arg = job_id
+	}
+	return agent_toolkit_core.DevcompanionOptions{
+		subcommand:     sub
+		workspace_path: workspace_path
+		arg:            arg
+		template:       template
+		request:        request
+		job_id:         job_id
+		no_llm:         no_llm
+	}
+}
+
+fn parse_loop_options(args []string) !agent_toolkit_core.LoopOptions {
+	mut sub := ''
+	mut workspace_path := ''
+	mut name := ''
+	mut custom_name := ''
+	mut force := false
+	mut quiet := false
+	mut runner := ''
+	mut pack := ''
+	mut no_llm := false
+	mut dry_run := false
+	mut cron := ''
+	mut list_mode := false
+	mut remove_mode := false
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a == '--json' {
+			i++
+			continue
+		}
+		if a == '--quiet' {
+			quiet = true
+			i++
+			continue
+		}
+		if a == '--force' {
+			force = true
+			i++
+			continue
+		}
+		if a == '--no-llm' {
+			no_llm = true
+			i++
+			continue
+		}
+		if a == '--dry-run' {
+			dry_run = true
+			i++
+			continue
+		}
+		if a == '--list' {
+			list_mode = true
+			i++
+			continue
+		}
+		if a == '--remove' {
+			remove_mode = true
+			i++
+			continue
+		}
+		if a in ['--name', '--runner', '--pack', '--workspace', '--cron'] {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			val := args[i + 1]
+			match a {
+				'--name' { custom_name = val }
+				'--runner' { runner = val }
+				'--pack' { pack = val }
+				'--workspace' { workspace_path = val }
+				'--cron' { cron = val }
+				else {}
+			}
+			i += 2
+			continue
+		}
+		if a.starts_with('--name=') {
+			custom_name = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--runner=') {
+			runner = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--pack=') {
+			pack = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--cron=') {
+			cron = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		if name.len == 0 {
+			name = a
+		}
+		i++
+	}
+	if no_llm && runner.len == 0 {
+		runner = 'skeleton'
+	}
+	return agent_toolkit_core.LoopOptions{
+		subcommand:     sub
+		workspace_path: workspace_path
+		name:           name
+		custom_name:    custom_name
+		force:          force
+		quiet:          quiet
+		runner:         runner
+		pack:           pack
+		no_llm:         no_llm
+		dry_run:        dry_run
+		cron:           cron
+		list_mode:      list_mode
+		remove_mode:    remove_mode
+	}
+}
+
+fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
+	mut sub := ''
+	mut workspace_path := ''
+	mut run_id := ''
+	mut gate_id := ''
+	mut recipe := ''
+	mut backend := ''
+	mut reason := ''
+	mut dry_run := false
+	mut force := false
+	mut task_parts := []string{}
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--dry-run' {
+			dry_run = true
+			i++
+			continue
+		}
+		if a == '--force' {
+			force = true
+			i++
+			continue
+		}
+		if a in ['--recipe', '--backend', '--ui', '--workspace', '--reason'] {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			val := args[i + 1]
+			match a {
+				'--recipe' { recipe = val }
+				'--backend' { backend = val }
+				'--ui' { backend = val }
+				'--workspace' { workspace_path = val }
+				'--reason' { reason = val }
+				else {}
+			}
+			i += 2
+			continue
+		}
+		if a.starts_with('--recipe=') {
+			recipe = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--backend=') || a.starts_with('--ui=') {
+			backend = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--reason=') {
+			reason = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		if run_id.len == 0 {
+			run_id = a
+			i++
+			continue
+		}
+		if gate_id.len == 0 && sub in ['approve', 'reject'] {
+			gate_id = a
+			i++
+			continue
+		}
+		task_parts << a
+		i++
+	}
+	mut task := task_parts.join(' ')
+	if sub == 'start' && task.len == 0 {
+		task = run_id
+		run_id = ''
+	}
+	return agent_toolkit_core.SwarmOptions{
+		subcommand:     sub
+		workspace_path: workspace_path
+		run_id:         run_id
+		gate_id:        gate_id
+		recipe:         recipe
+		backend:        backend
+		task:           task
+		reason:         reason
+		dry_run:        dry_run
+		force:          force
+	}
+}
+
+fn parse_plugin_options(args []string) agent_toolkit_core.PluginOptions {
+	mut sub := ''
+	for a in args {
+		if a in ['--json', '--quiet'] {
+			continue
+		}
+		if a.starts_with('-') {
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+		}
+	}
+	return agent_toolkit_core.PluginOptions{
+		subcommand: sub
+	}
+}
+
+fn parse_memory_options(args []string) !agent_toolkit_core.MemoryOptions {
+	mut sub := ''
+	mut entry_type := ''
+	mut title := ''
+	mut workspace_path := ''
+	mut fix := false
+	mut stale_after := 0
+	mut done := false
+	mut rest := []string{}
+	mut i := 0
+	for i < args.len {
+		a := args[i]
+		if a in ['--json', '--quiet'] {
+			i++
+			continue
+		}
+		if a == '--fix' {
+			fix = true
+			i++
+			continue
+		}
+		if a == '--done' {
+			done = true
+			i++
+			continue
+		}
+		if a in ['--type', '--title', '--workspace', '--stale-after'] {
+			if i + 1 >= args.len {
+				return error('${a} requires an argument')
+			}
+			val := args[i + 1]
+			match a {
+				'--type' { entry_type = val }
+				'--title' { title = val }
+				'--workspace' { workspace_path = val }
+				'--stale-after' { stale_after = val.int() }
+				else {}
+			}
+			i += 2
+			continue
+		}
+		if a.starts_with('--type=') {
+			entry_type = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--title=') {
+			title = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--workspace=') {
+			workspace_path = a.all_after('=')
+			i++
+			continue
+		}
+		if a.starts_with('--stale-after=') {
+			stale_after = a.all_after('=').int()
+			i++
+			continue
+		}
+		if a.starts_with('-') {
+			i++
+			continue
+		}
+		if sub.len == 0 {
+			sub = a
+			i++
+			continue
+		}
+		rest << a
+		i++
+	}
+	return agent_toolkit_core.MemoryOptions{
+		subcommand:     sub
+		entry_type:     entry_type
+		title:          title
+		content:        rest.join(' ')
+		query:          rest.join(' ')
+		workspace_path: workspace_path
+		fix:            fix
+		stale_after:    stale_after
+		show_done:      done
+	}
+}


### PR DESCRIPTION
## Summary
- Migrate V CLI dispatch to `vlib/cli` Command tree (Consumer/Advanced groups, nested families, aliases)
- Keep AT exit-code wrapper (walk tree; **do not** call `Command.parse()`): bad flags → 2, unknown → 1
- Peel leading global `--json` / `--quiet` before the command name
- Docs/CI use `./make.vsh` (shebang UX). Windows native-build CI exception: `"${VBIN}" run make.vsh` only
- Stacks with #730 (Makefile removal / make.vsh simplify / `--prefix`)

## Test plan
- [x] V unit tests for dispatch / leading `--json`
- [x] No documented `v run make.vsh`
- [ ] Required CI green