### PR TITLE
fix(tui): support LOOP.md, --workspace flag, bundled fallback

### DIFF
--- a/modules/agent_toolkit_cli/commands.v
+++ b/modules/agent_toolkit_cli/commands.v
@@ -977,10 +977,16 @@ fn serve_command() cli.Command {
 
 
 fn tui_command() cli.Command {
-	return cli.Command{
+	mut c := cli.Command{
 		name:        'tui'
 		description: 'Interactive TUI dashboard (loops, swarms, doctor)'
 		execute:     atk_exec
 		group:       'Advanced commands'
 	}
+	c.add_flag(cli.Flag{
+		flag:        .string
+		name:        'workspace'
+		description: 'Workspace path (default: auto-detect via AGENT_TOOLKIT_WORKSPACE / walk-up)'
+	})
+	return c
 }

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -252,8 +252,18 @@ fn execute_command(cmd_name string, rest []string, mode agent_toolkit_core.Rende
 		return render(agent_toolkit_core.swarm_result(report), mode)
 	}
 	if cmd_name == 'tui' {
+		mut ws := ''
+		for i, a in rest {
+			if a == '--workspace' && i + 1 < rest.len {
+				ws = rest[i + 1]
+				break
+			} else if a.starts_with('--workspace=') {
+				ws = a.all_after('=')
+				break
+			}
+		}
 		opts := agent_toolkit_tui.TuiOptions{
-			workspace_path: os.getwd()
+			workspace_path: ws
 		}
 		return agent_toolkit_tui.run_tui(opts)
 	}
@@ -494,9 +504,11 @@ If the matrix file is missing, prints where it is expected (research pipeline).
 		return agent_toolkit_core.swarm_help_text()
 	}
 	if name == 'tui' {
-		return 'Usage: agent-toolkit tui [--help]
+		return 'Usage: agent-toolkit tui [--workspace PATH] [--help]
 
 Interactive TUI dashboard (loops, skills, doctor) — ANSI colors, keyboard nav.
+
+  --workspace PATH  Workspace path (default: auto-detect via AGENT_TOOLKIT_WORKSPACE / HARNESS_DIR / walk-up)
 
 Screens:
   1 dashboard  Overview + workspace + loops preview
@@ -510,10 +522,12 @@ Keys:
   r/enter  run selected loop (no-llm, safe)   h/?  help   q/quit/exit  quit
 
 Runs in-process core calls (no HTTP), offline-first per ADR-494.
-Workspace auto-detected via walk-up (loops/.git/AGENTS.md/knowledge).
+Workspace auto-detected via --workspace, AGENT_TOOLKIT_WORKSPACE/HARNESS_DIR, or walk-up (loops/.git/AGENTS.md/knowledge).
+Loops from loops/ support loop.yaml or legacy LOOP.md; empty workspace falls back to bundled loops for preview.
 
 Examples:
   agent-toolkit tui
+  agent-toolkit tui --workspace ~/.ai-workspace
   printf "2\nj\nr\nq\n" | agent-toolkit tui   # batch navigation
 
 See: docs/v/advanced-command-disposition.md

--- a/modules/agent_toolkit_core/loop.v
+++ b/modules/agent_toolkit_core/loop.v
@@ -856,7 +856,7 @@ fn list_loop_dirs(ws string) []string {
 	return out
 }
 
-fn bundled_loop_dirs() []string {
+pub fn bundled_loop_dirs() []string {
 	mut out := []string{}
 	root := find_toolkit_root() or { return out }
 	bundled := os.join_path(root.path, 'loops')

--- a/modules/agent_toolkit_tui/app.v
+++ b/modules/agent_toolkit_tui/app.v
@@ -86,59 +86,115 @@ pub fn resolve_workspace(input string) string {
 	return os.getwd()
 }
 
-// list_loops scans loops/ for loop.yaml entries.
+// list_loops scans loops/ for loop.yaml or LOOP.md entries (legacy harness).
+// If workspace has no loops, falls back to bundled_loop_dirs() for parity with loop status.
 pub fn list_loops(workspace string) []LoopInfo {
 	mut out := []LoopInfo{}
 	dir := os.join_path(workspace, 'loops')
-	if !os.is_dir(dir) {
-		return out
-	}
-	for entry in os.ls(dir) or { []string{} } {
-		loop_dir := os.join_path(dir, entry)
-		yaml_path := os.join_path(loop_dir, 'loop.yaml')
-		if !os.is_file(yaml_path) {
-			continue
-		}
-		text := os.read_file(yaml_path) or { continue }
-		mut tier := 'L1'
-		mut cadence := '?'
-		for line in text.split_into_lines() {
-			t := line.trim_space()
-			if t.starts_with('tier:') {
-				tier = t.all_after('tier:').trim_space()
-			} else if t.starts_with('cadence:') {
-				cadence = t.all_after('cadence:').trim_space().trim('"')
+	if os.is_dir(dir) {
+		for entry in os.ls(dir) or { []string{} } {
+			loop_dir := os.join_path(dir, entry)
+			yaml_path := os.join_path(loop_dir, 'loop.yaml')
+			md_path := os.join_path(loop_dir, 'LOOP.md')
+			if !os.is_file(yaml_path) && !os.is_file(md_path) {
+				continue
 			}
-		}
-		state_path := os.join_path(loop_dir, 'STATE.md')
-		mut status := 'not_run'
-		mut runs := 0
-		if os.is_file(state_path) {
-			runs = 1
-			state_text := os.read_file(state_path) or { '' }
-			for sl in state_text.split_into_lines() {
-				if sl.trim_space().starts_with('last_run_status:') {
-					status = sl.all_after('last_run_status:').trim_space()
-					break
+			text := if os.is_file(yaml_path) {
+				os.read_file(yaml_path) or { continue }
+			} else {
+				os.read_file(md_path) or { continue }
+			}
+			mut tier := 'L1'
+			mut cadence := '?'
+			for line in text.split_into_lines() {
+				t := line.trim_space()
+				if t.starts_with('tier:') {
+					tier = t.all_after('tier:').trim_space()
+				} else if t.starts_with('cadence:') {
+					cadence = t.all_after('cadence:').trim_space().trim('"')
 				}
 			}
-			// Try to count additional runs from STATE if it contains runs_count or history
-			for sl in state_text.split_into_lines() {
-				tt := sl.trim_space()
-				if tt.starts_with('runs_count:') || tt.starts_with('run_count:') {
-					val := tt.all_after(':').trim_space()
-					if val.int() > runs {
-						runs = val.int()
+			state_path := os.join_path(loop_dir, 'STATE.md')
+			mut status := 'not_run'
+			if os.is_file(state_path) {
+				state_text := os.read_file(state_path) or { '' }
+				for sl in state_text.split_into_lines() {
+					if sl.trim_space().starts_with('last_run_status:') {
+						status = sl.all_after('last_run_status:').trim_space()
+						break
 					}
 				}
 			}
+			// Count runs from runs/ dir (correct count, not STATE heuristic)
+			runs_dir := os.join_path(loop_dir, 'runs')
+			mut runs := 0
+			if os.is_dir(runs_dir) {
+				entries := os.ls(runs_dir) or { []string{} }
+				runs = entries.len
+			} else if os.is_file(state_path) {
+				// Fallback: if runs dir missing but STATE exists, check runs_count field
+				state_text2 := os.read_file(state_path) or { '' }
+				for sl in state_text2.split_into_lines() {
+					tt := sl.trim_space()
+					if tt.starts_with('runs_count:') || tt.starts_with('run_count:') || tt.starts_with('runs_today:') {
+						val := tt.all_after(':').trim_space()
+						if val.int() > runs {
+							runs = val.int()
+						}
+					}
+				}
+				// Legacy: STATE.md exists implies at least 0 runs, not 1; keep 0 if no runs field
+			}
+			out << LoopInfo{
+				name:        entry
+				tier:        tier
+				cadence:     cadence
+				last_status: status
+				runs_count:  runs
+			}
 		}
-		out << LoopInfo{
-			name:        entry
-			tier:        tier
-			cadence:     cadence
-			last_status: status
-			runs_count:  runs
+	}
+	if out.len == 0 {
+		for bdir in agent_toolkit_core.bundled_loop_dirs() {
+			yaml_path := os.join_path(bdir, 'loop.yaml')
+			if !os.is_file(yaml_path) {
+				continue
+			}
+			text := os.read_file(yaml_path) or { continue }
+			mut tier := 'L1'
+			mut cadence := '?'
+			for line in text.split_into_lines() {
+				t := line.trim_space()
+				if t.starts_with('tier:') {
+					tier = t.all_after('tier:').trim_space()
+				} else if t.starts_with('cadence:') {
+					cadence = t.all_after('cadence:').trim_space().trim('"')
+				}
+			}
+			state_path := os.join_path(bdir, 'STATE.md')
+			mut status := 'not_run'
+			if os.is_file(state_path) {
+				state_text := os.read_file(state_path) or { '' }
+				for sl in state_text.split_into_lines() {
+					if sl.trim_space().starts_with('last_run_status:') {
+						status = sl.all_after('last_run_status:').trim_space()
+						break
+					}
+				}
+			}
+			runs_dir := os.join_path(bdir, 'runs')
+			mut runs := 0
+			if os.is_dir(runs_dir) {
+				entries := os.ls(runs_dir) or { []string{} }
+				runs = entries.len
+			}
+			out << LoopInfo{
+				name:        os.file_name(bdir)
+				tier:        tier
+				cadence:     cadence
+				last_status: status
+				runs_count:  runs
+			}
 		}
 	}
 	return out

--- a/modules/agent_toolkit_tui/render.v
+++ b/modules/agent_toolkit_tui/render.v
@@ -43,8 +43,15 @@ pub fn render_loops_detail(loops []LoopInfo, workspace string, selected int) str
 			lines << '│  Status: ${sel.last_status}  Runs: ${sel.runs_count}                         │'
 			loop_dir := os.join_path(workspace, 'loops', sel.name)
 			yaml_path := os.join_path(loop_dir, 'loop.yaml')
+			md_path := os.join_path(loop_dir, 'LOOP.md')
+			mut text_path := ''
 			if os.is_file(yaml_path) {
-				text := os.read_file(yaml_path) or { '' }
+				text_path = yaml_path
+			} else if os.is_file(md_path) {
+				text_path = md_path
+			}
+			if text_path.len > 0 {
+				text := os.read_file(text_path) or { '' }
 				mut goal := ''
 				for line in text.split_into_lines() {
 					t := line.trim_space()
@@ -188,7 +195,10 @@ pub fn render_help(workspace string) string {
 	lines << '│                                                     │'
 	lines << '│  Workspace:                                         │'
 	lines << '│    ${pad_right(workspace, 52)} │'
-	lines << '│  Auto-detected via walk-up (loops/.git/AGENTS.md)   │'
+	lines << '│  Flag: --workspace PATH (else AGENT_TOOLKIT_       │'
+	lines << '│  WORKSPACE / HARNESS_DIR / walk-up loops/.git)    │'
+	lines << '│  Loops: loop.yaml or legacy LOOP.md; empty →      │'
+	lines << '│  bundled loops                                     │'
 	lines << '│                                                     │'
 	lines << '│  Tips:                                              │'
 	lines << '│    • Colors: L1 ${ansi("green", "32")} L2 ${ansi("yellow", "33")} L3 ${ansi("red", "31")}                         │'


### PR DESCRIPTION
Fixes TUI not detecting loops in ~/.ai-workspace (my-ai-workspace).

## Problem
`agent-toolkit tui` showed `(no loops found)` in `~/.ai-workspace` despite 6 `LOOP.md` loops.
Root causes:
- `list_loops()` only accepted `loop.yaml`, ignored legacy `LOOP.md`
- No `--workspace` flag; dispatch hard-coded `os.getwd()`, ignoring `AGENT_TOOLKIT_WORKSPACE`/`HARNESS_DIR`
- No fallback to bundled loops when workspace empty (parity with `loop status`)
- Run count used STATE heuristic instead of `runs/` dir

## Fix
- `modules/agent_toolkit_tui/app.v:list_loops`: accept `loop.yaml` **or** `LOOP.md` (check both), parse `tier:`/`cadence:` from whichever exists, count runs via `runs/` dir (fallback to STATE `runs_count` if dir missing), fallback to `agent_toolkit_core.bundled_loop_dirs()` when workspace has 0 loops (#854 parity with `loop.v:841-875`).
- `modules/agent_toolkit_tui/app.v:resolve_workspace`: unchanged logic but now honors env when dispatch passes "" (was short-circuited by `getwd()`).
- `modules/agent_toolkit_core/loop.v:bundled_loop_dirs`: expose as `pub fn` for TUI fallback.
- `modules/agent_toolkit_cli/commands.v:tui_command`: add `--workspace` string flag.
- `modules/agent_toolkit_cli/dispatch.v:execute_command`: parse `--workspace` / `--workspace=PATH` and pass to `TuiOptions{workspace_path: ws}` (empty → env/walk-up).
- `dispatch.v:subcommand_help` and `modules/agent_toolkit_tui/render.v:render_help`: mention `--workspace`, auto-detect precedence, `loop.yaml`/`LOOP.md` support, and bundled fallback.
- `render.v:render_loops_detail`: support `LOOP.md` for goal preview.

## Verification
- `v vet modules/agent_toolkit_tui/` 0 errors (notices only)
- `v vet modules/agent_toolkit_cli/` 0 errors
- `v vet modules/agent_toolkit_core/` 0 errors (bundled_loop_dirs now pub, parity with loop status)

## Related
Plan: `.opencode/plan/tui-workspace-fix-plan.md`
Next: migrate `~/.ai-workspace/loops/*/LOOP.md` → `loop.yaml` (my-ai-workspace) and verify `agent-toolkit tui --workspace ~/.ai-workspace` shows 6 loops.
