### PR TITLE
fix(server): jobs log not found + workspace routing + args duplication

### DIFF
--- a/modules/agent_toolkit_server/jobs.v
+++ b/modules/agent_toolkit_server/jobs.v
@@ -17,6 +17,7 @@ pub mut:
 	started_at string
 	ended_at   string
 	exit_code  int = -1
+	workspace  string
 }
 
 pub struct JobRunner {
@@ -60,6 +61,7 @@ pub fn (mut r JobRunner) create(cmd string, args []string, workdir string) !Job 
 		args:       args
 		status:     'queued'
 		started_at: time.utc().format_rfc3339()
+		workspace:  workdir
 	}
 	r.jobs[id] = job
 	mut p := os.new_process('agent-toolkit')
@@ -72,12 +74,21 @@ pub fn (mut r JobRunner) create(cmd string, args []string, workdir string) !Job 
 	r.jobs[id].status = 'running'
 	r.running++
 	r.persist_locked()
+	os.write_file(r.log_path(id), '[running]\n') or {}
 	go r.watch(id, mut p)
 	return r.jobs[id]
 }
 
 fn (mut r JobRunner) watch(id string, mut p os.Process) {
 	p.wait()
+	out := p.stdout_slurp()
+	err := p.stderr_slurp()
+	combined := out + if err.len > 0 { '\n' + err } else { '' }
+	if combined.len > 0 {
+		os.write_file(r.log_path(id), '[exit ${p.code}]\n' + combined) or {}
+	} else {
+		os.write_file(r.log_path(id), '[exit ${p.code}]') or {}
+	}
 	r.mut.lock()
 	defer {
 		r.mut.unlock()

--- a/modules/agent_toolkit_server/server.veb.v
+++ b/modules/agent_toolkit_server/server.veb.v
@@ -180,9 +180,10 @@ pub fn (app &App) loops_list(mut ctx Ctx) veb.Result {
 	if deny != none {
 		return ctx.json(deny)
 	}
+	ws := agent_toolkit_core.find_workspace_root('') or { os.getwd() }
 	return ctx.json(cmd_resp(agent_toolkit_core.loop_result(agent_toolkit_core.run_loop(agent_toolkit_core.LoopOptions{
 		subcommand:     'list'
-		workspace_path: os.getwd()
+		workspace_path: ws
 	}))))
 }
 
@@ -192,9 +193,10 @@ pub fn (app &App) loops_status(mut ctx Ctx, name string) veb.Result {
 	if deny != none {
 		return ctx.json(deny)
 	}
+	ws := agent_toolkit_core.find_workspace_root('') or { os.getwd() }
 	report := agent_toolkit_core.run_loop(agent_toolkit_core.LoopOptions{
 		subcommand:     'status'
-		workspace_path: os.getwd()
+		workspace_path: ws
 		name:           name
 	})
 	if !report.ok && report.message.contains('not found') {
@@ -336,8 +338,9 @@ fn is_file(p string) bool {
 
 
 struct JobCreateReq {
-	cmd  string
-	args []string
+	cmd       string
+	args      []string
+	workspace string
 }
 
 @['/api/v1/jobs'; post]
@@ -352,10 +355,33 @@ pub fn (mut app App) jobs_create(mut ctx Ctx) veb.Result {
 	if req.cmd.len == 0 {
 		return ctx.json(DenyErr{ ok: false, error: 'cmd is required' })
 	}
-	mut args := [req.cmd]
-	args << req.args
-	job := app.runner.create(req.cmd, args, os.getwd()) or {
+	mut workspace := ''
+	if req.workspace.len > 0 {
+		if !os.is_dir(req.workspace) {
+			return ctx.json(DenyErr{ ok: false, error: 'workspace not found: ${req.workspace}' })
+		}
+		workspace = req.workspace
+	} else {
+		workspace = agent_toolkit_core.find_workspace_root('') or { os.getwd() }
+	}
+	mut args := []string{}
+	if req.args.len > 0 && req.args[0] == req.cmd {
+		args = req.args.clone()
+	} else {
+		args << req.cmd
+		args << req.args
+	}
+	has_ws := args.contains('--workspace') || args.contains('-w')
+	if !has_ws && workspace.len > 0 {
+		args << '--workspace'
+		args << workspace
+	}
+	job := app.runner.create(req.cmd, args, workspace) or {
 		return ctx.json(DenyErr{ ok: false, error: err.msg() })
+	}
+	lp := app.runner.log_path(job.id)
+	if !is_file(lp) {
+		os.write_file(lp, '[running]\n') or {}
 	}
 	return ctx.json(job)
 }
@@ -402,8 +428,15 @@ pub fn (mut app App) loops_run(mut ctx Ctx, name string) veb.Result {
 	if deny != none {
 		return ctx.json(deny)
 	}
-	// Enqueue as job for streaming (reuse jobs runner)
-	job := app.runner.create('loop', ['loop', 'run', name], os.getwd()) or {
+	// Enqueue as job for streaming (reuse jobs runner) — workspace-aware
+	workspace := agent_toolkit_core.find_workspace_root('') or { os.getwd() }
+	mut args := ['loop', 'run', name]
+	has_ws := args.contains('--workspace') || args.contains('-w')
+	if !has_ws && workspace.len > 0 {
+		args << '--workspace'
+		args << workspace
+	}
+	job := app.runner.create('loop', args, workspace) or {
 		return ctx.json(DenyErr{ ok: false, error: err.msg() })
 	}
 	return ctx.json(job)


### PR DESCRIPTION
Fixes critical server bugs:

- Jobs log not found: jobs.v watch() now captures stdout/stderr via stdout_slurp/stderr_slurp and writes to log_path with exit code; create writes initial [running] stub.
- Workspace routing: JobCreateReq adds workspace field; jobs_create resolves workspace via request > find_workspace_root > cwd, validates is_dir, injects --workspace flag if missing, passes workspace to runner. Fixes loops_list/loops_status/loops_run to be workspace-aware.
- Args duplication: normalizes args to avoid duplicate cmd when web sends {cmd:'loop', args:['loop','run',...]}.

Also adds workspace field to Job struct.

Verified with v vet modules/agent_toolkit_server/ 0 errors.