### PR TITLE
feat(products): add agent-toolkit-craft stable product (#753)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,6 +51,19 @@
         "automation",
         "forge"
       ]
+    },
+    {
+      "name": "agent-toolkit-craft",
+      "source": "./plugins/agent-toolkit-craft",
+      "description": "Writing quality and change-safety toolkit: cut AI tells (unslop), remove code slop (deslop), and prove blast radius before shipping.",
+      "version": "1.17.0",
+      "category": "quality",
+      "tags": [
+        "writing",
+        "quality",
+        "safety",
+        "blast-radius"
+      ]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -46,6 +46,19 @@
         "ci",
         "pr"
       ]
+    },
+    {
+      "name": "agent-toolkit-craft",
+      "source": "agent-toolkit-craft",
+      "description": "Writing quality and change-safety toolkit: cut AI tells (unslop), remove code slop (deslop), and prove blast radius before shipping.",
+      "version": "1.17.0",
+      "category": "quality",
+      "tags": [
+        "writing",
+        "quality",
+        "safety",
+        "blast-radius"
+      ]
     }
   ]
 }

--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -100,6 +100,26 @@ products:
       cursor:
         plugin_id: agent-toolkit-forge
         manifest: plugins/agent-toolkit-forge/.cursor-plugin/plugin.json
+  - id: agent-toolkit-craft
+    name: Agent Toolkit Craft
+    description: 'Writing quality and change-safety toolkit: cut AI tells (unslop), remove code slop (deslop), and prove blast radius before shipping.'
+    version_source: VERSION
+    stability: stable
+    includes:
+      skills:
+        - quality/unslop
+        - quality/deslop
+        - quality/blast-radius
+      agents: []
+      hooks: []
+      mcp: []
+    targets:
+      claude-code:
+        plugin_id: agent-toolkit-craft
+        manifest: plugins/agent-toolkit-craft/.claude-plugin/plugin.json
+      cursor:
+        plugin_id: agent-toolkit-craft
+        manifest: plugins/agent-toolkit-craft/.cursor-plugin/plugin.json
   - id: agent-toolkit-complete
     name: Agent Toolkit Complete
     description: Full stable skill catalog coverage for consumers who want everything (#50)

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -2,7 +2,7 @@
 
 > Generated from `distributions/products.yaml` — do not hand-edit. Run `./scripts/generate-skill-matrix.vsh` to regenerate, or `./scripts/generate-skill-matrix.vsh --check` in CI.
 
-_Generated from 4 products × 85 skills × 17 agents._
+_Generated from 5 products × 85 skills × 17 agents._
 
 ## Products and targets
 
@@ -11,6 +11,7 @@ _Generated from 4 products × 85 skills × 17 agents._
 | `agent-toolkit-core` | stable | claude-code, cursor, requires, security | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 17 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 8 | 0 |
+| `agent-toolkit-craft` | stable | claude-code, cursor | 3 | 0 |
 | `agent-toolkit-complete` | experimental | — | 85 | 0 |
 
 ## Skills → Products
@@ -87,14 +88,14 @@ _Generated from 4 products × 85 skills × 17 agents._
 | `ops/swarm-handoff` | `agent-toolkit-complete` | — |
 | `ops/swarm-observer` | `agent-toolkit-complete` | — |
 | `ops/triage` | `agent-toolkit-complete` | — |
-| `quality/blast-radius` | `agent-toolkit-complete` | — |
+| `quality/blast-radius` | `agent-toolkit-complete`, `agent-toolkit-craft` | claude-code, cursor |
 | `quality/codeql` | `agent-toolkit-complete` | — |
-| `quality/deslop` | `agent-toolkit-complete` | — |
+| `quality/deslop` | `agent-toolkit-complete`, `agent-toolkit-craft` | claude-code, cursor |
 | `quality/megalinter` | `agent-toolkit-complete` | — |
 | `quality/megalinter-check` | `agent-toolkit-complete` | — |
 | `quality/megalinter-fix` | `agent-toolkit-complete` | — |
 | `quality/megalinter-setup` | `agent-toolkit-complete` | — |
-| `quality/unslop` | `agent-toolkit-complete` | — |
+| `quality/unslop` | `agent-toolkit-complete`, `agent-toolkit-craft` | claude-code, cursor |
 | `tooling/chrome-devtools` | `agent-toolkit-complete` | — |
 | `tooling/cli-for-agents` | `agent-toolkit-complete` | — |
 | `tooling/herdr` | `agent-toolkit-complete` | — |

--- a/plugins/agent-toolkit-craft/.claude-plugin/plugin.json
+++ b/plugins/agent-toolkit-craft/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "agent-toolkit-craft",
+  "version": "1.17.0",
+  "description": "Writing quality and change-safety toolkit: cut AI tells (unslop), remove code slop (deslop), and prove blast radius before shipping.",
+  "author": {
+    "name": "ulises-jeremias",
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
+  },
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "repository": "https://github.com/ulises-jeremias/agent-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "agent-toolkit",
+    "craft"
+  ]
+}

