### PR TITLE
fix(assistant): remove ghost ui-ux-pro-max from ORCHESTRATION.md

### DIFF
--- a/plugins/agent-toolkit-complete/.github/skills/assistant/references/ORCHESTRATION.md
+++ b/plugins/agent-toolkit-complete/.github/skills/assistant/references/ORCHESTRATION.md
@@ -76,7 +76,7 @@ Reserved for anti-slop, static analysis, and deep review. Skills in this section
 | Domain | Skills | When to route |
 |--------|--------|---------------|
 | Figma | **figma**, **figma-implement-design**, **figma-code-connect-components** | Design-to-code, MCP |
-| Visual design | **frontend-design**, **frontend-design-review**, **ui-ux-pro-max** | UI aesthetics and review |
+| Visual design | **frontend-design**, **frontend-design-review** | UI aesthetics and review |
 | Guidelines | **web-design-guidelines** | Vercel web interface guidelines |
 
 ---

--- a/plugins/agent-toolkit-complete/.opencode/skills/assistant/references/ORCHESTRATION.md
+++ b/plugins/agent-toolkit-complete/.opencode/skills/assistant/references/ORCHESTRATION.md
@@ -76,7 +76,7 @@ Reserved for anti-slop, static analysis, and deep review. Skills in this section
 | Domain | Skills | When to route |
 |--------|--------|---------------|
 | Figma | **figma**, **figma-implement-design**, **figma-code-connect-components** | Design-to-code, MCP |
-| Visual design | **frontend-design**, **frontend-design-review**, **ui-ux-pro-max** | UI aesthetics and review |
+| Visual design | **frontend-design**, **frontend-design-review** | UI aesthetics and review |
 | Guidelines | **web-design-guidelines** | Vercel web interface guidelines |
 
 ---

