### PR TITLE
feat(compiler): spec-complete Cursor/Claude plugin.json manifests (#752)

### DIFF
--- a/modules/agent_toolkit_core/emitters.v
+++ b/modules/agent_toolkit_core/emitters.v
@@ -323,10 +323,12 @@ fn write_plugin_manifest(path string, product LoadedProduct, keywords []string, 
 	for k in keywords {
 		kw_json << '"${json_escape(k)}"'
 	}
-	body := '{\n' + '  "name": "${json_escape(product.id)}",\n' +
+	body := '{\n' + '  "\$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",\n' +
+		'  "name": "${json_escape(product.id)}",\n' +
 		'  "version": "${json_escape(ver)}",\n' +
 		'  "description": "${json_escape(product.description)}",\n' + '  "author": {\n' +
-		'    "name": "ulises-jeremias",\n' + '    "email": "ulisescf.24@gmail.com"\n' + '  },\n' +
+		'    "name": "ulises-jeremias",\n' + '    "email": "ulisescf.24@gmail.com",\n' +
+		'    "url": "https://github.com/ulises-jeremias/agent-toolkit"\n' + '  },\n' +
 		'  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
 		'  "repository": "https://github.com/ulises-jeremias/agent-toolkit",\n' +
 		'  "license": "MIT",\n' + '  "keywords": [\n    ${kw_json.join(',\n    ')}\n  ]\n}\n'

--- a/modules/agent_toolkit_core/emitters_test.v
+++ b/modules/agent_toolkit_core/emitters_test.v
@@ -42,6 +42,14 @@ fn test_compile_cursor_temp_product() {
 	assert 'agent:code-reviewer' in r.emitted
 	assert 'provenance' in r.emitted
 	assert os.is_file(os.join_path(out, 'agent-toolkit-core', '.cursor-plugin', 'plugin.json'))
+	manifest_raw := os.read_file(os.join_path(out, 'agent-toolkit-core', '.cursor-plugin',
+		'plugin.json')) or {
+		assert false, err.msg()
+		return
+	}
+	// #752: spec-complete manifests include the Agent Plugins 1.0.0 $schema + author.url
+	assert manifest_raw.contains('agent-plugins.org/schemas/1.0.0/plugin.schema.json')
+	assert manifest_raw.contains('"url": "https://github.com/ulises-jeremias/agent-toolkit"')
 	assert os.is_file(os.join_path(out, 'agent-toolkit-core', 'skills', 'assistant', 'SKILL.md'))
 	assert os.is_file(os.join_path(out, 'agent-toolkit-core', 'agents', 'code-reviewer', 'AGENT.md'))
 	assert os.is_file(os.join_path(out, 'agent-toolkit-core', '.provenance.json'))

--- a/plugins/agent-toolkit-agents/.claude-plugin/plugin.json
+++ b/plugins/agent-toolkit-agents/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-agents",
   "version": "1.17.0",
   "description": "Full set of 17 AI agent personas: architect, code-reviewer, security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",

--- a/plugins/agent-toolkit-agents/.cursor-plugin/plugin.json
+++ b/plugins/agent-toolkit-agents/.cursor-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-agents",
   "version": "1.17.0",
   "description": "Full set of 17 AI agent personas: architect, code-reviewer, security-reviewer, planner, database-reviewer, TypeScript-reviewer, and more.",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",

--- a/plugins/agent-toolkit-complete/.claude-plugin/plugin.json
+++ b/plugins/agent-toolkit-complete/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-complete",
   "version": "1.17.0",
   "description": "Full stable skill catalog coverage for consumers who want everything (",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",

--- a/plugins/agent-toolkit-complete/.cursor-plugin/plugin.json
+++ b/plugins/agent-toolkit-complete/.cursor-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-complete",
   "version": "1.17.0",
   "description": "Full stable skill catalog coverage for consumers who want everything (",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",

--- a/plugins/agent-toolkit-core/.claude-plugin/plugin.json
+++ b/plugins/agent-toolkit-core/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-core",
   "version": "1.17.0",
   "description": "Core orchestration skills, dev companion, output handshake, PR fallback, and code-reviewer agent. The baseline install for any project.",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",

--- a/plugins/agent-toolkit-core/.cursor-plugin/plugin.json
+++ b/plugins/agent-toolkit-core/.cursor-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-core",
   "version": "1.17.0",
   "description": "Core orchestration skills, dev companion, output handshake, PR fallback, and code-reviewer agent. The baseline install for any project.",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",

--- a/plugins/agent-toolkit-forge/.claude-plugin/plugin.json
+++ b/plugins/agent-toolkit-forge/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-forge",
   "version": "1.17.0",
   "description": "GitHub and GitLab automation skills: PR workflows, CI fixes, comment resolution, and contribution planning.",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",

--- a/plugins/agent-toolkit-forge/.cursor-plugin/plugin.json
+++ b/plugins/agent-toolkit-forge/.cursor-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-toolkit-forge",
   "version": "1.17.0",
   "description": "GitHub and GitLab automation skills: PR workflows, CI fixes, comment resolution, and contribution planning.",
   "author": {
     "name": "ulises-jeremias",
-    "email": "ulisescf.24@gmail.com"
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
   },
   "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
   "repository": "https://github.com/ulises-jeremias/agent-toolkit",


### PR DESCRIPTION
Implements #752 (epic #743): the Tier-1 Cursor/Claude `plugin.json` emitter now produces spec-complete manifests per the Agent Plugins 1.0.0 schema.

- `write_plugin_manifest` emits `$schema` (required) + `author.url`, matching the existing `agent-plugins` target
- Regenerated the 8 committed `.cursor-plugin/` + `.claude-plugin/` manifests
- `emitters_test.v`: assert `$schema` + `author.url` present

Closes #752