--- a/plugins/agent-toolkit-craft/.cursor-plugin/plugin.json
+++ b/plugins/agent-toolkit-craft/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "agent-toolkit-craft",
+  "version": "1.17.0",
+  "description": "Writing quality and change-safety toolkit: cut AI tells (unslop), remove code slop (deslop), and prove blast radius before shipping.",
+  "author": {
+    "name": "ulises-jeremias",
+    "email": "ulisescf.24@gmail.com",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
+  },
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "repository": "https://github.com/ulises-jeremias/agent-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "agent-toolkit",
+    "craft",
+    "cursor",
+    "skills",
+    "agents"
+  ]
+}

--- a/plugins/agent-toolkit-craft/plugin.json
+++ b/plugins/agent-toolkit-craft/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "agent-toolkit-craft",
+  "version": "1.17.0",
+  "description": "Writing quality and change-safety toolkit: cut AI tells (unslop), remove code slop (deslop), and prove blast radius before shipping.",
+  "author": {
+    "name": "ulises-jeremias",
+    "url": "https://github.com/ulises-jeremias/agent-toolkit"
+  },
+  "homepage": "https://github.com/ulises-jeremias/agent-toolkit",
+  "repository": "https://github.com/ulises-jeremias/agent-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "agent-toolkit",
+    "craft",
+    "skills",
+    "agents"
+  ]
+}

