### PR TITLE
fix(tui): skills not found from harness workspace — use find_toolkit_root + embedded

### DIFF
--- a/modules/agent_toolkit_core/inventory.v
+++ b/modules/agent_toolkit_core/inventory.v
@@ -26,6 +26,9 @@ pub:
 // load_inventory lists skills/, agents/, and distributions/products.yaml.
 // Catalog YAML is not decoded (vlib/yaml rejects folded descriptions); tree walk is the source.
 pub fn load_inventory() !InventorySnapshot {
+	if root := find_toolkit_root() {
+		return load_inventory_at(root.path)
+	}
 	root := lookup_checkout_root()
 	if root.len == 0 {
 		return error('Cannot locate agent-toolkit root (set AGENT_TOOLKIT_ROOT)')
@@ -35,6 +38,9 @@ pub fn load_inventory() !InventorySnapshot {
 
 // load_inventory_at is the injectable variant for tests.
 pub fn load_inventory_at(root string) !InventorySnapshot {
+	if is_embedded_root(root) {
+		return load_inventory_embedded()
+	}
 	skill_files := collect_named(os.join_path(root, 'skills'), 'SKILL.md')
 	mut domains := map[string]int{}
 	skills_root := os.join_path(root, 'skills')
@@ -89,6 +95,80 @@ pub fn load_inventory_at(root string) !InventorySnapshot {
 		domain_count:  domains.len
 		message:       lines.join('\n')
 	}
+}
+
+fn load_inventory_embedded() InventorySnapshot {
+	mut skill_files := []string{}
+	for k, _ in embedded_file_map {
+		if k.starts_with('skills/') && k.ends_with('SKILL.md') {
+			skill_files << k
+		}
+	}
+	mut domains := map[string]int{}
+	for p in skill_files {
+		parts := p.split('/')
+		if parts.len >= 2 {
+			domain := parts[1]
+			domains[domain] = domains[domain] + 1
+		}
+	}
+	mut agent_dirs := []string{}
+	for e in embedded_ls('agents') {
+		if embedded_is_dir('agents/' + e) {
+			agent_dirs << e
+		}
+	}
+	products := load_products_embedded()
+	mut lines := []string{}
+	lines << ''
+	lines << '═══ agent-toolkit Inventory ═══'
+	lines << ''
+	lines << 'Skills: ${skill_files.len} across ${domains.len} domains'
+	lines << ''
+	mut domain_names := domains.keys()
+	domain_names.sort()
+	skill_files.sort()
+	for d in domain_names {
+		lines << '  ${d}/ (${domains[d]})'
+		for p in skill_files {
+			parts := p.split('/')
+			if parts.len < 3 {
+				continue
+			}
+			if parts[1] != d {
+				continue
+			}
+			name := parts[2]
+			lines << '    ✓  ${name}'
+		}
+	}
+	lines << ''
+	lines << 'Agents: ${agent_dirs.len}'
+	mut agents := agent_dirs.clone()
+	agents.sort()
+	for a in agents {
+		lines << '  ✓  ${a}'
+	}
+	lines << ''
+	lines << 'Products: ${products.len}'
+	for p in products {
+		lines << '  ✓  ${p.id}'
+	}
+	lines << ''
+	return InventorySnapshot{
+		root:          'embedded'
+		skill_count:   skill_files.len
+		agent_count:   agent_dirs.len
+		product_count: products.len
+		domain_count:  domains.len
+		message:       lines.join('\n')
+	}
+}
+
+fn load_products_embedded() []ProductEntry {
+	text := embedded_read_file('distributions/products.yaml') or { return [] }
+	doc := yaml.decode[ProductsFile](text) or { return [] }
+	return doc.products
 }
 
 // inventory_result maps a snapshot to CommandResult.

--- a/modules/agent_toolkit_core/skills.v
+++ b/modules/agent_toolkit_core/skills.v
@@ -45,7 +45,13 @@ pub fn run_skills(opts SkillsOptions) SkillsReport {
 			message: skills_help_text()
 		}
 	}
-	root := if opts.toolkit_root.len > 0 { opts.toolkit_root } else { lookup_checkout_root() }
+	root := if opts.toolkit_root.len > 0 {
+		opts.toolkit_root
+	} else if r := find_toolkit_root() {
+		r.path
+	} else {
+		lookup_checkout_root()
+	}
 	if root.len == 0 {
 		return SkillsReport{
 			ok:      false
@@ -144,7 +150,13 @@ fn skills_list(root string, domain_filter string) SkillsReport {
 		lines << '── ${domain} ──'
 		for name in names {
 			path := os.join_path(root, 'skills', domain, name, 'SKILL.md')
-			exists_marker := if os.is_file(path) { '✓' } else { '✗' }
+			exists_marker := if is_embedded_root(root) {
+				if embedded_is_file('skills/${domain}/${name}/SKILL.md') { '✓' } else { '✗' }
+			} else if os.is_file(path) {
+				'✓'
+			} else {
+				'✗'
+			}
 			desc := skill_description(path)
 			desc_str := if desc.len > 0 { '  — ${desc}' } else { '' }
 			lines << '  ${exists_marker}  ${name:-40}${desc_str}'
@@ -199,6 +211,9 @@ fn skills_sync(root string, home string, requested []string) SkillsReport {
 }
 
 fn skills_validate(root string) SkillsReport {
+	if is_embedded_root(root) {
+		return skills_validate_embedded()
+	}
 	skills_dir := os.join_path(root, 'skills')
 	if !os.is_dir(skills_dir) {
 		return SkillsReport{
@@ -287,6 +302,14 @@ fn skills_validate(root string) SkillsReport {
 }
 
 fn load_skills_layout(root string) !SkillsLayoutFile {
+	if is_embedded_root(root) {
+		text := embedded_read_file('catalogs/skills-layout.json') or {
+			return error('Cannot parse skills-layout.json: ${err}')
+		}
+		return json.decode(SkillsLayoutFile, text) or {
+			return error('Cannot parse skills-layout.json: ${err}')
+		}
+	}
 	path := os.join_path(root, 'catalogs', 'skills-layout.json')
 	if !os.is_file(path) {
 		return error('skills-layout.json not found: ${path}')
@@ -298,6 +321,35 @@ fn load_skills_layout(root string) !SkillsLayoutFile {
 }
 
 fn skill_description(skill_md string) string {
+	if is_embedded_root(skill_md) || skill_md.starts_with('embedded/') || skill_md.starts_with('embedded\\') {
+		rel := strip_embedded_prefix(skill_md)
+		text := embedded_read_file(rel) or { return '' }
+		fm := parse_skill_frontmatter(text) or { return '' }
+		desc := fm['description'] or { '' }
+		if desc.len > 120 {
+			return desc[..120]
+		}
+		return desc
+	}
+	// Also handle case where caller passed an embedded-constructed path but root was embedded
+	// The path will be "embedded/skills/..." so above handles it. For completeness,
+	// if the file is actually embedded but path is filesystem-style without prefix, try embedded fallback.
+	if skill_md.contains('skills/') && !os.is_file(skill_md) {
+		// Try to infer embedded rel by extracting from "skills/"
+		idx := skill_md.index('skills/') or { -1 }
+		if idx != -1 {
+			rel := skill_md[idx..].replace('\\', '/')
+			if embedded_is_file(rel) {
+				text := embedded_read_file(rel) or { return '' }
+				fm := parse_skill_frontmatter(text) or { return '' }
+				desc := fm['description'] or { '' }
+				if desc.len > 120 {
+					return desc[..120]
+				}
+				return desc
+			}
+		}
+	}
 	if !os.is_file(skill_md) {
 		return ''
 	}
@@ -439,6 +491,124 @@ fn validate_skill_dir(skill_dir string, toolkit_dir string) (int, int, string) {
 		warnings++
 	}
 	if os.is_file(os.join_path(skill_dir, 'skill.json')) {
+		lines << '  ⚠  ${rel}: skill.json found — not needed, can be removed'
+		warnings++
+	}
+	if errors == 0 {
+		lines << '  ✓  ${rel}/SKILL.md'
+	}
+	return errors, warnings, lines.join('\n')
+}
+
+fn skills_validate_embedded() SkillsReport {
+	mut lines := []string{}
+	lines << ''
+	lines << 'Validating SKILL.md frontmatter...'
+	lines << ''
+	lines << '── skills/ ──'
+	mut total_errors := 0
+	mut total_warnings := 0
+	mut skill_count := 0
+	domains := embedded_ls('skills')
+	mut domain_names := domains.clone()
+	domain_names.sort()
+	for domain in domain_names {
+		if !embedded_is_dir('skills/' + domain) {
+			continue
+		}
+		entries := embedded_ls('skills/' + domain)
+		mut names := entries.clone()
+		names.sort()
+		for name in names {
+			spath := 'skills/' + domain + '/' + name
+			if !embedded_is_dir(spath) {
+				continue
+			}
+			skill_md := spath + '/SKILL.md'
+			if !embedded_is_file(skill_md) {
+				continue
+			}
+			errs, warns, msg := validate_skill_dir_embedded(spath)
+			total_errors += errs
+			total_warnings += warns
+			skill_count++
+			lines << msg
+		}
+	}
+	if embedded_is_dir('plugins') {
+		lines << ''
+		lines << '── plugins/ (bundled copies) ──'
+		for plugin in embedded_ls('plugins') {
+			ps := 'plugins/' + plugin + '/skills'
+			if !embedded_is_dir(ps) {
+				continue
+			}
+			sk := embedded_ls(ps)
+			mut sk_names := sk.clone()
+			sk_names.sort()
+			for name in sk_names {
+				spath := ps + '/' + name
+				if !embedded_is_dir(spath) {
+					continue
+				}
+				errs, warns, msg := validate_skill_dir_embedded(spath)
+				total_errors += errs
+				total_warnings += warns
+				lines << msg
+			}
+		}
+	}
+	lines << ''
+	lines << '── Summary ──'
+	lines << '  Skills validated: ${skill_count}'
+	if total_errors > 0 {
+		lines << ''
+		lines << '  ✗  ${total_errors} error(s) found'
+	} else if total_warnings > 0 {
+		lines << ''
+		lines << '  ⚠  All valid with ${total_warnings} warning(s)'
+	} else {
+		lines << ''
+		lines << '  ✓  All SKILL.md files are valid!'
+	}
+	return SkillsReport{
+		ok:       total_errors == 0
+		message:  lines.join('\n')
+		count:    skill_count
+		errors:   total_errors
+		warnings: total_warnings
+	}
+}
+
+fn validate_skill_dir_embedded(skill_dir string) (int, int, string) {
+	rel := skill_dir
+	skill_md := skill_dir + '/SKILL.md'
+	if !embedded_is_file(skill_md) {
+		return 1, 0, '  ✗  ${rel}: missing SKILL.md'
+	}
+	content := embedded_read_file(skill_md) or {
+		return 1, 0, '  ✗  ${rel}/SKILL.md: cannot read: ${err}'
+	}
+	fm := parse_skill_frontmatter(content) or {
+		return 1, 0, '  ✗  ${rel}/SKILL.md: no YAML frontmatter found (must start with ---)'
+	}
+	mut errors := 0
+	mut warnings := 0
+	mut lines := []string{}
+	for field in ['name', 'description'] {
+		val := fm[field] or { '' }
+		if val.len == 0 {
+			lines << "  ✗  ${rel}/SKILL.md: missing required frontmatter field '${field}'"
+			errors++
+		}
+	}
+	name := fm['name'] or { '' }
+	dir_name := skill_dir.split('/').last()
+	if name.len > 0 && name != dir_name {
+		lines << "  ⚠  ${rel}/SKILL.md: name '${name}' does not match directory '${dir_name}'"
+		warnings++
+	}
+	if embedded_is_file(skill_dir + '/skill.json') {
 		lines << '  ⚠  ${rel}: skill.json found — not needed, can be removed'
 		warnings++
 	}

--- a/modules/agent_toolkit_tui/render.v
+++ b/modules/agent_toolkit_tui/render.v
@@ -81,45 +81,41 @@ pub fn render_skills(workspace string, selected int) string {
 	lines << ansi('╭─ Skills ────────────────────────────────────────────╮', '35')
 	lines << '│  workspace: ${pad_right(workspace, 38)} │'
 	lines << '├─────────────────────────────────────────────────────┤'
-	// Try toolkit root lookup first, then workspace
-	mut root := agent_toolkit_core.lookup_checkout_root()
-	if root.len == 0 {
-		root = workspace
-	}
-	// If still not found, try to walk up from workspace
-	if !os.is_dir(os.join_path(root, 'skills')) {
+	// Use find_toolkit_root + embedded fallback per ADR-015/026 (like doctor does).
+	// load_inventory() handles embedded, XDG, FHS, checkout, and cwd transparently.
+	snap := agent_toolkit_core.load_inventory() or {
+		// Fallback for legacy: if workspace itself is a checkout with skills/
 		if os.is_dir(os.join_path(workspace, 'skills')) {
-			root = workspace
-		}
-	}
-	if !os.is_dir(os.join_path(root, 'skills')) {
-		lines << '│  (skills not found — check AGENT_TOOLKIT_ROOT)        │'
-	} else {
-		snap := agent_toolkit_core.load_inventory_at(root) or {
-			lines << '│  error: ${pad_right(err.msg(), 42)} │'
+			agent_toolkit_core.load_inventory_at(workspace) or {
+				lines << '│  (skills not found — check AGENT_TOOLKIT_ROOT)        │'
+				lines << ansi('╰─────────────────────────────────────────────────────╯', '35')
+				return lines.join('\n')
+			}
+		} else {
+			lines << '│  (skills not found — check AGENT_TOOLKIT_ROOT)        │'
 			lines << ansi('╰─────────────────────────────────────────────────────╯', '35')
 			return lines.join('\n')
 		}
-		lines << '│  Skills: ${snap.skill_count} across ${snap.domain_count} domains                │'
-		lines << '│  Agents: ${snap.agent_count}  Products: ${snap.product_count}                    │'
-		lines << '├─────────────────────────────────────────────────────┤'
-		// Show message lines truncated to box
-		for raw in snap.message.split_into_lines() {
-			if raw.trim_space().len == 0 {
-				continue
-			}
-			if raw.contains('═══') || raw.contains('──') {
-				continue
-			}
-			mut clean := raw.trim_space()
-			if clean.len > 52 {
-				clean = clean[..52]
-			}
-			lines << '│  ${pad_right(clean, 52)} │'
-			if lines.len > 22 {
-				lines << '│  ... (truncated, use `skills list` for full)         │'
-				break
-			}
+	}
+	lines << '│  Skills: ${snap.skill_count} across ${snap.domain_count} domains                │'
+	lines << '│  Agents: ${snap.agent_count}  Products: ${snap.product_count}                    │'
+	lines << '├─────────────────────────────────────────────────────┤'
+	// Show message lines truncated to box
+	for raw in snap.message.split_into_lines() {
+		if raw.trim_space().len == 0 {
+			continue
+		}
+		if raw.contains('═══') || raw.contains('──') {
+			continue
+		}
+		mut clean := raw.trim_space()
+		if clean.len > 52 {
+			clean = clean[..52]
+		}
+		lines << '│  ${pad_right(clean, 52)} │'
+		if lines.len > 22 {
+			lines << '│  ... (truncated, use `skills list` for full)         │'
+			break
 		}
 	}
 	lines << '│                                                     │'


### PR DESCRIPTION
Fixes TUI Skills screen showing '(skills not found — check AGENT_TOOLKIT_ROOT)' when run from ~/.ai-workspace.

**Root cause:** `render_skills()` used `lookup_checkout_root()` which only checks env vars and walk-up for `skills/`+`loops/`. From `~/.ai-workspace` (a harness workspace with `AGENTS.md`/`knowledge/` but no `skills/`), lookup fails, so TUI showed '(skills not found)'.

**Fix:**
- `inventory.v`: `load_inventory()` now tries `find_toolkit_root()` first (ADR-015 tiered resolution: override → XDG data/cache → embedded → FHS → checkout → cwd). Added `load_inventory_at('embedded')` handling via `embedded_file_map`/`embedded_ls` and `load_inventory_embedded()`. `load_inventory_embedded()` builds counts from embedded data.
- `skills.v`: `run_skills()` now uses `find_toolkit_root()` (like `doctor` does), `load_skills_layout()` and `skill_description()` handle `embedded` root via `embedded_read_file`, `skills_list` uses `embedded_is_file` for existence checks, and `skills_validate` now handles embedded via `skills_validate_embedded()`.
- `render.v`: `render_skills()` now calls `load_inventory()` (which handles embedded transparently) instead of `lookup_checkout_root()+load_inventory_at()`, with legacy fallback to `workspace/skills` for compat. Mirrors `doctor` pattern at `doctor.v:302-304`.

**Verification:**
- `v vet modules/agent_toolkit_core/` and `v vet modules/agent_toolkit_tui/` 0 errors
- `./build/agent-toolkit inventory` and `skills list` from `~/.ai-workspace` with `XDG_DATA_HOME=/tmp/empty` returns `root: embedded` and lists 84 skills (previously would error)
- `render_skills` from harness workspace now shows 'Skills: 84 across 14 domains' instead of '(skills not found)'

No version bump.