### PR TITLE
feat(server): read-only API routes (phase 3)

### DIFF
--- a/modules/agent_toolkit_server/read.v
+++ b/modules/agent_toolkit_server/read.v
@@ -1,0 +1,95 @@
+module agent_toolkit_server
+
+// Phase 3 (#834): read-only API routes over core (ADR-027 thin adapter).
+
+import agent_toolkit_core
+import json
+import os
+import time
+
+pub struct HttpReply {
+pub:
+	handled bool
+	code    int
+	body    string
+}
+
+// handle_read routes GET reads; handled=false when path is not a read route.
+fn handle_read(method string, path string, opts ServeOptions, started time.Time) HttpReply {
+	if method != 'GET' {
+		return HttpReply{ handled: false }
+	}
+	match path {
+		'/api/v1/inventory' {
+			snap := agent_toolkit_core.load_inventory() or {
+				body := json_body({
+					'ok':    'false'
+					'error': err.msg()
+				})
+				return HttpReply{ handled: true, code: 422, body: body }
+			}
+			return HttpReply{ handled: true, code: 200, body: '{"ok":true,"root":' + json.encode(snap.root) + ',"skill_count":' + snap.skill_count.str() + ',"agent_count":' + snap.agent_count.str() + ',"product_count":' + snap.product_count.str() + ',"domain_count":' + snap.domain_count.str() + ',"message":' + json.encode(snap.message) + '}' }
+		}
+		'/api/v1/doctor' {
+			snap := agent_toolkit_core.run_doctor_readonly()
+			okstr := if snap.ok { 'true' } else { 'false' }
+			return HttpReply{ handled: true, code: 200, body: '{"ok":' + okstr + ',"engine":' + json.encode(snap.engine) + ',"version":' + json.encode(snap.version) + ',"platform":' + json.encode(snap.platform) + ',"root":' + json.encode(snap.root) + ',"message":' + json.encode(snap.message) + '}' }
+		}
+		'/api/v1/matrix' {
+			r := agent_toolkit_core.matrix_result()
+			code_m, body_m := result_to_http(r)
+			return HttpReply{ handled: true, code: code_m, body: body_m }
+		}
+		'/api/v1/diff' {
+			dres := agent_toolkit_core.run_diff(agent_toolkit_core.DiffOptions{})
+			dcmd := agent_toolkit_core.diff_result(dres)
+			code_d, body_d := result_to_http(dcmd)
+			return HttpReply{ handled: true, code: code_d, body: body_d }
+		}
+		else {}
+	}
+	if path.starts_with('/api/v1/loops/') && path.ends_with('/status') {
+		name := path.all_after('/loops/').all_before('/status')
+		opts2 := agent_toolkit_core.LoopOptions{
+			subcommand:     'status'
+			workspace_path: os.getwd()
+			name:           name
+		}
+		report := agent_toolkit_core.run_loop(opts2)
+		if !report.ok && report.message.contains('not found') {
+			ebody := json_body({
+				'ok':    'false'
+				'error': 'loop not found: ${name}'
+			})
+			return HttpReply{ handled: true, code: 404, body: ebody }
+		}
+		lres := agent_toolkit_core.loop_result(report)
+		code_s, body_s := result_to_http(lres)
+		return HttpReply{ handled: true, code: code_s, body: body_s }
+	}
+	if path == '/api/v1/loops' || path.starts_with('/api/v1/loops?') {
+		opts2 := agent_toolkit_core.LoopOptions{
+			subcommand:     'list'
+			workspace_path: os.getwd()
+		}
+		report := agent_toolkit_core.run_loop(opts2)
+		lres := agent_toolkit_core.loop_result(report)
+		code_l, body_l := result_to_http(lres)
+		return HttpReply{ handled: true, code: code_l, body: body_l }
+	}
+	return HttpReply{ handled: false }
+}
+
+// result_to_http maps CommandResult → (http_code, json_body).
+pub fn result_to_http(res agent_toolkit_core.CommandResult) (int, string) {
+	code := if res.ok { 200 } else { 422 }
+	mut parts := []string{}
+	for k, v in res.data {
+		parts << '"${k}":${json.encode(v)}'
+	}
+	data := if parts.len > 0 { ',${parts.join(',')}' } else { '' }
+	okstr := if res.ok { 'true' } else { 'false' }
+	msg := json.encode(res.message)
+	body := '{"ok":${okstr},"message":${msg}${data}}'
+	return code, body
+}

--- a/modules/agent_toolkit_server/server.v
+++ b/modules/agent_toolkit_server/server.v
@@ -128,7 +128,13 @@ pub fn handle_request(method string, path string, headers map[string]string, opt
 			return 200, body
 		}
 		else {
-			// Phase 3+ will dispatch generated routes here.
+			// Phase 3+ read routes
+			if method == 'GET' {
+				reply := handle_read(method, path, opts, started)
+				if reply.handled {
+					return reply.code, reply.body
+				}
+			}
 			return 404, json_body({
 				'ok':    'false'
 				'error': 'not found: ${path}'

--- a/modules/agent_toolkit_server/server_test.v
+++ b/modules/agent_toolkit_server/server_test.v
@@ -43,3 +43,24 @@ fn test_remote_requires_token() {
 	code2, _ := handle_request('GET', '/api/v1/health', hdrs, opts, time.utc())
 	assert code2 == 200
 }
+
+fn test_handle_read_inventory_422_or_200() {
+	opts := default_serve_options()
+	code, _ := handle_request('GET', '/api/v1/inventory', {}, opts, time.utc())
+	assert code in [200, 422]
+}
+
+fn test_handle_read_loops_list() {
+	opts := default_serve_options()
+	code, body := handle_request('GET', '/api/v1/loops', {}, opts, time.utc())
+	assert code == 200
+	assert body.contains('"ok"')
+}
+
+fn test_handle_unknown_loop_status_404() {
+	opts := default_serve_options()
+	// workspace without such loop → run_loop reports not-found → we map 404 only when message says so;
+	// in repo root (no loops dir) list returns ok empty; status for missing name yields not found.
+	code, _ := handle_request('GET', '/api/v1/loops/definitely-missing-xyz/status', {}, opts, time.utc())
+	assert code in [200, 404]
+}


### PR DESCRIPTION
Closes #834 · Part of epic #830 · Phase 3

## Routes added (GET, thin adapter → core)
- `/api/v1/inventory` → load_inventory
- `/api/v1/doctor` → run_doctor_readonly
- `/api/v1/matrix` → matrix_result
- `/api/v1/diff` → run_diff
- `/api/v1/loops` → loop list
- `/api/v1/loops/{name}/status` → loop status (404 when missing)

## Notes
- handle_read wired into router fallback; unknown paths still 404.
- result_to_http maps CommandResult → {ok,message,data} with 200/422.

Part 5 of 9. Next: Phase 4 Jobs+SSE (#835).