### PR TITLE
docs(readme): add npm, PyPI, AUR, and Homebrew badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Docs** — Add npm / PyPI version + downloads, AUR, Homebrew, GHCR, and GitHub Release badges to the root README and published adapter READMEs; align AUR install examples to `agent-toolkit-bin`
 - **Docs/CI** — Invoke shebang `.vsh` scripts as `./scripts/…` / `./make.vsh` (not `v run scripts/…`); Windows GHA keeps `"${VBIN}" run make.vsh` exception
 - **Fixed** — `bump-version.vsh` updates `generatorVersion` in `plugins/*/.provenance.json` (not only digests / `"version"` sidecars)
 - **Breaking (contributor)** — Retire `scripts/gen-surfaces.vsh` and CI `check-surfaces` ([ADR-003](docs/adrs/ADR-003-retire-gen-surfaces.md) Remove). Sole surface gates: `agent-toolkit build --check` + `agent-toolkit plugin check`

--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@
 [![Validate](https://img.shields.io/github/actions/workflow/status/ulises-jeremias/agent-toolkit/validate.yml?branch=main&label=validate&style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/actions/workflows/validate.yml)
 [![MegaLinter](https://img.shields.io/github/actions/workflow/status/ulises-jeremias/agent-toolkit/mega-linter.yml?branch=main&label=MegaLinter&style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/actions/workflows/mega-linter.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+[![Discord](https://img.shields.io/discord/1527933660764831825?style=flat&label=Discord&labelColor=1f2937&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/bR5VyATgka)
 [![Agent Skills](https://img.shields.io/badge/Agent%20Skills-compatible-16a34a?style=flat&labelColor=1f2937)](https://github.com/vercel-labs/skills)
 [![Agent Plugins](https://img.shields.io/badge/Agent%20Plugins-1.0-7c3aed?style=flat&labelColor=1f2937)](https://agent-plugins.org)
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&label=npm&labelColor=1f2937&color=7c3aed&logo=npm&logoColor=white)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli?style=flat&label=npm%20downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&label=PyPI&labelColor=1f2937&color=7c3aed&logo=pypi&logoColor=white)](https://pypi.org/project/agent-toolkit-cli/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/agent-toolkit-cli?style=flat&label=PyPI%20downloads&labelColor=1f2937&color=0891b2)](https://pypi.org/project/agent-toolkit-cli/)
+[![AUR](https://img.shields.io/aur/version/agent-toolkit-bin?style=flat&label=AUR&labelColor=1f2937&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![Homebrew](https://img.shields.io/badge/Homebrew-ulises--jeremias%2Ftap-ea580c?style=flat&labelColor=1f2937&logo=homebrew&logoColor=white)](https://github.com/ulises-jeremias/homebrew-tap)
+[![GHCR](https://img.shields.io/badge/GHCR-agent--toolkit-2563eb?style=flat&labelColor=1f2937&logo=docker&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/pkgs/container/agent-toolkit)
 
 ![skills](https://img.shields.io/badge/skills-77-7c3aed?style=flat&labelColor=1f2937)
 ![agents](https://img.shields.io/badge/agents-17-0891b2?style=flat&labelColor=1f2937)
@@ -203,14 +213,15 @@ npx skills add ulises-jeremias/agent-toolkit -g
 </details>
 
 <details>
-<summary><strong>Homebrew / AUR</strong> — system package managers</summary>
+<summary><strong>Homebrew / AUR / GHCR</strong> — system packages and container</summary>
 
-Formulas live in dedicated repos ([homebrew-tap](https://github.com/ulises-jeremias/homebrew-tap), [aur-packages](https://github.com/ulises-jeremias/aur-packages)); release workflows notify them on tag.
+Formulas live in dedicated repos ([homebrew-tap](https://github.com/ulises-jeremias/homebrew-tap), [aur-packages](https://github.com/ulises-jeremias/aur-packages)); release workflows notify them on tag. The container image ships the same GitHub Release V binary.
 
 ```bash
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
-yay -S agent-toolkit-bin   # Arch Linux (AUR) — GitHub Release V binary
+yay -S agent-toolkit-bin   # Arch Linux (AUR) — GitHub Release V binary; not the Python AUR package
 npm i -g agent-toolkit-cli # optionalDependencies platform packages
+docker pull ghcr.io/ulises-jeremias/agent-toolkit
 ```
 
 </details>
@@ -513,12 +524,12 @@ See [How to add a skill](docs/HOW_TO_ADD_SKILL.md) for the full authoring guide.
 
 [📖 Docs](docs/) · [🐛 Issues](https://github.com/ulises-jeremias/agent-toolkit/issues) ·
 [💬 Discussions](https://github.com/ulises-jeremias/agent-toolkit/discussions) ·
+[Discord](https://discord.gg/bR5VyATgka) ·
 [MIT License](LICENSE)
 
 <sub>Built for the agentic age — one toolkit, every assistant.</sub>
 
 </div>
-
 
 ## Showcase
 

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -31,7 +31,7 @@ See [docs/CONCEPTS.md](docs/CONCEPTS.md) and [packs/README.md](packs/README.md) 
    - **Repo or snippet** (no secrets, license OK — MIT/Apache-2.0 preferred)
    - **Screenshot or GIF** if helpful
 
-We will curate accepted showcases into this file and link them from [README.md](README.md#community).
+We will curate accepted showcases into this file and link them from [README.md](README.md#showcase).
 
 ## Guidelines
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,5 +1,16 @@
 # Distribution contracts
 
+<div align="center">
+
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&label=npm&labelColor=1f2937&color=7c3aed&logo=npm&logoColor=white)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&label=PyPI&labelColor=1f2937&color=7c3aed&logo=pypi&logoColor=white)](https://pypi.org/project/agent-toolkit-cli/)
+[![AUR](https://img.shields.io/aur/version/agent-toolkit-bin?style=flat&label=AUR&labelColor=1f2937&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![Homebrew](https://img.shields.io/badge/Homebrew-ulises--jeremias%2Ftap-ea580c?style=flat&labelColor=1f2937&logo=homebrew&logoColor=white)](https://github.com/ulises-jeremias/homebrew-tap)
+[![GHCR](https://img.shields.io/badge/GHCR-agent--toolkit-2563eb?style=flat&labelColor=1f2937&logo=docker&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/pkgs/container/agent-toolkit)
+
+</div>
+
 **Issue:** [#534](https://github.com/ulises-jeremias/agent-toolkit/issues/534)  
 **EPIC:** [#463](https://github.com/ulises-jeremias/agent-toolkit/issues/463) (binary release engineering)
 

--- a/distribution/aur/README.md
+++ b/distribution/aur/README.md
@@ -1,5 +1,13 @@
 # AUR adapter
 
+<div align="center">
+
+[![AUR](https://img.shields.io/aur/version/agent-toolkit-bin?style=flat&label=AUR&labelColor=1f2937&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![AUR votes](https://img.shields.io/aur/votes/agent-toolkit-bin?style=flat&label=votes&labelColor=1f2937&color=0891b2)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+</div>
+
 **Issue:** [#539](https://github.com/ulises-jeremias/agent-toolkit/issues/539) · **ADR:** [#491](https://github.com/ulises-jeremias/agent-toolkit/issues/491) (ADR-024)
 
 **Owner:** [`ulises-jeremias/aur-packages`](https://github.com/ulises-jeremias/aur-packages) (not this tree). Playbook: [docs/AUR_PLAYBOOK.md](../../docs/AUR_PLAYBOOK.md). Notify: `.github/workflows/notify-aur.yml`.

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -1,5 +1,12 @@
 # Docker adapter
 
+<div align="center">
+
+[![GHCR](https://img.shields.io/badge/GHCR-agent--toolkit-2563eb?style=flat&labelColor=1f2937&logo=docker&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/pkgs/container/agent-toolkit)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+</div>
+
 **Issue:** [#537](https://github.com/ulises-jeremias/agent-toolkit/issues/537)  
 **Workflow:** `.github/workflows/docker.yml`  
 **Image:** `ghcr.io/ulises-jeremias/agent-toolkit`

--- a/distribution/github-release/README.md
+++ b/distribution/github-release/README.md
@@ -1,5 +1,12 @@
 # GitHub Release adapter
 
+<div align="center">
+
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/ulises-jeremias/agent-toolkit/total?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://github.com/ulises-jeremias/agent-toolkit/releases)
+
+</div>
+
 **Owner:** this repository (`.github/workflows/release.yml`).  
 **Names:** [ADR-018](../../docs/adrs/ADR-018-release-artifacts.md).
 

--- a/distribution/homebrew/README.md
+++ b/distribution/homebrew/README.md
@@ -1,5 +1,12 @@
 # Homebrew adapter
 
+<div align="center">
+
+[![Homebrew](https://img.shields.io/badge/Homebrew-ulises--jeremias%2Ftap-ea580c?style=flat&labelColor=1f2937&logo=homebrew&logoColor=white)](https://github.com/ulises-jeremias/homebrew-tap)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+</div>
+
 **Issue:** [#538](https://github.com/ulises-jeremias/agent-toolkit/issues/538) · **ADR:** [`docs/adrs/ADR-023-homebrew.md`](../../docs/adrs/ADR-023-homebrew.md) (discussion: [#490](https://github.com/ulises-jeremias/agent-toolkit/issues/490))
 
 **Owner:** [`ulises-jeremias/homebrew-tap`](https://github.com/ulises-jeremias/homebrew-tap) (not this tree). Notify: `.github/workflows/notify-homebrew.yml`.

--- a/distribution/npm/README.md
+++ b/distribution/npm/README.md
@@ -1,5 +1,14 @@
 # npm adapter
 
+<div align="center">
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&label=npm&labelColor=1f2937&color=7c3aed&logo=npm&logoColor=white)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![Node](https://img.shields.io/node/v/agent-toolkit-cli?style=flat&labelColor=1f2937)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+</div>
+
 **Issue:** [#536](https://github.com/ulises-jeremias/agent-toolkit/issues/536) · **ADR:** [ADR-025](../../docs/adrs/ADR-025-npm-binary.md) ([#487](https://github.com/ulises-jeremias/agent-toolkit/issues/487))
 
 Published name: **`agent-toolkit-cli`** (same as PyPI). Node is a launcher only; the product is the GitHub Release V binary (ADR-018).

--- a/distribution/pypi/README.md
+++ b/distribution/pypi/README.md
@@ -1,5 +1,14 @@
 # PyPI adapter
 
+<div align="center">
+
+[![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&label=PyPI&labelColor=1f2937&color=7c3aed&logo=pypi&logoColor=white)](https://pypi.org/project/agent-toolkit-cli/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/agent-toolkit-cli?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://pypi.org/project/agent-toolkit-cli/)
+[![Python](https://img.shields.io/pypi/pyversions/agent-toolkit-cli?style=flat&labelColor=1f2937)](https://pypi.org/project/agent-toolkit-cli/)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+</div>
+
 **Issue:** [#535](https://github.com/ulises-jeremias/agent-toolkit/issues/535) · **ADR:** [ADR-021](../../docs/adrs/ADR-021-pypi-binary.md)
 
 **Layout** (npm parallel under `packages/`):

--- a/distribution/workstation/README.md
+++ b/distribution/workstation/README.md
@@ -1,5 +1,15 @@
 # Agentic Workstation adapter
 
+<div align="center">
+
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+[![AUR](https://img.shields.io/aur/version/agent-toolkit-bin?style=flat&label=AUR&labelColor=1f2937&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![Homebrew](https://img.shields.io/badge/Homebrew-ulises--jeremias%2Ftap-ea580c?style=flat&labelColor=1f2937&logo=homebrew&logoColor=white)](https://github.com/ulises-jeremias/homebrew-tap)
+[![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&label=PyPI&labelColor=1f2937&color=7c3aed&logo=pypi&logoColor=white)](https://pypi.org/project/agent-toolkit-cli/)
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&label=npm&labelColor=1f2937&color=7c3aed&logo=npm&logoColor=white)](https://www.npmjs.com/package/agent-toolkit-cli)
+
+</div>
+
 **Epic:** [#469](https://github.com/ulises-jeremias/agent-toolkit/issues/469)  
 **Consumer issue:** [agentic-workstation#206](https://github.com/ulises-jeremias/agentic-workstation/issues/206)  
 **Consumer docs:** [agentic-workstation/docs/AGENT_TOOLKIT.md](https://github.com/ulises-jeremias/agentic-workstation/blob/main/docs/AGENT_TOOLKIT.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -4,6 +4,14 @@
 
 > Composable AI capabilities for every major coding assistant — one toolkit, any tool.
 
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&label=npm&labelColor=1f2937&color=7c3aed&logo=npm&logoColor=white)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&label=PyPI&labelColor=1f2937&color=7c3aed&logo=pypi&logoColor=white)](https://pypi.org/project/agent-toolkit-cli/)
+[![AUR](https://img.shields.io/aur/version/agent-toolkit-bin?style=flat&label=AUR&labelColor=1f2937&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![Homebrew](https://img.shields.io/badge/Homebrew-ulises--jeremias%2Ftap-ea580c?style=flat&labelColor=1f2937&logo=homebrew&logoColor=white)](https://github.com/ulises-jeremias/homebrew-tap)
+[![GHCR](https://img.shields.io/badge/GHCR-agent--toolkit-2563eb?style=flat&labelColor=1f2937&logo=docker&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/pkgs/container/agent-toolkit)
+[![Discord](https://img.shields.io/discord/1527933660764831825?style=flat&label=Discord&labelColor=1f2937&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/bR5VyATgka)
+
 agent-toolkit is a modular collection of skills, agent personas, MCP configuration templates,
 and loop engineering patterns designed to work across all major AI coding assistants. Instead of
 maintaining separate prompt libraries for each tool, you keep one source of truth and deploy exactly

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,5 +1,14 @@
 # packages/npm
 
+<div align="center">
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&label=npm&labelColor=1f2937&color=7c3aed&logo=npm&logoColor=white)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![Node](https://img.shields.io/node/v/agent-toolkit-cli?style=flat&labelColor=1f2937)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+</div>
+
 npm adapter sources. PyPI equivalent: [`packages/pypi/`](../pypi/).
 
 | Directory | npm name | Role |

--- a/packages/npm/agent-toolkit-cli-darwin-arm64/README.md
+++ b/packages/npm/agent-toolkit-cli-darwin-arm64/README.md
@@ -9,7 +9,9 @@
 **Native V binary** for macOS Apple Silicon — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-darwin-arm64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-arm64)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli-darwin-arm64?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-arm64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
 [![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 

--- a/packages/npm/agent-toolkit-cli-darwin-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-darwin-x64/README.md
@@ -9,7 +9,9 @@
 **Native V binary** for macOS Intel — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-darwin-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-x64)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli-darwin-x64?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli-darwin-x64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
 [![os](https://img.shields.io/badge/os-darwin-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 

--- a/packages/npm/agent-toolkit-cli-linux-arm64/README.md
+++ b/packages/npm/agent-toolkit-cli-linux-arm64/README.md
@@ -9,7 +9,9 @@
 **Native V binary** for Linux arm64 (glibc) — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-linux-arm64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-linux-arm64)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli-linux-arm64?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli-linux-arm64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
 [![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![cpu](https://img.shields.io/badge/cpu-arm64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![libc](https://img.shields.io/badge/libc-glibc-16a34a?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md)

--- a/packages/npm/agent-toolkit-cli-linux-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-linux-x64/README.md
@@ -9,7 +9,9 @@
 **Native V binary** for Linux x86_64 (glibc) — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-linux-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-linux-x64)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli-linux-x64?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli-linux-x64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
 [![os](https://img.shields.io/badge/os-linux-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![libc](https://img.shields.io/badge/libc-glibc-16a34a?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-019-linux-libc.md)

--- a/packages/npm/agent-toolkit-cli-win32-x64/README.md
+++ b/packages/npm/agent-toolkit-cli-win32-x64/README.md
@@ -9,7 +9,9 @@
 **Native V binary** for Windows x64 — optionalDependency of [`agent-toolkit-cli`](https://www.npmjs.com/package/agent-toolkit-cli).
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli-win32-x64?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli-win32-x64)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli-win32-x64?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli-win32-x64)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
 [![os](https://img.shields.io/badge/os-win32-0891b2?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 [![cpu](https://img.shields.io/badge/cpu-x64-ea580c?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/adrs/ADR-025-npm-binary.md)
 

--- a/packages/npm/agent-toolkit-cli/README.md
+++ b/packages/npm/agent-toolkit-cli/README.md
@@ -9,9 +9,17 @@
 **The official CLI for [agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit)** — install skills, agents, loops, and MCP configs across every major AI coding assistant.
 
 [![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&labelColor=1f2937&color=7c3aed)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![npm downloads](https://img.shields.io/npm/dm/agent-toolkit-cli?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://www.npmjs.com/package/agent-toolkit-cli)
 [![Node](https://img.shields.io/node/v/agent-toolkit-cli?style=flat&labelColor=1f2937)](https://www.npmjs.com/package/agent-toolkit-cli)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
 [![Validate](https://img.shields.io/github/actions/workflow/status/ulises-jeremias/agent-toolkit/validate.yml?branch=main&label=validate&style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/actions/workflows/validate.yml)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+[![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&label=PyPI&labelColor=1f2937&color=7c3aed&logo=pypi&logoColor=white)](https://pypi.org/project/agent-toolkit-cli/)
+[![AUR](https://img.shields.io/aur/version/agent-toolkit-bin?style=flat&label=AUR&labelColor=1f2937&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![Homebrew](https://img.shields.io/badge/Homebrew-ulises--jeremias%2Ftap-ea580c?style=flat&labelColor=1f2937&logo=homebrew&logoColor=white)](https://github.com/ulises-jeremias/homebrew-tap)
+[![GHCR](https://img.shields.io/badge/GHCR-agent--toolkit-2563eb?style=flat&labelColor=1f2937&logo=docker&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/pkgs/container/agent-toolkit)
+[![Discord](https://img.shields.io/discord/1527933660764831825?style=flat&label=Discord&labelColor=1f2937&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/bR5VyATgka)
 
 ![skills](https://img.shields.io/badge/skills-77-7c3aed?style=flat&labelColor=1f2937)
 ![agents](https://img.shields.io/badge/agents-17-0891b2?style=flat&labelColor=1f2937)
@@ -23,6 +31,7 @@
 [![Copilot](https://img.shields.io/badge/GitHub%20Copilot-instructions-16a34a?style=flat&labelColor=1f2937&logo=github&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/copilot)
 [![Windsurf](https://img.shields.io/badge/Windsurf-rules-2563eb?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/windsurf)
 [![Pi](https://img.shields.io/badge/Pi%20Agent-skills-db2777?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/pi)
+[![Muse Code](https://img.shields.io/badge/Muse%20Code-skills-ff6b35?style=flat&labelColor=1f2937)](https://developer.meta.com/ai/products/muse-code/)
 
 [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
 [Docs](https://github.com/ulises-jeremias/agent-toolkit/tree/main/docs) ·
@@ -96,7 +105,8 @@ uv tool install agent-toolkit-cli
 
 # System packages (release notify → dedicated taps)
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
-yay -S agent-toolkit-bin   # Arch Linux (AUR)
+yay -S agent-toolkit-bin   # Arch Linux (AUR) — GitHub Release V binary; not the Python AUR package
+docker pull ghcr.io/ulises-jeremias/agent-toolkit
 
 # Direct binary
 # https://github.com/ulises-jeremias/agent-toolkit/releases/latest
@@ -155,6 +165,7 @@ Full walkthrough: [docs/INSTALLATION.md](https://github.com/ulises-jeremias/agen
 | **GitHub Copilot** | `copilot-instructions.md` with domain selection |
 | **Windsurf** | Rules and memory files via Cascade (`~/.codeium/windsurf/`) |
 | **Pi Agent** | Skills and loop templates in Pi's native format |
+| **Muse Code** | Agent Skills under `~/.config/muse/skills/` |
 
 ```bash
 agent-toolkit install --tools claude-code,cursor
@@ -280,6 +291,6 @@ node packages/npm/agent-toolkit-cli/bin/agent-toolkit.js --help
 
 <div align="center">
 
-**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [npm](https://www.npmjs.com/package/agent-toolkit-cli) · [PyPI](https://pypi.org/project/agent-toolkit-cli/) · [AUR](https://aur.archlinux.org/packages/agent-toolkit-bin) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
 
 </div>

--- a/packages/pypi/README.md
+++ b/packages/pypi/README.md
@@ -1,5 +1,14 @@
 # packages/pypi
 
+<div align="center">
+
+[![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&label=PyPI&labelColor=1f2937&color=7c3aed&logo=pypi&logoColor=white)](https://pypi.org/project/agent-toolkit-cli/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/agent-toolkit-cli?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://pypi.org/project/agent-toolkit-cli/)
+[![Python](https://img.shields.io/pypi/pyversions/agent-toolkit-cli?style=flat&labelColor=1f2937)](https://pypi.org/project/agent-toolkit-cli/)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+</div>
+
 PyPI adapter sources. npm equivalent: [`packages/npm/`](../npm/).
 
 | Directory | PyPI name | Role |

--- a/packages/pypi/agent-toolkit-cli/README.md
+++ b/packages/pypi/agent-toolkit-cli/README.md
@@ -9,9 +9,17 @@
 **The official CLI for [agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit)** — install skills, agents, loops, and MCP configs across every major AI coding assistant.
 
 [![PyPI](https://img.shields.io/pypi/v/agent-toolkit-cli?style=flat&labelColor=1f2937&color=7c3aed)](https://pypi.org/project/agent-toolkit-cli/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/agent-toolkit-cli?style=flat&label=downloads&labelColor=1f2937&color=0891b2)](https://pypi.org/project/agent-toolkit-cli/)
 [![Python](https://img.shields.io/pypi/pyversions/agent-toolkit-cli?style=flat&labelColor=1f2937)](https://pypi.org/project/agent-toolkit-cli/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
 [![Validate](https://img.shields.io/github/actions/workflow/status/ulises-jeremias/agent-toolkit/validate.yml?branch=main&label=validate&style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/actions/workflows/validate.yml)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+[![npm](https://img.shields.io/npm/v/agent-toolkit-cli?style=flat&label=npm&labelColor=1f2937&color=7c3aed&logo=npm&logoColor=white)](https://www.npmjs.com/package/agent-toolkit-cli)
+[![AUR](https://img.shields.io/aur/version/agent-toolkit-bin?style=flat&label=AUR&labelColor=1f2937&logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/agent-toolkit-bin)
+[![Homebrew](https://img.shields.io/badge/Homebrew-ulises--jeremias%2Ftap-ea580c?style=flat&labelColor=1f2937&logo=homebrew&logoColor=white)](https://github.com/ulises-jeremias/homebrew-tap)
+[![GHCR](https://img.shields.io/badge/GHCR-agent--toolkit-2563eb?style=flat&labelColor=1f2937&logo=docker&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/pkgs/container/agent-toolkit)
+[![Discord](https://img.shields.io/discord/1527933660764831825?style=flat&label=Discord&labelColor=1f2937&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/bR5VyATgka)
 
 ![skills](https://img.shields.io/badge/skills-77-7c3aed?style=flat&labelColor=1f2937)
 ![agents](https://img.shields.io/badge/agents-17-0891b2?style=flat&labelColor=1f2937)
@@ -23,6 +31,7 @@
 [![Copilot](https://img.shields.io/badge/GitHub%20Copilot-instructions-16a34a?style=flat&labelColor=1f2937&logo=github&logoColor=white)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/copilot)
 [![Windsurf](https://img.shields.io/badge/Windsurf-rules-2563eb?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/windsurf)
 [![Pi](https://img.shields.io/badge/Pi%20Agent-skills-db2777?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/tree/main/profiles/pi)
+[![Muse Code](https://img.shields.io/badge/Muse%20Code-skills-ff6b35?style=flat&labelColor=1f2937)](https://developer.meta.com/ai/products/muse-code/)
 
 [Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
 [Docs](https://github.com/ulises-jeremias/agent-toolkit/tree/main/docs) ·
@@ -79,7 +88,8 @@ pipx install agent-toolkit-cli
 
 # System packages (release notify → dedicated taps)
 brew tap ulises-jeremias/homebrew-tap && brew install agent-toolkit
-yay -S agent-toolkit   # Arch Linux (AUR)
+yay -S agent-toolkit-bin   # Arch Linux (AUR) — GitHub Release V binary; not the Python AUR package
+docker pull ghcr.io/ulises-jeremias/agent-toolkit
 ```
 
 Full walkthrough: [docs/INSTALLATION.md](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
@@ -135,6 +145,7 @@ Full walkthrough: [docs/INSTALLATION.md](https://github.com/ulises-jeremias/agen
 | **GitHub Copilot** | `copilot-instructions.md` with domain selection |
 | **Windsurf** | Rules and memory files via Cascade (`~/.codeium/windsurf/`) |
 | **Pi Agent** | Skills and loop templates in Pi's native format |
+| **Muse Code** | Agent Skills under `~/.config/muse/skills/` |
 
 ```bash
 # Target specific tools
@@ -300,6 +311,6 @@ uv run --project packages/pypi/agent-toolkit-cli --directory . agent-toolkit --h
 
 <div align="center">
 
-**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [PyPI](https://pypi.org/project/agent-toolkit-cli/) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
+**MIT** © [ulises-jeremias](https://github.com/ulises-jeremias) · [PyPI](https://pypi.org/project/agent-toolkit-cli/) · [npm](https://www.npmjs.com/package/agent-toolkit-cli) · [AUR](https://aur.archlinux.org/packages/agent-toolkit-bin) · [GitHub](https://github.com/ulises-jeremias/agent-toolkit)
 
 </div>

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,8 +1,27 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
 # Plugins
+
+**Agent Plugins 1.0 portable bundles** plus legacy Claude Code / Cursor marketplaces.
+
+[![Agent Plugins](https://img.shields.io/badge/Agent%20Plugins-1.0-7c3aed?style=flat&labelColor=1f2937)](https://agent-plugins.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](../LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+[![Validate](https://img.shields.io/github/actions/workflow/status/ulises-jeremias/agent-toolkit/validate.yml?branch=main&label=validate&style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/actions/workflows/validate.yml)
+
+[Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
+[Installation](../docs/INSTALLATION.md) ·
+[Agent Plugins spec](../docs/AGENT_PLUGINS.md)
+
+</div>
 
 This directory contains marketplace plugin bundles — now **Agent Plugins 1.0 portable** + legacy Claude Code / Cursor.
 
-## Plugins
+## Bundles
 
 | Plugin | What's included | Portable (Agent Plugins 1.0) | Legacy |
 |--------|----------------|------------------------------|--------|

--- a/plugins/agent-toolkit-agents/README.md
+++ b/plugins/agent-toolkit-agents/README.md
@@ -1,8 +1,29 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
 # agent-toolkit-agents
 
-Full set of AI agent personas for specialized tasks.
+**Full set of AI agent personas** for specialized tasks.
+
+[![Agent Plugins](https://img.shields.io/badge/Agent%20Plugins-1.0-7c3aed?style=flat&labelColor=1f2937)](https://agent-plugins.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+![personas](https://img.shields.io/badge/personas-16-0891b2?style=flat&labelColor=1f2937)
+
+[Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
+[Marketplace](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/wiki/Plugin-Marketplace.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
 
 ## Agents included (16)
+
+Disk has **17** personas; `agentic-security-reviewer` is not in this plugin (see `agent-toolkit-complete` / the security pack).
 
 | Agent | Role |
 |-------|------|
@@ -25,6 +46,15 @@ Full set of AI agent personas for specialized tasks.
 
 ## Install
 
-```
+```text
+/plugin marketplace add ulises-jeremias/agent-toolkit
 /plugin install agent-toolkit-agents@agent-toolkit
+```
+
+Or via the CLI:
+
+```bash
+npm i -g agent-toolkit-cli
+# or: uv tool install agent-toolkit-cli
+agent-toolkit install
 ```

--- a/plugins/agent-toolkit-complete/README.md
+++ b/plugins/agent-toolkit-complete/README.md
@@ -1,0 +1,38 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
+# agent-toolkit-complete
+
+**Full stable skill catalog** for consumers who want everything. Experimental — portable manifest included; marketplace pending.
+
+[![Agent Plugins](https://img.shields.io/badge/Agent%20Plugins-1.0-7c3aed?style=flat&labelColor=1f2937)](https://agent-plugins.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+![skills](https://img.shields.io/badge/skills-77-7c3aed?style=flat&labelColor=1f2937)
+
+[Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
+[Products](https://github.com/ulises-jeremias/agent-toolkit/blob/main/distributions/products.yaml) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
+
+## What's included
+
+The complete product ships the full skill catalog (`plugin.json` + `skills/` + `mcp.json`) from [`distributions/products.yaml`](../../distributions/products.yaml). Prefer the split marketplace plugins (`core`, `agents`, `forge`) unless you need the entire catalog.
+
+## Install
+
+CLI (recommended until marketplace listing lands):
+
+```bash
+npm i -g agent-toolkit-cli
+# or: uv tool install agent-toolkit-cli
+agent-toolkit install
+```
+
+Claude Code / Cursor marketplaces currently ship `agent-toolkit-core`, `agent-toolkit-agents`, and `agent-toolkit-forge`. This bundle is the experimental full catalog.

--- a/plugins/agent-toolkit-core/README.md
+++ b/plugins/agent-toolkit-core/README.md
@@ -1,10 +1,29 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
 # agent-toolkit-core
 
-Core AI agent capabilities for any project.
+**Core AI agent capabilities** for any project — marketplace baseline plugin.
+
+[![Agent Plugins](https://img.shields.io/badge/Agent%20Plugins-1.0-7c3aed?style=flat&labelColor=1f2937)](https://agent-plugins.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+
+[Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
+[Marketplace](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/wiki/Plugin-Marketplace.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
 
 ## What's included
 
 **Skills:**
+
 - `assistant` — Primary orchestrator: repo inspection, routing, convention verification
 - `dev-companion` — Dev workflow companion (WHAT phases, gates, decisions)
 - `output-handshake` — Artifact gate: confirms destination before final output
@@ -13,16 +32,22 @@ Core AI agent capabilities for any project.
 - `onboarding` — Guided project onboarding for new team members
 
 **Agents:**
+
 - `code-reviewer` — Expert code review for quality, security, maintainability
 
 ## Install
 
-```
-/plugin install agent-toolkit-core@agent-toolkit
-```
-
-Or add the marketplace first:
-```
+```text
 /plugin marketplace add ulises-jeremias/agent-toolkit
 /plugin install agent-toolkit-core@agent-toolkit
 ```
+
+Or via the CLI (auto-detects supported tools):
+
+```bash
+npm i -g agent-toolkit-cli
+# or: uv tool install agent-toolkit-cli
+agent-toolkit install
+```
+
+→ [agent-toolkit-cli on npm](https://www.npmjs.com/package/agent-toolkit-cli) · [agent-toolkit-cli on PyPI](https://pypi.org/project/agent-toolkit-cli/)

--- a/plugins/agent-toolkit-forge/README.md
+++ b/plugins/agent-toolkit-forge/README.md
@@ -1,19 +1,49 @@
+<p align="center">
+  <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/banner.svg?raw=true" width="100%" alt="agent-toolkit banner">
+</p>
+
+<div align="center">
+
 # agent-toolkit-forge
 
-GitHub and GitLab automation skills.
+**GitHub and GitLab automation skills** — PR workflows, CI fixes, and contribution planning.
+
+[![Agent Plugins](https://img.shields.io/badge/Agent%20Plugins-1.0-7c3aed?style=flat&labelColor=1f2937)](https://agent-plugins.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-7c3aed?style=flat&labelColor=1f2937)](https://github.com/ulises-jeremias/agent-toolkit/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/ulises-jeremias/agent-toolkit?style=flat&label=release&labelColor=1f2937&color=16a34a)](https://github.com/ulises-jeremias/agent-toolkit/releases/latest)
+![skills](https://img.shields.io/badge/skills-7-7c3aed?style=flat&labelColor=1f2937)
+
+[Monorepo](https://github.com/ulises-jeremias/agent-toolkit) ·
+[Marketplace](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/wiki/Plugin-Marketplace.md) ·
+[Installation](https://github.com/ulises-jeremias/agent-toolkit/blob/main/docs/INSTALLATION.md)
+
+</div>
+
+---
 
 ## Skills included
 
 | Skill | What it does |
-|-------|-------------|
-| `github-cli-workflow` | GitHub operations via gh CLI |
-| `gitlab-cli-workflow` | GitLab operations via glab CLI |
+|-------|--------------|
+| `github-cli-workflow` | GitHub operations via `gh` CLI |
+| `gitlab-cli-workflow` | GitLab operations via `glab` CLI |
 | `gh-address-comments` | Fetch and resolve PR review comments |
 | `gh-fix-ci` | Diagnose and fix failing GitHub Actions |
 | `gh-contribution-planner` | Plan contributions across your repos |
+| `workflow-client-bootstrap` | Client delivery workflow bootstrap |
+| `workflow-generic-project` | Generic delivery phases (plan → implement → review → PR) |
 
 ## Install
 
-```
+```text
+/plugin marketplace add ulises-jeremias/agent-toolkit
 /plugin install agent-toolkit-forge@agent-toolkit
+```
+
+Or via the CLI:
+
+```bash
+npm i -g agent-toolkit-cli
+# or: uv tool install agent-toolkit-cli
+agent-toolkit install
 ```


### PR DESCRIPTION
## Summary

- Add live registry badges (npm / PyPI version + monthly downloads, AUR `agent-toolkit-bin`, Homebrew tap, GHCR, GitHub Release) to the root README and the published adapter READMEs, keeping the existing `flat` / `labelColor=1f2937` shield style.
- Align consumer install examples to the canonical AUR package `agent-toolkit-bin` (not the Python `agent-toolkit` AUR package) and add GHCR / Docker as an install channel.
- Polish marketplace plugin READMEs (banner + badges; complete plugin README; forge skill list matches `distributions/products.yaml`) and fix the Showcase README fragment (`#community` → `#showcase`).

## Type

- [ ] New skill
- [ ] New loop template
- [ ] New agent persona
- [ ] New profile (per-tool config)
- [ ] New pack
- [ ] Catalog update (skill-catalog, agent-catalog, loop-catalog)
- [ ] Schema update
- [x] Documentation
- [ ] Bug fix
- [ ] Other

## Changes

- `README.md` — status, registry, catalog, and tool badge rows; Discord; GHCR in advanced install
- `packages/npm/agent-toolkit-cli/README.md` and platform packages — downloads, sibling channels, Muse Code
- `packages/pypi/agent-toolkit-cli/README.md` — downloads, sibling channels, AUR `-bin`, Muse Code
- `packages/{npm,pypi}/README.md` and `distribution/**/README.md` — matching channel badges
- `plugins/**/README.md` — banner + Agent Plugins badges; `agent-toolkit-complete` README; forge skills include `workflow-*`
- `docs/wiki/Home.md`, `SHOWCASE.md`, `CHANGELOG.md`

## Testing

**Primary (match CI):**
- [x] Documentation-only — skill/agent/loop/catalog validators not applicable
- [x] `markdownlint` (`.markdownlint.yaml`) on changed READMEs
- [ ] `./scripts/validate-skills.vsh` (if skill changes)
- [ ] `./scripts/validate-agents.vsh` (if agent changes)
- [ ] Loop schemas via `python3` + `schemas/loop.schema.json` (if loop changes) — see `validate-loops` in `.github/workflows/validate.yml`
- [ ] `./scripts/generate-catalogs.vsh` (if skill/agent/loop added; never hand-edit `*-catalog.yaml`)
- [ ] `python3 scripts/validate-upstream.py --check` + `python3 scripts/provenance.py check` (if upstream/vendored skills)
- [ ] `./make.vsh test && ./make.vsh build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check`

**Adapter-only (optional unless changing PyPI/npm trampolines):**
- [ ] `uv run … pytest` / `npm test --prefix packages/npm/agent-toolkit-cli`

**Manual (optional):**
- [x] Confirmed live endpoints: npm `agent-toolkit-cli`, PyPI `agent-toolkit-cli`, AUR `agent-toolkit-bin` (1.14.1-1), Homebrew formula, GHCR package page, shields.io badge URLs
- [ ] Tested with at least one supported AI tool (Claude Code, Cursor, Copilot, etc.)

## Checklist

- [x] No secrets, tokens, API keys, or credentials committed
- [x] Documentation updated to reflect any behavior changes
- [x] Branding-neutral: no organization-specific references in public-facing files
- [x] Commit messages are in English and follow conventional commits format
- [ ] `SKILL.md` frontmatter present (`name`, `description`) — no `skill.json` (removed in v1.0.4)
- [ ] Loop `loops/<name>/loop.yaml` includes required fields: `name`, `goal`, `request`
- [ ] Loop `tier` set (`L1`/`L2`/`L3`) with `budget` (`max_tokens`, `max_runs_per_day`, `max_wall_seconds`) and `exit_conditions`
- [ ] Loop `allowlist`/`deny` scoped correctly for tier
- [ ] Loop `loop.yaml` validates against `schemas/loop.schema.json`
- [ ] Catalog entries regenerated (`./scripts/generate-catalogs.vsh`) if a skill, agent, or loop was added
- [ ] Upstream skills: body is literal upstream copy; Toolkit overlay only in frontmatter; `body_checksum` in lock; LICENSE preserved
