### PR TITLE
chore: integration audit — inventory, docs, CHANGELOG (#756)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,7 @@ agent-toolkit install [--force]                # deploy profiles to detected AI 
 agent-toolkit doctor                           # verify installation health
 
 # Skills and inventory
-agent-toolkit inventory                        # list all 80 skills
+agent-toolkit inventory                        # list all 86 skills
 agent-toolkit skills list                      # list with domain breakdown
 agent-toolkit skills validate                  # check SKILL.md compliance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+- **Feat** — Complete Epic #743 (cursor/plugins adoption): vendor `tooling/cli-for-agents` ([#779](https://github.com/ulises-jeremias/agent-toolkit/pull/779)), absorb fix-ci patterns into `forge/gh-fix-ci` ([#780](https://github.com/ulises-jeremias/agent-toolkit/pull/780)), add `forge/fix-merge-conflicts` ([#781](https://github.com/ulises-jeremias/agent-toolkit/pull/781)), extend `core/workspace-knowledge-sync` with learned facts ([#792](https://github.com/ulises-jeremias/agent-toolkit/pull/792)), and add first-party `quality/deep-review` rubric ([#808](https://github.com/ulises-jeremias/agent-toolkit/pull/808))
+- **Feat** — Emit `hooks/hooks.json` for Cursor from the canonical `capabilities/hooks/*.yaml` registry ([#794](https://github.com/ulises-jeremias/agent-toolkit/pull/794))
+- **Feat** — Spec-complete Cursor/Claude `plugin.json` manifests (`$schema` + `author.url` per Agent Plugins 1.0.0) ([#795](https://github.com/ulises-jeremias/agent-toolkit/pull/795))
+- **Feat** — New stable `agent-toolkit-craft` product (unslop + deslop + blast-radius), registered in Claude Code and Cursor marketplaces ([#796](https://github.com/ulises-jeremias/agent-toolkit/pull/796))
+- **Chore** — Integration audit: inventory counts (86 skills / 17 agents / 5 products), marketplace docs (four plugins) ([#756](https://github.com/ulises-jeremias/agent-toolkit/issues/756))
+
 ## [1.16.0] — 2026-08-19
 
 - **Docs** — Add upstream vs first-party governance (`docs/UPSTREAM_VS_FIRST_PARTY.md`), skill integration checklist, and `ORCHESTRATION.md` routing table (Epic #743, Wave 0) ([#757](https://github.com/ulises-jeremias/agent-toolkit/pull/757))

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ agent-toolkit doctor
       <h3>🛠️ Skills</h3>
       <sub>Reusable capability units (<code>SKILL.md</code>) that teach an agent how to do a job — delivery workflows, forge CLIs, design, data, ops.</sub>
       <br><br>
-      <sub>80 skills across 14 domains. Browse <code>skills/</code> or <code>agent-toolkit inventory</code>.</sub>
+      <sub>86 skills across 14 domains. Browse <code>skills/</code> or <code>agent-toolkit inventory</code>.</sub>
     </td>
     <td width="50%" valign="top">
       <h3>🤖 Agents</h3>
@@ -463,7 +463,7 @@ One source of truth, deployed per-tool. Each profile in `profiles/` adapts the s
 
 ```text
 agent-toolkit/
-├── skills/              # 80 skills (SKILL.md frontmatter)
+├── skills/              # 86 skills (SKILL.md frontmatter)
 ├── agents/              # 17 tool-agnostic agent persona definitions
 ├── profiles/
 │   ├── claude-code/     # Plugin manifest, skill references, settings

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -63,7 +63,7 @@ In your AI tool, invoke an existing core skill — e.g. `core/assistant`:
 > Use the core/assistant skill to bootstrap this workspace
 ```
 
-You should see the assistant skill instructions load. Browse the full catalog: `catalogs/skill-catalog.yaml` (80 skills), regenerate with `./scripts/generate-catalogs.vsh`.
+You should see the assistant skill instructions load. Browse the full catalog: `catalogs/skill-catalog.yaml` (86 skills), regenerate with `./scripts/generate-catalogs.vsh`.
 
 ## 6. Try Swarms (optional — multi-agent orchestration)
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -58,7 +58,7 @@ Tool compatibility is declared via optional `tools` frontmatter and validated by
 
 ## Skill Domains
 
-Skills live under `skills/<domain>/<name>/`. There are **14 domains** (80 skills). Membership in marketplace products is a subset — see [`SKILL_PRODUCT_MATRIX.md`](SKILL_PRODUCT_MATRIX.md) and `agent-toolkit inventory`.
+Skills live under `skills/<domain>/<name>/`. There are **14 domains** (86 skills). Membership in marketplace products is a subset — see [`SKILL_PRODUCT_MATRIX.md`](SKILL_PRODUCT_MATRIX.md) and `agent-toolkit inventory`.
 
 | Domain | Count | Examples |
 |--------|------:|----------|

--- a/docs/compatibility/matrix-generation.md
+++ b/docs/compatibility/matrix-generation.md
@@ -8,7 +8,7 @@ Canonical: distributions/products.yaml (products → includes.skills/includes.ag
 
 Generated: docs/SKILL_PRODUCT_MATRIX.md via scripts/generate-skill-matrix.vsh (do not hand-edit — header says Generated from distributions/products.yaml — do not hand-edit).
 
-Current: Generated from 4 products × 80 skills × 17 agents. via products.yaml (4 products: agent-toolkit-core stable claude-code,cursor 6 skills, agent-toolkit-agents 16 agents, agent-toolkit-forge 7 skills, agent-toolkit-complete experimental 80 skills).
+Current: Generated from 5 products × 86 skills × 17 agents. via products.yaml (5 products: agent-toolkit-core stable claude-code,cursor 6 skills, agent-toolkit-agents 17 agents, agent-toolkit-forge 8 skills, agent-toolkit-craft stable claude-code,cursor 3 skills, agent-toolkit-complete experimental 86 skills).
 
 Honest per-skill support (validated, not badges): inventory JSON is source of truth; docs/matrix generated via conversion, not duplication. scripts/generate-skill-matrix.vsh --check enforces in CI.
 

--- a/docs/wiki/Plugin-Marketplace.md
+++ b/docs/wiki/Plugin-Marketplace.md
@@ -1,6 +1,6 @@
 # Plugin Marketplace
 
-agent-toolkit ships three plugins for the Claude Code and Cursor marketplaces. Plugins bundle
+agent-toolkit ships four plugins for the Claude Code and Cursor marketplaces. Plugins bundle
 skills and agents into installable units so you can get exactly the capabilities you need without
 loading the entire toolkit.
 
@@ -23,13 +23,15 @@ install individual plugins from it.
 /plugin install agent-toolkit-core@agent-toolkit
 /plugin install agent-toolkit-agents@agent-toolkit
 /plugin install agent-toolkit-forge@agent-toolkit
+/plugin install agent-toolkit-craft@agent-toolkit
 ```
 
-You do not need to install all three. Install what you need:
+You do not need to install all four. Install what you need:
 
 - **Just getting started:** install `agent-toolkit-core`
 - **Want specialist subagents:** add `agent-toolkit-agents`
 - **GitHub/GitLab automation:** add `agent-toolkit-forge`
+- **Writing quality + change safety:** add `agent-toolkit-craft`
 
 ### Step 3: Verify
 
@@ -43,7 +45,7 @@ Skills from installed plugins should appear in the response.
 
 ---
 
-## The Three Plugins Explained
+## The Four Plugins Explained
 
 ### agent-toolkit-core
 
@@ -128,6 +130,24 @@ contribution planning.
 **Use this plugin if:** You do a lot of GitHub PR work and want automated CI triage and PR
 automation.
 
+### agent-toolkit-craft
+
+**Install command:** `/plugin install agent-toolkit-craft@agent-toolkit`
+
+Writing quality and change-safety skills: cut AI tells from prose, remove AI-generated code
+slop, and prove the blast radius of a change before it ships.
+
+**Included skills:**
+
+| Skill | What it does |
+|-------|-------------|
+| `unslop` | Cut AI tells from any writing. |
+| `deslop` | Remove AI-generated code slop and clean up code style. |
+| `blast-radius` | Find what a change could break before it ships, beyond the diff. |
+
+**Use this plugin if:** You want focused writing/quality guardrails without loading the full
+catalog.
+
 ---
 
 ## Cursor: Installing from the Marketplace
@@ -193,6 +213,7 @@ After a new release of agent-toolkit, update installed plugins:
 /plugin update agent-toolkit-core@agent-toolkit
 /plugin update agent-toolkit-agents@agent-toolkit
 /plugin update agent-toolkit-forge@agent-toolkit
+/plugin update agent-toolkit-craft@agent-toolkit
 ```
 
 Or update all installed plugins at once:


### PR DESCRIPTION
Final audit closing Epic #743.

- CHANGELOG [Unreleased]: entries for #747-755
- Inventory counts 80→86 skills in README, AGENTS.md, SKILLS.md, GETTING_STARTED.md, compatibility matrix (5 products)
- docs/wiki/Plugin-Marketplace.md: four plugins + craft install/update sections

Note: `modules/agent_toolkit_core/embedded_data.v` is regenerated by `make.vsh gen-embedded` at build/release time; no local V execution per instruction.

Closes #756