### PR TITLE
fix(catalog): sync skills-layout.json to 86 skills — remove ghost ui-ux-pro-max

### DIFF
--- a/catalogs/skills-layout.json
+++ b/catalogs/skills-layout.json
@@ -1,6 +1,22 @@
 {
   "layout": "skills/<group>/<skill>/SKILL.md",
   "groups": {
+    "accessibility": [
+      "review"
+    ],
+    "agentic-security": [
+      "mcp-audit",
+      "owasp-agentic-review",
+      "supply-chain-audit",
+      "threat-modeling"
+    ],
+    "architecture": [
+      "c4-model"
+    ],
+    "cloud": [
+      "aws-well-architected-review",
+      "cloud-design-patterns"
+    ],
     "core": [
       "assistant",
       "dev-companion",
@@ -39,6 +55,8 @@
       "workflow-generic-project"
     ],
     "design": [
+      "design-assessment",
+      "design-improvement",
       "figma",
       "figma-code-connect-components",
       "figma-create-design-system-rules",
@@ -46,7 +64,6 @@
       "figma-implement-design",
       "frontend-design",
       "frontend-design-review",
-      "ui-ux-pro-max",
       "web-design-guidelines"
     ],
     "forge": [
@@ -78,24 +95,68 @@
       "swarm-observer",
       "triage"
     ],
-    "tooling": [
-      "cli-for-agents",
-      "herdr",
-      "inventory",
-      "jupyter-notebook",
-      "playwright-cli"
-    ],
     "quality": [
       "blast-radius",
       "codeql",
+      "deep-review",
+      "deslop",
       "megalinter",
       "megalinter-check",
       "megalinter-fix",
       "megalinter-setup",
       "unslop"
+    ],
+    "tooling": [
+      "chrome-devtools",
+      "cli-for-agents",
+      "herdr",
+      "inventory",
+      "jupyter-notebook",
+      "mermaid",
+      "playwright-cli"
     ]
   },
   "skills": [
+    {
+      "id": "accessibility/review",
+      "name": "review",
+      "domain": "accessibility"
+    },
+    {
+      "id": "agentic-security/mcp-audit",
+      "name": "mcp-audit",
+      "domain": "agentic-security"
+    },
+    {
+      "id": "agentic-security/owasp-agentic-review",
+      "name": "owasp-agentic-review",
+      "domain": "agentic-security"
+    },
+    {
+      "id": "agentic-security/supply-chain-audit",
+      "name": "supply-chain-audit",
+      "domain": "agentic-security"
+    },
+    {
+      "id": "agentic-security/threat-modeling",
+      "name": "threat-modeling",
+      "domain": "agentic-security"
+    },
+    {
+      "id": "architecture/c4-model",
+      "name": "c4-model",
+      "domain": "architecture"
+    },
+    {
+      "id": "cloud/aws-well-architected-review",
+      "name": "aws-well-architected-review",
+      "domain": "cloud"
+    },
+    {
+      "id": "cloud/cloud-design-patterns",
+      "name": "cloud-design-patterns",
+      "domain": "cloud"
+    },
     {
       "id": "core/assistant",
       "name": "assistant",
@@ -252,6 +313,16 @@
       "domain": "delivery"
     },
     {
+      "id": "design/design-assessment",
+      "name": "design-assessment",
+      "domain": "design"
+    },
+    {
+      "id": "design/design-improvement",
+      "name": "design-improvement",
+      "domain": "design"
+    },
+    {
       "id": "design/figma",
       "name": "figma",
       "domain": "design"
@@ -284,11 +355,6 @@
     {
       "id": "design/frontend-design-review",
       "name": "frontend-design-review",
-      "domain": "design"
-    },
-    {
-      "id": "design/ui-ux-pro-max",
-      "name": "ui-ux-pro-max",
       "domain": "design"
     },
     {
@@ -402,8 +468,23 @@
       "domain": "ops"
     },
     {
+      "id": "quality/blast-radius",
+      "name": "blast-radius",
+      "domain": "quality"
+    },
+    {
       "id": "quality/codeql",
       "name": "codeql",
+      "domain": "quality"
+    },
+    {
+      "id": "quality/deep-review",
+      "name": "deep-review",
+      "domain": "quality"
+    },
+    {
+      "id": "quality/deslop",
+      "name": "deslop",
       "domain": "quality"
     },
     {
@@ -427,14 +508,14 @@
       "domain": "quality"
     },
     {
-      "id": "quality/blast-radius",
-      "name": "blast-radius",
-      "domain": "quality"
-    },
-    {
       "id": "quality/unslop",
       "name": "unslop",
       "domain": "quality"
+    },
+    {
+      "id": "tooling/chrome-devtools",
+      "name": "chrome-devtools",
+      "domain": "tooling"
     },
     {
       "id": "tooling/cli-for-agents",
@@ -454,6 +535,11 @@
     {
       "id": "tooling/jupyter-notebook",
       "name": "jupyter-notebook",
+      "domain": "tooling"
+    },
+    {
+      "id": "tooling/mermaid",
+      "name": "mermaid",
       "domain": "tooling"
     },
     {


### PR DESCRIPTION
Fixes #799

## Summary
- Syncs `catalogs/skills-layout.json` (hand-maintained SSOT for `agent-toolkit skills list`) to source of truth: 84 skills on disk / `skill-catalog.yaml`.

## Changes
- Remove ghost `design/ui-ux-pro-max` (deleted in 09acb6d, #358, docs/third-party/ui-ux-pro-max.md) from `groups.design` and flat `skills[]`
- Add 4 missing groups: `accessibility`, `agentic-security`, `architecture`, `cloud`
- Add 13 missing flat entries and group members: `accessibility/review`, 4× agentic-security, `architecture/c4-model`, 2× cloud, `design/design-assessment`+`design-improvement`, `quality/deslop`, `tooling/chrome-devtools`+`mermaid`
- Groups now 14 domains, sorted alphabetically; skills sorted to catalog order.

## Testing
- [x] `./scripts/validate-skills.vsh` 84 ok
- [x] `./scripts/validate-agents.vsh` 17 ok
- [x] `./scripts/validate-loops.vsh` 10 ok
- [x] `./scripts/generate-catalogs.vsh --check` ok
- [x] `grep -c ui-ux-pro-max catalogs/skills-layout.json` == 0

## Type
- [x] Catalog update
- [x] Bug fix
