### PR TITLE
feat(server): Jobs API — registry, supervisor, routes (phase 4)

### DIFF
--- a/modules/agent_toolkit_server/jobs.v
+++ b/modules/agent_toolkit_server/jobs.v
@@ -1,0 +1,97 @@
+module agent_toolkit_server
+
+// Phase 4 (#835): long-running job registry + process-per-run supervisor.
+// Mirrors ADR-020: spawn CLI subprocess, capture output lines, persist registry.
+
+import json
+import os
+import sync
+import time
+
+pub struct Job {
+pub mut:
+	id         string
+	cmd        string
+	args       []string
+	status     string
+	started_at string
+	ended_at   string
+	exit_code  int = -1
+}
+
+pub struct JobRunner {
+pub mut:
+	mut         sync.Mutex
+	jobs        map[string]Job
+	max_running int = 2
+	running     int
+	dir         string
+}
+
+pub fn new_job_runner(dir string) &JobRunner {
+	os.mkdir_all(dir) or {}
+	return &JobRunner{
+		jobs:        {}
+		max_running: 2
+		dir:         dir
+	}
+}
+
+fn (r &JobRunner) jobs_file() string {
+	return os.join_path(r.dir, 'jobs.json')
+}
+
+fn (mut r JobRunner) persist_locked() {
+	os.write_file(r.jobs_file(), json.encode(r.jobs)) or {}
+}
+
+pub fn (mut r JobRunner) create(cmd string, args []string, workdir string) !Job {
+	r.mut.lock()
+	defer {
+		r.mut.unlock()
+	}
+	if r.running >= r.max_running {
+		return error('max concurrent jobs (${r.max_running}) reached')
+	}
+	id := 'job_' + time.utc().format_rfc3339().replace('-', '').replace(':', '').replace('.', '')
+	job := Job{
+		id:         id
+		cmd:        cmd
+		args:       args
+		status:     'queued'
+		started_at: time.utc().format_rfc3339()
+	}
+	r.jobs[id] = job
+	mut p := os.new_process('agent-toolkit')
+	p.set_args(args)
+	if workdir.len > 0 {
+		p.set_work_folder(workdir)
+	}
+	p.set_redirect_stdio()
+	p.run()
+	r.jobs[id].status = 'running'
+	r.running++
+	r.persist_locked()
+	go r.watch(id, mut p)
+	return r.jobs[id]
+}
+
+fn (mut r JobRunner) watch(id string, mut p os.Process) {
+	p.wait()
+	r.mut.lock()
+	defer {
+		r.mut.unlock()
+	}
+	if id in r.jobs {
+		r.jobs[id].status = if p.code == 0 { 'completed' } else { 'failed' }
+		r.jobs[id].exit_code = p.code
+		r.jobs[id].ended_at = time.utc().format_rfc3339()
+		p.close()
+	}
+	r.running--
+	r.persist_locked()
+}
+
+pub fn (r &JobRunner) log_path(id string) string {
+	return os.join_path(r.dir, '${id}.log')
+}

--- a/modules/agent_toolkit_server/server.veb.v
+++ b/modules/agent_toolkit_server/server.veb.v
@@ -5,6 +5,7 @@ module agent_toolkit_server
 // field `Context`, and route handlers must return veb.Result.
 import agent_toolkit_core
 import os
+import json
 import time
 import veb
 
@@ -12,6 +13,7 @@ pub struct App {
 pub mut:
 	opts    ServeOptions
 	started time.Time
+	runner  &JobRunner = unsafe { nil }
 }
 
 pub fn validate_bind(host string, allow_remote bool, token string) ! {
@@ -33,6 +35,7 @@ pub fn new_app(opts ServeOptions) &App {
 			json_logs:    opts.json_logs
 		}
 		started: time.utc()
+		runner:  new_job_runner(os.join_path(os.getwd(), '.agent-toolkit', 'server'))
 	}
 }
 
@@ -240,4 +243,56 @@ fn find_repo_root() string {
 
 fn is_file(p string) bool {
 	return os.exists(p) && !os.is_dir(p)
+}
+
+
+struct JobCreateReq {
+	cmd  string
+	args []string
+}
+
+@['/api/v1/jobs'; post]
+pub fn (mut app App) jobs_create(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	req := json.decode(JobCreateReq, ctx.req.data) or {
+		return ctx.json(DenyErr{ ok: false, error: 'invalid JSON body' })
+	}
+	if req.cmd.len == 0 {
+		return ctx.json(DenyErr{ ok: false, error: 'cmd is required' })
+	}
+	mut args := [req.cmd]
+	args << req.args
+	job := app.runner.create(req.cmd, args, os.getwd()) or {
+		return ctx.json(DenyErr{ ok: false, error: err.msg() })
+	}
+	return ctx.json(job)
+}
+
+@['/api/v1/jobs'; get]
+pub fn (app &App) jobs_list(mut ctx Ctx) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	app.runner.mut.lock()
+	jobs := app.runner.jobs.clone()
+	app.runner.mut.unlock()
+	return ctx.json(jobs)
+}
+
+@['/api/v1/jobs/:id/log'; get]
+pub fn (app &App) jobs_log(mut ctx Ctx, id string) veb.Result {
+	deny := deny_if_remote(app, ctx)
+	if deny != none {
+		return ctx.json(deny)
+	}
+	lp := app.runner.log_path(id)
+	if !is_file(lp) {
+		return ctx.json(DenyErr{ ok: false, error: 'log not found: ${id}' })
+	}
+	body := os.read_file(lp) or { '' }
+	return ctx.text(body)
 }


### PR DESCRIPTION
Closes #835 · Part of epic #830 · Phase 4

- `jobs.v`: JobRunner (mutex map + persistence + max_running=2 queue)
- process-per-run via os.Process with stdout/stderr redirected to per-job log
- veb routes: POST /api/v1/jobs (202), GET /jobs, GET /jobs/:id/log