--- a/plugins/agent-toolkit-complete/.provenance.json
+++ b/plugins/agent-toolkit-complete/.provenance.json
@@ -1,1 +1,955 @@
-{"generatorVersion":"1.17.0","product":"agent-toolkit-complete","target":"agent-plugins","artifacts":[{"path":"agent-toolkit-complete/plugin.json","sourceFile":"generated","sourceDigest":"n/a","generatedDigest":"5d6c60852e32"},{"path":"agent-toolkit-complete/skills/assistant/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/SKILL.md","sourceDigest":"594d0f376a14","generatedDigest":"594d0f376a14"},{"path":"agent-toolkit-complete/skills/assistant/references/REPO_INSPECTION.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/references/REPO_INSPECTION.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-complete/skills/assistant/references/ORCHESTRATION.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/references/ORCHESTRATION.md","sourceDigest":"eb16fb608d67","generatedDigest":"eb16fb608d67"},{"path":"agent-toolkit-complete/skills/assistant/references/AGENTS_TEMPLATE.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/references/AGENTS_TEMPLATE.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-complete/skills/dev-companion/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/dev-companion/SKILL.md","sourceDigest":"cb145011d670","generatedDigest":"cb145011d670"},{"path":"agent-toolkit-complete/skills/dev-companion/references/LOOP_GUARDRAILS.md","sourceFile":"/tmp/agent-toolkit/skills/core/dev-companion/references/LOOP_GUARDRAILS.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-complete/skills/onboarding/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/onboarding/SKILL.md","sourceDigest":"441d78df299d","generatedDigest":"441d78df299d"},{"path":"agent-toolkit-complete/skills/output-handshake/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/output-handshake/SKILL.md","sourceDigest":"6788635e1f67","generatedDigest":"6788635e1f67"},{"path":"agent-toolkit-complete/skills/pr-fallback/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/pr-fallback/SKILL.md","sourceDigest":"4a57cea05792","generatedDigest":"4a57cea05792"},{"path":"agent-toolkit-complete/skills/pr-fallback/references/pr-body-default.md","sourceFile":"/tmp/agent-toolkit/skills/core/pr-fallback/references/pr-body-default.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-complete/skills/workspace-knowledge-sync/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/workspace-knowledge-sync/SKILL.md","sourceDigest":"5e715edb4fe1","generatedDigest":"5e715edb4fe1"},{"path":"agent-toolkit-complete/skills/dbt-validation/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/data/dbt-validation/SKILL.md","sourceDigest":"6d180ee3b0fe","generatedDigest":"6d180ee3b0fe"},{"path":"agent-toolkit-complete/skills/snowflake-validation/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/data/snowflake-validation/SKILL.md","sourceDigest":"4eadae9c015d","generatedDigest":"4eadae9c015d"},{"path":"agent-toolkit-complete/skills/adr/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/adr/SKILL.md","sourceDigest":"84613c43c11f","generatedDigest":"84613c43c11f"},{"path":"agent-toolkit-complete/skills/adr/references/example-001-graphql-adoption.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/adr/references/example-001-graphql-adoption.md","sourceDigest":"c963cd0f4c82","generatedDigest":"c963cd0f4c82"},{"path":"agent-toolkit-complete/skills/adr/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/adr/references/default-template.md","sourceDigest":"af47d8f458ce","generatedDigest":"af47d8f458ce"},{"path":"agent-toolkit-complete/skills/agreement/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/agreement/SKILL.md","sourceDigest":"f13e000487d5","generatedDigest":"f13e000487d5"},{"path":"agent-toolkit-complete/skills/agreement/references/example-api-versioning.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/agreement/references/example-api-versioning.md","sourceDigest":"f5bbfcea1a40","generatedDigest":"f5bbfcea1a40"},{"path":"agent-toolkit-complete/skills/agreement/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/agreement/references/default-template.md","sourceDigest":"87f78f74499e","generatedDigest":"87f78f74499e"},{"path":"agent-toolkit-complete/skills/bug/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/bug/SKILL.md","sourceDigest":"70f50ca342a0","generatedDigest":"70f50ca342a0"},{"path":"agent-toolkit-complete/skills/bug/references/example-search-filter-bug.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/bug/references/example-search-filter-bug.md","sourceDigest":"04be13752319","generatedDigest":"04be13752319"},{"path":"agent-toolkit-complete/skills/bug/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/bug/references/default-template.md","sourceDigest":"3b96fd29bbe4","generatedDigest":"3b96fd29bbe4"},{"path":"agent-toolkit-complete/skills/decision-log/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/decision-log/SKILL.md","sourceDigest":"d36e09995230","generatedDigest":"d36e09995230"},{"path":"agent-toolkit-complete/skills/decision-log/references/example-repository-pattern.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/decision-log/references/example-repository-pattern.md","sourceDigest":"ffdbbd48a5a7","generatedDigest":"ffdbbd48a5a7"},{"path":"agent-toolkit-complete/skills/decision-log/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/decision-log/references/default-template.md","sourceDigest":"446f1b1189fc","generatedDigest":"446f1b1189fc"},{"path":"agent-toolkit-complete/skills/development-workflow/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/development-workflow/SKILL.md","sourceDigest":"d4f42f72e015","generatedDigest":"d4f42f72e015"},{"path":"agent-toolkit-complete/skills/development-workflow/references/default-workflow-checklist.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/development-workflow/references/default-workflow-checklist.md","sourceDigest":"06cb550e2fe4","generatedDigest":"06cb550e2fe4"},{"path":"agent-toolkit-complete/skills/epic/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/epic/SKILL.md","sourceDigest":"f19ef11e00b7","generatedDigest":"f19ef11e00b7"},{"path":"agent-toolkit-complete/skills/epic/references/example-unified-dashboard.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/epic/references/example-unified-dashboard.md","sourceDigest":"509f55fc6a30","generatedDigest":"509f55fc6a30"},{"path":"agent-toolkit-complete/skills/epic/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/epic/references/default-template.md","sourceDigest":"0ae47ea138d0","generatedDigest":"0ae47ea138d0"},{"path":"agent-toolkit-complete/skills/incident/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/incident/SKILL.md","sourceDigest":"e275ca28ca5e","generatedDigest":"e275ca28ca5e"},{"path":"agent-toolkit-complete/skills/incident/references/example-payment-outage.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/incident/references/example-payment-outage.md","sourceDigest":"0d3fc61f10d9","generatedDigest":"0d3fc61f10d9"},{"path":"agent-toolkit-complete/skills/incident/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/incident/references/default-template.md","sourceDigest":"fd880a679199","generatedDigest":"fd880a679199"},{"path":"agent-toolkit-complete/skills/management-unit-assessment/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/management-unit-assessment/SKILL.md","sourceDigest":"29c025f4c96a","generatedDigest":"29c025f4c96a"},{"path":"agent-toolkit-complete/skills/management-unit-assessment/references/example-team-assessment.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/management-unit-assessment/references/example-team-assessment.md","sourceDigest":"56017d2a21fd","generatedDigest":"56017d2a21fd"},{"path":"agent-toolkit-complete/skills/management-unit-assessment/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/management-unit-assessment/references/default-template.md","sourceDigest":"7ab8856f4700","generatedDigest":"7ab8856f4700"},{"path":"agent-toolkit-complete/skills/meeting-minutes/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/meeting-minutes/SKILL.md","sourceDigest":"c0aa9c46d9f5","generatedDigest":"c0aa9c46d9f5"},{"path":"agent-toolkit-complete/skills/meeting-minutes/references/example-weekly-sync.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/meeting-minutes/references/example-weekly-sync.md","sourceDigest":"dff943b160c7","generatedDigest":"dff943b160c7"},{"path":"agent-toolkit-complete/skills/meeting-minutes/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/meeting-minutes/references/default-template.md","sourceDigest":"4d5a3919db35","generatedDigest":"4d5a3919db35"},{"path":"agent-toolkit-complete/skills/planning/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/planning/SKILL.md","sourceDigest":"129d731aba0f","generatedDigest":"129d731aba0f"},{"path":"agent-toolkit-complete/skills/planning/references/example-sprint-planning.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/planning/references/example-sprint-planning.md","sourceDigest":"4a36df7d4319","generatedDigest":"4a36df7d4319"},{"path":"agent-toolkit-complete/skills/planning/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/planning/references/default-template.md","sourceDigest":"32c67e6f6b55","generatedDigest":"32c67e6f6b55"},{"path":"agent-toolkit-complete/skills/prd/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/prd/SKILL.md","sourceDigest":"0d93a06db51f","generatedDigest":"0d93a06db51f"},{"path":"agent-toolkit-complete/skills/prd/references/example-unified-api.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/prd/references/example-unified-api.md","sourceDigest":"1799c99217c8","generatedDigest":"1799c99217c8"},{"path":"agent-toolkit-complete/skills/prd/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/prd/references/default-template.md","sourceDigest":"7baacc8afed8","generatedDigest":"7baacc8afed8"},{"path":"agent-toolkit-complete/skills/project-assessment/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/project-assessment/SKILL.md","sourceDigest":"4825e39ced22","generatedDigest":"4825e39ced22"},{"path":"agent-toolkit-complete/skills/project-assessment/references/example-platform-assessment.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/project-assessment/references/example-platform-assessment.md","sourceDigest":"95d5cd12c4d3","generatedDigest":"95d5cd12c4d3"},{"path":"agent-toolkit-complete/skills/project-assessment/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/project-assessment/references/default-template.md","sourceDigest":"ba7323b39ec5","generatedDigest":"ba7323b39ec5"},{"path":"agent-toolkit-complete/skills/project-assessment-evidence/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/project-assessment-evidence/SKILL.md","sourceDigest":"f6720f1026d5","generatedDigest":"f6720f1026d5"},{"path":"agent-toolkit-complete/skills/project-assessment-evidence/references/example-evidence-map.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/project-assessment-evidence/references/example-evidence-map.md","sourceDigest":"ce2c4cec9e46","generatedDigest":"ce2c4cec9e46"},{"path":"agent-toolkit-complete/skills/project-assessment-evidence/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/project-assessment-evidence/references/default-template.md","sourceDigest":"3e490c54ab95","generatedDigest":"3e490c54ab95"},{"path":"agent-toolkit-complete/skills/spike/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/spike/SKILL.md","sourceDigest":"8bb9e72fff5d","generatedDigest":"8bb9e72fff5d"},{"path":"agent-toolkit-complete/skills/spike/references/example-graphql-federation.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/spike/references/example-graphql-federation.md","sourceDigest":"d553e4a078ce","generatedDigest":"d553e4a078ce"},{"path":"agent-toolkit-complete/skills/spike/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/spike/references/default-template.md","sourceDigest":"87f3ac6e496f","generatedDigest":"87f3ac6e496f"},{"path":"agent-toolkit-complete/skills/task/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/task/SKILL.md","sourceDigest":"fa56bf88586e","generatedDigest":"fa56bf88586e"},{"path":"agent-toolkit-complete/skills/task/references/example-nav-system.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/task/references/example-nav-system.md","sourceDigest":"69a43bd02605","generatedDigest":"69a43bd02605"},{"path":"agent-toolkit-complete/skills/task/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/task/references/default-template.md","sourceDigest":"a16314295ee8","generatedDigest":"a16314295ee8"},{"path":"agent-toolkit-complete/skills/technical-unit-assessment/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/SKILL.md","sourceDigest":"676a0fb1c91a","generatedDigest":"676a0fb1c91a"},{"path":"agent-toolkit-complete/skills/technical-unit-assessment/references/indicator-groups.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/references/indicator-groups.md","sourceDigest":"706e313123b1","generatedDigest":"706e313123b1"},{"path":"agent-toolkit-complete/skills/technical-unit-assessment/references/example-frontend-assessment.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/references/example-frontend-assessment.md","sourceDigest":"f49d04307787","generatedDigest":"f49d04307787"},{"path":"agent-toolkit-complete/skills/technical-unit-assessment/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/references/default-template.md","sourceDigest":"0bb95c977466","generatedDigest":"0bb95c977466"},{"path":"agent-toolkit-complete/skills/trd/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/trd/SKILL.md","sourceDigest":"0b8cafc07d70","generatedDigest":"0b8cafc07d70"},{"path":"agent-toolkit-complete/skills/trd/references/example-api-migration.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/trd/references/example-api-migration.md","sourceDigest":"a8fd88e1927a","generatedDigest":"a8fd88e1927a"},{"path":"agent-toolkit-complete/skills/trd/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/trd/references/default-template.md","sourceDigest":"a8674fef47b2","generatedDigest":"a8674fef47b2"},{"path":"agent-toolkit-complete/skills/user-story/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/user-story/SKILL.md","sourceDigest":"91e413abe065","generatedDigest":"91e413abe065"},{"path":"agent-toolkit-complete/skills/user-story/references/example-advanced-filtering.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/user-story/references/example-advanced-filtering.md","sourceDigest":"20d95e43e9dc","generatedDigest":"20d95e43e9dc"},{"path":"agent-toolkit-complete/skills/user-story/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/user-story/references/default-template.md","sourceDigest":"165f9da7ac52","generatedDigest":"165f9da7ac52"},{"path":"agent-toolkit-complete/skills/work-item/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/work-item/SKILL.md","sourceDigest":"79c16b141a87","generatedDigest":"79c16b141a87"},{"path":"agent-toolkit-complete/skills/work-item/references/example-routing-dashboard.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/work-item/references/example-routing-dashboard.md","sourceDigest":"fb72ff9ec30d","generatedDigest":"fb72ff9ec30d"},{"path":"agent-toolkit-complete/skills/work-item/references/default-template.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/work-item/references/default-template.md","sourceDigest":"e4f6ba16019b","generatedDigest":"e4f6ba16019b"},{"path":"agent-toolkit-complete/skills/workflow-client-bootstrap/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/workflow-client-bootstrap/SKILL.md","sourceDigest":"b6d6a3e237c9","generatedDigest":"b6d6a3e237c9"},{"path":"agent-toolkit-complete/skills/workflow-generic-project/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/delivery/workflow-generic-project/SKILL.md","sourceDigest":"3e9b3acfb76a","generatedDigest":"3e9b3acfb76a"},{"path":"agent-toolkit-complete/skills/figma/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma/SKILL.md","sourceDigest":"082616c0497b","generatedDigest":"082616c0497b"},{"path":"agent-toolkit-complete/skills/figma/references/figma-tools-and-prompts.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma/references/figma-tools-and-prompts.md","sourceDigest":"428add063f23","generatedDigest":"428add063f23"},{"path":"agent-toolkit-complete/skills/figma/references/figma-mcp-config.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma/references/figma-mcp-config.md","sourceDigest":"15392180e305","generatedDigest":"15392180e305"},{"path":"agent-toolkit-complete/skills/figma-code-connect-components/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma-code-connect-components/SKILL.md","sourceDigest":"fec6d6496ccb","generatedDigest":"fec6d6496ccb"},{"path":"agent-toolkit-complete/skills/figma-code-connect-components/references/mapping-checklist.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma-code-connect-components/references/mapping-checklist.md","sourceDigest":"81f85e1eb6c5","generatedDigest":"81f85e1eb6c5"},{"path":"agent-toolkit-complete/skills/figma-create-design-system-rules/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma-create-design-system-rules/SKILL.md","sourceDigest":"b4b0264b7220","generatedDigest":"b4b0264b7220"},{"path":"agent-toolkit-complete/skills/figma-create-design-system-rules/references/rule-template.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma-create-design-system-rules/references/rule-template.md","sourceDigest":"78947775e307","generatedDigest":"78947775e307"},{"path":"agent-toolkit-complete/skills/figma-create-new-file/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma-create-new-file/SKILL.md","sourceDigest":"1bd05e4db51c","generatedDigest":"1bd05e4db51c"},{"path":"agent-toolkit-complete/skills/figma-implement-design/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/figma-implement-design/SKILL.md","sourceDigest":"b0998ad1f5a2","generatedDigest":"b0998ad1f5a2"},{"path":"agent-toolkit-complete/skills/design-assessment/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/design-assessment/SKILL.md","sourceDigest":"28e249cf36ec","generatedDigest":"28e249cf36ec"},{"path":"agent-toolkit-complete/skills/design-assessment/references/design-scorecard-template.md","sourceFile":"/tmp/agent-toolkit/skills/design/design-assessment/references/design-scorecard-template.md","sourceDigest":"8f4da244c422","generatedDigest":"8f4da244c422"},{"path":"agent-toolkit-complete/skills/design-improvement/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/design-improvement/SKILL.md","sourceDigest":"54ba177c2844","generatedDigest":"54ba177c2844"},{"path":"agent-toolkit-complete/skills/design-improvement/references/improvement-plan-template.md","sourceFile":"/tmp/agent-toolkit/skills/design/design-improvement/references/improvement-plan-template.md","sourceDigest":"9923920585e2","generatedDigest":"9923920585e2"},{"path":"agent-toolkit-complete/skills/frontend-design/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/frontend-design/SKILL.md","sourceDigest":"6a714fca842a","generatedDigest":"6a714fca842a"},{"path":"agent-toolkit-complete/skills/frontend-design-review/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/frontend-design-review/SKILL.md","sourceDigest":"52a8648b5c7c","generatedDigest":"52a8648b5c7c"},{"path":"agent-toolkit-complete/skills/frontend-design-review/references/review-type-modifiers.md","sourceFile":"/tmp/agent-toolkit/skills/design/frontend-design-review/references/review-type-modifiers.md","sourceDigest":"a8e2347d4195","generatedDigest":"a8e2347d4195"},{"path":"agent-toolkit-complete/skills/frontend-design-review/references/review-output-format.md","sourceFile":"/tmp/agent-toolkit/skills/design/frontend-design-review/references/review-output-format.md","sourceDigest":"0735f13a4eff","generatedDigest":"0735f13a4eff"},{"path":"agent-toolkit-complete/skills/frontend-design-review/references/quick-checklist.md","sourceFile":"/tmp/agent-toolkit/skills/design/frontend-design-review/references/quick-checklist.md","sourceDigest":"8043fd995ae8","generatedDigest":"8043fd995ae8"},{"path":"agent-toolkit-complete/skills/frontend-design-review/references/pattern-examples.md","sourceFile":"/tmp/agent-toolkit/skills/design/frontend-design-review/references/pattern-examples.md","sourceDigest":"072f2a647de3","generatedDigest":"072f2a647de3"},{"path":"agent-toolkit-complete/skills/web-design-guidelines/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/design/web-design-guidelines/SKILL.md","sourceDigest":"079555dcf79f","generatedDigest":"079555dcf79f"},{"path":"agent-toolkit-complete/skills/web-design-guidelines/references/web-interface-guidelines.md","sourceFile":"/tmp/agent-toolkit/skills/design/web-design-guidelines/references/web-interface-guidelines.md","sourceDigest":"eea73cb6dd46","generatedDigest":"eea73cb6dd46"},{"path":"agent-toolkit-complete/skills/web-design-guidelines/references/LICENSE","sourceFile":"/tmp/agent-toolkit/skills/design/web-design-guidelines/references/LICENSE","sourceDigest":"6cd1609c9c12","generatedDigest":"6cd1609c9c12"},{"path":"agent-toolkit-complete/skills/supply-chain-audit/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/agentic-security/supply-chain-audit/SKILL.md","sourceDigest":"fba4830eb1fc","generatedDigest":"fba4830eb1fc"},{"path":"agent-toolkit-complete/skills/fix-merge-conflicts/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/fix-merge-conflicts/SKILL.md","sourceDigest":"ada35e42bf19","generatedDigest":"ada35e42bf19"},{"path":"agent-toolkit-complete/skills/gh-address-comments/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/gh-address-comments/SKILL.md","sourceDigest":"83ac0e2e372d","generatedDigest":"83ac0e2e372d"},{"path":"agent-toolkit-complete/skills/gh-contribution-planner/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/gh-contribution-planner/SKILL.md","sourceDigest":"dc7ae8e23af3","generatedDigest":"dc7ae8e23af3"},{"path":"agent-toolkit-complete/skills/gh-fix-ci/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/gh-fix-ci/SKILL.md","sourceDigest":"a8137bb752a7","generatedDigest":"a8137bb752a7"},{"path":"agent-toolkit-complete/skills/github-cli-workflow/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/github-cli-workflow/SKILL.md","sourceDigest":"618084f066f5","generatedDigest":"618084f066f5"},{"path":"agent-toolkit-complete/skills/gitlab-cli-workflow/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/gitlab-cli-workflow/SKILL.md","sourceDigest":"dc6f673c9f44","generatedDigest":"dc6f673c9f44"},{"path":"agent-toolkit-complete/skills/workflow-client-bootstrap/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/workflow-client-bootstrap/SKILL.md","sourceDigest":"49cf32c2bd7c","generatedDigest":"49cf32c2bd7c"},{"path":"agent-toolkit-complete/skills/workflow-generic-project/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/workflow-generic-project/SKILL.md","sourceDigest":"6e7460cb935b","generatedDigest":"6e7460cb935b"},{"path":"agent-toolkit-complete/skills/clickup-cli/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/clickup-cli/SKILL.md","sourceDigest":"70b8cd4895f4","generatedDigest":"70b8cd4895f4"},{"path":"agent-toolkit-complete/skills/clickup-cli/references/time-tracking.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/clickup-cli/references/time-tracking.md","sourceDigest":"d42bd69d71f3","generatedDigest":"d42bd69d71f3"},{"path":"agent-toolkit-complete/skills/clickup-cli/references/task-management.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/clickup-cli/references/task-management.md","sourceDigest":"c052630a13e0","generatedDigest":"c052630a13e0"},{"path":"agent-toolkit-complete/skills/clickup-cli/references/docs-management.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/clickup-cli/references/docs-management.md","sourceDigest":"2f2a9bbb7958","generatedDigest":"2f2a9bbb7958"},{"path":"agent-toolkit-complete/skills/linear/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/linear/SKILL.md","sourceDigest":"a754121f7305","generatedDigest":"a754121f7305"},{"path":"agent-toolkit-complete/skills/slack-assistant/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/slack-assistant/SKILL.md","sourceDigest":"ca78bf35e508","generatedDigest":"ca78bf35e508"},{"path":"agent-toolkit-complete/skills/slack-cli/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/slack-cli/SKILL.md","sourceDigest":"1230496dec64","generatedDigest":"1230496dec64"},{"path":"agent-toolkit-complete/skills/slack-cli/references/INSTALLATION.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/slack-cli/references/INSTALLATION.md","sourceDigest":"da2cd2a943d7","generatedDigest":"da2cd2a943d7"},{"path":"agent-toolkit-complete/skills/loop-runner/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/loops/loop-runner/SKILL.md","sourceDigest":"6491c61915a1","generatedDigest":"6491c61915a1"},{"path":"agent-toolkit-complete/skills/docs-generator/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/ops/docs-generator/SKILL.md","sourceDigest":"af8059a9aa96","generatedDigest":"af8059a9aa96"},{"path":"agent-toolkit-complete/skills/llm-cost-advisor/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/ops/llm-cost-advisor/SKILL.md","sourceDigest":"a2618beaa316","generatedDigest":"a2618beaa316"},{"path":"agent-toolkit-complete/skills/swarm/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/ops/swarm/SKILL.md","sourceDigest":"d55d5a4a7756","generatedDigest":"d55d5a4a7756"},{"path":"agent-toolkit-complete/skills/swarm-handoff/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/ops/swarm-handoff/SKILL.md","sourceDigest":"970cefce234c","generatedDigest":"970cefce234c"},{"path":"agent-toolkit-complete/skills/swarm-observer/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/ops/swarm-observer/SKILL.md","sourceDigest":"e1f29e946fdb","generatedDigest":"e1f29e946fdb"},{"path":"agent-toolkit-complete/skills/triage/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/ops/triage/SKILL.md","sourceDigest":"c7238486db2c","generatedDigest":"c7238486db2c"},{"path":"agent-toolkit-complete/skills/herdr/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/herdr/SKILL.md","sourceDigest":"3bad25c18389","generatedDigest":"3bad25c18389"},{"path":"agent-toolkit-complete/skills/cli-for-agents/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/cli-for-agents/SKILL.md","sourceDigest":"73e8703fd50e","generatedDigest":"73e8703fd50e"},{"path":"agent-toolkit-complete/skills/inventory/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/inventory/SKILL.md","sourceDigest":"f7843a134529","generatedDigest":"f7843a134529"},{"path":"agent-toolkit-complete/skills/jupyter-notebook/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/jupyter-notebook/SKILL.md","sourceDigest":"1dbad970a4f1","generatedDigest":"1dbad970a4f1"},{"path":"agent-toolkit-complete/skills/jupyter-notebook/references/tutorial-patterns.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/tutorial-patterns.md","sourceDigest":"8c194bb640de","generatedDigest":"8c194bb640de"},{"path":"agent-toolkit-complete/skills/jupyter-notebook/references/quality-checklist.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/quality-checklist.md","sourceDigest":"ed01afe6ff47","generatedDigest":"ed01afe6ff47"},{"path":"agent-toolkit-complete/skills/jupyter-notebook/references/notebook-structure.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/notebook-structure.md","sourceDigest":"9a6f1c649af5","generatedDigest":"9a6f1c649af5"},{"path":"agent-toolkit-complete/skills/jupyter-notebook/references/experiment-patterns.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/experiment-patterns.md","sourceDigest":"1ff9c04281c0","generatedDigest":"1ff9c04281c0"},{"path":"agent-toolkit-complete/skills/review/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/accessibility/review/SKILL.md","sourceDigest":"43313ce15d28","generatedDigest":"43313ce15d28"},{"path":"agent-toolkit-complete/skills/review/references/research.md","sourceFile":"/tmp/agent-toolkit/skills/accessibility/review/references/research.md","sourceDigest":"1520d7b7250c","generatedDigest":"1520d7b7250c"},{"path":"agent-toolkit-complete/skills/review/references/a11y-findings-template.md","sourceFile":"/tmp/agent-toolkit/skills/accessibility/review/references/a11y-findings-template.md","sourceDigest":"2dd9f2eb4c51","generatedDigest":"2dd9f2eb4c51"},{"path":"agent-toolkit-complete/skills/review/references/a11y-checklist.md","sourceFile":"/tmp/agent-toolkit/skills/accessibility/review/references/a11y-checklist.md","sourceDigest":"02d5f32242df","generatedDigest":"02d5f32242df"},{"path":"agent-toolkit-complete/skills/mcp-audit/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/agentic-security/mcp-audit/SKILL.md","sourceDigest":"b4ee4c43c3df","generatedDigest":"b4ee4c43c3df"},{"path":"agent-toolkit-complete/skills/mcp-audit/references/mcp-audit-template.md","sourceFile":"/tmp/agent-toolkit/skills/agentic-security/mcp-audit/references/mcp-audit-template.md","sourceDigest":"c5a0b8677ddf","generatedDigest":"c5a0b8677ddf"},{"path":"agent-toolkit-complete/skills/owasp-agentic-review/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/agentic-security/owasp-agentic-review/SKILL.md","sourceDigest":"50706d049435","generatedDigest":"50706d049435"},{"path":"agent-toolkit-complete/skills/owasp-agentic-review/references/owasp-agentic-template.md","sourceFile":"/tmp/agent-toolkit/skills/agentic-security/owasp-agentic-review/references/owasp-agentic-template.md","sourceDigest":"e393481aa492","generatedDigest":"e393481aa492"},{"path":"agent-toolkit-complete/skills/threat-modeling/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/agentic-security/threat-modeling/SKILL.md","sourceDigest":"9c8b7ecf285f","generatedDigest":"9c8b7ecf285f"},{"path":"agent-toolkit-complete/skills/threat-modeling/references/threat-model-template.md","sourceFile":"/tmp/agent-toolkit/skills/agentic-security/threat-modeling/references/threat-model-template.md","sourceDigest":"0e2b9fac163f","generatedDigest":"0e2b9fac163f"},{"path":"agent-toolkit-complete/skills/megalinter/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/megalinter/SKILL.md","sourceDigest":"c67fbb4cfc07","generatedDigest":"c67fbb4cfc07"},{"path":"agent-toolkit-complete/skills/megalinter-setup/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/megalinter-setup/SKILL.md","sourceDigest":"8742a0343d9b","generatedDigest":"8742a0343d9b"},{"path":"agent-toolkit-complete/skills/megalinter-check/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/megalinter-check/SKILL.md","sourceDigest":"e6e847180507","generatedDigest":"e6e847180507"},{"path":"agent-toolkit-complete/skills/megalinter-fix/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/megalinter-fix/SKILL.md","sourceDigest":"6cc38525a2b8","generatedDigest":"6cc38525a2b8"},{"path":"agent-toolkit-complete/skills/codeql/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/codeql/SKILL.md","sourceDigest":"cad085cedc79","generatedDigest":"cad085cedc79"},{"path":"agent-toolkit-complete/skills/codeql/references/codeql-queries.md","sourceFile":"/tmp/agent-toolkit/skills/quality/codeql/references/codeql-queries.md","sourceDigest":"24a02b9dd516","generatedDigest":"24a02b9dd516"},{"path":"agent-toolkit-complete/skills/unslop/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/unslop/SKILL.md","sourceDigest":"68146c649097","generatedDigest":"68146c649097"},{"path":"agent-toolkit-complete/skills/deslop/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/deslop/SKILL.md","sourceDigest":"77d95266acf8","generatedDigest":"77d95266acf8"},{"path":"agent-toolkit-complete/skills/blast-radius/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/quality/blast-radius/SKILL.md","sourceDigest":"6ada7029300f","generatedDigest":"6ada7029300f"},{"path":"agent-toolkit-complete/skills/chrome-devtools/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/chrome-devtools/SKILL.md","sourceDigest":"81a9dbb9ba16","generatedDigest":"81a9dbb9ba16"},{"path":"agent-toolkit-complete/skills/playwright-cli/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/playwright-cli/SKILL.md","sourceDigest":"ee541f4d9895","generatedDigest":"ee541f4d9895"},{"path":"agent-toolkit-complete/skills/playwright-cli/references/workflows.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/playwright-cli/references/workflows.md","sourceDigest":"545a3b1a48a3","generatedDigest":"545a3b1a48a3"},{"path":"agent-toolkit-complete/skills/playwright-cli/references/cli.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/playwright-cli/references/cli.md","sourceDigest":"a78a986f91bc","generatedDigest":"a78a986f91bc"},{"path":"agent-toolkit-complete/skills/project/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/project/SKILL.md","sourceDigest":"267f5549391c","generatedDigest":"267f5549391c"},{"path":"agent-toolkit-complete/skills/workspace/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/workspace/SKILL.md","sourceDigest":"e950294a680d","generatedDigest":"e950294a680d"},{"path":"agent-toolkit-complete/skills/worktree/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/forge/worktree/SKILL.md","sourceDigest":"7303ece6d351","generatedDigest":"7303ece6d351"},{"path":"agent-toolkit-complete/skills/mcp/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/integrations/mcp/SKILL.md","sourceDigest":"e7f61f94c702","generatedDigest":"e7f61f94c702"},{"path":"agent-toolkit-complete/skills/cloud-design-patterns/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/cloud/cloud-design-patterns/SKILL.md","sourceDigest":"60e4d70ada55","generatedDigest":"60e4d70ada55"},{"path":"agent-toolkit-complete/skills/aws-well-architected-review/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/cloud/aws-well-architected-review/SKILL.md","sourceDigest":"5267e9a97a72","generatedDigest":"5267e9a97a72"},{"path":"agent-toolkit-complete/skills/mermaid/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/tooling/mermaid/SKILL.md","sourceDigest":"bd9c1c623d0c","generatedDigest":"bd9c1c623d0c"},{"path":"agent-toolkit-complete/skills/c4-model/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/architecture/c4-model/SKILL.md","sourceDigest":"65b2d4c2f03c","generatedDigest":"65b2d4c2f03c"}]}
+{
+  "generatorVersion": "1.17.0",
+  "product": "agent-toolkit-complete",
+  "target": "agent-plugins",
+  "artifacts": [
+    {
+      "path": "agent-toolkit-complete/plugin.json",
+      "sourceFile": "generated",
+      "sourceDigest": "n/a",
+      "generatedDigest": "5d6c60852e32"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/assistant/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/SKILL.md",
+      "sourceDigest": "594d0f376a14",
+      "generatedDigest": "594d0f376a14"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/assistant/references/REPO_INSPECTION.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/references/REPO_INSPECTION.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/assistant/references/ORCHESTRATION.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/references/ORCHESTRATION.md",
+      "sourceDigest": "fac96733592b",
+      "generatedDigest": "fac96733592b"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/assistant/references/AGENTS_TEMPLATE.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/references/AGENTS_TEMPLATE.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/dev-companion/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/dev-companion/SKILL.md",
+      "sourceDigest": "cb145011d670",
+      "generatedDigest": "cb145011d670"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/dev-companion/references/LOOP_GUARDRAILS.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/dev-companion/references/LOOP_GUARDRAILS.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/onboarding/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/onboarding/SKILL.md",
+      "sourceDigest": "441d78df299d",
+      "generatedDigest": "441d78df299d"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/output-handshake/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/output-handshake/SKILL.md",
+      "sourceDigest": "6788635e1f67",
+      "generatedDigest": "6788635e1f67"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/pr-fallback/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/pr-fallback/SKILL.md",
+      "sourceDigest": "4a57cea05792",
+      "generatedDigest": "4a57cea05792"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/pr-fallback/references/pr-body-default.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/pr-fallback/references/pr-body-default.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/workspace-knowledge-sync/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/workspace-knowledge-sync/SKILL.md",
+      "sourceDigest": "5e715edb4fe1",
+      "generatedDigest": "5e715edb4fe1"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/dbt-validation/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/data/dbt-validation/SKILL.md",
+      "sourceDigest": "6d180ee3b0fe",
+      "generatedDigest": "6d180ee3b0fe"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/snowflake-validation/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/data/snowflake-validation/SKILL.md",
+      "sourceDigest": "4eadae9c015d",
+      "generatedDigest": "4eadae9c015d"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/adr/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/adr/SKILL.md",
+      "sourceDigest": "84613c43c11f",
+      "generatedDigest": "84613c43c11f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/adr/references/example-001-graphql-adoption.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/adr/references/example-001-graphql-adoption.md",
+      "sourceDigest": "c963cd0f4c82",
+      "generatedDigest": "c963cd0f4c82"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/adr/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/adr/references/default-template.md",
+      "sourceDigest": "af47d8f458ce",
+      "generatedDigest": "af47d8f458ce"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/agreement/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/agreement/SKILL.md",
+      "sourceDigest": "f13e000487d5",
+      "generatedDigest": "f13e000487d5"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/agreement/references/example-api-versioning.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/agreement/references/example-api-versioning.md",
+      "sourceDigest": "f5bbfcea1a40",
+      "generatedDigest": "f5bbfcea1a40"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/agreement/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/agreement/references/default-template.md",
+      "sourceDigest": "87f78f74499e",
+      "generatedDigest": "87f78f74499e"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/bug/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/bug/SKILL.md",
+      "sourceDigest": "70f50ca342a0",
+      "generatedDigest": "70f50ca342a0"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/bug/references/example-search-filter-bug.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/bug/references/example-search-filter-bug.md",
+      "sourceDigest": "04be13752319",
+      "generatedDigest": "04be13752319"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/bug/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/bug/references/default-template.md",
+      "sourceDigest": "3b96fd29bbe4",
+      "generatedDigest": "3b96fd29bbe4"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/decision-log/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/decision-log/SKILL.md",
+      "sourceDigest": "d36e09995230",
+      "generatedDigest": "d36e09995230"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/decision-log/references/example-repository-pattern.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/decision-log/references/example-repository-pattern.md",
+      "sourceDigest": "ffdbbd48a5a7",
+      "generatedDigest": "ffdbbd48a5a7"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/decision-log/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/decision-log/references/default-template.md",
+      "sourceDigest": "446f1b1189fc",
+      "generatedDigest": "446f1b1189fc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/development-workflow/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/development-workflow/SKILL.md",
+      "sourceDigest": "d4f42f72e015",
+      "generatedDigest": "d4f42f72e015"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/development-workflow/references/default-workflow-checklist.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/development-workflow/references/default-workflow-checklist.md",
+      "sourceDigest": "06cb550e2fe4",
+      "generatedDigest": "06cb550e2fe4"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/epic/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/epic/SKILL.md",
+      "sourceDigest": "f19ef11e00b7",
+      "generatedDigest": "f19ef11e00b7"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/epic/references/example-unified-dashboard.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/epic/references/example-unified-dashboard.md",
+      "sourceDigest": "509f55fc6a30",
+      "generatedDigest": "509f55fc6a30"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/epic/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/epic/references/default-template.md",
+      "sourceDigest": "0ae47ea138d0",
+      "generatedDigest": "0ae47ea138d0"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/incident/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/incident/SKILL.md",
+      "sourceDigest": "e275ca28ca5e",
+      "generatedDigest": "e275ca28ca5e"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/incident/references/example-payment-outage.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/incident/references/example-payment-outage.md",
+      "sourceDigest": "0d3fc61f10d9",
+      "generatedDigest": "0d3fc61f10d9"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/incident/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/incident/references/default-template.md",
+      "sourceDigest": "fd880a679199",
+      "generatedDigest": "fd880a679199"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/management-unit-assessment/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/management-unit-assessment/SKILL.md",
+      "sourceDigest": "29c025f4c96a",
+      "generatedDigest": "29c025f4c96a"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/management-unit-assessment/references/example-team-assessment.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/management-unit-assessment/references/example-team-assessment.md",
+      "sourceDigest": "56017d2a21fd",
+      "generatedDigest": "56017d2a21fd"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/management-unit-assessment/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/management-unit-assessment/references/default-template.md",
+      "sourceDigest": "7ab8856f4700",
+      "generatedDigest": "7ab8856f4700"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/meeting-minutes/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/meeting-minutes/SKILL.md",
+      "sourceDigest": "c0aa9c46d9f5",
+      "generatedDigest": "c0aa9c46d9f5"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/meeting-minutes/references/example-weekly-sync.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/meeting-minutes/references/example-weekly-sync.md",
+      "sourceDigest": "dff943b160c7",
+      "generatedDigest": "dff943b160c7"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/meeting-minutes/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/meeting-minutes/references/default-template.md",
+      "sourceDigest": "4d5a3919db35",
+      "generatedDigest": "4d5a3919db35"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/planning/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/planning/SKILL.md",
+      "sourceDigest": "129d731aba0f",
+      "generatedDigest": "129d731aba0f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/planning/references/example-sprint-planning.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/planning/references/example-sprint-planning.md",
+      "sourceDigest": "4a36df7d4319",
+      "generatedDigest": "4a36df7d4319"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/planning/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/planning/references/default-template.md",
+      "sourceDigest": "32c67e6f6b55",
+      "generatedDigest": "32c67e6f6b55"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/prd/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/prd/SKILL.md",
+      "sourceDigest": "0d93a06db51f",
+      "generatedDigest": "0d93a06db51f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/prd/references/example-unified-api.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/prd/references/example-unified-api.md",
+      "sourceDigest": "1799c99217c8",
+      "generatedDigest": "1799c99217c8"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/prd/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/prd/references/default-template.md",
+      "sourceDigest": "7baacc8afed8",
+      "generatedDigest": "7baacc8afed8"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/project-assessment/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/project-assessment/SKILL.md",
+      "sourceDigest": "4825e39ced22",
+      "generatedDigest": "4825e39ced22"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/project-assessment/references/example-platform-assessment.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/project-assessment/references/example-platform-assessment.md",
+      "sourceDigest": "95d5cd12c4d3",
+      "generatedDigest": "95d5cd12c4d3"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/project-assessment/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/project-assessment/references/default-template.md",
+      "sourceDigest": "ba7323b39ec5",
+      "generatedDigest": "ba7323b39ec5"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/project-assessment-evidence/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/project-assessment-evidence/SKILL.md",
+      "sourceDigest": "f6720f1026d5",
+      "generatedDigest": "f6720f1026d5"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/project-assessment-evidence/references/example-evidence-map.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/project-assessment-evidence/references/example-evidence-map.md",
+      "sourceDigest": "ce2c4cec9e46",
+      "generatedDigest": "ce2c4cec9e46"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/project-assessment-evidence/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/project-assessment-evidence/references/default-template.md",
+      "sourceDigest": "3e490c54ab95",
+      "generatedDigest": "3e490c54ab95"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/spike/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/spike/SKILL.md",
+      "sourceDigest": "8bb9e72fff5d",
+      "generatedDigest": "8bb9e72fff5d"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/spike/references/example-graphql-federation.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/spike/references/example-graphql-federation.md",
+      "sourceDigest": "d553e4a078ce",
+      "generatedDigest": "d553e4a078ce"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/spike/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/spike/references/default-template.md",
+      "sourceDigest": "87f3ac6e496f",
+      "generatedDigest": "87f3ac6e496f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/task/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/task/SKILL.md",
+      "sourceDigest": "fa56bf88586e",
+      "generatedDigest": "fa56bf88586e"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/task/references/example-nav-system.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/task/references/example-nav-system.md",
+      "sourceDigest": "69a43bd02605",
+      "generatedDigest": "69a43bd02605"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/task/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/task/references/default-template.md",
+      "sourceDigest": "a16314295ee8",
+      "generatedDigest": "a16314295ee8"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/technical-unit-assessment/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/SKILL.md",
+      "sourceDigest": "676a0fb1c91a",
+      "generatedDigest": "676a0fb1c91a"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/technical-unit-assessment/references/indicator-groups.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/references/indicator-groups.md",
+      "sourceDigest": "706e313123b1",
+      "generatedDigest": "706e313123b1"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/technical-unit-assessment/references/example-frontend-assessment.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/references/example-frontend-assessment.md",
+      "sourceDigest": "f49d04307787",
+      "generatedDigest": "f49d04307787"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/technical-unit-assessment/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/technical-unit-assessment/references/default-template.md",
+      "sourceDigest": "0bb95c977466",
+      "generatedDigest": "0bb95c977466"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/trd/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/trd/SKILL.md",
+      "sourceDigest": "0b8cafc07d70",
+      "generatedDigest": "0b8cafc07d70"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/trd/references/example-api-migration.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/trd/references/example-api-migration.md",
+      "sourceDigest": "a8fd88e1927a",
+      "generatedDigest": "a8fd88e1927a"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/trd/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/trd/references/default-template.md",
+      "sourceDigest": "a8674fef47b2",
+      "generatedDigest": "a8674fef47b2"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/user-story/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/user-story/SKILL.md",
+      "sourceDigest": "91e413abe065",
+      "generatedDigest": "91e413abe065"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/user-story/references/example-advanced-filtering.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/user-story/references/example-advanced-filtering.md",
+      "sourceDigest": "20d95e43e9dc",
+      "generatedDigest": "20d95e43e9dc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/user-story/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/user-story/references/default-template.md",
+      "sourceDigest": "165f9da7ac52",
+      "generatedDigest": "165f9da7ac52"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/work-item/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/work-item/SKILL.md",
+      "sourceDigest": "79c16b141a87",
+      "generatedDigest": "79c16b141a87"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/work-item/references/example-routing-dashboard.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/work-item/references/example-routing-dashboard.md",
+      "sourceDigest": "fb72ff9ec30d",
+      "generatedDigest": "fb72ff9ec30d"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/work-item/references/default-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/work-item/references/default-template.md",
+      "sourceDigest": "e4f6ba16019b",
+      "generatedDigest": "e4f6ba16019b"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/workflow-client-bootstrap/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/workflow-client-bootstrap/SKILL.md",
+      "sourceDigest": "b6d6a3e237c9",
+      "generatedDigest": "b6d6a3e237c9"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/workflow-generic-project/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/delivery/workflow-generic-project/SKILL.md",
+      "sourceDigest": "3e9b3acfb76a",
+      "generatedDigest": "3e9b3acfb76a"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma/SKILL.md",
+      "sourceDigest": "082616c0497b",
+      "generatedDigest": "082616c0497b"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma/references/figma-tools-and-prompts.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma/references/figma-tools-and-prompts.md",
+      "sourceDigest": "428add063f23",
+      "generatedDigest": "428add063f23"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma/references/figma-mcp-config.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma/references/figma-mcp-config.md",
+      "sourceDigest": "15392180e305",
+      "generatedDigest": "15392180e305"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma-code-connect-components/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma-code-connect-components/SKILL.md",
+      "sourceDigest": "fec6d6496ccb",
+      "generatedDigest": "fec6d6496ccb"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma-code-connect-components/references/mapping-checklist.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma-code-connect-components/references/mapping-checklist.md",
+      "sourceDigest": "81f85e1eb6c5",
+      "generatedDigest": "81f85e1eb6c5"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma-create-design-system-rules/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma-create-design-system-rules/SKILL.md",
+      "sourceDigest": "b4b0264b7220",
+      "generatedDigest": "b4b0264b7220"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma-create-design-system-rules/references/rule-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma-create-design-system-rules/references/rule-template.md",
+      "sourceDigest": "78947775e307",
+      "generatedDigest": "78947775e307"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma-create-new-file/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma-create-new-file/SKILL.md",
+      "sourceDigest": "1bd05e4db51c",
+      "generatedDigest": "1bd05e4db51c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/figma-implement-design/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/figma-implement-design/SKILL.md",
+      "sourceDigest": "b0998ad1f5a2",
+      "generatedDigest": "b0998ad1f5a2"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/design-assessment/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/design-assessment/SKILL.md",
+      "sourceDigest": "28e249cf36ec",
+      "generatedDigest": "28e249cf36ec"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/design-assessment/references/design-scorecard-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/design-assessment/references/design-scorecard-template.md",
+      "sourceDigest": "8f4da244c422",
+      "generatedDigest": "8f4da244c422"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/design-improvement/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/design-improvement/SKILL.md",
+      "sourceDigest": "54ba177c2844",
+      "generatedDigest": "54ba177c2844"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/design-improvement/references/improvement-plan-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/design-improvement/references/improvement-plan-template.md",
+      "sourceDigest": "9923920585e2",
+      "generatedDigest": "9923920585e2"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/frontend-design/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/frontend-design/SKILL.md",
+      "sourceDigest": "6a714fca842a",
+      "generatedDigest": "6a714fca842a"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/frontend-design-review/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/frontend-design-review/SKILL.md",
+      "sourceDigest": "52a8648b5c7c",
+      "generatedDigest": "52a8648b5c7c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/frontend-design-review/references/review-type-modifiers.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/frontend-design-review/references/review-type-modifiers.md",
+      "sourceDigest": "a8e2347d4195",
+      "generatedDigest": "a8e2347d4195"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/frontend-design-review/references/review-output-format.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/frontend-design-review/references/review-output-format.md",
+      "sourceDigest": "0735f13a4eff",
+      "generatedDigest": "0735f13a4eff"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/frontend-design-review/references/quick-checklist.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/frontend-design-review/references/quick-checklist.md",
+      "sourceDigest": "8043fd995ae8",
+      "generatedDigest": "8043fd995ae8"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/frontend-design-review/references/pattern-examples.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/frontend-design-review/references/pattern-examples.md",
+      "sourceDigest": "072f2a647de3",
+      "generatedDigest": "072f2a647de3"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/web-design-guidelines/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/web-design-guidelines/SKILL.md",
+      "sourceDigest": "079555dcf79f",
+      "generatedDigest": "079555dcf79f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/web-design-guidelines/references/web-interface-guidelines.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/web-design-guidelines/references/web-interface-guidelines.md",
+      "sourceDigest": "eea73cb6dd46",
+      "generatedDigest": "eea73cb6dd46"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/web-design-guidelines/references/LICENSE",
+      "sourceFile": "/tmp/agent-toolkit/skills/design/web-design-guidelines/references/LICENSE",
+      "sourceDigest": "6cd1609c9c12",
+      "generatedDigest": "6cd1609c9c12"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/supply-chain-audit/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/agentic-security/supply-chain-audit/SKILL.md",
+      "sourceDigest": "fba4830eb1fc",
+      "generatedDigest": "fba4830eb1fc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/fix-merge-conflicts/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/fix-merge-conflicts/SKILL.md",
+      "sourceDigest": "ada35e42bf19",
+      "generatedDigest": "ada35e42bf19"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/gh-address-comments/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/gh-address-comments/SKILL.md",
+      "sourceDigest": "83ac0e2e372d",
+      "generatedDigest": "83ac0e2e372d"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/gh-contribution-planner/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/gh-contribution-planner/SKILL.md",
+      "sourceDigest": "dc7ae8e23af3",
+      "generatedDigest": "dc7ae8e23af3"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/gh-fix-ci/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/gh-fix-ci/SKILL.md",
+      "sourceDigest": "a8137bb752a7",
+      "generatedDigest": "a8137bb752a7"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/github-cli-workflow/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/github-cli-workflow/SKILL.md",
+      "sourceDigest": "618084f066f5",
+      "generatedDigest": "618084f066f5"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/gitlab-cli-workflow/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/gitlab-cli-workflow/SKILL.md",
+      "sourceDigest": "dc6f673c9f44",
+      "generatedDigest": "dc6f673c9f44"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/workflow-client-bootstrap/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/workflow-client-bootstrap/SKILL.md",
+      "sourceDigest": "49cf32c2bd7c",
+      "generatedDigest": "49cf32c2bd7c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/workflow-generic-project/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/workflow-generic-project/SKILL.md",
+      "sourceDigest": "6e7460cb935b",
+      "generatedDigest": "6e7460cb935b"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/clickup-cli/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/clickup-cli/SKILL.md",
+      "sourceDigest": "70b8cd4895f4",
+      "generatedDigest": "70b8cd4895f4"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/clickup-cli/references/time-tracking.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/clickup-cli/references/time-tracking.md",
+      "sourceDigest": "d42bd69d71f3",
+      "generatedDigest": "d42bd69d71f3"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/clickup-cli/references/task-management.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/clickup-cli/references/task-management.md",
+      "sourceDigest": "c052630a13e0",
+      "generatedDigest": "c052630a13e0"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/clickup-cli/references/docs-management.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/clickup-cli/references/docs-management.md",
+      "sourceDigest": "2f2a9bbb7958",
+      "generatedDigest": "2f2a9bbb7958"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/linear/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/linear/SKILL.md",
+      "sourceDigest": "a754121f7305",
+      "generatedDigest": "a754121f7305"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/slack-assistant/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/slack-assistant/SKILL.md",
+      "sourceDigest": "ca78bf35e508",
+      "generatedDigest": "ca78bf35e508"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/slack-cli/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/slack-cli/SKILL.md",
+      "sourceDigest": "1230496dec64",
+      "generatedDigest": "1230496dec64"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/slack-cli/references/INSTALLATION.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/slack-cli/references/INSTALLATION.md",
+      "sourceDigest": "da2cd2a943d7",
+      "generatedDigest": "da2cd2a943d7"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/loop-runner/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/loops/loop-runner/SKILL.md",
+      "sourceDigest": "6491c61915a1",
+      "generatedDigest": "6491c61915a1"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/docs-generator/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/ops/docs-generator/SKILL.md",
+      "sourceDigest": "af8059a9aa96",
+      "generatedDigest": "af8059a9aa96"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/llm-cost-advisor/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/ops/llm-cost-advisor/SKILL.md",
+      "sourceDigest": "a2618beaa316",
+      "generatedDigest": "a2618beaa316"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/swarm/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/ops/swarm/SKILL.md",
+      "sourceDigest": "d55d5a4a7756",
+      "generatedDigest": "d55d5a4a7756"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/swarm-handoff/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/ops/swarm-handoff/SKILL.md",
+      "sourceDigest": "970cefce234c",
+      "generatedDigest": "970cefce234c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/swarm-observer/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/ops/swarm-observer/SKILL.md",
+      "sourceDigest": "e1f29e946fdb",
+      "generatedDigest": "e1f29e946fdb"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/triage/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/ops/triage/SKILL.md",
+      "sourceDigest": "c7238486db2c",
+      "generatedDigest": "c7238486db2c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/herdr/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/herdr/SKILL.md",
+      "sourceDigest": "3bad25c18389",
+      "generatedDigest": "3bad25c18389"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/cli-for-agents/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/cli-for-agents/SKILL.md",
+      "sourceDigest": "73e8703fd50e",
+      "generatedDigest": "73e8703fd50e"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/inventory/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/inventory/SKILL.md",
+      "sourceDigest": "f7843a134529",
+      "generatedDigest": "f7843a134529"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/jupyter-notebook/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/jupyter-notebook/SKILL.md",
+      "sourceDigest": "1dbad970a4f1",
+      "generatedDigest": "1dbad970a4f1"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/jupyter-notebook/references/tutorial-patterns.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/tutorial-patterns.md",
+      "sourceDigest": "8c194bb640de",
+      "generatedDigest": "8c194bb640de"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/jupyter-notebook/references/quality-checklist.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/quality-checklist.md",
+      "sourceDigest": "ed01afe6ff47",
+      "generatedDigest": "ed01afe6ff47"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/jupyter-notebook/references/notebook-structure.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/notebook-structure.md",
+      "sourceDigest": "9a6f1c649af5",
+      "generatedDigest": "9a6f1c649af5"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/jupyter-notebook/references/experiment-patterns.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/jupyter-notebook/references/experiment-patterns.md",
+      "sourceDigest": "1ff9c04281c0",
+      "generatedDigest": "1ff9c04281c0"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/review/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/accessibility/review/SKILL.md",
+      "sourceDigest": "43313ce15d28",
+      "generatedDigest": "43313ce15d28"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/review/references/research.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/accessibility/review/references/research.md",
+      "sourceDigest": "1520d7b7250c",
+      "generatedDigest": "1520d7b7250c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/review/references/a11y-findings-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/accessibility/review/references/a11y-findings-template.md",
+      "sourceDigest": "2dd9f2eb4c51",
+      "generatedDigest": "2dd9f2eb4c51"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/review/references/a11y-checklist.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/accessibility/review/references/a11y-checklist.md",
+      "sourceDigest": "02d5f32242df",
+      "generatedDigest": "02d5f32242df"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/mcp-audit/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/agentic-security/mcp-audit/SKILL.md",
+      "sourceDigest": "b4ee4c43c3df",
+      "generatedDigest": "b4ee4c43c3df"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/mcp-audit/references/mcp-audit-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/agentic-security/mcp-audit/references/mcp-audit-template.md",
+      "sourceDigest": "c5a0b8677ddf",
+      "generatedDigest": "c5a0b8677ddf"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/owasp-agentic-review/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/agentic-security/owasp-agentic-review/SKILL.md",
+      "sourceDigest": "50706d049435",
+      "generatedDigest": "50706d049435"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/owasp-agentic-review/references/owasp-agentic-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/agentic-security/owasp-agentic-review/references/owasp-agentic-template.md",
+      "sourceDigest": "e393481aa492",
+      "generatedDigest": "e393481aa492"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/threat-modeling/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/agentic-security/threat-modeling/SKILL.md",
+      "sourceDigest": "9c8b7ecf285f",
+      "generatedDigest": "9c8b7ecf285f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/threat-modeling/references/threat-model-template.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/agentic-security/threat-modeling/references/threat-model-template.md",
+      "sourceDigest": "0e2b9fac163f",
+      "generatedDigest": "0e2b9fac163f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/megalinter/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/megalinter/SKILL.md",
+      "sourceDigest": "c67fbb4cfc07",
+      "generatedDigest": "c67fbb4cfc07"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/megalinter-setup/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/megalinter-setup/SKILL.md",
+      "sourceDigest": "8742a0343d9b",
+      "generatedDigest": "8742a0343d9b"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/megalinter-check/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/megalinter-check/SKILL.md",
+      "sourceDigest": "e6e847180507",
+      "generatedDigest": "e6e847180507"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/megalinter-fix/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/megalinter-fix/SKILL.md",
+      "sourceDigest": "6cc38525a2b8",
+      "generatedDigest": "6cc38525a2b8"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/codeql/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/codeql/SKILL.md",
+      "sourceDigest": "cad085cedc79",
+      "generatedDigest": "cad085cedc79"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/codeql/references/codeql-queries.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/codeql/references/codeql-queries.md",
+      "sourceDigest": "24a02b9dd516",
+      "generatedDigest": "24a02b9dd516"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/unslop/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/unslop/SKILL.md",
+      "sourceDigest": "68146c649097",
+      "generatedDigest": "68146c649097"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/deslop/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/deslop/SKILL.md",
+      "sourceDigest": "77d95266acf8",
+      "generatedDigest": "77d95266acf8"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/blast-radius/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/quality/blast-radius/SKILL.md",
+      "sourceDigest": "6ada7029300f",
+      "generatedDigest": "6ada7029300f"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/chrome-devtools/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/chrome-devtools/SKILL.md",
+      "sourceDigest": "81a9dbb9ba16",
+      "generatedDigest": "81a9dbb9ba16"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/playwright-cli/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/playwright-cli/SKILL.md",
+      "sourceDigest": "ee541f4d9895",
+      "generatedDigest": "ee541f4d9895"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/playwright-cli/references/workflows.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/playwright-cli/references/workflows.md",
+      "sourceDigest": "545a3b1a48a3",
+      "generatedDigest": "545a3b1a48a3"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/playwright-cli/references/cli.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/playwright-cli/references/cli.md",
+      "sourceDigest": "a78a986f91bc",
+      "generatedDigest": "a78a986f91bc"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/project/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/project/SKILL.md",
+      "sourceDigest": "267f5549391c",
+      "generatedDigest": "267f5549391c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/workspace/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/workspace/SKILL.md",
+      "sourceDigest": "e950294a680d",
+      "generatedDigest": "e950294a680d"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/worktree/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/forge/worktree/SKILL.md",
+      "sourceDigest": "7303ece6d351",
+      "generatedDigest": "7303ece6d351"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/mcp/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/integrations/mcp/SKILL.md",
+      "sourceDigest": "e7f61f94c702",
+      "generatedDigest": "e7f61f94c702"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/cloud-design-patterns/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/cloud/cloud-design-patterns/SKILL.md",
+      "sourceDigest": "60e4d70ada55",
+      "generatedDigest": "60e4d70ada55"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/aws-well-architected-review/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/cloud/aws-well-architected-review/SKILL.md",
+      "sourceDigest": "5267e9a97a72",
+      "generatedDigest": "5267e9a97a72"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/mermaid/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/tooling/mermaid/SKILL.md",
+      "sourceDigest": "bd9c1c623d0c",
+      "generatedDigest": "bd9c1c623d0c"
+    },
+    {
+      "path": "agent-toolkit-complete/skills/c4-model/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/architecture/c4-model/SKILL.md",
+      "sourceDigest": "65b2d4c2f03c",
+      "generatedDigest": "65b2d4c2f03c"
+    }
+  ]
+}

