### PR TITLE
docs(readme): add star CTA, issue links, and contributors footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,17 +520,28 @@ See [How to add a skill](docs/HOW_TO_ADD_SKILL.md) for the full authoring guide.
 
 ---
 
+## Showcase
+
+See [SHOWCASE.md](SHOWCASE.md) for community usage examples and pack walkthroughs.
+
+---
+
 <div align="center">
 
-[📖 Docs](docs/) · [🐛 Issues](https://github.com/ulises-jeremias/agent-toolkit/issues) ·
-[💬 Discussions](https://github.com/ulises-jeremias/agent-toolkit/discussions) ·
-[Discord](https://discord.gg/bR5VyATgka) ·
-[MIT License](LICENSE)
+**⭐ Star this repo** if you use it — it helps others discover it.
 
-<sub>Built for the agentic age — one toolkit, every assistant.</sub>
+[Report a bug](https://github.com/ulises-jeremias/agent-toolkit/issues/new?template=bug-report.yml) · [Request a feature](https://github.com/ulises-jeremias/agent-toolkit/issues/new?template=feature-request.yml)
+
+[📖 Docs](docs/) · [💬 Discussions](https://github.com/ulises-jeremias/agent-toolkit/discussions) · [Discord](https://discord.gg/bR5VyATgka) · [MIT License](LICENSE)
+
+<sub>Built with ❤️ for AI-assisted software delivery</sub>
 
 </div>
 
-## Showcase
+## 👥 Contributors
 
-See [SHOWCASE.md](SHOWCASE.md).
+<a href="https://github.com/ulises-jeremias/agent-toolkit/contributors">
+  <img alt="Contributors" src="https://contrib.rocks/image?repo=ulises-jeremias/agent-toolkit"/>
+</a>
+
+Made with [contributors-img](https://contrib.rocks).

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -176,6 +176,7 @@ products:
         - quality/megalinter-fix
         - quality/codeql
         - quality/unslop
+        - quality/deslop
         - quality/blast-radius
         - tooling/chrome-devtools
         - tooling/playwright-cli

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -11,7 +11,7 @@ _Generated from 4 products × 83 skills × 17 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor, requires, security | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 17 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 7 | 0 |
-| `agent-toolkit-complete` | experimental | — | 82 | 0 |
+| `agent-toolkit-complete` | experimental | — | 83 | 0 |
 
 ## Skills → Products
 
@@ -88,7 +88,7 @@ _Generated from 4 products × 83 skills × 17 agents._
 | `ops/triage` | `agent-toolkit-complete` | — |
 | `quality/blast-radius` | `agent-toolkit-complete` | — |
 | `quality/codeql` | `agent-toolkit-complete` | — |
-| `quality/deslop` | _uncovered_ | — |
+| `quality/deslop` | `agent-toolkit-complete` | — |
 | `quality/megalinter` | `agent-toolkit-complete` | — |
 | `quality/megalinter-check` | `agent-toolkit-complete` | — |
 | `quality/megalinter-fix` | `agent-toolkit-complete` | — |


### PR DESCRIPTION
## Summary
- Add star CTA and direct links to bug/feature issue templates (`bug-report.yml`, `feature-request.yml`)
- Add contributors grid via contrib.rocks (aligned with agentic-workstation)
- Move Showcase section above the footer and expand its one-liner
- Update closing tagline to match the ecosystem voice

## Test plan
- [x] README renders correctly on GitHub (markdown preview)
- [ ] CI green on `Required CI`