### PR TITLE
docs: Homebrew formula PR 403 in RELEASING

### DIFF
--- a/distribution/homebrew/README.md
+++ b/distribution/homebrew/README.md
@@ -22,6 +22,12 @@ After `notify-homebrew.yml` dispatches the tap, `update-formula.yml` pushes `cho
 2. Ensure environment secret `HOMEBREW_TAP_TOKEN` (fine-grained PAT) has **Contents: R/W** and **Pull requests: R/W** on `ulises-jeremias/homebrew-tap` (fallback when the Actions toggle is off).
 3. Same secret on this repo’s `homebrew` environment for `notify-homebrew.yml` → `repository_dispatch`.
 
+```bash
+gh api -X PUT repos/ulises-jeremias/homebrew-tap/actions/permissions/workflow \
+  -f default_workflow_permissions=write \
+  -F can_approve_pull_request_reviews=true
+```
+
 Details: [homebrew-tap README](https://github.com/ulises-jeremias/homebrew-tap#ci-secrets-and-permissions-maintainer).
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -131,6 +131,8 @@ Failure visibility on the releasing repo:
 * If downstream is red, re-dispatch per playbook (see below) and re-check; do not close the release as done until both downstream runs are green or explicitly deferred for maintenance.
 * For AUR, a maintenance failure is expected — document it in the release comment and retry when AUR leaves maintenance; do not auto-open issues on every window.
 
+* Homebrew PR-create 403 (`not permitted to create or approve pull requests`): enable **Allow GitHub Actions to create and approve pull requests** on `homebrew-tap`, and/or ensure `HOMEBREW_TAP_TOKEN` has **Pull requests: Write**. See [`distribution/homebrew/README.md`](../distribution/homebrew/README.md#maintainer-formula-pr-must-open-automatically).
+
 
 
 ## Downstream install source (GitHub Release V binaries)


### PR DESCRIPTION
## Summary
- Add RELEASING failure-visibility note for Homebrew PR-create 403
- Include `gh api` one-liner under `distribution/homebrew/README.md` maintainer section

## Test plan
- [ ] Links resolve to the homebrew maintainer section


Made with [Cursor](https://cursor.com)