--- a/plugins/agent-toolkit-complete/skills/assistant/references/ORCHESTRATION.md
+++ b/plugins/agent-toolkit-complete/skills/assistant/references/ORCHESTRATION.md
@@ -76,7 +76,7 @@ Reserved for anti-slop, static analysis, and deep review. Skills in this section
 | Domain | Skills | When to route |
 |--------|--------|---------------|
 | Figma | **figma**, **figma-implement-design**, **figma-code-connect-components** | Design-to-code, MCP |
-| Visual design | **frontend-design**, **frontend-design-review**, **ui-ux-pro-max** | UI aesthetics and review |
+| Visual design | **frontend-design**, **frontend-design-review** | UI aesthetics and review |
 | Guidelines | **web-design-guidelines** | Vercel web interface guidelines |
 
 ---

--- a/plugins/agent-toolkit-core/.github/skills/assistant/references/ORCHESTRATION.md
+++ b/plugins/agent-toolkit-core/.github/skills/assistant/references/ORCHESTRATION.md
@@ -76,7 +76,7 @@ Reserved for anti-slop, static analysis, and deep review. Skills in this section
 | Domain | Skills | When to route |
 |--------|--------|---------------|
 | Figma | **figma**, **figma-implement-design**, **figma-code-connect-components** | Design-to-code, MCP |
