### PR TITLE
Docs/mcp templates readme

### DIFF
--- a/docs/LOOPS.md
+++ b/docs/LOOPS.md
@@ -120,7 +120,7 @@ In practice, most teams run all loops at L1 or L2. Reserve L3 for proven, tightl
 
 ### changelog-drafter
 
-**Tier:** L1 | **Cadence:** daily | **Max tokens:** 20,000
+**Tier:** L1 | **Cadence:** daily | **Max tokens:** 20,000 | **[README](../loops/changelog-drafter/README.md)**
 
 Collects all PRs merged since the last git tag and drafts a release notes entry in keep-a-changelog format. Writes to `report.md` only. Never commits, pushes, or tags. Useful for maintaining a changelog without manual effort.
 
@@ -130,7 +130,7 @@ Allowlist: none (read-only). Deny: merge, push, commit, tag.
 
 ### ci-sweeper
 
-**Tier:** L2 | **Cadence:** every 15 minutes | **Max tokens:** 100,000 per run, 48 runs/day max
+**Tier:** L2 | **Cadence:** every 15 minutes | **Max tokens:** 100,000 per run, 48 runs/day max | **[README](../loops/ci-sweeper/README.md)**
 
 Monitors failing CI runs on open PRs and the main branch. For straightforward failures (less than 20 lines, no design impact), opens a draft PR with a minimal fix. For complex failures, posts a diagnosis comment only. Caps at 2 draft PRs per run to avoid spam.
 
@@ -142,7 +142,7 @@ Allowlist: comment, create_draft_pr. Deny: merge, approve, close, force-push, de
 
 ### daily-triage
 
-**Tier:** L1 | **Cadence:** daily | **Max tokens:** 30,000
+**Tier:** L1 | **Cadence:** daily | **Max tokens:** 30,000 | **[README](../loops/daily-triage/README.md)**
 
 Reviews all open issues created in the last 24 hours. Proposes labels and priority scores. Does not apply anything — writes a report only. The lowest-cost loop for staying on top of a single repo.
 
@@ -152,7 +152,7 @@ Allowlist: none (report-only). Deny: merge, close, label, comment, push.
 
 ### dep-sweeper
 
-**Tier:** L2 | **Cadence:** daily | **Max tokens:** 50,000
+**Tier:** L2 | **Cadence:** daily | **Max tokens:** 50,000 | **[README](../loops/dep-sweeper/README.md)**
 
 Detects available patch-level dependency updates across npm, pip, cargo, and other ecosystems. Groups updates by ecosystem. For each ecosystem with patch updates, creates a worktree, applies the updates, runs the test suite, and opens a draft PR if tests pass. Never bumps major or minor versions.
 
@@ -162,7 +162,7 @@ Allowlist: create_draft_pr, comment. Deny: merge, approve, major-version-bump, m
 
 ### issue-triage
 
-**Tier:** L1 | **Cadence:** every 4 hours | **Max tokens:** 25,000 per run, 6 runs/day
+**Tier:** L1 | **Cadence:** every 4 hours | **Max tokens:** 25,000 per run, 6 runs/day | **[README](../loops/issue-triage/README.md)**
 
 Finds open issues with no labels and proposes label assignments and triage routing. Flags security issues immediately for human escalation. Writes proposals to `report.md`. Does not apply labels directly.
 
@@ -172,7 +172,7 @@ Allowlist: none (propose-only). Deny: label, comment, close, merge.
 
 ### oss-daily-briefing
 
-**Tier:** L1 | **Cadence:** daily | **Max tokens:** 80,000
+**Tier:** L1 | **Cadence:** daily | **Max tokens:** 80,000 | **[README](../loops/oss-daily-briefing/README.md)**
 
 Produces a daily read-only briefing across all repos in the configured OSS ecosystem. Covers new PRs in the last 24 hours, issues needing attention, and CI health on main. Supports resumability via `STATE.md` checkpointing. No mutations of any kind.
 