--- a/plugins/agent-toolkit-craft/skills/blast-radius/SKILL.md
+++ b/plugins/agent-toolkit-craft/skills/blast-radius/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: blast-radius
+description: |
+  Find what a change could break somewhere else before it ships, beyond the diff, and prove the one fact it's safe because of by running real code instead of writing it up. Use for 'blast radius of X', 'what could this break', or reviewing a small diff you don't trust.
+disable-model-invocation: true
+origin:
+  type: upstream
+upstream:
+  repository: cursor/plugins
+  path: pstack/skills/blast-radius
+  ref: 60c641e4fad674784b30abcf9f8915dea39df38d
+  license: MIT
+trust:
+  tier: reviewed
+  reviewed_at: '2026-08-19'
+  reviewed_by: ulises-jeremias
+  reviewed_provenance: sha256:672544bad541446f8de290191079a6fbcd009d5e07393126b20cc9101aa107d1
+maintenance:
+  status: active
+  last_checked: '2026-08-19'
+distribution:
+  mode: vendored
+  redistribution_allowed: true
+  attribution_file: LICENSE
+security:
+  scripts: false
+  shell: false
+  network: false
+  mcp: []
+  hooks: []
+  dangerous_permissions: []
+  cve_policy: not-applicable
+updates:
+  strategy: pull-request
+  cadence: weekly
+---
+
+# Blast radius
+
+Find what a change breaks somewhere else, before it ships. Use for "blast radius of X", "what could this break", or reviewing a small diff you don't trust yet.
+
+Companion to `how` and `why`. `how` tells you what the code does. `why` tells you why it's shaped that way. Blast radius tells you what it breaks somewhere else.
+
+Listing the callers is not the job. The agent can grep those in a second. The job is the breakage grep won't show you.
+
+## Don't trust your own writeup
+
+A blast-radius writeup that sounds right is worthless. It reads as convincing whether or not it's true, and that is the trap you are walking into. So don't hand back the writeup. Find the one or two facts the whole thing depends on and prove them by running code. Words are where you start, not what you ship.
+
+### How sure are you
+
+For each fact the change's safety depends on, get it as far down this list as is cheap, and say where it stopped.
+
+1. You said so. Worthless on its own.
+2. You pointed at the line. A real `file:line`, or the library's own source.
+3. You showed the bad case can't happen. You walked the failure step by step and it doesn't reach.
+4. You ran it. A script or test that calls the real code and fails loud if you're wrong.
+5. You reproduced it in the running app.
+
+Any safety fact you can't get to step 4, say so out loud. Don't write it up as settled. Step 4 is usually one small script that imports the same library the app ships and calls the exact function you're worried about.
+
+## Steps
+
+1. Read the change. The diff, the symbols it adds, changes, and deletes, and what it now does differently, including the part the diff doesn't spell out. Use `why` step 2 to pull the PR and commits.
+2. Find the one fact it's safe because of. Most changes that look scary are safe because of a single fact, like "this call only drops already-dead cache entries and does nothing else". Find that fact. If it holds, most of the scary cases die at once. Spend your time here, not on a long list of maybes.
+3. Look where grep stops. Read the source of the library you call, and check its pinned version and any local patch. Work out when things run: microtasks, unmount and teardown, Solid versus React. Follow what a symbol search misses: the JSON an API returns, a DB column, a wire format, another language reading the same bytes, a feature flag, code three hops downstream.
+4. Be honest about each risk. Give it a real chance of happening and a real cost if it does. Keep the risks you confirmed; list the ones you checked and cleared separately. Same rules as `why`. Cite a real `file:line`, a search that finds nothing is still an answer, and never make up a caller or an API.
+5. Prove the one fact. Write a script or test that runs the real code, run it, and paste what happened. If you can't prove it cheaply, mark it unproven. Don't round up.
+6. For a big or wide change, run it as an `arena`. Ask several models the same question and merge the answers. Different models catch different real bugs.
+
+## What to hand back
+
+- **What it does.** What changed, including the part that isn't obvious.
+- **The one fact it's safe because of.** State it, say which step you got it to, and show the proof. If you couldn't prove it, write unproven.
+- **Risks.** Only the real ones. Each names how it breaks, the `file:line`, how likely and how bad, and how to check. Paste the proof for the ones that matter.
+- **Cleared.** What you checked and why it's fine.
+- **Before you merge.** The cheapest test or repro that catches the real bug, including the script you wrote.
+
+Write it through `unslop`, cite real code, and strip anything private before it goes anywhere public.
+
+**Reply:** the writeup above, with the one safety fact either proven or marked unproven.

--- a/plugins/agent-toolkit-craft/skills/deslop/SKILL.md
+++ b/plugins/agent-toolkit-craft/skills/deslop/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: deslop
+description: Remove AI-generated code slop and clean up code style
+origin:
+  type: upstream
+upstream:
+  repository: cursor/plugins
+  path: cursor-team-kit/skills/deslop
+  ref: 60c641e4fad674784b30abcf9f8915dea39df38d
+  license: MIT
+trust:
+  tier: reviewed
+  reviewed_at: '2026-08-19'
+  reviewed_by: ulises-jeremias
+  reviewed_provenance: sha256:7b61bbc5400565b3da44417658b7f6be1c0104f9f216b0a6965345293f8bd130
+maintenance:
+  status: active
+  last_checked: '2026-08-19'
+distribution:
+  mode: vendored
+  redistribution_allowed: true
+  attribution_file: LICENSE
+security:
+  scripts: false
+  shell: false
+  network: false
+  mcp: []
+  hooks: []
+  dangerous_permissions: []
+  cve_policy: not-applicable
+updates:
+  strategy: pull-request
+  cadence: weekly
+---
+
+
+# Remove AI code slop
+
+Check the diff against main and remove AI-generated slop introduced in the branch.
+
+## Focus Areas
+
+- Extra comments that are unnecessary or inconsistent with local style
+- Defensive checks or try/catch blocks that are abnormal for trusted code paths
+- Casts to `any` used only to bypass type issues
+- Deeply nested code that should be simplified with early returns
+- Other patterns inconsistent with the file and surrounding codebase
+
+## Guardrails
+
+- Keep behavior unchanged unless fixing a clear bug.
+- Prefer minimal, focused edits over broad rewrites.
+- Keep the final summary concise (1-3 sentences).