-| Visual design | **frontend-design**, **frontend-design-review**, **ui-ux-pro-max** | UI aesthetics and review |
+| Visual design | **frontend-design**, **frontend-design-review** | UI aesthetics and review |
 | Guidelines | **web-design-guidelines** | Vercel web interface guidelines |
 
 ---

--- a/plugins/agent-toolkit-core/.opencode/skills/assistant/references/ORCHESTRATION.md
+++ b/plugins/agent-toolkit-core/.opencode/skills/assistant/references/ORCHESTRATION.md
@@ -76,7 +76,7 @@ Reserved for anti-slop, static analysis, and deep review. Skills in this section
 | Domain | Skills | When to route |
 |--------|--------|---------------|
 | Figma | **figma**, **figma-implement-design**, **figma-code-connect-components** | Design-to-code, MCP |
-| Visual design | **frontend-design**, **frontend-design-review**, **ui-ux-pro-max** | UI aesthetics and review |
+| Visual design | **frontend-design**, **frontend-design-review** | UI aesthetics and review |
 | Guidelines | **web-design-guidelines** | Vercel web interface guidelines |
 
 ---

--- a/plugins/agent-toolkit-core/.provenance.json
+++ b/plugins/agent-toolkit-core/.provenance.json
@@ -1,1 +1,79 @@
-{"generatorVersion":"1.17.0","product":"agent-toolkit-core","target":"agent-plugins","artifacts":[{"path":"agent-toolkit-core/plugin.json","sourceFile":"generated","sourceDigest":"n/a","generatedDigest":"6261fab3b2f6"},{"path":"agent-toolkit-core/skills/assistant/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/SKILL.md","sourceDigest":"594d0f376a14","generatedDigest":"594d0f376a14"},{"path":"agent-toolkit-core/skills/assistant/references/REPO_INSPECTION.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/references/REPO_INSPECTION.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-core/skills/assistant/references/ORCHESTRATION.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/references/ORCHESTRATION.md","sourceDigest":"eb16fb608d67","generatedDigest":"eb16fb608d67"},{"path":"agent-toolkit-core/skills/assistant/references/AGENTS_TEMPLATE.md","sourceFile":"/tmp/agent-toolkit/skills/core/assistant/references/AGENTS_TEMPLATE.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-core/skills/dev-companion/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/dev-companion/SKILL.md","sourceDigest":"cb145011d670","generatedDigest":"cb145011d670"},{"path":"agent-toolkit-core/skills/dev-companion/references/LOOP_GUARDRAILS.md","sourceFile":"/tmp/agent-toolkit/skills/core/dev-companion/references/LOOP_GUARDRAILS.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-core/skills/output-handshake/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/output-handshake/SKILL.md","sourceDigest":"6788635e1f67","generatedDigest":"6788635e1f67"},{"path":"agent-toolkit-core/skills/pr-fallback/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/pr-fallback/SKILL.md","sourceDigest":"4a57cea05792","generatedDigest":"4a57cea05792"},{"path":"agent-toolkit-core/skills/pr-fallback/references/pr-body-default.md","sourceFile":"/tmp/agent-toolkit/skills/core/pr-fallback/references/pr-body-default.md","sourceDigest":"e3b0c44298fc","generatedDigest":"e3b0c44298fc"},{"path":"agent-toolkit-core/skills/workspace-knowledge-sync/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/workspace-knowledge-sync/SKILL.md","sourceDigest":"5e715edb4fe1","generatedDigest":"5e715edb4fe1"},{"path":"agent-toolkit-core/skills/onboarding/SKILL.md","sourceFile":"/tmp/agent-toolkit/skills/core/onboarding/SKILL.md","sourceDigest":"441d78df299d","generatedDigest":"441d78df299d"}]}
+{
+  "generatorVersion": "1.17.0",
+  "product": "agent-toolkit-core",
+  "target": "agent-plugins",
+  "artifacts": [
+    {
+      "path": "agent-toolkit-core/plugin.json",
+      "sourceFile": "generated",
+      "sourceDigest": "n/a",
+      "generatedDigest": "6261fab3b2f6"
+    },
+    {
+      "path": "agent-toolkit-core/skills/assistant/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/SKILL.md",
+      "sourceDigest": "594d0f376a14",
+      "generatedDigest": "594d0f376a14"
+    },
+    {
+      "path": "agent-toolkit-core/skills/assistant/references/REPO_INSPECTION.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/references/REPO_INSPECTION.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-core/skills/assistant/references/ORCHESTRATION.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/references/ORCHESTRATION.md",
+      "sourceDigest": "fac96733592b",
+      "generatedDigest": "fac96733592b"
+    },
+    {
+      "path": "agent-toolkit-core/skills/assistant/references/AGENTS_TEMPLATE.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/assistant/references/AGENTS_TEMPLATE.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-core/skills/dev-companion/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/dev-companion/SKILL.md",
+      "sourceDigest": "cb145011d670",
+      "generatedDigest": "cb145011d670"
+    },
+    {
+      "path": "agent-toolkit-core/skills/dev-companion/references/LOOP_GUARDRAILS.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/dev-companion/references/LOOP_GUARDRAILS.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-core/skills/output-handshake/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/output-handshake/SKILL.md",
+      "sourceDigest": "6788635e1f67",
+      "generatedDigest": "6788635e1f67"
+    },
+    {
+      "path": "agent-toolkit-core/skills/pr-fallback/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/pr-fallback/SKILL.md",
+      "sourceDigest": "4a57cea05792",
+      "generatedDigest": "4a57cea05792"
+    },
+    {
+      "path": "agent-toolkit-core/skills/pr-fallback/references/pr-body-default.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/pr-fallback/references/pr-body-default.md",
+      "sourceDigest": "e3b0c44298fc",
+      "generatedDigest": "e3b0c44298fc"
+    },
+    {
+      "path": "agent-toolkit-core/skills/workspace-knowledge-sync/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/workspace-knowledge-sync/SKILL.md",
+      "sourceDigest": "5e715edb4fe1",
+      "generatedDigest": "5e715edb4fe1"
+    },
+    {
+      "path": "agent-toolkit-core/skills/onboarding/SKILL.md",
+      "sourceFile": "/tmp/agent-toolkit/skills/core/onboarding/SKILL.md",
+      "sourceDigest": "441d78df299d",
+      "generatedDigest": "441d78df299d"
+    }
+  ]
+}

