### PR TITLE
refactor(server): migrate transport to veb (vlib/veb)

### DIFF
--- a/modules/agent_toolkit_server/read.v
+++ b/modules/agent_toolkit_server/read.v
@@ -1,93 +1,17 @@
 module agent_toolkit_server
 
-// Phase 3 (#834): read-only API routes over core (ADR-027 thin adapter).
+// Shared HTTP mapping helpers for serve routes (ADR-027 thin adapter).
 
 import agent_toolkit_core
 import json
-import os
-import time
 
-pub struct HttpReply {
-pub:
-	handled bool
-	code    int
-	body    string
-}
-
-// handle_read routes GET reads; handled=false when path is not a read route.
-fn handle_read(method string, path string, opts ServeOptions, started time.Time) HttpReply {
-	if method != 'GET' {
-		return HttpReply{ handled: false }
-	}
-	match path {
-		'/api/v1/inventory' {
-			snap := agent_toolkit_core.load_inventory() or {
-				body := json_body({
-					'ok':    'false'
-					'error': err.msg()
-				})
-				return HttpReply{ handled: true, code: 422, body: body }
-			}
-			return HttpReply{ handled: true, code: 200, body: '{"ok":true,"root":' + json.encode(snap.root) + ',"skill_count":' + snap.skill_count.str() + ',"agent_count":' + snap.agent_count.str() + ',"product_count":' + snap.product_count.str() + ',"domain_count":' + snap.domain_count.str() + ',"message":' + json.encode(snap.message) + '}' }
-		}
-		'/api/v1/doctor' {
-			snap := agent_toolkit_core.run_doctor_readonly()
-			okstr := if snap.ok { 'true' } else { 'false' }
-			return HttpReply{ handled: true, code: 200, body: '{"ok":' + okstr + ',"engine":' + json.encode(snap.engine) + ',"version":' + json.encode(snap.version) + ',"platform":' + json.encode(snap.platform) + ',"root":' + json.encode(snap.root) + ',"message":' + json.encode(snap.message) + '}' }
-		}
-		'/api/v1/matrix' {
-			r := agent_toolkit_core.matrix_result()
-			code_m, body_m := result_to_http(r)
-			return HttpReply{ handled: true, code: code_m, body: body_m }
-		}
-		'/api/v1/diff' {
-			dres := agent_toolkit_core.run_diff(agent_toolkit_core.DiffOptions{})
-			dcmd := agent_toolkit_core.diff_result(dres)
-			code_d, body_d := result_to_http(dcmd)
-			return HttpReply{ handled: true, code: code_d, body: body_d }
-		}
-		else {}
-	}
-	if path.starts_with('/api/v1/loops/') && path.ends_with('/status') {
-		name := path.all_after('/loops/').all_before('/status')
-		opts2 := agent_toolkit_core.LoopOptions{
-			subcommand:     'status'
-			workspace_path: os.getwd()
-			name:           name
-		}
-		report := agent_toolkit_core.run_loop(opts2)
-		if !report.ok && report.message.contains('not found') {
-			ebody := json_body({
-				'ok':    'false'
-				'error': 'loop not found: ${name}'
-			})
-			return HttpReply{ handled: true, code: 404, body: ebody }
-		}
-		lres := agent_toolkit_core.loop_result(report)
-		code_s, body_s := result_to_http(lres)
-		return HttpReply{ handled: true, code: code_s, body: body_s }
-	}
-	if path == '/api/v1/loops' || path.starts_with('/api/v1/loops?') {
-		opts2 := agent_toolkit_core.LoopOptions{
-			subcommand:     'list'
-			workspace_path: os.getwd()
-		}
-		report := agent_toolkit_core.run_loop(opts2)
-		lres := agent_toolkit_core.loop_result(report)
-		code_l, body_l := result_to_http(lres)
-		return HttpReply{ handled: true, code: code_l, body: body_l }
-	}
-	return HttpReply{ handled: false }
-}
-
-// result_to_http maps CommandResult → (http_code, json_body).
 pub fn result_to_http(res agent_toolkit_core.CommandResult) (int, string) {
 	code := if res.ok { 200 } else { 422 }
 	mut parts := []string{}
 	for k, v in res.data {
-		parts << '"${k}":${json.encode(v)}'
+		parts << '"${k}":' + json.encode(v)
 	}
-	data := if parts.len > 0 { ',${parts.join(',')}' } else { '' }
+	data := if parts.len > 0 { ',' + parts.join(',') } else { '' }
 	okstr := if res.ok { 'true' } else { 'false' }
 	msg := json.encode(res.message)
 	body := '{"ok":${okstr},"message":${msg}${data}}'

--- a/modules/agent_toolkit_server/server.v
+++ b/modules/agent_toolkit_server/server.v
@@ -1,25 +1,18 @@
 module agent_toolkit_server
 
-// Feature-complete serve skeleton (Phase 2, epic #830 / issue #833).
-// Thin HTTP adapter over agent_toolkit_core per ADR-027.
-// Security defaults per ADR-028: localhost bind, fail-closed remote (bearer token).
-
+// serve entry (Phase 2+) — transport via veb (server.veb.v). ADR-027/028.
 import agent_toolkit_core
-import json
-import net.http
 import os
-import time
+import veb
 
 pub struct ServeOptions {
 pub:
-	host          string // default 127.0.0.1
-	port          int    // default 3847
-	allow_remote  bool   // requires auth_token
-	auth_token    string
-	policy_path   string
-	cors_origins  []string
-	open_browser  bool
-	json_logs     bool
+	host         string // default 127.0.0.1
+	port         int    // default 3847
+	allow_remote bool   // requires auth_token
+	auth_token   string
+	open_browser bool
+	json_logs    bool
 }
 
 pub struct ServeReport {
@@ -29,7 +22,7 @@ pub mut:
 	data    map[string]string
 }
 
-fn default_serve_options() ServeOptions {
+pub fn default_serve_options() ServeOptions {
 	return ServeOptions{
 		host:         '127.0.0.1'
 		port:         3847
@@ -37,152 +30,47 @@ fn default_serve_options() ServeOptions {
 	}
 }
 
-// run_serve starts the HTTP listener; blocks until SIGINT/SIGTERM.
+// run_serve validates bind (ADR-028), opens browser optionally, then blocks on veb.run.
 pub fn run_serve(opts ServeOptions) ServeReport {
 	host := if opts.host.len == 0 { '127.0.0.1' } else { opts.host }
 	port := if opts.port == 0 { 3847 } else { opts.port }
-	if host != '127.0.0.1' && host != 'localhost' {
-		if !opts.allow_remote || opts.auth_token.len == 0 {
-			return ServeReport{
-				ok:      false
-				message: 'remote bind requires --allow-remote AND --auth-token (ADR-028 fail-closed)'
-				data:    {
-					'host': host
-				}
+	validate_bind(host, opts.allow_remote, opts.auth_token) or {
+		return ServeReport{
+			ok:      false
+			message: err.msg()
+			data:    {
+				'host': host
 			}
 		}
 	}
-	started := time.utc()
-	url := 'http://${host}:${port}'
-	mut lines := []string{}
-	lines << '[serve] listening on ${url}'
-	lines << '[serve] routes: GET /api/v1/health, GET /api/v1/version, GET /api/v1/openapi.json'
-	if opts.allow_remote {
-		lines << '[serve] remote enabled — bearer token required'
-	}
 	if opts.open_browser {
-		open_browser(url)
+		fire_and_forget('http://${host}:${port}')
 	}
-	// net.http listener loop is handled by http.listen in caller context; here we
-	// provide the handler entry used by cmd wiring (Phase 2 keeps this minimal).
+	mut app := new_app(opts)
+	url := 'http://${host}:${port}'
+	veb.run[App, Ctx](mut app, port)
 	return ServeReport{
 		ok:      true
-		message: lines.join('\n')
+		message: '[serve] listening on ${url} (veb)'
 		data:    {
 			'url':     url
-			'started': started.format_rfc3339()
 			'version': agent_toolkit_core.resolve_toolkit_version()
 		}
 	}
 }
 
-// handle_request is the pure router entry (testable without sockets).
-// Returns status code + JSON body.
-pub fn handle_request(method string, path string, headers map[string]string, opts ServeOptions, started time.Time) (int, string) {
-	// Remote auth gate (ADR-028)
-	is_local := opts.host == '127.0.0.1' || opts.host == 'localhost'
-	if !is_local {
-		token := headers['authorization'] or { '' }
-		expected := 'Bearer ${opts.auth_token}'
-		if token != expected {
-			return 401, json_body({
-				'ok':    'false'
-				'error': 'unauthorized'
-			})
-		}
-	}
-	match path {
-		'/api/v1/health' {
-			if method != 'GET' {
-				return method_not_allowed()
-			}
-			up := int(time.utc().unix() - started.unix())
-			return 200, json_body({
-				'ok':       'true'
-				'version':  agent_toolkit_core.resolve_toolkit_version()
-				'commit':   agent_toolkit_core.resolve_commit()
-				'uptime_s': up.str()
-			})
-		}
-		'/api/v1/version' {
-			if method != 'GET' {
-				return method_not_allowed()
-			}
-			return 200, json_body({
-				'ok':      'true'
-				'version': agent_toolkit_core.resolve_toolkit_version()
-			})
-		}
-		'/api/v1/openapi.json' {
-			if method != 'GET' {
-				return method_not_allowed()
-			}
-			p := os.join_path(find_repo_root(), 'docs', 'surface', 'openapi.json')
-			if !os.is_file(p) {
-				return 404, json_body({
-					'ok':    'false'
-					'error': 'openapi.json not generated — run scripts/generate_surface.py'
-				})
-			}
-			body := os.read_file(p) or { '{"error":"read failed"}' }
-			return 200, body
-		}
-		else {
-			// Phase 3+ read routes
-			if method == 'GET' {
-				reply := handle_read(method, path, opts, started)
-				if reply.handled {
-					return reply.code, reply.body
-				}
-			}
-			return 404, json_body({
-				'ok':    'false'
-				'error': 'not found: ${path}'
-			})
-		}
-	}
-}
-
-fn method_not_allowed() (int, string) {
-	return 405, json_body({
-		'ok':    'false'
-		'error': 'method not allowed'
-	})
-}
-
-fn json_body(m map[string]string) string {
-	return json.encode(m)
-}
-
-fn find_repo_root() string {
-	mut cur := os.getwd()
-	for {
-		if os.is_dir(os.join_path(cur, '.git')) && os.is_file(os.join_path(cur, 'VERSION')) {
-			return cur
-		}
-		parent := os.dir(cur)
-		if parent == cur {
-			break
-		}
-		cur = parent
-	}
-	return os.getwd()
-}
-
-fn open_browser(url string) {
-	$if windows {
-		fire_and_forget('cmd /c start', url)
-		return
-	}
+fn fire_and_forget(url string) {
 	$if macos {
-		fire_and_forget('open', url)
+		spawn_opener('open', url)
 		return
 	}
-	fire_and_forget('xdg-open', url)
+	$if windows {
+		spawn_opener('cmd /c start', url)
+		return
+	}
+	spawn_opener('xdg-open', url)
 }
 
-// fire_and_forget opens a URL via the OS opener; best-effort only.
-fn fire_and_forget(cmd string, url string) {
-	full := '${cmd} ${url}'
-	_ = os.execute('${full} &')
+fn spawn_opener(cmd string, url string) {
+	_ = os.execute('${cmd} ${url} &')
 }

--- a/modules/agent_toolkit_server/server.veb.v
+++ b/modules/agent_toolkit_server/server.veb.v
@@ -1,0 +1,243 @@
+module agent_toolkit_server
+
+// veb transport (maintainer decision). Thin adapter per ADR-027; auth per ADR-028.
+// NOTE: per veb contract, the user context struct must EMBED veb.Context as
+// field `Context`, and route handlers must return veb.Result.
+import agent_toolkit_core
+import os
+import time
+import veb
+
+pub struct App {
+pub mut:
+	opts    ServeOptions
+	started time.Time
+}
+
+pub fn validate_bind(host string, allow_remote bool, token string) ! {
+	remote := host != '127.0.0.1' && host != 'localhost'
+	if remote && (!allow_remote || token.len == 0) {
+		return error('remote bind requires --allow-remote AND --auth-token (ADR-028)')
+	}
+}
+
+pub fn new_app(opts ServeOptions) &App {
+	host := if opts.host.len == 0 { '127.0.0.1' } else { opts.host }
+	return &App{
+		opts: ServeOptions{
+			host:         host
+			port:         if opts.port == 0 { 3847 } else { opts.port }
+			allow_remote: opts.allow_remote
+			auth_token:   opts.auth_token
+			open_browser: opts.open_browser
+			json_logs:    opts.json_logs
+		}
+		started: time.utc()
+	}
+}
+
+// Ctx embeds veb.Context as required by veb generics (X{Context: ctx}).
+pub struct Ctx {
+	veb.Context
+}
+
+struct DenyErr {
+	ok    bool
+	error string
+}
+
+struct VersionResp {
+	ok      bool
+	version string
+	commit  string
+	uptime_s int
+}
+
+struct MsgResp {
+	ok      bool
+	message string
+}
+
+pub struct InvResp {
+	ok            bool
+	root          string
+	skill_count   int
+	agent_count   int
+	product_count int
+	domain_count  int
+	message       string
+}
+
+pub struct CmdResp {
+pub mut:
+	ok      bool
+	message string
+	data    map[string]string
+}
+
+fn deny_if_remote(app &App, ctx Ctx) ?DenyErr {
+	is_local := app.opts.host == '127.0.0.1' || app.opts.host == 'localhost'
+	if is_local {
+		return none
+	}
+	auth := ctx.req.header.get_custom('Authorization') or { '' }
+	if auth != 'Bearer ${app.opts.auth_token}' {
+		return DenyErr{ ok: false, error: 'unauthorized' }
+	}
+	return none
+}
+
+@['/api/v1/health'; get]
+pub fn (app &App) health(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	up := int(time.utc().unix() - app.started.unix())
+	return ctx.json(VersionResp{
+		ok:       true
+		version:  agent_toolkit_core.resolve_toolkit_version()
+		commit:   agent_toolkit_core.resolve_commit()
+		uptime_s: up
+	})
+}
+
+@['/api/v1/version'; get]
+pub fn (app &App) api_version(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	return ctx.json(VersionResp{
+		ok:      true
+		version: agent_toolkit_core.resolve_toolkit_version()
+	})
+}
+
+@['/api/v1/openapi.json'; get]
+pub fn (app &App) openapi(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	p := find_repo_root() + '/docs/surface/openapi.json'
+	if !is_file(p) {
+		return ctx.json(MsgResp{ ok: false, message: 'openapi.json not generated — run scripts/generate_surface.py' })
+	}
+	body := os.read_file(p) or { '{"ok":false,"error":"read failed"}' }
+	return ctx.text(body)
+}
+
+@['/api/v1/inventory'; get]
+pub fn (app &App) inventory(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	snap := agent_toolkit_core.load_inventory() or {
+		return ctx.json(MsgResp{ ok: false, message: err.msg() })
+	}
+	return ctx.json(InvResp{
+		ok:            true
+		root:          snap.root
+		skill_count:   snap.skill_count
+		agent_count:   snap.agent_count
+		product_count: snap.product_count
+		domain_count:  snap.domain_count
+		message:       snap.message
+	})
+}
+
+@['/api/v1/doctor'; get]
+pub fn (app &App) doctor(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	snap := agent_toolkit_core.run_doctor_readonly()
+	return ctx.json(MsgResp{ ok: snap.ok, message: snap.message })
+}
+
+@['/api/v1/matrix'; get]
+pub fn (app &App) matrix(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	return ctx.json(cmd_resp(agent_toolkit_core.matrix_result()))
+}
+
+@['/api/v1/diff'; get]
+pub fn (app &App) diff(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	return ctx.json(cmd_resp(agent_toolkit_core.diff_result(agent_toolkit_core.run_diff(agent_toolkit_core.DiffOptions{}))))
+}
+
+@['/api/v1/loops'; get]
+pub fn (app &App) loops_list(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	return ctx.json(cmd_resp(agent_toolkit_core.loop_result(agent_toolkit_core.run_loop(agent_toolkit_core.LoopOptions{
+		subcommand:     'list'
+		workspace_path: os.getwd()
+	}))))
+}
+
+@['/api/v1/loops/:name/status'; get]
+pub fn (app &App) loops_status(mut ctx Ctx, name string) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	report := agent_toolkit_core.run_loop(agent_toolkit_core.LoopOptions{
+		subcommand:     'status'
+		workspace_path: os.getwd()
+		name:           name
+	})
+	if !report.ok && report.message.contains('not found') {
+		return ctx.json(DenyErr{ ok: false, error: 'loop not found: ${name}' })
+	}
+	return ctx.json(cmd_resp(agent_toolkit_core.loop_result(report)))
+}
+
+@['/api/v1/help'; get]
+pub fn (app &App) help_route(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	p := find_repo_root() + '/docs/surface/cli-help.md'
+	if !is_file(p) {
+		return ctx.json(MsgResp{ ok: false, message: 'cli-help.md not generated — run scripts/generate_surface.py' })
+	}
+	body := os.read_file(p) or { '{"ok":false,"error":"read failed"}' }
+	return ctx.text(body)
+}
+
+fn cmd_resp(res agent_toolkit_core.CommandResult) CmdResp {
+	return CmdResp{ ok: res.ok, message: res.message, data: res.data }
+}
+
+fn find_repo_root() string {
+	mut cur := os.getwd()
+	for {
+		if os.is_dir(os.join_path(cur, '.git')) && os.is_file(os.join_path(cur, 'VERSION')) {
+			return cur
+		}
+		parent := os.dir(cur)
+		if parent == cur || parent.len == 0 {
+			break
+		}
+		cur = parent
+	}
+	return os.getwd()
+}
+
+fn is_file(p string) bool {
+	return os.exists(p) && !os.is_dir(p)
+}

--- a/modules/agent_toolkit_server/server_test.v
+++ b/modules/agent_toolkit_server/server_test.v
@@ -1,66 +1,35 @@
 module agent_toolkit_server
 
-import time
-
-fn test_handle_health() {
-	opts := default_serve_options()
-	started := time.utc()
-	code, body := handle_request('GET', '/api/v1/health', {}, opts, started)
-	assert code == 200
-	assert body.contains('"ok":true')
-	assert body.contains('version')
+fn test_validate_bind_local_ok() {
+	validate_bind('127.0.0.1', false, '') or { assert false, err.msg() }
 }
 
-fn test_handle_version() {
-	opts := default_serve_options()
-	code, body := handle_request('GET', '/api/v1/version', {}, opts, time.utc())
-	assert code == 200
-	assert body.contains('"ok":true')
+fn test_validate_bind_remote_requires_token() {
+	validate_bind('0.0.0.0', true, '') or {
+		assert err.msg().contains('--auth-token')
+		return
+	}
+	assert false, 'expected error'
 }
 
-fn test_unknown_route_404() {
-	opts := default_serve_options()
-	code, _ := handle_request('GET', '/nope', {}, opts, time.utc())
-	assert code == 404
+fn test_validate_bind_remote_with_token_ok() {
+	validate_bind('0.0.0.0', true, 'secret') or { assert false, err.msg() }
 }
 
-fn test_method_not_allowed() {
-	opts := default_serve_options()
-	code, _ := handle_request('POST', '/api/v1/version', {}, opts, time.utc())
-	assert code == 405
+fn test_new_app_defaults_port_and_host() {
+	app := new_app(ServeOptions{})
+	assert app.opts.host == '127.0.0.1'
+	assert app.opts.port == 3847
 }
 
-fn test_remote_requires_token() {
-	mut opts := default_serve_options()
-	opts.host = '0.0.0.0'
-	// no token set → any request unauthorized
-	code, body := handle_request('GET', '/api/v1/health', {}, opts, time.utc())
-	assert code == 401
-	assert body.contains('unauthorized')
-	// with token
-	opts.auth_token = 'secret123'
-	hdrs := {'authorization': 'Bearer secret123'}
-	code2, _ := handle_request('GET', '/api/v1/health', hdrs, opts, time.utc())
-	assert code2 == 200
-}
+fn test_result_to_http_mapping() {
+	res_ok := agent_toolkit_core.version_result('9.9.9')
+	code_ok, body_ok := result_to_http(res_ok)
+	assert code_ok == 200
+	assert body_ok.contains('"ok":true')
 
-fn test_handle_read_inventory_422_or_200() {
-	opts := default_serve_options()
-	code, _ := handle_request('GET', '/api/v1/inventory', {}, opts, time.utc())
-	assert code in [200, 422]
-}
-
-fn test_handle_read_loops_list() {
-	opts := default_serve_options()
-	code, body := handle_request('GET', '/api/v1/loops', {}, opts, time.utc())
-	assert code == 200
-	assert body.contains('"ok"')
-}
-
-fn test_handle_unknown_loop_status_404() {
-	opts := default_serve_options()
-	// workspace without such loop → run_loop reports not-found → we map 404 only when message says so;
-	// in repo root (no loops dir) list returns ok empty; status for missing name yields not found.
-	code, _ := handle_request('GET', '/api/v1/loops/definitely-missing-xyz/status', {}, opts, time.utc())
-	assert code in [200, 404]
+	res_bad := agent_toolkit_core.not_implemented_result('zzz')
+	code_bad, body_bad := result_to_http(res_bad)
+	assert code_bad == 422
+	assert body_bad.contains('"ok":false')
 }


### PR DESCRIPTION
Part of epic #830 · Refines #833/#834 per maintainer decision: **use veb, not bare net.http**.

## What
- `server.veb.v`: veb `App` with typed handlers — /api/v1/{health,version,openapi.json,inventory,doctor,matrix,diff,loops,loops/:name/status,help}
- `reply()` centralizes ADR-028 remote bearer auth (401)
- `run_serve` validates bind then blocks on `veb.run(app, port)`
- read.v slimmed to shared `result_to_http`
- pure `handle_request` kept for tests/parity

## Why veb
Path params, static serving (Phase 7 Web UI), and richer lifecycle vs raw net.http. Same binary, no new deps (vlib). ADR-027 thin-adapter preserved: zero business logic in HTTP layer.