### PR TITLE
fix(packs): remove dangling loops and phantom agent

### DIFF
--- a/packs/agentic-security/config.yaml
+++ b/packs/agentic-security/config.yaml
@@ -19,7 +19,4 @@ agents:
     enabled: true
   agentic-security-reviewer:
     enabled: true
-loops:
-  security-audit:
-    enabled: false
-    cadence: 1d
+# loops: none — security-audit loop does not exist (removed, see #801)

--- a/packs/architecture/config.yaml
+++ b/packs/architecture/config.yaml
@@ -21,7 +21,4 @@ skills:
 agents:
   architect:
     enabled: true
-loops:
-  architecture-review:
-    enabled: false
-    cadence: 1w
+# loops: none — architecture-review loop does not exist (removed, see #801)

--- a/packs/delivery-discipline/config.yaml
+++ b/packs/delivery-discipline/config.yaml
@@ -40,3 +40,8 @@ agents:
     enabled: true
   planner:
     enabled: true
+
+# ---------------------------------------------------------------------------
+# Loops
+# ---------------------------------------------------------------------------
+# No loops — pack is delivery discipline only (see #801 and packs/README.md)

--- a/packs/design-engineering/config.yaml
+++ b/packs/design-engineering/config.yaml
@@ -33,9 +33,4 @@ agents:
     enabled: true
   code-reviewer:
     enabled: true
-  design-assessment:
-    enabled: true
-loops:
-  design-review:
-    enabled: false
-    cadence: 1d
+# loops: none — design-review loop does not exist (removed, see #801)

--- a/packs/engineering-workflow/config.yaml
+++ b/packs/engineering-workflow/config.yaml
@@ -19,7 +19,7 @@ version: "1.0"
 # packs/README.md and ADR-006 for the design decision.
 
 skills:
-  forge/workflow-generic-project:
+  delivery/workflow-generic-project:
     enabled: true
   delivery/development-workflow:
     enabled: true


### PR DESCRIPTION
Fixes #801

## Summary
- Remove 3 dangling loop refs (enabled:false but no `loops/<name>/loop.yaml`): `security-audit`, `architecture-review`, `design-review`
- Remove phantom agent `design-assessment` (skill, not agent) from design-engineering
- Document delivery-discipline has no loops
- Migrate `forge/workflow-generic-project` → `delivery/workflow-generic-project` (deprecated alias)

## Testing
- [x] `grep -R security-audit packs/` 0
- [x] `validate-loops.vsh` 10 ok
- [x] packs refs now resolve to catalogs

## Type
- [x] Bug fix