@@ -184,7 +184,7 @@ See the [OSS Maintenance Patterns](#oss-maintenance-patterns) section below for 
 
 ### oss-pr-monitor
 
-**Tier:** L3 | **Cadence:** daily | **Max tokens:** 300,000
+**Tier:** L3 | **Cadence:** daily | **Max tokens:** 300,000 | **[README](../loops/oss-pr-monitor/README.md)**
 
 The most powerful loop in the toolkit. Monitors all open PRs across every configured OSS repo. Merges Dependabot PRs with passing CI, closes dirty Dependabot PRs (they regenerate automatically), and reports on human PRs with CI failures or conflicts. Never merges or closes human PRs. Requires **L3** because `loop-gh-gate` forbids merge/close at L2.
 
@@ -198,7 +198,7 @@ See the [OSS Maintenance Patterns](#oss-maintenance-patterns) section below for 
 
 ### oss-triage
 
-**Tier:** L1 | **Cadence:** daily | **Max tokens:** 150,000
+**Tier:** L1 | **Cadence:** daily | **Max tokens:** 150,000 | **[README](../loops/oss-triage/README.md)**
 
 Scans open issues across all configured OSS repos. Applies labels, responds to questions where the right answer is obvious, asks for minimal reproducers on bug reports, and escalates security reports. Supports resumability. Uses roughly half the budget of `oss-pr-monitor`.
 
@@ -210,7 +210,7 @@ See the [OSS Maintenance Patterns](#oss-maintenance-patterns) section below for 
 
 ### post-merge-cleanup
 
-**Tier:** L2 | **Cadence:** every 6 hours | **Max tokens:** 20,000 per run, 4 runs/day
+**Tier:** L2 | **Cadence:** every 6 hours | **Max tokens:** 20,000 per run, 4 runs/day | **[README](../loops/post-merge-cleanup/README.md)**
 
 Off-peak housekeeping after merges. Deletes branches that have been merged into main for more than 7 days (skips main, develop, release/*). Closes issues that were closed by merged PRs but not yet marked closed. Posts stale comments on issues with no activity in 90+ days (does not close them). Skips any action it is uncertain about.
 
@@ -220,7 +220,7 @@ Allowlist: delete_merged_branch, close_stale_issue, comment. Deny: merge, approv
 
 ### pr-babysitter
 
-**Tier:** L2 | **Cadence:** every 15 minutes | **Max tokens:** 80,000 per run, 96 runs/day
+**Tier:** L2 | **Cadence:** every 15 minutes | **Max tokens:** 80,000 per run, 96 runs/day | **[README](../loops/pr-babysitter/README.md)**
 
 Reviews open PRs that have not received a review in the last hour. Posts a constructive review comment with a summary and 1–3 specific suggestions. Never approves, requests changes, merges, or closes. Escalates on security issues.
 

--- a/loops/changelog-drafter/README.md
+++ b/loops/changelog-drafter/README.md
@@ -1,0 +1,106 @@
+# changelog-drafter
+
+> **Tier L1 — Read-only** | Runs once per day | Low cost
+
+Collects all pull requests merged since the last git tag and drafts a release notes entry in [keep-a-changelog](https://keepachangelog.com) format. It writes the draft to `report.md` for a human to review and edit before publishing. It never commits, tags, or pushes anything.
+
+---
+
+## What Problem Does This Solve?
+
+Writing release notes by hand means reviewing every PR that merged since the last release — tedious, error-prone, and often skipped entirely. This loop does that review automatically every day so your changelog is always one edit away from being published.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L1 — read-only, zero mutations |
+| **Cadence** | `1d` — once every 24 hours |
+| **Max tokens / run** | 20,000 |
+| **Max wall time** | 3 minutes (180 seconds) |
+| **Resumable** | No |
+| **Verifier** | None |
+
+---
+
+## What It Does — Step by Step
+
+1. Finds the latest git tag: `git describe --tags --abbrev=0`
+2. Lists all PRs merged after that tag: `gh pr list --state merged --search "merged:>DATE"`
+3. Groups the PRs into changelog sections:
+   - **Added** — new features
+   - **Changed** — behaviour changes
+   - **Fixed** — bug fixes
+   - **Deprecated** — things being phased out
+   - **Removed** — deleted features
+   - **Security** — vulnerability fixes
+4. Writes a draft `CHANGELOG` entry to `loops/changelog-drafter/report.md`
+5. Stops — nothing is committed or pushed
+
+---
+
+## What It Will NEVER Do
+
+```
+✗ Commit changes
+✗ Push to any branch
+✗ Create or move a git tag
+✗ Open a pull request
+✗ Modify CHANGELOG.md directly
+```
+
+---
+
+## Output
+
+After each run, `loops/changelog-drafter/report.md` contains a draft like:
+
+```markdown
+## [Unreleased] — 2026-08-14
+
+### Added
+- feat: add `memory inject` command (#201)
+- feat: support Pi Coding Agent profile (#198)
+
+### Fixed
+- fix: `doctor` command exits 1 on missing optional tool (#195)
+
+### Changed
+- chore: bump V runtime to 0.4.9 (#199)
+```
+
+Copy this into your `CHANGELOG.md`, replace `[Unreleased]` with the version number, and you're done.
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- At least one git tag in the repository (the loop uses the latest tag as its starting point)
+- Read access to pull requests
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run changelog-drafter
+```
+
+---
+
+## Safety Contract
+
+```yaml
+allowlist: []     # read-only
+deny:
+  - merge
+  - push
+  - commit
+  - tag
+```

--- a/loops/changelog-drafter/README.md
+++ b/loops/changelog-drafter/README.md
@@ -1,106 +1,19 @@
 # changelog-drafter
 
-> **Tier L1 — Read-only** | Runs once per day | Low cost
+Drafts release notes in [Keep a Changelog](https://keepachangelog.com/) format by collecting all pull requests merged since the last git tag.
 
-Collects all pull requests merged since the last git tag and drafts a release notes entry in [keep-a-changelog](https://keepachangelog.com) format. It writes the draft to `report.md` for a human to review and edit before publishing. It never commits, tags, or pushes anything.
+## When to Use
+Use this loop to automate draft release notes creation for review before tagging or publishing a release.
 
----
-
-## What Problem Does This Solve?
-
-Writing release notes by hand means reviewing every PR that merged since the last release — tedious, error-prone, and often skipped entirely. This loop does that review automatically every day so your changelog is always one edit away from being published.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L1 — read-only, zero mutations |
-| **Cadence** | `1d` — once every 24 hours |
-| **Max tokens / run** | 20,000 |
-| **Max wall time** | 3 minutes (180 seconds) |
-| **Resumable** | No |
-| **Verifier** | None |
-
----
-
-## What It Does — Step by Step
-
-1. Finds the latest git tag: `git describe --tags --abbrev=0`
-2. Lists all PRs merged after that tag: `gh pr list --state merged --search "merged:>DATE"`
-3. Groups the PRs into changelog sections:
-   - **Added** — new features
-   - **Changed** — behaviour changes
-   - **Fixed** — bug fixes
-   - **Deprecated** — things being phased out
-   - **Removed** — deleted features
-   - **Security** — vulnerability fixes
-4. Writes a draft `CHANGELOG` entry to `loops/changelog-drafter/report.md`
-5. Stops — nothing is committed or pushed
-
----
-
-## What It Will NEVER Do
-
-```
-✗ Commit changes
-✗ Push to any branch
-✗ Create or move a git tag
-✗ Open a pull request
-✗ Modify CHANGELOG.md directly
-```
-
----
-
-## Output
-
-After each run, `loops/changelog-drafter/report.md` contains a draft like:
-
-```markdown
-## [Unreleased] — 2026-08-14
-
-### Added
-- feat: add `memory inject` command (#201)
-- feat: support Pi Coding Agent profile (#198)
-
-### Fixed
-- fix: `doctor` command exits 1 on missing optional tool (#195)
-
-### Changed
-- chore: bump V runtime to 0.4.9 (#199)
-```
-
-Copy this into your `CHANGELOG.md`, replace `[Unreleased]` with the version number, and you're done.
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated (`gh auth login`)
-- At least one git tag in the repository (the loop uses the latest tag as its starting point)
-- Read access to pull requests
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run changelog-drafter
 ```
 
----
+## Details
+* **Artifact Output:** Draft changelog is written to `loops/changelog-drafter/runs/<run_id>/report.md` on each run.
+* **Safety:** This loop is L1 (Observe and Report). It does not commit, tag, or push to the repository.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## Safety Contract
-
-```yaml
-allowlist: []     # read-only
-deny:
-  - merge
-  - push
-  - commit
-  - tag
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/ci-sweeper/README.md
+++ b/loops/ci-sweeper/README.md
@@ -1,133 +1,19 @@
 # ci-sweeper
 
-> **Tier L2 — Controlled writes** | Runs every 15 minutes | Very high cost
+Monitors failing CI runs on open PRs and the main branch, diagnoses the root cause, and opens a draft PR with a minimal fix if straightforward.
 
-Monitors CI runs across open PRs and the main branch. When it finds a failing CI run, it diagnoses the root cause, attempts a minimal fix (under 20 lines), and opens a **draft PR** with the proposed fix. If the fix is too complex or uncertain, it posts a diagnostic comment instead. It never auto-merges and never force-pushes.
+## When to Use
+Use this loop to automatically detect and propose fixes for minor, repetitive CI breakages (such as lockfile issues, syntax bugs, or test environment problems).
 
----
-
-## What Problem Does This Solve?
-
-A failing CI run blocks every contributor working on the repository. Finding the failure, reading the logs, and writing a fix takes time — especially if it is a flaky test, a lockfile issue, or a missing environment variable. This loop catches those failures within 15 minutes and proposes fixes so the team can unblock quickly.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L2 — limited write access |
-| **Cadence** | `15m` — every 15 minutes |
-| **Max tokens / run** | 100,000 |
-| **Max runs / day** | 48 |
-| **Max wall time** | 15 minutes (900 seconds) |
-| **Max iterations** | 3 |
-| **Resumable** | No |
-| **Verifier** | `agent-toolkit-code-reviewer` |
-
-> ⚠️ **This loop is expensive.** It runs 48 times per day with a 100k token budget. Start at L1 observation for at least 3 days before enabling this loop on a production repository. The default budget is intentionally conservative.
-
----
-
-## What It Does — Step by Step
-
-1. Lists failing CI runs: `gh run list --status failure`
-2. For each failing run (max 2 per execution):
-   - Fetches full logs: `gh run view --log`
-   - Identifies the root cause
-   - If the fix is **straightforward** (< 20 lines, no architectural impact):
-     - Creates a worktree
-     - Applies the fix
-     - Opens a **draft PR** with a clear description of what failed and why
-   - If the fix is **complex or uncertain**:
-     - Posts a diagnostic comment on the relevant PR or commit — no code changes
-3. Writes `plan.md` summarising: failures found, fixes attempted, draft PRs opened
-
----
-
-## Permitted Actions (Allowlist)
-
-```
-✓ comment           — post diagnostic comments on PRs/commits
-✓ create_draft_pr   — open a draft PR with a proposed fix
-```
-
-## What It Will NEVER Do
-
-```
-✗ Merge any PR
-✗ Approve any PR
-✗ Close any PR or issue
-✗ Force-push to any branch
-✗ Delete any branch
-✗ Push directly to main
-```
-
----
-
-## Output
-
-After each run, `loops/ci-sweeper/plan.md` is written with:
-
-```markdown
-## CI Sweeper — 2026-08-14T08:15Z
-
-### Failures Found
-| Run ID | Branch | Failure | Root Cause |
-|--------|--------|---------|------------|
-| #4821 | feat/login | test_auth failed | Missing env var AUTH_SECRET |
-
-### Actions Taken
-| PR | Action | Outcome |
-|----|--------|---------|
-| #draft-1 | Opened draft PR with fix | Added AUTH_SECRET to test env |
-
-### Skipped (too complex)
-- Run #4818 on main: compile error in new V module — requires architectural review
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated (`gh auth login`)
-- Write access to open draft PRs in the repository
-- CI must be configured (GitHub Actions, or another system visible via `gh run list`)
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run ci-sweeper
 ```
 
----
+## Details
+* **Artifact Output:** Execution plans are written to `loops/ci-sweeper/runs/<run_id>/plan.md` on each run.
+* **Safety:** This loop is L2 (Controlled Mutations). It only comments or opens draft PRs. It never merges, force-pushes, or deletes branches.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## Graduated Deployment
-
-> Never deploy this loop at L2 immediately.
-
-1. **Observe first:** Comment out the `create_draft_pr` action and run at L1 for 3 days. Confirm the diagnostic comments are accurate.
-2. **Enable writes:** Re-enable `create_draft_pr`. Monitor the first 5 draft PRs manually before trusting the loop fully.
-3. **Adjust budget:** If the loop consistently finishes in 2 iterations, lower `max_iterations` from 3 to 2 to save tokens.
-
----
-
-## Safety Contract
-
-```yaml
-tier: L2
-allowlist:
-  - comment
-  - create_draft_pr
-deny:
-  - merge
-  - approve
-  - close
-  - force-push
-  - delete-branch
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/ci-sweeper/README.md
+++ b/loops/ci-sweeper/README.md
@@ -1,0 +1,133 @@
+# ci-sweeper
+
+> **Tier L2 — Controlled writes** | Runs every 15 minutes | Very high cost
+
+Monitors CI runs across open PRs and the main branch. When it finds a failing CI run, it diagnoses the root cause, attempts a minimal fix (under 20 lines), and opens a **draft PR** with the proposed fix. If the fix is too complex or uncertain, it posts a diagnostic comment instead. It never auto-merges and never force-pushes.
+
+---
+
+## What Problem Does This Solve?
+
+A failing CI run blocks every contributor working on the repository. Finding the failure, reading the logs, and writing a fix takes time — especially if it is a flaky test, a lockfile issue, or a missing environment variable. This loop catches those failures within 15 minutes and proposes fixes so the team can unblock quickly.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L2 — limited write access |
+| **Cadence** | `15m` — every 15 minutes |
+| **Max tokens / run** | 100,000 |
+| **Max runs / day** | 48 |
+| **Max wall time** | 15 minutes (900 seconds) |
+| **Max iterations** | 3 |
+| **Resumable** | No |
+| **Verifier** | `agent-toolkit-code-reviewer` |
+
+> ⚠️ **This loop is expensive.** It runs 48 times per day with a 100k token budget. Start at L1 observation for at least 3 days before enabling this loop on a production repository. The default budget is intentionally conservative.
+
+---
+
+## What It Does — Step by Step
+
+1. Lists failing CI runs: `gh run list --status failure`
+2. For each failing run (max 2 per execution):
+   - Fetches full logs: `gh run view --log`
+   - Identifies the root cause
+   - If the fix is **straightforward** (< 20 lines, no architectural impact):
+     - Creates a worktree
+     - Applies the fix
+     - Opens a **draft PR** with a clear description of what failed and why
+   - If the fix is **complex or uncertain**:
+     - Posts a diagnostic comment on the relevant PR or commit — no code changes
+3. Writes `plan.md` summarising: failures found, fixes attempted, draft PRs opened
+
+---
+
+## Permitted Actions (Allowlist)
+
+```
+✓ comment           — post diagnostic comments on PRs/commits
+✓ create_draft_pr   — open a draft PR with a proposed fix
+```
+
+## What It Will NEVER Do
+
+```
+✗ Merge any PR
+✗ Approve any PR
+✗ Close any PR or issue
+✗ Force-push to any branch
+✗ Delete any branch
+✗ Push directly to main
+```
+
+---
+
+## Output
+
+After each run, `loops/ci-sweeper/plan.md` is written with:
+
+```markdown
+## CI Sweeper — 2026-08-14T08:15Z
+
+### Failures Found
+| Run ID | Branch | Failure | Root Cause |
+|--------|--------|---------|------------|
+| #4821 | feat/login | test_auth failed | Missing env var AUTH_SECRET |
+
+### Actions Taken
+| PR | Action | Outcome |
+|----|--------|---------|
+| #draft-1 | Opened draft PR with fix | Added AUTH_SECRET to test env |
+
+### Skipped (too complex)
+- Run #4818 on main: compile error in new V module — requires architectural review
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- Write access to open draft PRs in the repository
+- CI must be configured (GitHub Actions, or another system visible via `gh run list`)
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run ci-sweeper
+```
+
+---
+
+## Graduated Deployment
+
+> Never deploy this loop at L2 immediately.
+
+1. **Observe first:** Comment out the `create_draft_pr` action and run at L1 for 3 days. Confirm the diagnostic comments are accurate.
+2. **Enable writes:** Re-enable `create_draft_pr`. Monitor the first 5 draft PRs manually before trusting the loop fully.
+3. **Adjust budget:** If the loop consistently finishes in 2 iterations, lower `max_iterations` from 3 to 2 to save tokens.
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L2
+allowlist:
+  - comment
+  - create_draft_pr
+deny:
+  - merge
+  - approve
+  - close
+  - force-push
+  - delete-branch
+```

--- a/loops/daily-triage/README.md
+++ b/loops/daily-triage/README.md
@@ -1,110 +1,20 @@
 # daily-triage
 
-> **Tier L1 — Read-only** | Runs once per day | Low cost
+Scans open issues created in the last 24 hours to propose priority scores, labels, and brief summaries.
 
-Scans every new GitHub issue opened in the last 24 hours and proposes labels, priority scores, and a brief summary for each one. It writes these proposals to `report.md` for a human maintainer to review. It never touches the repository — no labels applied, no comments posted, nothing changed.
+## When to Use
+Use this loop to stay on top of incoming issues on a single repository with a low token budget.
 
----
-
-## What Problem Does This Solve?
-
-On active repositories, new issues pile up quickly. Without triage, issues go unlabeled for days, making it impossible to filter, prioritize, or search them. This loop watches for new issues every day so nothing falls through the cracks.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L1 — read-only, zero mutations |
-| **Cadence** | `1d` — once every 24 hours |
-| **Max tokens / run** | 30,000 |
-| **Max wall time** | 5 minutes (300 seconds) |
-| **Resumable** | No |
-| **Verifier** | None |
-
----
-
-## What It Does — Step by Step
-
-1. Lists all open issues created in the last 24 hours using `gh issue list`
-2. For each issue, reads the title and body
-3. Proposes:
-   - **Priority** — `critical` / `high` / `medium` / `low`
-   - **Labels** — based on the issue content and the repo's existing label taxonomy
-   - **Summary** — 1–2 sentence description of the issue
-4. Writes all proposals to `loops/daily-triage/report.md`
-5. Stops — does not apply anything
-
----
-
-## What It Will NEVER Do
-
-```
-✗ Apply labels
-✗ Post comments on issues
-✗ Close or merge anything
-✗ Push code
-✗ Take any action that modifies the repository
-```
-
----
-
-## Output
-
-After each run, `loops/daily-triage/report.md` is written with a table similar to:
-
-```markdown
-## Daily Triage Report — 2026-08-14
-
-| # | Title | Proposed Labels | Priority | Summary |
-|---|-------|----------------|----------|---------|
-| #42 | Login fails on mobile | bug, ux | high | Users cannot log in on iOS Safari due to a cookie scope issue. |
-| #43 | Add dark mode | enhancement | low | Feature request to add a dark mode toggle to the settings page. |
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated (`gh auth login`)
-- Read access to the repository's issues
-
----
-
-## How to Run
-
+## Execution
+To initialize and run this loop:
 ```bash
-# Run once manually
+agent-toolkit loop init daily-triage
 agent-toolkit loop run daily-triage
-
-# Initialise for a specific repo
-./bin/loop init daily-triage --repo owner/repo
-./bin/loop run daily-triage
 ```
 
----
+## Details
+* **Artifact Output:** Triage proposals are written to `loops/daily-triage/runs/<run_id>/report.md`.
+* **Safety:** This loop is L1 (Observe and Report). It does not write comments or apply labels directly.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## When to Upgrade to L2
-
-Once you have reviewed 3+ consecutive reports and confirmed the proposed labels are accurate, you can upgrade to an L2 version of this loop that applies labels directly. The L2 version would move `label` from the `deny` list to the `allowlist`.
-
-> **Start here. Run it clean for at least 3 days before applying labels automatically.**
-
----
-
-## Safety Contract
-
-This loop is **L1**. The loop runner enforces that the actions listed in `deny` are never executed, regardless of what the agent decides. Even if the LLM reasons that it should apply a label, the runner blocks it.
-
-```yaml
-allowlist: []       # nothing permitted beyond reading
-deny:
-  - merge
-  - close
-  - label
-  - comment
-  - push
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/daily-triage/README.md
+++ b/loops/daily-triage/README.md
@@ -1,0 +1,110 @@
+# daily-triage
+
+> **Tier L1 — Read-only** | Runs once per day | Low cost
+
+Scans every new GitHub issue opened in the last 24 hours and proposes labels, priority scores, and a brief summary for each one. It writes these proposals to `report.md` for a human maintainer to review. It never touches the repository — no labels applied, no comments posted, nothing changed.
+
+---
+
+## What Problem Does This Solve?
+
+On active repositories, new issues pile up quickly. Without triage, issues go unlabeled for days, making it impossible to filter, prioritize, or search them. This loop watches for new issues every day so nothing falls through the cracks.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L1 — read-only, zero mutations |
+| **Cadence** | `1d` — once every 24 hours |
+| **Max tokens / run** | 30,000 |
+| **Max wall time** | 5 minutes (300 seconds) |
+| **Resumable** | No |
+| **Verifier** | None |
+
+---
+
+## What It Does — Step by Step
+
+1. Lists all open issues created in the last 24 hours using `gh issue list`
+2. For each issue, reads the title and body
+3. Proposes:
+   - **Priority** — `critical` / `high` / `medium` / `low`
+   - **Labels** — based on the issue content and the repo's existing label taxonomy
+   - **Summary** — 1–2 sentence description of the issue
+4. Writes all proposals to `loops/daily-triage/report.md`
+5. Stops — does not apply anything
+
+---
+
+## What It Will NEVER Do
+
+```
+✗ Apply labels
+✗ Post comments on issues
+✗ Close or merge anything
+✗ Push code
+✗ Take any action that modifies the repository
+```
+
+---
+
+## Output
+
+After each run, `loops/daily-triage/report.md` is written with a table similar to:
+
+```markdown
+## Daily Triage Report — 2026-08-14
+
+| # | Title | Proposed Labels | Priority | Summary |
+|---|-------|----------------|----------|---------|
+| #42 | Login fails on mobile | bug, ux | high | Users cannot log in on iOS Safari due to a cookie scope issue. |
+| #43 | Add dark mode | enhancement | low | Feature request to add a dark mode toggle to the settings page. |
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- Read access to the repository's issues
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run daily-triage
+
+# Initialise for a specific repo
+./bin/loop init daily-triage --repo owner/repo
+./bin/loop run daily-triage
+```
+
+---
+
+## When to Upgrade to L2
+
+Once you have reviewed 3+ consecutive reports and confirmed the proposed labels are accurate, you can upgrade to an L2 version of this loop that applies labels directly. The L2 version would move `label` from the `deny` list to the `allowlist`.
+
+> **Start here. Run it clean for at least 3 days before applying labels automatically.**
+
+---
+
+## Safety Contract
+
+This loop is **L1**. The loop runner enforces that the actions listed in `deny` are never executed, regardless of what the agent decides. Even if the LLM reasons that it should apply a label, the runner blocks it.
+
+```yaml
+allowlist: []       # nothing permitted beyond reading
+deny:
+  - merge
+  - close
+  - label
+  - comment
+  - push
+```

--- a/loops/dep-sweeper/README.md
+++ b/loops/dep-sweeper/README.md
@@ -1,118 +1,20 @@
 # dep-sweeper
 
-> **Tier L2 — Controlled writes** | Runs once per day | Medium cost
+Scans for available patch-level updates across ecosystems (npm, pip, cargo, etc.) and opens draft PRs if local tests pass.
 
-Scans for available **patch-level** dependency updates across all ecosystems in the repository (npm, pip, cargo, etc.), applies them in a worktree, runs the test suite, and opens a **draft PR** per ecosystem if tests pass. It strictly avoids major and minor version bumps — those require human review.
+## When to Use
+Use this loop to automate mechanical, low-risk dependencies maintenance without manual checking.
 
----
-
-## What Problem Does This Solve?
-
-Patch-level updates (e.g. `1.2.3 → 1.2.4`) are low-risk security and bug-fix releases. Ignoring them builds up dependency debt and leaves known vulnerabilities unpatched. This loop handles the safe, mechanical part of dependency maintenance so humans can focus on evaluating major and minor version upgrades.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L2 — limited write access |
-| **Cadence** | `1d` — once every 24 hours |
-| **Max tokens / run** | 50,000 |
-| **Max wall time** | 10 minutes (600 seconds) |
-| **Resumable** | No |
-| **Verifier** | `agent-toolkit-code-reviewer` |
-
----
-
-## What It Does — Step by Step
-
-1. Detects available updates per ecosystem:
-   - **npm**: `npm outdated`
-   - **pip**: `pip list --outdated`
-   - **cargo**: `cargo outdated`
-   - *(other ecosystems detected automatically)*
-2. Filters to **patch-level only** — skips any major (`X.0.0`) or minor (`0.X.0`) updates
-3. Groups updates by ecosystem
-4. For each ecosystem that has patch updates:
-   - Creates a worktree to isolate changes
-   - Applies the patch updates
-   - Runs the test suite (`npm test`, `pytest`, `cargo test`, etc.)
-   - **If tests pass** → opens a draft PR titled `chore: patch dep updates (YYYY-MM-DD)`
-   - **If tests fail** → posts a comment with the failure details, skips the draft PR
-5. Writes `plan.md` summarising: ecosystems checked, updates found, PRs opened, failures
-
----
-
-## Permitted Actions (Allowlist)
-
-```
-✓ create_draft_pr   — open a draft PR with patch updates
-✓ comment           — post failure details if tests break
-```
-
-## What It Will NEVER Do
-
-```
-✗ Merge any PR
-✗ Approve any PR
-✗ Apply major version updates (e.g. v1 → v2)
-✗ Apply minor version updates (e.g. v1.2 → v1.3)
-✗ Push directly to main
-```
-
----
-
-## Output
-
-After each run, `loops/dep-sweeper/plan.md` is written with:
-
-```markdown
-## Dep Sweeper — 2026-08-14
-
-### Ecosystems Checked
-| Ecosystem | Updates Found | Patch Only | PR Opened |
-|-----------|--------------|------------|-----------|
-| npm | 12 | 8 | ✅ #draft-4 |
-| pip | 3 | 3 | ✅ #draft-5 |
-| cargo | 0 | 0 | — |
-
-### Skipped (test failures)
-- npm: `lodash` patch broke 2 snapshot tests (see comment on draft PR)
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated (`gh auth login`)
-- Ecosystem package managers available in the CI environment (`npm`, `pip`, `cargo`, etc.)
-- A runnable test suite for each ecosystem
-- Write access to open draft PRs
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run dep-sweeper
 ```
 
----
+## Details
+* **Artifact Output:** Execution plans are written to `loops/dep-sweeper/runs/<run_id>/plan.md`.
+* **SemVer Safety:** Only patch updates are applied. The loop skips updates when the major or minor versions in the version string change.
+* **Safety:** This loop is L2 (Controlled Mutations). It only comments or opens draft PRs. It never merges or force-pushes.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## Safety Contract
-
-```yaml
-tier: L2
-allowlist:
-  - create_draft_pr
-  - comment
-deny:
-  - merge
-  - approve
-  - major-version-bump
-  - minor-version-bump
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/dep-sweeper/README.md
+++ b/loops/dep-sweeper/README.md
@@ -1,0 +1,118 @@
+# dep-sweeper
+
+> **Tier L2 — Controlled writes** | Runs once per day | Medium cost
+
+Scans for available **patch-level** dependency updates across all ecosystems in the repository (npm, pip, cargo, etc.), applies them in a worktree, runs the test suite, and opens a **draft PR** per ecosystem if tests pass. It strictly avoids major and minor version bumps — those require human review.
+
+---
+
+## What Problem Does This Solve?
+
+Patch-level updates (e.g. `1.2.3 → 1.2.4`) are low-risk security and bug-fix releases. Ignoring them builds up dependency debt and leaves known vulnerabilities unpatched. This loop handles the safe, mechanical part of dependency maintenance so humans can focus on evaluating major and minor version upgrades.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L2 — limited write access |
+| **Cadence** | `1d` — once every 24 hours |
+| **Max tokens / run** | 50,000 |
+| **Max wall time** | 10 minutes (600 seconds) |
+| **Resumable** | No |
+| **Verifier** | `agent-toolkit-code-reviewer` |
+
+---
+
+## What It Does — Step by Step
+
+1. Detects available updates per ecosystem:
+   - **npm**: `npm outdated`
+   - **pip**: `pip list --outdated`
+   - **cargo**: `cargo outdated`
+   - *(other ecosystems detected automatically)*
+2. Filters to **patch-level only** — skips any major (`X.0.0`) or minor (`0.X.0`) updates
+3. Groups updates by ecosystem
+4. For each ecosystem that has patch updates:
+   - Creates a worktree to isolate changes
+   - Applies the patch updates
+   - Runs the test suite (`npm test`, `pytest`, `cargo test`, etc.)
+   - **If tests pass** → opens a draft PR titled `chore: patch dep updates (YYYY-MM-DD)`
+   - **If tests fail** → posts a comment with the failure details, skips the draft PR
+5. Writes `plan.md` summarising: ecosystems checked, updates found, PRs opened, failures
+
+---
+
+## Permitted Actions (Allowlist)
+
+```
+✓ create_draft_pr   — open a draft PR with patch updates
+✓ comment           — post failure details if tests break
+```
+
+## What It Will NEVER Do
+
+```
+✗ Merge any PR
+✗ Approve any PR
+✗ Apply major version updates (e.g. v1 → v2)
+✗ Apply minor version updates (e.g. v1.2 → v1.3)
+✗ Push directly to main
+```
+
+---
+
+## Output
+
+After each run, `loops/dep-sweeper/plan.md` is written with:
+
+```markdown
+## Dep Sweeper — 2026-08-14
+
+### Ecosystems Checked
+| Ecosystem | Updates Found | Patch Only | PR Opened |
+|-----------|--------------|------------|-----------|
+| npm | 12 | 8 | ✅ #draft-4 |
+| pip | 3 | 3 | ✅ #draft-5 |
+| cargo | 0 | 0 | — |
+
+### Skipped (test failures)
+- npm: `lodash` patch broke 2 snapshot tests (see comment on draft PR)
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- Ecosystem package managers available in the CI environment (`npm`, `pip`, `cargo`, etc.)
+- A runnable test suite for each ecosystem
+- Write access to open draft PRs
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run dep-sweeper
+```
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L2
+allowlist:
+  - create_draft_pr
+  - comment
+deny:
+  - merge
+  - approve
+  - major-version-bump
+  - minor-version-bump
+```

--- a/loops/issue-triage/README.md
+++ b/loops/issue-triage/README.md
@@ -1,0 +1,104 @@
+# issue-triage
+
+> **Tier L1 — Read-only** | Runs every 4 hours | Low cost
+
+Scans unlabeled issues and proposes the appropriate labels, type classification, and priority for each one. Proposals are written to `report.md` for a human to apply. It never touches the repository — no labels applied, no comments posted.
+
+---
+
+## What Problem Does This Solve?
+
+Issues that arrive without labels are invisible to search filters, project boards, and milestone tracking. On active repositories, unlabeled issues pile up within hours. This loop catches them every 4 hours and generates a ready-to-apply labelling proposal so maintainers spend seconds reviewing rather than minutes classifying.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L1 — read-only, zero mutations |
+| **Cadence** | `4h` — every 4 hours |
+| **Max tokens / run** | 25,000 |
+| **Max runs / day** | 6 |
+| **Max wall time** | 4 minutes (240 seconds) |
+| **Resumable** | No |
+| **Verifier** | None |
+
+---
+
+## What It Does — Step by Step
+
+1. Finds all open issues with no labels: `gh issue list --label ""`
+2. Processes up to 20 unlabeled issues per run
+3. For each issue, reads the title and body then proposes:
+   - **Label(s)** — e.g. `bug`, `enhancement`, `documentation`, `question`
+   - **Type** — `bug` / `feature` / `question` / `docs`
+   - **Priority** — `critical` / `high` / `medium` / `low`
+   - **Reasoning** — a brief explanation for the proposal
+4. **Security flag** — if an issue looks like a security report, immediately raises a `human_escalation` exit condition instead of continuing
+5. Writes all proposals to `loops/issue-triage/report.md`
+
+---
+
+## What It Will NEVER Do
+
+```
+✗ Apply labels to any issue
+✗ Post comments on any issue
+✗ Close any issue
+✗ Merge anything
+```
+
+---
+
+## Output
+
+After each run, `loops/issue-triage/report.md` is written:
+
+```markdown
+## Issue Triage Report — 2026-08-14T08:00Z
+
+| # | Title | Proposed Labels | Type | Priority | Reasoning |
+|---|-------|----------------|------|----------|-----------|
+| #55 | Button not working on Firefox | bug, browser-compat | bug | high | User reports specific browser + version. Likely CSS or JS compatibility issue. |
+| #56 | Add export to CSV | enhancement | feature | medium | Clear feature request with no urgency signals. |
+| #57 | How do I configure the timeout? | question, docs | question | low | User seeking documentation. No bug or feature implied. |
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- Read access to the repository's issues
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run issue-triage
+```
+
+---
+
+## When to Upgrade to L2
+
+After the reports are accurate for several consecutive runs, an L2 version can apply labels directly by moving `label` from `deny` to `allowlist` and updating the request prompt to apply rather than propose.
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L1
+allowlist: []
+deny:
+  - label
+  - comment
+  - close
+  - merge
+```

--- a/loops/issue-triage/README.md
+++ b/loops/issue-triage/README.md
@@ -1,104 +1,19 @@
 # issue-triage
 
-> **Tier L1 — Read-only** | Runs every 4 hours | Low cost
+Triages unlabeled issues by proposing labels, type classifications, and priority ratings.
 
-Scans unlabeled issues and proposes the appropriate labels, type classification, and priority for each one. Proposals are written to `report.md` for a human to apply. It never touches the repository — no labels applied, no comments posted.
+## When to Use
+Use this loop to stay organized on repositories with high issue activity.
 
----
-
-## What Problem Does This Solve?
-
-Issues that arrive without labels are invisible to search filters, project boards, and milestone tracking. On active repositories, unlabeled issues pile up within hours. This loop catches them every 4 hours and generates a ready-to-apply labelling proposal so maintainers spend seconds reviewing rather than minutes classifying.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L1 — read-only, zero mutations |
-| **Cadence** | `4h` — every 4 hours |
-| **Max tokens / run** | 25,000 |
-| **Max runs / day** | 6 |
-| **Max wall time** | 4 minutes (240 seconds) |
-| **Resumable** | No |
-| **Verifier** | None |
-
----
-
-## What It Does — Step by Step
-
-1. Finds all open issues with no labels: `gh issue list --label ""`
-2. Processes up to 20 unlabeled issues per run
-3. For each issue, reads the title and body then proposes:
-   - **Label(s)** — e.g. `bug`, `enhancement`, `documentation`, `question`
-   - **Type** — `bug` / `feature` / `question` / `docs`
-   - **Priority** — `critical` / `high` / `medium` / `low`
-   - **Reasoning** — a brief explanation for the proposal
-4. **Security flag** — if an issue looks like a security report, immediately raises a `human_escalation` exit condition instead of continuing
-5. Writes all proposals to `loops/issue-triage/report.md`
-
----
-
-## What It Will NEVER Do
-
-```
-✗ Apply labels to any issue
-✗ Post comments on any issue
-✗ Close any issue
-✗ Merge anything
-```
-
----
-
-## Output
-
-After each run, `loops/issue-triage/report.md` is written:
-
-```markdown
-## Issue Triage Report — 2026-08-14T08:00Z
-
-| # | Title | Proposed Labels | Type | Priority | Reasoning |
-|---|-------|----------------|------|----------|-----------|
-| #55 | Button not working on Firefox | bug, browser-compat | bug | high | User reports specific browser + version. Likely CSS or JS compatibility issue. |
-| #56 | Add export to CSV | enhancement | feature | medium | Clear feature request with no urgency signals. |
-| #57 | How do I configure the timeout? | question, docs | question | low | User seeking documentation. No bug or feature implied. |
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated (`gh auth login`)
-- Read access to the repository's issues
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run issue-triage
 ```
 
----
+## Details
+* **Artifact Output:** Triage proposals are written to `loops/issue-triage/runs/<run_id>/report.md` on each run.
+* **Safety:** This loop is L1 (Observe and Report). It does not apply labels or write comments directly.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## When to Upgrade to L2
-
-After the reports are accurate for several consecutive runs, an L2 version can apply labels directly by moving `label` from `deny` to `allowlist` and updating the request prompt to apply rather than propose.
-
----
-
-## Safety Contract
-
-```yaml
-tier: L1
-allowlist: []
-deny:
-  - label
-  - comment
-  - close
-  - merge
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/oss-daily-briefing/README.md
+++ b/loops/oss-daily-briefing/README.md
@@ -1,133 +1,20 @@
 # oss-daily-briefing
 
-> **Tier L1 — Read-only** | Runs once per day | Low cost | Resumable
+Generates a daily read-only briefing across configured OSS ecosystem repositories, covering new PRs, active issues, and CI health.
 
-Produces a daily read-only briefing across all configured OSS repositories. For each repo it collects new pull requests, issues needing attention, and CI health on the main branch, then writes a structured report. Nothing is modified — the loop is pure observation.
+## When to Use
+Use this loop to stay updated on multiple open-source repositories from a single report.
 
----
-
-## What Problem Does This Solve?
-
-Maintaining multiple open-source repositories means checking many dashboards every morning. This loop consolidates that into a single daily report: new activity, things needing attention, and CI health — all in one place.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L1 — read-only, zero mutations |
-| **Cadence** | `1d` — once every 24 hours |
-| **Max tokens / run** | 80,000 |
-| **Max wall time** | 15 minutes (900 seconds) |
-| **Resumable** | Yes — uses `STATE.md` checkpoints |
-| **Verifier** | None |
-
----
-
-## What It Does — Step by Step
-
-1. Reads `loops/oss-daily-briefing/STATE.md` — if `last_processed_repo` is set, resumes from where the previous run stopped
-2. For each configured repo, collects:
-   - **New PRs** in the last 24 hours
-   - **New issues** or issues with recent activity
-   - **CI status** on the main branch
-3. After processing each repo, writes a checkpoint to `STATE.md`
-4. Writes the full briefing to `loops/oss-daily-briefing/report.md`
-5. On successful completion, clears `last_processed_repo` in `STATE.md`
-
----
-
-## What It Will NEVER Do
-
-```
-✗ Comment on any issue or PR
-✗ Apply labels
-✗ Assign anyone
-✗ Merge anything
-✗ Approve anything
-✗ Push or force-push
-```
-
----
-
-## Resumability
-
-This loop is **resumable**. If it hits the token budget mid-run, it writes its current position to `STATE.md`:
-
-```markdown
-last_processed_repo: owner/repo-name
-last_run: 2026-08-14T02:30:00Z
-last_run_status: partial (budget_exhausted)
-```
-
-The next scheduled run reads this file and skips the repos that were already processed. This allows the loop to reliably cover large multi-repo ecosystems even with conservative token budgets.
-
-> `STATE.md` is a runtime artifact. Do not commit it.
-
----
-
-## Output
-
-After a complete run, `loops/oss-daily-briefing/report.md` looks like:
-
-```markdown
-## OSS Daily Briefing — 2026-08-14
-
-### New PRs (last 24h)
-| Repo | # | Title | Author |
-|------|---|-------|--------|
-| owner/repo-a | #88 | feat: add retry logic | alice |
-| owner/repo-b | #34 | fix: null pointer in parser | bob |
-
-### Issues Needing Attention
-| Repo | # | Title | Last Comment |
-|------|---|-------|-------------|
-| owner/repo-a | #71 | Memory leak on long sessions | 3 days ago |
-
-### CI Health
-| Repo | Status |
-|------|--------|
-| owner/repo-a | ✅ passing |
-| owner/repo-b | ❌ failing (2 jobs) |
-
-### Highlights
-- owner/repo-a shipped v2.1.0 yesterday
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated (`gh auth login`)
-- Read access to all configured repositories
-- For large ecosystems (10+ repos): ensure `resumable: true` is set and `max_tokens` is sized appropriately (see token budget table in `docs/HOW_TO_CREATE_LOOP.md`)
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run oss-daily-briefing
 ```
 
----
+## Details
+* **Artifact Output:** The daily briefing is written to `loops/oss-daily-briefing/runs/<run_id>/report.md`.
+* **State Checkpointing:** Supports progress checkpointing via `loops/oss-daily-briefing/STATE.md`.
+* **Safety:** This loop is L1 (Observe and Report) and does not perform any mutations on repositories.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## Safety Contract
-
-```yaml
-tier: L1
-allowlist: []
-deny:
-  - comment
-  - label
-  - assign
-  - merge
-  - close
-  - push
-  - approve
-  - force-push
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/oss-daily-briefing/README.md
+++ b/loops/oss-daily-briefing/README.md
@@ -1,0 +1,133 @@
+# oss-daily-briefing
+
+> **Tier L1 — Read-only** | Runs once per day | Low cost | Resumable
+
+Produces a daily read-only briefing across all configured OSS repositories. For each repo it collects new pull requests, issues needing attention, and CI health on the main branch, then writes a structured report. Nothing is modified — the loop is pure observation.
+
+---
+
+## What Problem Does This Solve?
+
+Maintaining multiple open-source repositories means checking many dashboards every morning. This loop consolidates that into a single daily report: new activity, things needing attention, and CI health — all in one place.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L1 — read-only, zero mutations |
+| **Cadence** | `1d` — once every 24 hours |
+| **Max tokens / run** | 80,000 |
+| **Max wall time** | 15 minutes (900 seconds) |
+| **Resumable** | Yes — uses `STATE.md` checkpoints |
+| **Verifier** | None |
+
+---
+
+## What It Does — Step by Step
+
+1. Reads `loops/oss-daily-briefing/STATE.md` — if `last_processed_repo` is set, resumes from where the previous run stopped
+2. For each configured repo, collects:
+   - **New PRs** in the last 24 hours
+   - **New issues** or issues with recent activity
+   - **CI status** on the main branch
+3. After processing each repo, writes a checkpoint to `STATE.md`
+4. Writes the full briefing to `loops/oss-daily-briefing/report.md`
+5. On successful completion, clears `last_processed_repo` in `STATE.md`
+
+---
+
+## What It Will NEVER Do
+
+```
+✗ Comment on any issue or PR
+✗ Apply labels
+✗ Assign anyone
+✗ Merge anything
+✗ Approve anything
+✗ Push or force-push
+```
+
+---
+
+## Resumability
+
+This loop is **resumable**. If it hits the token budget mid-run, it writes its current position to `STATE.md`:
+
+```markdown
+last_processed_repo: owner/repo-name
+last_run: 2026-08-14T02:30:00Z
+last_run_status: partial (budget_exhausted)
+```
+
+The next scheduled run reads this file and skips the repos that were already processed. This allows the loop to reliably cover large multi-repo ecosystems even with conservative token budgets.
+
+> `STATE.md` is a runtime artifact. Do not commit it.
+
+---
+
+## Output
+
+After a complete run, `loops/oss-daily-briefing/report.md` looks like:
+
+```markdown
+## OSS Daily Briefing — 2026-08-14
+
+### New PRs (last 24h)
+| Repo | # | Title | Author |
+|------|---|-------|--------|
+| owner/repo-a | #88 | feat: add retry logic | alice |
+| owner/repo-b | #34 | fix: null pointer in parser | bob |
+
+### Issues Needing Attention
+| Repo | # | Title | Last Comment |
+|------|---|-------|-------------|
+| owner/repo-a | #71 | Memory leak on long sessions | 3 days ago |
+
+### CI Health
+| Repo | Status |
+|------|--------|
+| owner/repo-a | ✅ passing |
+| owner/repo-b | ❌ failing (2 jobs) |
+
+### Highlights
+- owner/repo-a shipped v2.1.0 yesterday
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- Read access to all configured repositories
+- For large ecosystems (10+ repos): ensure `resumable: true` is set and `max_tokens` is sized appropriately (see token budget table in `docs/HOW_TO_CREATE_LOOP.md`)
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run oss-daily-briefing
+```
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L1
+allowlist: []
+deny:
+  - comment
+  - label
+  - assign
+  - merge
+  - close
+  - push
+  - approve
+  - force-push
+```

--- a/loops/oss-pr-monitor/README.md
+++ b/loops/oss-pr-monitor/README.md
@@ -1,118 +1,20 @@
 # oss-pr-monitor
 
-> **Tier L3 — High Autonomy (Merge/Close Allowlisted)** | Runs once per day | High cost | Resumable
+Evaluates open pull requests across all configured OSS repositories. Auto-merges Dependabot PRs with passing CI, closes dirty Dependabot PRs, and reports on human PRs.
 
-Monitors open pull requests across a multi-repository open-source software (OSS) ecosystem. It evaluates open PRs, auto-merges Dependabot PRs with passing CI, closes broken Dependabot PRs, and drafts diagnoses for failing human PRs. Because it merges and closes PRs, it requires L3 permissions.
+## When to Use
+Use this loop to automate Dependabot updates and get quick diagnostics on human-submitted PRs across a multi-repo ecosystem.
 
----
-
-## What Problem Does This Solve?
-
-Maintaining 20–50 repositories means dealing with constant dependency bumps (e.g., from Dependabot) and pull requests. Checking every single one manually takes significant time. This loop automates the clean, mechanical updates (merging passing Dependabot PRs) and organizes human-submitted PRs into a checklist report so you only need to focus on what requires human review.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L3 — High-autonomy (Merge/Close allowed) |
-| **Cadence** | `1d` — once every 24 hours |
-| **Max tokens / run** | 300,000 |
-| **Max runs / day** | 1 |
-| **Max wall time** | 30 minutes (1800 seconds) |
-| **Resumable** | Yes — uses `STATE.md` checkpoints |
-| **Verifier** | `agent-toolkit-code-reviewer` |
-
-> ⚠️ **L3 loops are high-autonomy.** They possess merge and close capabilities. Ensure you run this loop in L1 report-only mode first to observe its decisions before enabling mutations in a production environment.
-
----
-
-## What It Does — Step by Step
-
-1. Reads `loops/oss-pr-monitor/STATE.md` to resume from the last processed repository if interrupted.
-2. For each configured repository in the pack:
-   - Lists open PRs using the GitHub API.
-   - Classifies each PR: Dependabot PR, other Bot PR, or Human PR.
-3. Takes action on Dependabot PRs:
-   - Checks CI test status.
-   - **All checks passing** → Merges the PR silently (`gh pr merge --squash`).
-   - **CI checks failing** → Skips and notes in the report.
-   - **Dirty/conflict state** → Closes the PR (`gh pr close`) so Dependabot can regenerate it.
-4. Triages Human PRs:
-   - Reads the diff summary, checks CI status, and flags merge conflicts.
-   - Proposes feedback in `report.md` but **never merges or closes human PRs**.
-5. Saves a checkpoint to `STATE.md` after each repository.
-6. Writes a detailed summary to `loops/oss-pr-monitor/report.md` on completion.
-
----
-
-## Permitted Actions (Allowlist)
-
-```
-✓ merge     — Merge passing Dependabot PRs
-✓ close     — Close broken/dirty Dependabot PRs
-✓ comment   — Write diagnostic help on human PRs
-✓ label     — Label PRs based on triage classification
-```
-
-## What It Will NEVER Do
-
-```
-✗ Approve human PRs
-✗ Merge human PRs
-✗ Force-push to any branch
-✗ Directly push commits to main/master branches
-✗ Delete repository branches
-```
-
----
-
-## Output
-
-Writes a checklist report to `loops/oss-pr-monitor/report.md`:
-
-```markdown
-## OSS PR Monitor Report — 2026-08-14
-
-| # | Repo | Title | Author | Type | CI | Action | Pending Reason |
-|---|------|-------|--------|------|----|--------|----------------|
-| #10 | org/repo-a | bump lodash from 1.0.0 to 1.0.1 | dependabot | Dep | ✅ Passing | Merged | — |
-| #12 | org/repo-a | fix: handle socket timeout | human-dev | Human | ❌ Failing | None | CI Failing; needs contributor update |
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated with write/merge permissions (`gh auth login`).
-- A configured client context pack (e.g., `packs/my-ecosystem.yaml`) defining the repositories to scan.
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run with a repository pack definition
-agent-toolkit loop run oss-pr-monitor --pack packs/my-ecosystem.yaml
+agent-toolkit loop run oss-pr-monitor
 ```
 
----
+## Details
+* **Artifact Output:** Triage details are written to `loops/oss-pr-monitor/runs/<run_id>/report.md` on each run.
+* **State Checkpointing:** Supports progress checkpointing via `loops/oss-pr-monitor/STATE.md`.
+* **Safety:** This loop is L3 (High Autonomy). It only merges or closes Dependabot PRs under passing CI. It never merges or closes human PRs.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints. For discovery, see `docs/LOOPS.md` and `examples/oss-maintenance/README.md`.
 
-## Safety Contract
-
-```yaml
-tier: L3
-allowlist:
-  - merge
-  - close
-  - comment
-  - label
-deny:
-  - approve
-  - force-push
-  - push-to-main
-  - delete-branch
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/oss-pr-monitor/README.md
+++ b/loops/oss-pr-monitor/README.md
@@ -1,0 +1,118 @@
+# oss-pr-monitor
+
+> **Tier L3 — High Autonomy (Merge/Close Allowlisted)** | Runs once per day | High cost | Resumable
+
+Monitors open pull requests across a multi-repository open-source software (OSS) ecosystem. It evaluates open PRs, auto-merges Dependabot PRs with passing CI, closes broken Dependabot PRs, and drafts diagnoses for failing human PRs. Because it merges and closes PRs, it requires L3 permissions.
+
+---
+
+## What Problem Does This Solve?
+
+Maintaining 20–50 repositories means dealing with constant dependency bumps (e.g., from Dependabot) and pull requests. Checking every single one manually takes significant time. This loop automates the clean, mechanical updates (merging passing Dependabot PRs) and organizes human-submitted PRs into a checklist report so you only need to focus on what requires human review.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L3 — High-autonomy (Merge/Close allowed) |
+| **Cadence** | `1d` — once every 24 hours |
+| **Max tokens / run** | 300,000 |
+| **Max runs / day** | 1 |
+| **Max wall time** | 30 minutes (1800 seconds) |
+| **Resumable** | Yes — uses `STATE.md` checkpoints |
+| **Verifier** | `agent-toolkit-code-reviewer` |
+
+> ⚠️ **L3 loops are high-autonomy.** They possess merge and close capabilities. Ensure you run this loop in L1 report-only mode first to observe its decisions before enabling mutations in a production environment.
+
+---
+
+## What It Does — Step by Step
+
+1. Reads `loops/oss-pr-monitor/STATE.md` to resume from the last processed repository if interrupted.
+2. For each configured repository in the pack:
+   - Lists open PRs using the GitHub API.
+   - Classifies each PR: Dependabot PR, other Bot PR, or Human PR.
+3. Takes action on Dependabot PRs:
+   - Checks CI test status.
+   - **All checks passing** → Merges the PR silently (`gh pr merge --squash`).
+   - **CI checks failing** → Skips and notes in the report.
+   - **Dirty/conflict state** → Closes the PR (`gh pr close`) so Dependabot can regenerate it.
+4. Triages Human PRs:
+   - Reads the diff summary, checks CI status, and flags merge conflicts.
+   - Proposes feedback in `report.md` but **never merges or closes human PRs**.
+5. Saves a checkpoint to `STATE.md` after each repository.
+6. Writes a detailed summary to `loops/oss-pr-monitor/report.md` on completion.
+
+---
+
+## Permitted Actions (Allowlist)
+
+```
+✓ merge     — Merge passing Dependabot PRs
+✓ close     — Close broken/dirty Dependabot PRs
+✓ comment   — Write diagnostic help on human PRs
+✓ label     — Label PRs based on triage classification
+```
+
+## What It Will NEVER Do
+
+```
+✗ Approve human PRs
+✗ Merge human PRs
+✗ Force-push to any branch
+✗ Directly push commits to main/master branches
+✗ Delete repository branches
+```
+
+---
+
+## Output
+
+Writes a checklist report to `loops/oss-pr-monitor/report.md`:
+
+```markdown
+## OSS PR Monitor Report — 2026-08-14
+
+| # | Repo | Title | Author | Type | CI | Action | Pending Reason |
+|---|------|-------|--------|------|----|--------|----------------|
+| #10 | org/repo-a | bump lodash from 1.0.0 to 1.0.1 | dependabot | Dep | ✅ Passing | Merged | — |
+| #12 | org/repo-a | fix: handle socket timeout | human-dev | Human | ❌ Failing | None | CI Failing; needs contributor update |
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated with write/merge permissions (`gh auth login`).
+- A configured client context pack (e.g., `packs/my-ecosystem.yaml`) defining the repositories to scan.
+
+---
+
+## How to Run
+
+```bash
+# Run with a repository pack definition
+agent-toolkit loop run oss-pr-monitor --pack packs/my-ecosystem.yaml
+```
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L3
+allowlist:
+  - merge
+  - close
+  - comment
+  - label
+deny:
+  - approve
+  - force-push
+  - push-to-main
+  - delete-branch
+```

--- a/loops/oss-triage/README.md
+++ b/loops/oss-triage/README.md
@@ -1,0 +1,113 @@
+# oss-triage
+
+> **Tier L1 — Read-only / Propose-only** | Runs once per day | Medium cost | Resumable
+
+Scans open issues across a multi-repository open-source software (OSS) ecosystem. It identifies issues needing attention, applies labels, and posts helpful comments (such as answering simple questions or asking for missing reproduction steps). Any complex triage items are logged in a report.
+
+---
+
+## What Problem Does This Solve?
+
+Managing issues across 20–50 repositories is overwhelming. Simple questions sit unanswered, and bug reports frequently lack reproducer code, which slows down development. This loop acts as a triage assistant: answering the easy questions, requesting information on incomplete bug reports, and applying labels so maintainers can focus on solving triaged problems.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L1 — Read-only / Propose-only (Limited mutations allowed for label/comment) |
+| **Cadence** | `1d` — once every 24 hours |
+| **Max tokens / run** | 150,000 |
+| **Max runs / day** | 1 |
+| **Max wall time** | 20 minutes (1200 seconds) |
+| **Resumable** | Yes — uses `STATE.md` checkpoints |
+| **Verifier** | None |
+
+---
+
+## What It Does — Step by Step
+
+1. Reads `loops/oss-triage/STATE.md` to resume from the last processed repository if interrupted.
+2. For each configured repository:
+   - Scans open issues where the last comment is **not** from a maintainer.
+   - Evaluates the issue:
+     - **Obvious question with no response** → Drafts and posts a response comment.
+     - **Issue with no labels** → Applies appropriate taxonomy labels (e.g., `bug`, `documentation`).
+     - **Bug with no reproduction steps** → Comments requesting a minimal reproducer.
+     - **Security report detected** → Immediately raises a `human_escalation` exit.
+3. Saves a checkpoint to `STATE.md` after each repository.
+4. Writes a detailed summary to `loops/oss-triage/report.md` showing actions taken and pending items.
+
+---
+
+## Permitted Actions (Allowlist)
+
+```
+✓ label     — Apply labels to issues
+✓ comment   — Post comments seeking details or answering questions
+✓ assign    — Assign issues to relevant contributors
+```
+
+## What It Will NEVER Do
+
+```
+✗ Close any issue
+✗ Merge any code
+✗ Approve pull requests
+✗ Force-push to any branch
+```
+
+---
+
+## Output
+
+Writes a daily report to `loops/oss-triage/report.md` detailing all activities:
+
+```markdown
+## OSS Triage Report — 2026-08-14
+
+### Actions Taken
+- **org/repo-a #102**: Applied `bug` label.
+- **org/repo-a #105**: Commented requesting a reproduction repository.
+- **org/repo-b #44**: Answered setup question regarding config options.
+
+### Pending Items (Needs Maintainer Review)
+- **org/repo-a #99**: Complex feature request proposing structural API changes.
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated with issue write permissions (`gh auth login`).
+- Repo read/write access for the targeted repositories.
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run oss-triage
+```
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L1
+allowlist:
+  - label
+  - comment
+  - assign
+deny:
+  - merge
+  - close
+  - push
+  - approve
+  - force-push
+```

--- a/loops/oss-triage/README.md
+++ b/loops/oss-triage/README.md
@@ -1,113 +1,20 @@
 # oss-triage
 
-> **Tier L1 — Read-only / Propose-only** | Runs once per day | Medium cost | Resumable
+Scans open issues across configured OSS repositories. Flags security issues, applies labels, and drafts/posts response comments.
 
-Scans open issues across a multi-repository open-source software (OSS) ecosystem. It identifies issues needing attention, applies labels, and posts helpful comments (such as answering simple questions or asking for missing reproduction steps). Any complex triage items are logged in a report.
+## When to Use
+Use this loop to automate basic triage tasks (like labelling or asking for reproducers) across a multi-repository ecosystem.
 
----
-
-## What Problem Does This Solve?
-
-Managing issues across 20–50 repositories is overwhelming. Simple questions sit unanswered, and bug reports frequently lack reproducer code, which slows down development. This loop acts as a triage assistant: answering the easy questions, requesting information on incomplete bug reports, and applying labels so maintainers can focus on solving triaged problems.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L1 — Read-only / Propose-only (Limited mutations allowed for label/comment) |
-| **Cadence** | `1d` — once every 24 hours |
-| **Max tokens / run** | 150,000 |
-| **Max runs / day** | 1 |
-| **Max wall time** | 20 minutes (1200 seconds) |
-| **Resumable** | Yes — uses `STATE.md` checkpoints |
-| **Verifier** | None |
-
----
-
-## What It Does — Step by Step
-
-1. Reads `loops/oss-triage/STATE.md` to resume from the last processed repository if interrupted.
-2. For each configured repository:
-   - Scans open issues where the last comment is **not** from a maintainer.
-   - Evaluates the issue:
-     - **Obvious question with no response** → Drafts and posts a response comment.
-     - **Issue with no labels** → Applies appropriate taxonomy labels (e.g., `bug`, `documentation`).
-     - **Bug with no reproduction steps** → Comments requesting a minimal reproducer.
-     - **Security report detected** → Immediately raises a `human_escalation` exit.
-3. Saves a checkpoint to `STATE.md` after each repository.
-4. Writes a detailed summary to `loops/oss-triage/report.md` showing actions taken and pending items.
-
----
-
-## Permitted Actions (Allowlist)
-
-```
-✓ label     — Apply labels to issues
-✓ comment   — Post comments seeking details or answering questions
-✓ assign    — Assign issues to relevant contributors
-```
-
-## What It Will NEVER Do
-
-```
-✗ Close any issue
-✗ Merge any code
-✗ Approve pull requests
-✗ Force-push to any branch
-```
-
----
-
-## Output
-
-Writes a daily report to `loops/oss-triage/report.md` detailing all activities:
-
-```markdown
-## OSS Triage Report — 2026-08-14
-
-### Actions Taken
-- **org/repo-a #102**: Applied `bug` label.
-- **org/repo-a #105**: Commented requesting a reproduction repository.
-- **org/repo-b #44**: Answered setup question regarding config options.
-
-### Pending Items (Needs Maintainer Review)
-- **org/repo-a #99**: Complex feature request proposing structural API changes.
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated with issue write permissions (`gh auth login`).
-- Repo read/write access for the targeted repositories.
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run oss-triage
 ```
 
----
+## Details
+* **Artifact Output:** Triaged items are written to `loops/oss-triage/runs/<run_id>/report.md` on each run.
+* **State Checkpointing:** Supports progress checkpointing via `loops/oss-triage/STATE.md`.
+* **Safety:** This loop is L1 (Observe and Report). The runner hard-gates all L1 loops as report-only, blocking mutations regardless of allowlist declarations.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## Safety Contract
-
-```yaml
-tier: L1
-allowlist:
-  - label
-  - comment
-  - assign
-deny:
-  - merge
-  - close
-  - push
-  - approve
-  - force-push
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/post-merge-cleanup/README.md
+++ b/loops/post-merge-cleanup/README.md
@@ -1,110 +1,19 @@
 # post-merge-cleanup
 
-> **Tier L2 — Controlled writes** | Runs every 6 hours | Low cost
+Performs off-peak housekeeping tasks on the repository. Scans for merged branches to delete, closes resolved issues, and warns on stale ones.
 
-Performs off-peak housekeeping tasks on the repository. It scans for git branches that have already been merged into `main` and deletes them. It also closes issues resolved by merged PRs and flags stale issues that have seen no activity for over 90 days.
+## When to Use
+Use this loop to keep git history, pull request interfaces, and issue boards clean on an active repository.
 
----
-
-## What Problem Does This Solve?
-
-Over time, active repositories build up hundreds of merged feature branches and abandoned issues, cluttering git histories, PR interfaces, and project boards. Doing this cleanup by hand is tedious. This loop automates branch deletions, updates issue states, and keeps the tracker tidy.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L2 — limited write access |
-| **Cadence** | `6h` — every 6 hours |
-| **Max tokens / run** | 20,000 |
-| **Max runs / day** | 4 |
-| **Max wall time** | 5 minutes (300 seconds) |
-| **Resumable** | No |
-| **Verifier** | None |
-
----
-
-## What It Does — Step by Step
-
-1. Lists remote branches merged into main: `git branch -r --merged main`
-2. Deletes remote branches merged **more than 7 days ago** (skips protected branches like `main`, `develop`, and release branches `release/*`).
-3. Lists issues linked to merged PRs that are still open, and closes them.
-4. Identifies issues with no activity for **90+ days** and posts a gentle status query comment (does **not** close the issue).
-5. Writes a summary of actions to `loops/post-merge-cleanup/plan.md`.
-
----
-
-## Permitted Actions (Allowlist)
-
-```
-✓ delete_merged_branch  — Delete remote git branches merged > 7 days ago
-✓ close_stale_issue     — Close issues resolved by merged PRs
-✓ comment               — Post stale warning messages
-```
-
-## What It Will NEVER Do
-
-```
-✗ Merge any PR
-✗ Approve any PR
-✗ Delete unmerged branches
-✗ Close active issues
-✗ Force-push to main or update git tags
-```
-
----
-
-## Output
-
-Writes a cleanup summary to `loops/post-merge-cleanup/plan.md`:
-
-```markdown
-## Post-Merge Cleanup — 2026-08-14T12:00Z
-
-### Deleted Branches
-- `origin/feat/auth-login` (merged 9 days ago)
-- `origin/fix/docs-broken-link` (merged 7 days ago)
-
-### Closed Issues
-- **Issue #88** (Resolved by PR #92)
-
-### Stale Warnings Posted
-- **Issue #12** (No activity for 95 days)
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated with write/delete permissions (`gh auth login`).
-- Local git clone access to query branches.
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run post-merge-cleanup
 ```
 
----
+## Details
+* **Artifact Output:** Cleaned up items are written to `loops/post-merge-cleanup/runs/<run_id>/plan.md` on each run.
+* **Safety:** This loop is L2 (Controlled Mutations). It deletes branches merged more than 7 days ago and closes resolved issues. It never force-pushes or deletes unmerged branches.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## Safety Contract
-
-```yaml
-tier: L2
-allowlist:
-  - delete_merged_branch
-  - close_stale_issue
-  - comment
-deny:
-  - merge
-  - approve
-  - delete-unmerged-branch
-  - close-active-issue
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/post-merge-cleanup/README.md
+++ b/loops/post-merge-cleanup/README.md
@@ -1,0 +1,110 @@
+# post-merge-cleanup
+
+> **Tier L2 — Controlled writes** | Runs every 6 hours | Low cost
+
+Performs off-peak housekeeping tasks on the repository. It scans for git branches that have already been merged into `main` and deletes them. It also closes issues resolved by merged PRs and flags stale issues that have seen no activity for over 90 days.
+
+---
+
+## What Problem Does This Solve?
+
+Over time, active repositories build up hundreds of merged feature branches and abandoned issues, cluttering git histories, PR interfaces, and project boards. Doing this cleanup by hand is tedious. This loop automates branch deletions, updates issue states, and keeps the tracker tidy.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L2 — limited write access |
+| **Cadence** | `6h` — every 6 hours |
+| **Max tokens / run** | 20,000 |
+| **Max runs / day** | 4 |
+| **Max wall time** | 5 minutes (300 seconds) |
+| **Resumable** | No |
+| **Verifier** | None |
+
+---
+
+## What It Does — Step by Step
+
+1. Lists remote branches merged into main: `git branch -r --merged main`
+2. Deletes remote branches merged **more than 7 days ago** (skips protected branches like `main`, `develop`, and release branches `release/*`).
+3. Lists issues linked to merged PRs that are still open, and closes them.
+4. Identifies issues with no activity for **90+ days** and posts a gentle status query comment (does **not** close the issue).
+5. Writes a summary of actions to `loops/post-merge-cleanup/plan.md`.
+
+---
+
+## Permitted Actions (Allowlist)
+
+```
+✓ delete_merged_branch  — Delete remote git branches merged > 7 days ago
+✓ close_stale_issue     — Close issues resolved by merged PRs
+✓ comment               — Post stale warning messages
+```
+
+## What It Will NEVER Do
+
+```
+✗ Merge any PR
+✗ Approve any PR
+✗ Delete unmerged branches
+✗ Close active issues
+✗ Force-push to main or update git tags
+```
+
+---
+
+## Output
+
+Writes a cleanup summary to `loops/post-merge-cleanup/plan.md`:
+
+```markdown
+## Post-Merge Cleanup — 2026-08-14T12:00Z
+
+### Deleted Branches
+- `origin/feat/auth-login` (merged 9 days ago)
+- `origin/fix/docs-broken-link` (merged 7 days ago)
+
+### Closed Issues
+- **Issue #88** (Resolved by PR #92)
+
+### Stale Warnings Posted
+- **Issue #12** (No activity for 95 days)
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated with write/delete permissions (`gh auth login`).
+- Local git clone access to query branches.
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run post-merge-cleanup
+```
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L2
+allowlist:
+  - delete_merged_branch
+  - close_stale_issue
+  - comment
+deny:
+  - merge
+  - approve
+  - delete-unmerged-branch
+  - close-active-issue
+```

--- a/loops/pr-babysitter/README.md
+++ b/loops/pr-babysitter/README.md
@@ -1,113 +1,19 @@
 # pr-babysitter
 
-> **Tier L2 — Controlled writes** | Runs every 15 minutes | High cost
+Monitors open PRs that have received no activity or reviews for over an hour and posts constructive review comments.
 
-Monitors open pull requests on the repository. It scans for PRs that have received no activity or reviews for over an hour, performs a comprehensive diff analysis on the code changes, and posts constructive review comments directly to the PR. It never merges or approves PRs.
+## When to Use
+Use this loop to reduce pull request review latency and keep contributors unblocked on active repositories.
 
----
-
-## What Problem Does This Solve?
-
-Pull requests frequently sit waiting for reviews, blocking contributors and slowing down code integration. Maintainers can easily miss updates or get sidetracked. This loop acts as a "babysitter" for open PRs — providing immediate, constructive code analysis and feedback within minutes so contributors aren't left waiting.
-
----
-
-## At a Glance
-
-| Property | Value |
-|----------|-------|
-| **Tier** | L2 — limited write access |
-| **Cadence** | `15m` — every 15 minutes |
-| **Max tokens / run** | 80,000 |
-| **Max runs / day** | 96 |
-| **Max wall time** | 10 minutes (600 seconds) |
-| **Resumable** | No |
-| **Verifier** | `agent-toolkit-code-reviewer` |
-
-> ⚠️ **This loop is active.** It runs every 15 minutes. Ensure the token budget matches your repository's PR volume to avoid running up excessive LLM API costs.
-
----
-
-## What It Does — Step by Step
-
-1. Lists all open pull requests: `gh pr list`
-2. For each PR that has received **no review in the last 60 minutes**:
-   - Reads the code diff: `gh pr diff`
-   - Analyzes the changes for issues, style violations, and correctness.
-   - Posts a constructive review comment containing:
-     - A brief summary of the changes.
-     - 1–3 specific, actionable suggestions.
-     - Any identified blockers or bugs.
-3. If a potential security vulnerability is detected, it raises a `human_escalation` exit.
-4. Writes a summary of reviews posted to `loops/pr-babysitter/plan.md`.
-
----
-
-## Permitted Actions (Allowlist)
-
-```
-✓ comment   — Post code review comments on PRs
-```
-
-## What It Will NEVER Do
-
-```
-✗ Merge any PR
-✗ Approve any PR
-✗ Close any PR or issue
-✗ Push code to any branch
-✗ Label PRs
-```
-
----
-
-## Output
-
-Writes a plan log to `loops/pr-babysitter/plan.md`:
-
-```markdown
-## PR Babysitter — 2026-08-14T10:15Z
-
-### Reviews Posted
-| PR # | Title | Author | Comments Posted |
-|------|-------|--------|-----------------|
-| #112 | fix: secure session cookies | dev-user | Highlighted cookie attributes recommendation |
-| #114 | docs: update installer guide | doc-writer | Suggested correction to bash command syntax |
-
-### Escalated
-- **PR #115**: Flagged potential SQL Injection vector; escalated for human review.
-```
-
-> **This file is a runtime artifact.** It is generated on every run and should not be committed.
-
----
-
-## Requirements
-
-- `gh` CLI installed and authenticated with review comment permissions (`gh auth login`).
-- Repo read/write access.
-
----
-
-## How to Run
-
+## Execution
+To run this loop:
 ```bash
-# Run once manually
 agent-toolkit loop run pr-babysitter
 ```
 
----
+## Details
+* **Artifact Output:** Execution logs are written to `loops/pr-babysitter/runs/<run_id>/plan.md` on each run.
+* **Safety:** This loop is L2 (Controlled Mutations). It only writes review comments. It never merges, force-pushes, or deletes branches.
+* **Configuration:** See [loop.yaml](loop.yaml) for tier, cadence, budget, and safety constraints.
 
-## Safety Contract
-
-```yaml
-tier: L2
-allowlist:
-  - comment
-deny:
-  - merge
-  - approve
-  - close
-  - push
-  - label
-```
+For more details on loops and safety tiers, see [docs/LOOPS.md](../../docs/LOOPS.md).

--- a/loops/pr-babysitter/README.md
+++ b/loops/pr-babysitter/README.md
@@ -1,0 +1,113 @@
+# pr-babysitter
+
+> **Tier L2 — Controlled writes** | Runs every 15 minutes | High cost
+
+Monitors open pull requests on the repository. It scans for PRs that have received no activity or reviews for over an hour, performs a comprehensive diff analysis on the code changes, and posts constructive review comments directly to the PR. It never merges or approves PRs.
+
+---
+
+## What Problem Does This Solve?
+
+Pull requests frequently sit waiting for reviews, blocking contributors and slowing down code integration. Maintainers can easily miss updates or get sidetracked. This loop acts as a "babysitter" for open PRs — providing immediate, constructive code analysis and feedback within minutes so contributors aren't left waiting.
+
+---
+
+## At a Glance
+
+| Property | Value |
+|----------|-------|
+| **Tier** | L2 — limited write access |
+| **Cadence** | `15m` — every 15 minutes |
+| **Max tokens / run** | 80,000 |
+| **Max runs / day** | 96 |
+| **Max wall time** | 10 minutes (600 seconds) |
+| **Resumable** | No |
+| **Verifier** | `agent-toolkit-code-reviewer` |
+
+> ⚠️ **This loop is active.** It runs every 15 minutes. Ensure the token budget matches your repository's PR volume to avoid running up excessive LLM API costs.
+
+---
+
+## What It Does — Step by Step
+
+1. Lists all open pull requests: `gh pr list`
+2. For each PR that has received **no review in the last 60 minutes**:
+   - Reads the code diff: `gh pr diff`
+   - Analyzes the changes for issues, style violations, and correctness.
+   - Posts a constructive review comment containing:
+     - A brief summary of the changes.
+     - 1–3 specific, actionable suggestions.
+     - Any identified blockers or bugs.
+3. If a potential security vulnerability is detected, it raises a `human_escalation` exit.
+4. Writes a summary of reviews posted to `loops/pr-babysitter/plan.md`.
+
+---
+
+## Permitted Actions (Allowlist)
+
+```
+✓ comment   — Post code review comments on PRs
+```
+
+## What It Will NEVER Do
+
+```
+✗ Merge any PR
+✗ Approve any PR
+✗ Close any PR or issue
+✗ Push code to any branch
+✗ Label PRs
+```
+
+---
+
+## Output
+
+Writes a plan log to `loops/pr-babysitter/plan.md`:
+
+```markdown
+## PR Babysitter — 2026-08-14T10:15Z
+
+### Reviews Posted
+| PR # | Title | Author | Comments Posted |
+|------|-------|--------|-----------------|
+| #112 | fix: secure session cookies | dev-user | Highlighted cookie attributes recommendation |
+| #114 | docs: update installer guide | doc-writer | Suggested correction to bash command syntax |
+
+### Escalated
+- **PR #115**: Flagged potential SQL Injection vector; escalated for human review.
+```
+
+> **This file is a runtime artifact.** It is generated on every run and should not be committed.
+
+---
+
+## Requirements
+
+- `gh` CLI installed and authenticated with review comment permissions (`gh auth login`).
+- Repo read/write access.
+
+---
+
+## How to Run
+
+```bash
+# Run once manually
+agent-toolkit loop run pr-babysitter
+```
+
+---
+
+## Safety Contract
+
+```yaml
+tier: L2
+allowlist:
+  - comment
+deny:
+  - merge
+  - approve
+  - close
+  - push
+  - label
+```

--- a/mcp/templates/github/README.md
+++ b/mcp/templates/github/README.md
@@ -4,9 +4,16 @@ Official server: [`github/github-mcp-server`](https://github.com/github/github-m
 (`ghcr.io/github/github-mcp-server`). The npm package
 `@modelcontextprotocol/server-github` is **deprecated** as of April 2025.
 
+Provides comprehensive tools to interact with GitHub repositories, pull requests, issues, and file content.
+
 ## Required environment variables
 
 - `GITHUB_PERSONAL_ACCESS_TOKEN` — fine-grained or classic PAT
+
+### Getting a Token
+1. Go to [GitHub Developer Settings](https://github.com/settings/tokens).
+2. Generate a new Fine-grained Personal Access Token (recommended).
+3. Grant `Repository permissions` for the repos you want the agent to access (e.g., `Contents: Read & write`, `Pull Requests: Read & write`, `Issues: Read & write`).
 
 ## Usage
 

--- a/mcp/templates/notion/README.md
+++ b/mcp/templates/notion/README.md
@@ -1,7 +1,21 @@
 # Notion MCP Template
 
+Official Server: [`@modelcontextprotocol/server-notion`](https://github.com/modelcontextprotocol/servers/tree/main/src/notion)
+
+Provides tools to interact with Notion workspaces, allowing agents to search, read, and write pages and databases.
+
 ## Required environment variables
 
-- `NOTION_API_TOKEN`
+- `NOTION_API_TOKEN` — An internal integration token.
 
-Use `config.template.json` and `wrapper.sh` as baseline examples.
+### Getting a Token
+1. Go to [Notion My Integrations](https://www.notion.so/my-integrations)
+2. Create a new integration
+3. Copy the "Internal Integration Secret"
+4. **Important**: You must share specific Notion pages/databases with your integration via the "Share" menu in the top right of the Notion UI before the MCP server can access them.
+
+## Usage
+
+1. Copy `config.template.json` into your MCP client config (e.g., `claude_desktop_config.json`).
+2. Export `NOTION_API_TOKEN` or add it to the client config.
+3. Optionally run `./wrapper.sh` as a local launcher example.

--- a/mcp/templates/slack/README.md
+++ b/mcp/templates/slack/README.md
@@ -1,8 +1,23 @@
 # Slack MCP Template
 
+Official Server: [`@modelcontextprotocol/server-slack`](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)
+
+Provides tools to interact with Slack workspaces, allowing agents to read channels, post messages, and reply to threads.
+
 ## Required environment variables
 
-- `SLACK_BOT_TOKEN`
-- `SLACK_APP_TOKEN`
+- `SLACK_BOT_TOKEN` (starts with `xoxb-`)
+- `SLACK_APP_TOKEN` (starts with `xapp-`)
+- `SLACK_TEAM_ID` (optional, for workspace scoping)
 
-Use `config.template.json` and `wrapper.sh` as baseline examples.
+### Getting Tokens
+1. Go to [Slack API Apps](https://api.slack.com/apps) and Create a New App.
+2. Under **OAuth & Permissions**, add required Bot Token Scopes (e.g., `channels:history`, `channels:read`, `chat:write`).
+3. Install the app to your workspace and copy the **Bot User OAuth Token** (`SLACK_BOT_TOKEN`).
+4. Under **Basic Information > App-Level Tokens**, generate a token with `connections:write` scope to get your `SLACK_APP_TOKEN`.
+
+## Usage
+
+1. Copy `config.template.json` into your MCP client config.
+2. Export `SLACK_BOT_TOKEN`.
+3. Optionally run `./wrapper.sh` as a local launcher example.


### PR DESCRIPTION
Resolves #339.

This PR expands the documentation for the MCP templates to make onboarding easier for new users. Changes include:
- **Notion**: Added API token generation instructions and highlighted the requirement to explicitly share pages/databases with the integration.
- **Slack**: Added detailed steps for generating both `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` with the correct OAuth scopes.
- **GitHub**: Added instructions for generating a Fine-grained PAT and the required repository permissions.
