### PR TITLE
feat(hooks): emit Cursor hooks.json from capabilities/hooks (#754)

### DIFF
--- a/docs/targets/cursor-certification.md
+++ b/docs/targets/cursor-certification.md
@@ -26,12 +26,12 @@
 | Agents | **Certified** | Emits `agents/<name>/AGENT.md` |
 | Rules (`.mdc`) | **Profile surface** | Installed to `~/.cursor/rules/` via `agent-toolkit install`; not duplicated in plugin bundle |
 | MCP | **Manual** | User configures `~/.cursor/mcp.json`; reported as unsupported in plugin compile |
-| Hooks | **Not implemented** | Reported in `result.unsupported` |
+| Hooks | **Certified** | Emits `hooks/hooks.json` from `capabilities/hooks/*.yaml` when a product includes hooks (#754) |
 
 ## Gaps (documented, not hidden)
 
 1. Plugin compile does not emit `.mdc` rules — by design (different semantic from skills).
-2. MCP and hooks are not generated from canonical IR until registry/hook model lands.
+2. MCP is not generated from canonical IR until the MCP registry model lands; hooks are emitted for Cursor from the canonical hook registry (#754).
 
 ## Validation
 

--- a/modules/agent_toolkit_core/emitters.v
+++ b/modules/agent_toolkit_core/emitters.v
@@ -79,7 +79,7 @@ pub fn compile_tier1(target_id string, graph CanonicalGraph, product LoadedProdu
 	mut records := []ArtifactRecord{}
 	match target_id {
 		'cursor' {
-			emit_cursor(mut result, mut records, graph, product, out_dir, output_root)
+			emit_cursor(mut result, mut records, graph, product, out_dir, output_root, repo_root)
 		}
 		'claude-code' {
 			emit_claude_code(mut result, mut records, graph, product, out_dir, output_root)
@@ -91,7 +91,6 @@ pub fn compile_tier1(target_id string, graph CanonicalGraph, product LoadedProdu
 			result.errors << "unknown Tier-1 target '${target_id}'"
 		}
 	}
-	_ = repo_root
 	if result.is_valid() && records.len > 0 {
 		prov := write_provenance(out_dir, product.id, target_id, records) or {
 			result.warnings << 'provenance write skipped: ${err}'
@@ -103,7 +102,7 @@ pub fn compile_tier1(target_id string, graph CanonicalGraph, product LoadedProdu
 	return result
 }
 
-fn emit_cursor(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
+fn emit_cursor(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string, repo_root string) {
 	manifest_path := os.join_path(out_dir, '.cursor-plugin', 'plugin.json')
 	keywords := ['agent-toolkit', product.id.replace('agent-toolkit-', ''), 'cursor', 'skills',
 		'agents']
@@ -116,9 +115,83 @@ fn emit_cursor(mut result CompilationResult, mut records []ArtifactRecord, graph
 		output_root)
 	emit_agents_under(mut result, mut records, graph, product, os.join_path(out_dir, 'agents'),
 		output_root)
-	result.unsupported << 'hooks (pending canonical hook model — Cursor uses workspaceOpen/sessionStart events)'
+	emit_cursor_hooks(mut result, mut records, graph, product, out_dir, output_root, repo_root)
 	result.unsupported << 'mcp (.cursor/mcp.json — user configures manually; not bundled in plugin)'
 	result.unsupported << 'cursor-rules (.mdc) — generated as a separate profile surface, not in plugin bundle'
+}
+
+// emit_cursor_hooks emits hooks/hooks.json (Cursor lifecycle events) from canonical
+// capabilities/hooks/*.yaml when a product includes hooks (#754). Handler scripts are
+// copied next to hooks.json and command paths rewritten to the plugin-relative location.
+fn emit_cursor_hooks(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string, repo_root string) {
+	if product.included_hooks.len == 0 {
+		return
+	}
+	mut grouped := map[string][]string{}
+	for hid in product.included_hooks {
+		h := graph.hooks[hid] or {
+			result.warnings << "Hook '${hid}' not found — skipping"
+			continue
+		}
+		if h.cursor_event.len == 0 {
+			result.unsupported << 'hook:${hid} (event ${h.event} not supported by Cursor lifecycle)'
+			continue
+		}
+		cmd := hook_command_for_target(h.command, repo_root, out_dir, mut result)
+		timeout := if h.timeout_ms > 0 { h.timeout_ms } else { 5000 }
+		grouped[h.cursor_event] << '      {\n        "type": "command",\n        "command": "${json_escape(cmd)}",\n        "timeout": ${timeout}\n      }'
+	}
+	if grouped.len == 0 {
+		result.unsupported << 'hooks (no included hook maps to a Cursor lifecycle event)'
+		return
+	}
+	mut events := []string{}
+	for ev, _ in grouped {
+		events << ev
+	}
+	events.sort()
+	mut body := '{\n  "hooks": {\n'
+	for i, ev in events {
+		if i > 0 {
+			body += ',\n'
+		}
+		body += '    "${ev}": [\n${grouped[ev].join(',\n')}\n    ]'
+	}
+	body += '\n  }\n}\n'
+	write_text_artifact(os.join_path(out_dir, 'hooks', 'hooks.json'), body, 'generated',
+		output_root, mut result, mut records)
+	result.emitted << 'hooks'
+}
+
+// hook_command_for_target rewrites canonical hook command paths to the plugin bundle
+// (copies handler scripts under hooks/scripts/) and returns a shell command string.
+fn hook_command_for_target(command []string, repo_root string, out_dir string, mut result CompilationResult) string {
+	mut parts := []string{}
+	for arg in command {
+		mut a := arg
+		if a.starts_with('capabilities/hooks/scripts/') {
+			rel := a['capabilities/hooks/scripts/'.len..]
+			src := os.join_path(repo_root, 'capabilities', 'hooks', 'scripts', rel)
+			dst := os.join_path(out_dir, 'hooks', 'scripts', rel)
+			if os.is_file(src) {
+				os.mkdir_all(os.dir(dst)) or {
+					result.errors << 'mkdir hooks scripts failed: ${err}'
+					return a
+				}
+				content := os.read_file(src) or {
+					result.errors << 'read hook script failed: ${err}'
+					return a
+				}
+				os.write_file(dst, content) or {
+					result.errors << 'write hook script failed: ${err}'
+					return a
+				}
+				a = 'hooks/scripts/${rel}'
+			}
+		}
+		parts << a
+	}
+	return parts.join(' ')
 }
 
 fn emit_claude_code(mut result CompilationResult, mut records []ArtifactRecord, graph CanonicalGraph, product LoadedProduct, out_dir string, output_root string) {
@@ -252,9 +325,8 @@ fn write_plugin_manifest(path string, product LoadedProduct, keywords []string, 
 	}
 	body := '{\n' + '  "name": "${json_escape(product.id)}",\n' +
 		'  "version": "${json_escape(ver)}",\n' +
-		'  "description": "${json_escape(product.description)}",\n' +
-		'  "author": {\n' + '    "name": "ulises-jeremias",\n' +
-		'    "email": "ulisescf.24@gmail.com"\n' + '  },\n' +
+		'  "description": "${json_escape(product.description)}",\n' + '  "author": {\n' +
+		'    "name": "ulises-jeremias",\n' + '    "email": "ulisescf.24@gmail.com"\n' + '  },\n' +
 		'  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
 		'  "repository": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
 		'  "license": "MIT",\n' + '  "keywords": [\n    ${kw_json.join(',\n    ')}\n  ]\n}\n'
@@ -329,7 +401,11 @@ pub fn compilation_result_data(r CompilationResult) map[string]string {
 	return {
 		'target':      r.target
 		'product':     r.product
-		'ok':          if r.is_valid() { 'true' } else { 'false' }
+		'ok':          if r.is_valid() {
+			'true'
+		} else {
+			'false'
+		}
 		'emitted':     r.emitted.join('|')
 		'omitted':     r.omitted.join('|')
 		'unsupported': r.unsupported.join('|')

--- a/modules/agent_toolkit_core/emitters_test.v
+++ b/modules/agent_toolkit_core/emitters_test.v
@@ -85,6 +85,48 @@ fn test_compile_unknown_target() {
 	assert !r.is_valid()
 }
 
+fn test_compile_cursor_hooks_emission() {
+	root := os.join_path(os.temp_dir(), 'at-emit-hooks-${os.getpid()}')
+	os.mkdir_all(os.join_path(root, 'skills', 'core', 'assistant')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'distributions')) or { assert false, err.msg() }
+	os.mkdir_all(os.join_path(root, 'capabilities', 'hooks', 'scripts')) or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'skills', 'core', 'assistant', 'SKILL.md'),
+		'---\nname: assistant\n---\nbody\n') or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'capabilities', 'hooks', 'session-start-context.yaml'),
+		'id: session-start-context\nevent: session.start\nhandler:\n  command:\n    - bash\n    - capabilities/hooks/scripts/session-start-context.sh\n  timeout_ms: 5000\n') or {
+		assert false, err.msg()
+	}
+	os.write_file(os.join_path(root, 'capabilities', 'hooks', 'scripts', 'session-start-context.sh'),
+		'#!/usr/bin/env bash\necho hi\n') or { assert false, err.msg() }
+	os.write_file(os.join_path(root, 'distributions', 'products.yaml'),
+		'products:\n  - id: demo\n    includes:\n      skills:\n        - core/assistant\n      agents: []\n      hooks:\n        - session-start-context\n') or {
+		assert false, err.msg()
+	}
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	g := load_graph(root)
+	assert g.is_valid()
+	product := g.select_product('demo') or {
+		assert false, 'missing product'
+		return
+	}
+	out := os.join_path(root, 'out')
+	r := compile_tier1('cursor', g, product, out, root)
+	assert r.is_valid(), r.errors.str()
+	assert 'hooks' in r.emitted
+	hooks_json := os.join_path(out, 'demo', 'hooks', 'hooks.json')
+	assert os.is_file(hooks_json)
+	raw := os.read_file(hooks_json) or {
+		assert false, err.msg()
+		return
+	}
+	assert raw.contains('SessionStart')
+	assert raw.contains('hooks/scripts/session-start-context.sh')
+	// handler script is copied next to hooks.json
+	assert os.is_file(os.join_path(out, 'demo', 'hooks', 'scripts', 'session-start-context.sh'))
+}
+
 fn test_compile_real_core_if_checkout() {
 	root := find_repo_root() or { return }
 	g := load_graph(root)

--- a/modules/agent_toolkit_core/loader.v
+++ b/modules/agent_toolkit_core/loader.v
@@ -22,6 +22,21 @@ struct ProductsDoc {
 	products []ProductYaml
 }
 
+// HookHandlerYaml mirrors the `handler` block of a canonical hook definition
+// (capabilities/hooks/*.yaml). Only the fields needed for adapter emission are decoded.
+struct HookHandlerYaml {
+	command    []string
+	timeout_ms int
+}
+
+// HookYaml is one canonical lifecycle hook (ADR-026 hook registry, #754).
+struct HookYaml {
+	id        string
+	event     string
+	handler   HookHandlerYaml
+	platforms map[string]string
+}
+
 // LoadedSkill is a capability node from skills/<domain>/<name>/SKILL.md.
 pub struct LoadedSkill {
 pub:
@@ -37,6 +52,16 @@ pub:
 	id          string
 	name        string
 	source_path string
+}
+
+// LoadedHook is a canonical lifecycle hook from capabilities/hooks/*.yaml (#754).
+pub struct LoadedHook {
+pub:
+	id           string
+	event        string
+	command      []string
+	timeout_ms   int
+	cursor_event string // Cursor adapter event name, empty = unsupported
 }
 
 // LoadedProduct is a product selected from distributions/products.yaml.
@@ -57,6 +82,7 @@ pub struct CanonicalGraph {
 pub mut:
 	skills   map[string]LoadedSkill
 	agents   map[string]LoadedAgent
+	hooks    map[string]LoadedHook
 	products map[string]LoadedProduct
 	errors   []string
 	warnings []string
@@ -85,6 +111,7 @@ pub fn load_graph(repo_root string) CanonicalGraph {
 	}
 	g.skills = load_skill_ids(os.join_path(repo_root, 'skills'))
 	g.agents = load_agent_ids(os.join_path(repo_root, 'agents'))
+	g.hooks = load_hooks(os.join_path(repo_root, 'capabilities', 'hooks'))
 	products, perrs := load_products_file(os.join_path(repo_root, 'distributions', 'products.yaml'))
 	g.errors << perrs
 	for p in products {
@@ -100,7 +127,9 @@ pub fn load_products_file(path string) ([]LoadedProduct, []string) {
 	if !os.is_file(path) {
 		return []LoadedProduct{}, ['products.yaml not found: ${path}']
 	}
-	text := os.read_file(path) or { return []LoadedProduct{}, ['cannot read products.yaml: ${err}'] }
+	text := os.read_file(path) or {
+		return []LoadedProduct{}, ['cannot read products.yaml: ${err}']
+	}
 	doc := yaml.decode[ProductsDoc](text) or {
 		return []LoadedProduct{}, ['products.yaml decode failed: ${err}']
 	}
@@ -175,7 +204,50 @@ fn validate_product_refs(mut g CanonicalGraph) {
 				g.warnings << "Product '${pid}' references agent '${aid}' not found in agents/"
 			}
 		}
+		for hid in product.included_hooks {
+			if hid !in g.hooks {
+				g.warnings << "Product '${pid}' references hook '${hid}' not found in capabilities/hooks/"
+			}
+		}
 	}
+}
+
+// cursor_hook_event maps a canonical hook event to a Cursor lifecycle event name.
+// Returns an empty string when the event is not supported by the Cursor hook surface.
+fn cursor_hook_event(event string) string {
+	return match event {
+		'session.start' { 'SessionStart' }
+		'tool.before' { 'BeforeFileWrite' }
+		else { '' }
+	}
+}
+
+// load_hooks reads capabilities/hooks/*.yaml into canonical hook definitions.
+fn load_hooks(hooks_root string) map[string]LoadedHook {
+	mut out := map[string]LoadedHook{}
+	if !os.is_dir(hooks_root) {
+		return out
+	}
+	entries := os.ls(hooks_root) or { return out }
+	for e in entries {
+		if !e.ends_with('.yaml') {
+			continue
+		}
+		p := os.join_path(hooks_root, e)
+		text := os.read_file(p) or { continue }
+		h := yaml.decode[HookYaml](text) or { continue }
+		if h.id.len == 0 {
+			continue
+		}
+		out[h.id] = LoadedHook{
+			id:           h.id
+			event:        h.event
+			command:      h.handler.command
+			timeout_ms:   h.handler.timeout_ms
+			cursor_event: cursor_hook_event(h.event)
+		}
+	}
+	return out
 }
 
 fn collect_named_files(dir string, name string) []string {


### PR DESCRIPTION
Implements #754 (epic #743): the Cursor adapter now emits `hooks/hooks.json` from the canonical `capabilities/hooks/*.yaml` registry when a product includes hooks.

- `loader.v`: load canonical hooks into `CanonicalGraph`, map `session.start` → `SessionStart`, `tool.before` → `BeforeFileWrite`
- `emitters.v`: `emit_cursor_hooks` writes `hooks/hooks.json` + copies handler scripts under `hooks/scripts/`, rewriting command paths plugin-relative
- `emitters_test.v`: test for hooks.json emission + script copy
- `docs/targets/cursor-certification.md`: hooks row Not implemented → Certified

Closes #754