### PR TITLE
test(layout): add coverage for skills-layout.json drift

### DIFF
--- a/tests/test_skills_layout.py
+++ b/tests/test_skills_layout.py
@@ -1,0 +1,44 @@
+"""Validate catalogs/skills-layout.json matches skill-catalog.yaml and disk."""
+
+import json
+import pathlib
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+LAYOUT = REPO / "catalogs" / "skills-layout.json"
+CATALOG = REPO / "catalogs" / "skill-catalog.yaml"
+
+
+def test_layout_equals_catalog_and_disk():
+    layout = json.loads(LAYOUT.read_text(encoding="utf-8"))
+    catalog = yaml.safe_load(CATALOG.read_text(encoding="utf-8"))
+
+    layout_ids = {s["id"] for s in layout["skills"]}
+    catalog_ids = {s["id"] for s in catalog["skills"]}
+    disk_ids = {
+        f"{p.parent.parent.name}/{p.parent.name}" for p in (REPO / "skills").rglob("SKILL.md")
+    }
+
+    # layout must equal catalog and disk
+    assert layout_ids == catalog_ids, (
+        f"layout vs catalog diff: layout - catalog {layout_ids - catalog_ids}, catalog - layout {catalog_ids - layout_ids}"
+    )
+    assert layout_ids == disk_ids, (
+        f"layout vs disk diff: {layout_ids - disk_ids} vs {disk_ids - layout_ids}"
+    )
+
+    # no ghost
+    assert "design/ui-ux-pro-max" not in layout_ids
+
+    # groups must cover all domains
+    assert set(layout["groups"].keys()) >= {
+        "accessibility",
+        "agentic-security",
+        "architecture",
+        "cloud",
+    }
+
+    # every skill in groups must match flat list
+    grouped = {f"{g}/{s}" for g, lst in layout["groups"].items() for s in lst}
+    assert grouped == layout_ids, f"groups vs flat mismatch {grouped ^ layout_ids}"


### PR DESCRIPTION
Fixes #806

## Summary
Add pytest that validates `catalogs/skills-layout.json` equals `skill-catalog.yaml` and disk, no ghost `ui-ux-pro-max`, groups cover 14 domains, and groups == flat.

## Testing
- `uv run pytest tests/test_skills_layout.py -v` fails on main (drift present) and passes after #799 merges (expected). Documents the gap.

## Type
- [x] Testing