--- a/plugins/agent-toolkit-craft/skills/unslop/SKILL.md
+++ b/plugins/agent-toolkit-craft/skills/unslop/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: unslop
+description: Cut AI tells from any writing. Must always apply.
+origin:
+  type: upstream
+upstream:
+  repository: cursor/plugins
+  path: pstack/skills/unslop
+  ref: 60c641e4fad674784b30abcf9f8915dea39df38d
+  license: MIT
+trust:
+  tier: reviewed
+  reviewed_at: '2026-08-19'
+  reviewed_by: ulises-jeremias
+  reviewed_provenance: sha256:81344bee0dcaeef8acb4f8f19e5e781c27020c0dd18d4e27cba092768cc47bc8
+maintenance:
+  status: active
+  last_checked: '2026-08-19'
+distribution:
+  mode: vendored
+  redistribution_allowed: true
+  attribution_file: LICENSE
+security:
+  scripts: false
+  shell: false
+  network: false
+  mcp: []
+  hooks: []
+  dangerous_permissions: []
+  cve_policy: not-applicable
+updates:
+  strategy: pull-request
+  cadence: weekly
+---
+
+# Unslop
+
+Edit text to remove AI patterns and add human voice.
+
+## Process
+
+1. Scan for the patterns below.
+2. Rewrite. Preserve meaning, match intended tone.
+3. Add soul (see next section).
+4. Self-audit: "What makes this obviously AI generated?" Fix remaining tells.
+
+## Adding soul
+
+Removing patterns is half the job. Sterile, voiceless writing is just as obvious.
+
+- **Have opinions.** React to facts instead of neutrally listing pros and cons.
+- **Vary rhythm.** Short sentences. Then longer ones that take their time. Mix it up.
+- **Acknowledge complexity.** "Impressive but also kind of unsettling" beats "impressive."
+- **Use "I" when it fits.** First person isn't unprofessional.
+- **Let some mess in.** Perfect structure looks machine-made.
+- **Be specific.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am."
+
+## Patterns to detect and fix
+
+### Content
+
+1. **Puffery.** "pivotal moment", "testament to", "evolving landscape", "setting the stage for", "indelible mark", "deeply rooted". Cut puffery, state what happened.
+2. **Name-dropping.** Listing media outlets without context. Pick one, say what was said.
+3. **Superficial -ing phrases.** "highlighting...", "ensuring...", "reflecting...", "showcasing...", "fostering...". Delete or expand with real sources.
+4. **Promotional language.** "nestled", "vibrant", "breathtaking", "groundbreaking", "renowned", "stunning", "must-visit". Use neutral descriptions.
+5. **Vague attributions.** "Experts believe", "Industry reports suggest", "Some critics argue". Name the source or delete.
+6. **Formulaic challenges.** "Despite challenges... continues to thrive." Replace with specific facts.
+
+### Language
+
+7. **AI vocabulary.** Additionally, crucial, delve, enduring, enhance, fostering, garner, interplay, intricate, landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore, vibrant. Replace with plain words.
+8. **Fancy ways to say "is".** "serves as", "stands as", "boasts", "features". Just say "is" or "has".
+9. **"Not just X, but Y."** State the point directly instead.
+10. **Rule of three.** Forcing ideas into groups of three. Use the natural number.
+11. **Synonym cycling.** Protagonist, main character, central figure, hero all in one paragraph. Pick one, repeat it.
+12. **False ranges.** "from X to Y" where X and Y aren't on a meaningful scale. List topics directly.
+
+### Style
+
+13. **Em dash overuse.** Avoid em dashes entirely. Use periods or commas only (no parentheses, no en dashes, no hyphen-as-dash substitutes). Em dashes are an AI tell, and reaching for parentheses instead just trades one tell for another. If a thought needs separation, end the sentence or use a comma.
+14. **Colon overuse.** Colons are fine before a list or example. Not as mid-sentence connectors. "If you're coming from traditional automation: instead of registering event handlers, you describe conditions" adds nothing with the colon. Rewrite to let the point stand on its own without comparison framing. "Describing when the scheduler should fire works best as plain English." Same meaning, no crutch punctuation.
+15. **Boldface overuse.** Don't bold every proper noun or acronym.
+16. **Inline-header lists.** The tell is a bold label and colon that restates the line: "**Performance:** Performance improved...". Convert those to prose. A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail ("**Schema in TypeScript.** Tables live in one file.") is fine, not a tell.
+17. **Title case headings.** Use sentence case.
+18. **Decorative emojis.** Remove from headings and bullets.
+19. **Curly quotes.** Replace with straight quotes.
+
+### Communication artifacts
+
+20. **Chatbot phrases.** "I hope this helps!", "Let me know if...", "Of course!", "Certainly!", "Found the smoking gun!" Remove.
+21. **Cutoff disclaimers.** "While specific details are limited..." Find sources or remove.
+22. **Sycophantic tone.** "Great question! You're absolutely right!" Respond directly.
+
+### Filler
+
+23. **Filler phrases.** "In order to" becomes "To". "Due to the fact that" becomes "Because". "It is important to note that" gets deleted.
+24. **Excessive hedging.** "could potentially possibly be argued that it might" becomes "may".
+25. **Generic conclusions.** "The future looks bright." State specific plans or facts.
+
+### Jargon
+
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, ratchet (as metaphor), evacuate (for moving code), endgame, north star, flywheel. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Ratchet" becomes the mechanism's real name or "a limit that only tightens". "Evacuate" becomes "move out". "Endgame" becomes "the last phase". Pick the concrete word.
+
+### Plain speech
+
+27. **Say what it does, not how it feels.** "the database stays close at hand", "SQL you can read", "types that follow your schema" name a feeling. The fix names the mechanism or a number: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build". Ask what the sentence tells the reader to do or know, then write that. If you can't restate it as a concrete instruction, fact, or number, cut it. One more check: if the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+28. **Shorten or split dense sentences.** If the reader has to backtrack to parse a sentence, break it in two or drop clauses. One idea per sentence.
+29. **Active voice.** Prefer it. Catch "is/are/was/were + past participle" and name the actor: "queries are validated" becomes "the compiler validates queries", "the file is parsed by the loader" becomes "the loader parses the file". Passive is fine only when the actor is unknown or genuinely doesn't matter.
+30. **Cut adverbs, or use a stronger verb.** "runs quickly" becomes "is fast" or the number. "significantly improves" becomes the measured delta. An adverb propping up a weak verb means the verb is wrong.
+31. **Prefer the plain word.** "utilize" becomes "use", "leverage" becomes "use", "facilitate" becomes "help", "numerous" becomes "many", "in the event that" becomes "if". The fancier synonym is rarely clearer.


### PR DESCRIPTION
Implements #753 (epic #743): new stable `agent-toolkit-craft` product bundling the writing-quality/change-safety skills.

- `quality/unslop` + `quality/deslop` + `quality/blast-radius`
- Registered in both Claude Code and Cursor marketplaces (category quality)
- `plugins/agent-toolkit-craft/` manifests (root Agent Plugins + `.cursor-plugin` + `.claude-plugin`) + committed skills tree
- Product matrix regenerated (5 products)

Closes #753