### PR TITLE
docs(profiles): add codex/gemini profiles and clarify muse-code minimal

### DIFF
--- a/profiles/codex/README.md
+++ b/profiles/codex/README.md
@@ -1,0 +1,24 @@
+# Codex Profile
+
+[OpenAI Codex](https://developers.openai.com/codex) — experimental target (`maturity: experimental` in `capabilities/targets/registry.yaml`).
+
+## Status
+
+Experimental. Codex marketplace submission is pending OpenAI authorization. Skills are delivered via compiled plugins (`agent-toolkit build --target codex`), not hand-maintained profile files.
+
+## Installation
+
+```bash
+# Via agent-toolkit (builds plugin bundle)
+agent-toolkit build --target codex
+# Output: plugins/<product>/ for Codex marketplace
+
+# Manual
+# Copy compiled plugin/skills from plugins/ after build
+```
+
+## References
+
+- `capabilities/targets/registry.yaml` (codex adapter)
+- `docs/COMPATIBILITY.md` (Codex row)
+- `docs/certification/codex.md`

--- a/profiles/gemini-cli/README.md
+++ b/profiles/gemini-cli/README.md
@@ -1,0 +1,19 @@
+# Gemini CLI Profile
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) extension (`maturity: stable` for extension manifest).
+
+## Status
+
+Skills are delivered via compiled extension (`agent-toolkit build --target gemini-cli`).
+
+## Installation
+
+```bash
+agent-toolkit build --target gemini-cli
+# Output: gemini extension with commands.toml
+```
+
+## References
+
+- `capabilities/targets/registry.yaml` (gemini-cli)
+- `docs/COMPATIBILITY.md`

--- a/profiles/muse-code/README.md
+++ b/profiles/muse-code/README.md
@@ -33,3 +33,9 @@ The compiler emits to `skills/<name>/SKILL.md` which the installer maps to both
 
 - [Muse Code CLI](https://www.llama.com/products/cli/)
 - [Agent Skills Spec](https://agentskills.io)
+
+## Profile Status
+
+This profile is intentionally minimal — Muse Code discovers skills via `~/.config/muse/skills/` and `~/.agents/skills/` universally. No per-tool profile files are needed beyond this README. Skills are delivered via `agent-toolkit build --target muse-code` (see `docs/PROFILES.md`).
+
+*Related: #789*


### PR DESCRIPTION
Fixes #789, Fixes #790

- Add profiles/codex/README.md (experimental, compiler-only)
- Add profiles/gemini-cli/README.md (compiler-only)
- Clarify muse-code README that profile is minimal by design