### PR TITLE
docs(mcp): fix dead links MCP_TEMPLATES.md and 7 vs 8 wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ agent-toolkit doctor
       <h3>🔗 MCP</h3>
       <sub>Provider registry + ready templates (GitHub, Slack, Notion, Linear, Figma, ClickUp, Chrome DevTools) emitted into target-native MCP configs.</sub>
       <br><br>
-      <sub>7 templates · <code>mcp/registry/</code> · <code>mcp/templates/</code> · <code>agent-toolkit mcp</code></sub>
+      <sub>7 providers · <code>mcp/registry/</code> · <code>mcp/templates/</code> · <code>agent-toolkit mcp</code></sub>
     </td>
   </tr>
 </table>
@@ -474,7 +474,7 @@ agent-toolkit/
 │   ├── pi/              # Skill definitions in Pi's native format
 │   └── muse-code/       # Muse Code Agent Skills
 ├── loops/               # 10 recurring loop engineering templates
-├── mcp/templates/       # 7 MCP config templates (JSON)
+├── mcp/templates/       # 7 providers (8 JSON files — Notion has local fallback)
 ├── packs/               # 7 solution packs
 ├── catalogs/            # skill-catalog.yaml, agent-catalog.yaml
 ├── schemas/             # JSON schemas for validation

--- a/mcp/templates/figma/README.md
+++ b/mcp/templates/figma/README.md
@@ -51,4 +51,4 @@ registration time. Restart your AI tool so it re-reads the MCP config.
 
 - `~/.local/share/agent-toolkit/skills/figma/SKILL.md` and the `figma-*` skill
   family.
-- `docs/MCP_TEMPLATES.md`
+- `docs/MCP.md`

--- a/mcp/templates/linear/README.md
+++ b/mcp/templates/linear/README.md
@@ -46,4 +46,4 @@ That snippet is also embedded in `config.template.json` under the
 
 - `~/.local/share/agent-toolkit/skills/linear/SKILL.md` — the linear skill that
   drives this MCP.
-- `docs/MCP_TEMPLATES.md`
+- `docs/MCP.md`

--- a/skills/integrations/linear/SKILL.md
+++ b/skills/integrations/linear/SKILL.md
@@ -12,7 +12,7 @@ Structured workflow for managing Linear issues, projects and cycles through the
 official Linear MCP server (`https://mcp.linear.app/mcp`, OAuth).
 
 This skill assumes the MCP is wired into your AI tool. See
-[`docs/MCP_TEMPLATES.md`](../../../../../../docs/MCP_TEMPLATES.md) and
+[`docs/MCP.md`](../../../../../../docs/MCP.md) and
 `~/.local/share/agent-toolkit/mcp/linear/` for the managed template.
 
 ## When to use

--- a/skills/integrations/mcp/SKILL.md
+++ b/skills/integrations/mcp/SKILL.md
@@ -28,7 +28,7 @@ Wire **Model Context Protocol** servers so agents can call external tools (GitHu
 
 - `agent-toolkit` installed; `mcp/` definitions exist in the repo or `~/.local/share/agent-toolkit/mcp/`.
 - Auth for each provider: `gh auth login` (GitHub), `clickup auth login` (ClickUp), etc. Keys in `~/.config/agent-toolkit/` or env.
-- Target tool supports MCP (Claude Code, Cursor, OpenCode — see `mcp/README.md` and `docs/MCP.md`).
+- Target tool supports MCP (Claude Code, Cursor, OpenCode — see `docs/MCP.md`).
 
 ## Workflow
 
@@ -37,7 +37,6 @@ Wire **Model Context Protocol** servers so agents can call external tools (GitHu
 ```bash
 agent-toolkit mcp list
 agent-toolkit mcp doctor
-cat mcp/README.md
 cat docs/MCP.md
 ls mcp/
 ls ~/.local/share/agent-toolkit/mcp/ 2>&1 | head


### PR DESCRIPTION
Fixes #804

- MCP_TEMPLATES.md -> MCP.md (4 files)
- mcp/README.md -> docs/MCP.md
- 7 templates -> 7 providers (8 JSON files — Notion has local fallback)