--- a/plugins/agent-toolkit-core/skills/assistant/references/ORCHESTRATION.md
+++ b/plugins/agent-toolkit-core/skills/assistant/references/ORCHESTRATION.md
@@ -76,7 +76,7 @@ Reserved for anti-slop, static analysis, and deep review. Skills in this section
 | Domain | Skills | When to route |
 |--------|--------|---------------|
 | Figma | **figma**, **figma-implement-design**, **figma-code-connect-components** | Design-to-code, MCP |
-| Visual design | **frontend-design**, **frontend-design-review**, **ui-ux-pro-max** | UI aesthetics and review |
+| Visual design | **frontend-design**, **frontend-design-review** | UI aesthetics and review |
 | Guidelines | **web-design-guidelines** | Vercel web interface guidelines |
 
 ---

--- a/skills/core/assistant/references/ORCHESTRATION.md
+++ b/skills/core/assistant/references/ORCHESTRATION.md
@@ -76,7 +76,7 @@ Reserved for anti-slop, static analysis, and deep review. Skills in this section
 | Domain | Skills | When to route |
 |--------|--------|---------------|
 | Figma | **figma**, **figma-implement-design**, **figma-code-connect-components** | Design-to-code, MCP |
-| Visual design | **frontend-design**, **frontend-design-review**, **ui-ux-pro-max** | UI aesthetics and review |
+| Visual design | **frontend-design**, **frontend-design-review** | UI aesthetics and review |
 | Guidelines | **web-design-guidelines** | Vercel web interface guidelines |
 
 ---


### PR DESCRIPTION
Fixes #800

## Summary
Remove ghost `ui-ux-pro-max` from `skills/core/assistant/references/ORCHESTRATION.md:79` (deleted in 09acb6d, #358, `docs/third-party/ui-ux-pro-max.md` REJECT). Compiler was copying ghost to plugins.

## Changes
- `skills/core/assistant/references/ORCHESTRATION.md` — Visual design row: `frontend-design, frontend-design-review, ui-ux-pro-max` → `frontend-design, frontend-design-review`

## Testing
- [x] `grep -r ui-ux-pro-max skills/ --include="*.md" | grep -v third-party` == 0
- [x] `./scripts/validate-skills.vsh` 84+ ok (now 86 with main updates)
