### PR TITLE
feat(862): target capability research and registry (all harnesses)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -231,6 +231,38 @@ jobs:
       - name: Check skill→product→target matrix is up to date
         run: ./scripts/generate-skill-matrix.vsh --check
 
+  check-target-matrix:
+    name: Check Target Capability Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install dependencies
+        run: pip install pyyaml==6.0.2 jsonschema==4.23.0
+
+      - name: Validate target registry against schema
+        run: |
+          python3 - <<'PYEOF'
+          import json, yaml, sys
+          from pathlib import Path
+          from jsonschema import validate, ValidationError
+          schema = json.loads(Path("schemas/target-capability-registry.schema.json").read_text())
+          data = yaml.safe_load(Path("capabilities/targets/registry.yaml").read_text())
+          try:
+              validate(data, schema)
+          except ValidationError as e:
+              print(f"FAIL: capabilities/targets/registry.yaml: {e.message}", file=sys.stderr)
+              sys.exit(1)
+          print("OK: capabilities/targets/registry.yaml validates against target-capability-registry.schema.json")
+          # profiles coverage is validated inside generate-target-matrix.py
+          import subprocess
+          res = subprocess.run([sys.executable, "scripts/generate-target-matrix.py", "--check"])
+          sys.exit(res.returncode)
+          PYEOF
+
+      - name: Check target capability matrix drift
+        run: python3 scripts/generate-target-matrix.py --check
+
   # ── Job 5: Validate loop.yaml files against loop.schema.json ──────────────
   validate-loops:
     name: Validate Loop Templates
@@ -783,6 +815,7 @@ jobs:
       - check-v-modules
       - check-catalogs
       - check-skill-matrix
+      - check-target-matrix
       - validate-loops
       - validate-products
       - secret-scan
@@ -807,6 +840,7 @@ jobs:
           if [[ "${{ needs.check-v-modules.result }}" != "success" ]]; then echo "check-v-modules failed: ${{ needs.check-v-modules.result }}"; failed="true"; fi
           if [[ "${{ needs.check-catalogs.result }}" != "success" ]]; then echo "check-catalogs failed: ${{ needs.check-catalogs.result }}"; failed="true"; fi
           if [[ "${{ needs.check-skill-matrix.result }}" != "success" ]]; then echo "check-skill-matrix failed: ${{ needs.check-skill-matrix.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-target-matrix.result }}" != "success" ]]; then echo "check-target-matrix failed: ${{ needs.check-target-matrix.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-loops.result }}" != "success" ]]; then echo "validate-loops failed: ${{ needs.validate-loops.result }}"; failed="true"; fi
           if [[ "${{ needs.validate-products.result }}" != "success" ]]; then echo "validate-products failed: ${{ needs.validate-products.result }}"; failed="true"; fi
           if [[ "${{ needs.secret-scan.result }}" != "success" ]]; then echo "secret-scan failed: ${{ needs.secret-scan.result }}"; failed="true"; fi

--- a/capabilities/targets/registry.yaml
+++ b/capabilities/targets/registry.yaml
@@ -1,90 +1,362 @@
 # Declarative target registry — single source for CLI build/diff/release target lists.
+# Extended per #862: canonical target capability registry for all harness targets.
+# Each target is researched against official docs; uncertain fields are marked
+# `partial` or `unknown` rather than guessed. Consumers should read
+# docs/TARGET_CAPABILITY_MATRIX.md (generated) or this file directly.
+# Validate with: python3 scripts/generate-target-matrix.py --check
+# Schema: schemas/target-capability-registry.schema.json
 version: 1
 targets:
   - id: claude-code
+    display_name: Claude Code
     adapter: agent_toolkit.compiler.targets.claude_code.ClaudeCodeAdapter
     aliases: []
     commands:
       build: true
       diff: true
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: v1
+      native_custom_agents: true
+      primary_agents: true
+      subagents: true
+      automatic_delegation: true
+      nested_delegation: true
+      parallel_agents: true
+      agent_permissions: true
+      agent_models: true
+      mcp: true
+      hooks: true
+      commands: true
+      rules: true
+      plugin_marketplace: true
+    researched_at: "2026-08-25"
+    sources:
+      - https://docs.anthropic.com/en/docs/claude-code
+      - https://code.claude.com/docs/en/plugins
+      - https://code.claude.com/docs/en/hooks
+      - https://agent-plugins.org
+      - https://modelcontextprotocol.io
+    maturity: stable
+    notes: Full plugin (.claude-plugin/) with native skills, agents, subagents, hooks (33 events), MCP, and Agent Plugins v1 portable.
 
   - id: cursor
+    display_name: Cursor
     adapter: agent_toolkit.compiler.targets.cursor.CursorAdapter
     aliases: []
     commands:
       build: true
       diff: true
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: v1
+      native_custom_agents: true
+      primary_agents: true
+      subagents: true
+      automatic_delegation: true
+      nested_delegation: partial
+      parallel_agents: true
+      agent_permissions: true
+      agent_models: true
+      mcp: true
+      hooks: true
+      commands: true
+      rules: true
+      plugin_marketplace: true
+    researched_at: "2026-08-25"
+    sources:
+      - https://docs.cursor.com
+      - https://cursor.com/docs/plugins
+      - https://docs.cursor.com/context/rules
+      - https://docs.cursor.com/context/mcp
+      - https://agent-plugins.org
+    maturity: stable
+    notes: Plugin (.cursor-plugin/) stable GA v2.5+; hooks 16+ events, MCP native, rules .mdc. Nested delegation partially confirmed.
 
   - id: opencode
+    display_name: OpenCode
     adapter: agent_toolkit.compiler.targets.opencode.OpenCodeAdapter
     aliases: []
     commands:
       build: true
       diff: true
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: custom
+      native_custom_agents: true
+      primary_agents: partial
+      subagents: true
+      automatic_delegation: partial
+      nested_delegation: partial
+      parallel_agents: true
+      agent_permissions: true
+      agent_models: true
+      mcp: partial
+      hooks: partial
+      commands: true
+      rules: true
+      plugin_marketplace: partial
+    researched_at: "2026-08-25"
+    sources:
+      - https://opencode.ai/docs
+      - https://opencode.ai/docs/plugins
+      - https://opencode.ai/docs/mcp
+    maturity: stable
+    notes: JS/TS module via opencode.json + .opencode/skills; hooks/MCP/tool interception require TypeScript runtime plugin (issue #10) — bridged, hence partial.
 
   - id: gemini-cli
+    display_name: Gemini CLI
     adapter: agent_toolkit.compiler.targets.gemini_cli.GeminiCLIAdapter
     aliases: [gemini]
     commands:
       build: true
       diff: false
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: custom
+      native_custom_agents: true
+      primary_agents: partial
+      subagents: partial
+      automatic_delegation: partial
+      nested_delegation: partial
+      parallel_agents: partial
+      agent_permissions: true
+      agent_models: true
+      mcp: true
+      hooks: true
+      commands: true
+      rules: true
+      plugin_marketplace: true
+    researched_at: "2026-08-25"
+    sources:
+      - https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/index.md
+      - https://github.com/google-gemini/gemini-cli
+      - https://geminicli.com/docs
+      - https://modelcontextprotocol.io
+    maturity: stable
+    notes: Extension (gemini-extension.json) + commands.toml; hooks 8+ events, MCP native, TOML commands. Subagent/parallel partially confirmed.
 
   - id: copilot-cli
+    display_name: GitHub Copilot CLI
     adapter: agent_toolkit.compiler.targets.copilot.CopilotCLIAdapter
     aliases: [copilot]
     commands:
       build: true
       diff: false
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: v1
+      native_custom_agents: true
+      primary_agents: true
+      subagents: partial
+      automatic_delegation: partial
+      nested_delegation: partial
+      parallel_agents: partial
+      agent_permissions: partial
+      agent_models: partial
+      mcp: unknown
+      hooks: unknown
+      commands: true
+      rules: true
+      plugin_marketplace: true
+    researched_at: "2026-08-25"
+    sources:
+      - https://docs.github.com/en/copilot
+      - https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference
+      - https://agent-plugins.org
+    maturity: stable
+    notes: Plugin (root plugin.json) via Open Plugin Spec; MCP/hooks not confirmed in official docs — marked unknown per source-ledger.
 
   - id: copilot-repository
+    display_name: GitHub Copilot Repository
     adapter: agent_toolkit.compiler.targets.copilot.CopilotRepositoryAdapter
     aliases: []
     commands:
       build: true
       diff: false
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: none
+      native_custom_agents: true
+      primary_agents: false
+      subagents: false
+      automatic_delegation: false
+      nested_delegation: false
+      parallel_agents: false
+      agent_permissions: partial
+      agent_models: false
+      mcp: false
+      hooks: false
+      commands: partial
+      rules: true
+      plugin_marketplace: false
+    researched_at: "2026-08-25"
+    sources:
+      - https://docs.github.com/en/copilot/customizing-copilot
+      - https://docs.github.com/en/copilot/customizing-copilot/using-custom-instructions
+    maturity: stable
+    notes: Repository customization (.github/copilot-instructions.md, .github/agents/*.agent.md, .github/skills/); no plugin marketplace — repo-scoped only.
 
   - id: pi
+    display_name: Pi Coding Agent
     adapter: agent_toolkit.compiler.targets.pi.PiAdapter
     aliases: []
     commands:
       build: true
       diff: false
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: custom
+      native_custom_agents: true
+      primary_agents: partial
+      subagents: true
+      automatic_delegation: partial
+      nested_delegation: partial
+      parallel_agents: partial
+      agent_permissions: true
+      agent_models: true
+      mcp: partial
+      hooks: partial
+      commands: true
+      rules: true
+      plugin_marketplace: partial
+    researched_at: "2026-08-25"
+    sources:
+      - https://pi.dev/docs/latest/extensions
+      - https://pi.dev/docs
+      - https://opencode.ai/docs/plugins
+    maturity: stable
+    notes: npm package (pi-package.json) auto-discovery; hooks/MCP/tool registration require TypeScript ExtensionAPI — partial.
 
   - id: windsurf
+    display_name: Windsurf
     adapter: agent_toolkit.compiler.targets.windsurf.WindsurfAdapter
     aliases: []
     commands:
       build: true
       diff: false
       release: true
+    capabilities:
+      agent_skills: partial
+      agent_plugins: none
+      native_custom_agents: partial
+      primary_agents: false
+      subagents: false
+      automatic_delegation: false
+      nested_delegation: false
+      parallel_agents: false
+      agent_permissions: false
+      agent_models: false
+      mcp: true
+      hooks: false
+      commands: false
+      rules: true
+      plugin_marketplace: false
+    researched_at: "2026-08-25"
+    sources:
+      - https://docs.devin.ai/desktop/getting-started
+      - https://docs.codeium.com/windsurf
+      - https://docs.codeium.com/windsurf/cascade
+    maturity: limited
+    notes: No open marketplace extensions (docs.devin.ai) — distributed as customization bundle (rules .mdc + manual MCP). Skills via generated rules.
 
   - id: codex
+    display_name: OpenAI Codex
     adapter: agent_toolkit.compiler.targets.codex.CodexAdapter
     aliases: []
     commands:
       build: true
       diff: false
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: v1
+      native_custom_agents: true
+      primary_agents: true
+      subagents: true
+      automatic_delegation: partial
+      nested_delegation: partial
+      parallel_agents: true
+      agent_permissions: partial
+      agent_models: true
+      mcp: partial
+      hooks: unknown
+      commands: partial
+      rules: true
+      plugin_marketplace: true
+    researched_at: "2026-08-25"
+    sources:
+      - https://developers.openai.com/codex
+      - https://github.com/openai/codex
+      - https://agent-plugins.org
+    maturity: experimental
+    notes: Plugin (.codex-plugin/) experimental launched March 2026; hooks/MCP not confirmed — marked unknown/partial; self-serve marketplace pending.
 
   - id: muse-code
+    display_name: Muse Code
     adapter: agent_toolkit.compiler.targets.muse_code.MuseCodeAdapter
     aliases: [muse]
     commands:
       build: true
       diff: false
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: custom
+      native_custom_agents: true
+      primary_agents: false
+      subagents: false
+      automatic_delegation: false
+      nested_delegation: false
+      parallel_agents: false
+      agent_permissions: partial
+      agent_models: partial
+      mcp: partial
+      hooks: false
+      commands: true
+      rules: true
+      plugin_marketplace: false
+    researched_at: "2026-08-25"
+    sources:
+      - https://developer.meta.com/ai/products/muse-code/
+      - https://github.com/vercel-labs/skills
+    maturity: stable
+    notes: Agent Skills under ~/.config/muse/skills/<name>/SKILL.md + .agents/skills fallback; custom plugin format, no marketplace yet.
 
   - id: agent-plugins
+    display_name: Agent Plugins (Portable)
     adapter: agent_toolkit.compiler.targets.agent_plugins.AgentPluginsAdapter
     aliases: []
     commands:
       build: true
       diff: true
       release: true
+    capabilities:
+      agent_skills: true
+      agent_plugins: v1
+      native_custom_agents: true
+      primary_agents: false
+      subagents: false
+      automatic_delegation: false
+      nested_delegation: false
+      parallel_agents: false
+      agent_permissions: false
+      agent_models: false
+      mcp: true
+      hooks: false
+      commands: true
+      rules: false
+      plugin_marketplace: true
+    researched_at: "2026-08-25"
+    sources:
+      - https://agent-plugins.org
+      - https://github.com/vercel-labs/skills
+    maturity: stable
+    notes: Synthetic portable target (plugin.json + skills/ + mcp.json) for Cursor/VS Code/Copilot/Kiro/Codex; agents via com.anthropic.claude-code extension; not a harness.

--- a/docs/TARGET_CAPABILITY_MATRIX.md
+++ b/docs/TARGET_CAPABILITY_MATRIX.md
@@ -1,0 +1,211 @@
+# Target Capability Matrix
+
+> Generated from `capabilities/targets/registry.yaml` — do not hand-edit.
+> Run `python3 scripts/generate-target-matrix.py` to regenerate, or `python3 scripts/generate-target-matrix.py --check` in CI.
+
+_Researched at: 2026-08-25 — sources per target below._
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Supported (native/stable) |
+| ❌ | Not supported |
+| ◐ partial | Partial / bridged / requires runtime |
+| ❓ unknown | Could not confirm from official docs |
+| `v1` | Agent Plugins 1.0 portable |
+| `custom` | Tool-specific custom format |
+| — | None / not applicable |
+
+## Capability × Target
+
+| Capability | Claude Code | Cursor | OpenCode | Gemini CLI | GitHub Copilot CLI | GitHub Copilot Repository | Pi Coding Agent | Windsurf | OpenAI Codex | Muse Code | Agent Plugins (Portable) |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Agent Skills | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ partial | ✅ | ✅ | ✅ |
+| Agent Plugins | `v1` | `v1` | `custom` | `custom` | `v1` | — | `custom` | — | `v1` | `custom` | `v1` |
+| Native Custom Agents | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ partial | ✅ | ✅ | ✅ |
+| Primary / Default Agents | ✅ | ✅ | ◐ partial | ◐ partial | ✅ | ❌ | ◐ partial | ❌ | ✅ | ❌ | ❌ |
+| Subagents | ✅ | ✅ | ✅ | ◐ partial | ◐ partial | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Automatic Delegation | ✅ | ✅ | ◐ partial | ◐ partial | ◐ partial | ❌ | ◐ partial | ❌ | ◐ partial | ❌ | ❌ |
+| Nested Delegation | ✅ | ◐ partial | ◐ partial | ◐ partial | ◐ partial | ❌ | ◐ partial | ❌ | ◐ partial | ❌ | ❌ |
+| Parallel Agents | ✅ | ✅ | ✅ | ◐ partial | ◐ partial | ❌ | ◐ partial | ❌ | ✅ | ❌ | ❌ |
+| Agent Permissions | ✅ | ✅ | ✅ | ✅ | ◐ partial | ◐ partial | ✅ | ❌ | ◐ partial | ◐ partial | ❌ |
+| Agent Models | ✅ | ✅ | ✅ | ✅ | ◐ partial | ❌ | ✅ | ❌ | ✅ | ◐ partial | ❌ |
+| MCP | ✅ | ✅ | ◐ partial | ✅ | ❓ unknown | ❌ | ◐ partial | ✅ | ◐ partial | ◐ partial | ✅ |
+| Hooks | ✅ | ✅ | ◐ partial | ✅ | ❓ unknown | ❌ | ◐ partial | ❌ | ❓ unknown | ❌ | ❌ |
+| Commands | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ partial | ✅ | ❌ | ◐ partial | ✅ | ✅ |
+| Rules / Instructions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Plugin Marketplace | ✅ | ✅ | ◐ partial | ✅ | ✅ | ❌ | ◐ partial | ❌ | ✅ | ❌ | ✅ |
+
+## Build Commands
+
+| Target | `build` | `diff` | `release` | Maturity | Aliases |
+|--------|---------|--------|-----------|----------|---------|
+| Claude Code (`claude-code`) | ✅ | ✅ | ✅ | stable | — |
+| Cursor (`cursor`) | ✅ | ✅ | ✅ | stable | — |
+| OpenCode (`opencode`) | ✅ | ✅ | ✅ | stable | — |
+| Gemini CLI (`gemini-cli`) | ✅ | ❌ | ✅ | stable | `gemini` |
+| GitHub Copilot CLI (`copilot-cli`) | ✅ | ❌ | ✅ | stable | `copilot` |
+| GitHub Copilot Repository (`copilot-repository`) | ✅ | ❌ | ✅ | stable | — |
+| Pi Coding Agent (`pi`) | ✅ | ❌ | ✅ | stable | — |
+| Windsurf (`windsurf`) | ✅ | ❌ | ✅ | limited | — |
+| OpenAI Codex (`codex`) | ✅ | ❌ | ✅ | experimental | — |
+| Muse Code (`muse-code`) | ✅ | ❌ | ✅ | stable | `muse` |
+| Agent Plugins (Portable) (`agent-plugins`) | ✅ | ✅ | ✅ | stable | — |
+
+## Per-Target Details
+
+### Claude Code (`claude-code`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.claude_code.ClaudeCodeAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=✅ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://docs.anthropic.com/en/docs/claude-code
+  - https://code.claude.com/docs/en/plugins
+  - https://code.claude.com/docs/en/hooks
+  - https://agent-plugins.org
+  - https://modelcontextprotocol.io
+- **Notes:** Full plugin (.claude-plugin/) with native skills, agents, subagents, hooks (33 events), MCP, and Agent Plugins v1 portable.
+
+### Cursor (`cursor`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.cursor.CursorAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=✅ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://docs.cursor.com
+  - https://cursor.com/docs/plugins
+  - https://docs.cursor.com/context/rules
+  - https://docs.cursor.com/context/mcp
+  - https://agent-plugins.org
+- **Notes:** Plugin (.cursor-plugin/) stable GA v2.5+; hooks 16+ events, MCP native, rules .mdc. Nested delegation partially confirmed.
+
+### OpenCode (`opencode`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.opencode.OpenCodeAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=✅ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://opencode.ai/docs
+  - https://opencode.ai/docs/plugins
+  - https://opencode.ai/docs/mcp
+- **Notes:** JS/TS module via opencode.json + .opencode/skills; hooks/MCP/tool interception require TypeScript runtime plugin (issue
+
+### Gemini CLI (`gemini-cli`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.gemini_cli.GeminiCLIAdapter`
+- **Aliases:** `gemini`
+- **Commands:** build=✅ diff=❌ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/index.md
+  - https://github.com/google-gemini/gemini-cli
+  - https://geminicli.com/docs
+  - https://modelcontextprotocol.io
+- **Notes:** Extension (gemini-extension.json) + commands.toml; hooks 8+ events, MCP native, TOML commands. Subagent/parallel partially confirmed.
+
+### GitHub Copilot CLI (`copilot-cli`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.copilot.CopilotCLIAdapter`
+- **Aliases:** `copilot`
+- **Commands:** build=✅ diff=❌ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://docs.github.com/en/copilot
+  - https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference
+  - https://agent-plugins.org
+- **Notes:** Plugin (root plugin.json) via Open Plugin Spec; MCP/hooks not confirmed in official docs — marked unknown per source-ledger.
+
+### GitHub Copilot Repository (`copilot-repository`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.copilot.CopilotRepositoryAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=❌ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://docs.github.com/en/copilot/customizing-copilot
+  - https://docs.github.com/en/copilot/customizing-copilot/using-custom-instructions
+- **Notes:** Repository customization (.github/copilot-instructions.md, .github/agents/*.agent.md, .github/skills/); no plugin marketplace — repo-scoped only.
+
+### Pi Coding Agent (`pi`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.pi.PiAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=❌ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://pi.dev/docs/latest/extensions
+  - https://pi.dev/docs
+  - https://opencode.ai/docs/plugins
+- **Notes:** npm package (pi-package.json) auto-discovery; hooks/MCP/tool registration require TypeScript ExtensionAPI — partial.
+
+### Windsurf (`windsurf`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.windsurf.WindsurfAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=❌ release=✅
+- **Maturity:** limited
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://docs.devin.ai/desktop/getting-started
+  - https://docs.codeium.com/windsurf
+  - https://docs.codeium.com/windsurf/cascade
+- **Notes:** No open marketplace extensions (docs.devin.ai) — distributed as customization bundle (rules .mdc + manual MCP). Skills via generated rules.
+
+### OpenAI Codex (`codex`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.codex.CodexAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=❌ release=✅
+- **Maturity:** experimental
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://developers.openai.com/codex
+  - https://github.com/openai/codex
+  - https://agent-plugins.org
+- **Notes:** Plugin (.codex-plugin/) experimental launched March 2026; hooks/MCP not confirmed — marked unknown/partial; self-serve marketplace pending.
+
+### Muse Code (`muse-code`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.muse_code.MuseCodeAdapter`
+- **Aliases:** `muse`
+- **Commands:** build=✅ diff=❌ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://developer.meta.com/ai/products/muse-code/
+  - https://github.com/vercel-labs/skills
+- **Notes:** Agent Skills under ~/.config/muse/skills/<name>/SKILL.md + .agents/skills fallback; custom plugin format, no marketplace yet.
+
+### Agent Plugins (Portable) (`agent-plugins`)
+
+- **Adapter:** `agent_toolkit.compiler.targets.agent_plugins.AgentPluginsAdapter`
+- **Aliases:** —
+- **Commands:** build=✅ diff=✅ release=✅
+- **Maturity:** stable
+- **Researched at:** 2026-08-25
+- **Sources:**
+  - https://agent-plugins.org
+  - https://github.com/vercel-labs/skills
+- **Notes:** Synthetic portable target (plugin.json + skills/ + mcp.json) for Cursor/VS Code/Copilot/Kiro/Codex; agents via com.anthropic.claude-code extension; not a harness.
+
+## See also
+
+- `capabilities/targets/registry.yaml` — source of truth (validated by `schemas/target-capability-registry.schema.json`)
+- `schemas/target-capability-registry.schema.json` — JSON schema
+- `docs/TARGETS.md` — supported targets overview and install commands
+- `docs/research/platform-capability-matrix.md` — prior research (2026-08-04) and capability value definitions
+- `docs/research/source-ledger.md` — source URLs and dates
+- `agent-toolkit build --check` — compiler drift check
+

--- a/schemas/target-capability-registry.schema.json
+++ b/schemas/target-capability-registry.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/target-capability-registry.schema.json",
+  "title": "Target Capability Registry",
+  "description": "Canonical target capability registry — schemas for capabilities/targets/registry.yaml (issue #862). Validates display_name, adapter, aliases, commands, 15 capability fields, researched_at and sources per target.",
+  "type": "object",
+  "required": ["version", "targets"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Registry schema version",
+      "minimum": 1
+    },
+    "researched_at": {
+      "type": "string",
+      "description": "Global research date (ISO 8601) if all targets share same date",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/target"
+      }
+    }
+  },
+  "$defs": {
+    "capabilityBoolean": {
+      "description": "Boolean capability with partial/unknown markers; true/false booleans or string enums partial/unknown/native variants",
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "string", "enum": ["true", "false", "partial", "unknown", "native", "native-experimental", "generated", "bridged", "manual", "unsupported", "unknown-blocked"] }
+      ]
+    },
+    "target": {
+      "type": "object",
+      "required": ["id", "display_name", "adapter", "aliases", "commands", "capabilities", "researched_at", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Kebab-case target identifier",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable display name"
+        },
+        "adapter": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Python/V adapter class path"
+        },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z0-9-]+$" }
+        },
+        "commands": {
+          "type": "object",
+          "required": ["build", "diff", "release"],
+          "additionalProperties": false,
+          "properties": {
+            "build": { "type": "boolean" },
+            "diff": { "type": "boolean" },
+            "release": { "type": "boolean" }
+          }
+        },
+        "capabilities": {
+          "type": "object",
+          "required": [
+            "agent_skills",
+            "agent_plugins",
+            "native_custom_agents",
+            "primary_agents",
+            "subagents",
+            "automatic_delegation",
+            "nested_delegation",
+            "parallel_agents",
+            "agent_permissions",
+            "agent_models",
+            "mcp",
+            "hooks",
+            "commands",
+            "rules",
+            "plugin_marketplace"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "agent_skills": { "$ref": "#/$defs/capabilityBoolean" },
+            "agent_plugins": {
+              "type": "string",
+              "enum": ["v1", "none", "custom"],
+              "description": "Agent Plugins spec support: v1=native portable, custom=tool-specific format, none=no plugin manifest"
+            },
+            "native_custom_agents": { "$ref": "#/$defs/capabilityBoolean" },
+            "primary_agents": { "$ref": "#/$defs/capabilityBoolean" },
+            "subagents": { "$ref": "#/$defs/capabilityBoolean" },
+            "automatic_delegation": { "$ref": "#/$defs/capabilityBoolean" },
+            "nested_delegation": { "$ref": "#/$defs/capabilityBoolean" },
+            "parallel_agents": { "$ref": "#/$defs/capabilityBoolean" },
+            "agent_permissions": { "$ref": "#/$defs/capabilityBoolean" },
+            "agent_models": { "$ref": "#/$defs/capabilityBoolean" },
+            "mcp": { "$ref": "#/$defs/capabilityBoolean" },
+            "hooks": { "$ref": "#/$defs/capabilityBoolean" },
+            "commands": { "$ref": "#/$defs/capabilityBoolean" },
+            "rules": { "$ref": "#/$defs/capabilityBoolean" },
+            "plugin_marketplace": { "$ref": "#/$defs/capabilityBoolean" }
+          }
+        },
+        "researched_at": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "format": "uri" }
+        },
+        "notes": {
+          "type": "string"
+        },
+        "maturity": {
+          "type": "string",
+          "enum": ["stable", "experimental", "deprecated", "limited"]
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate-target-matrix.py
+++ b/scripts/generate-target-matrix.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Generate docs/TARGET_CAPABILITY_MATRIX.md from capabilities/targets/registry.yaml.
+
+Usage:
+  python3 scripts/generate-target-matrix.py              # write docs/TARGET_CAPABILITY_MATRIX.md
+  python3 scripts/generate-target-matrix.py --check      # fail on drift
+  python3 scripts/generate-target-matrix.py --output PATH
+
+Also validates that registry covers all profiles/ dirs (copilot maps to copilot-cli + copilot-repository).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = REPO_ROOT / "capabilities" / "targets" / "registry.yaml"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "TARGET_CAPABILITY_MATRIX.md"
+PROFILES_DIR = REPO_ROOT / "profiles"
+
+# Capability order per issue #862
+CAPABILITIES = [
+    "agent_skills",
+    "agent_plugins",
+    "native_custom_agents",
+    "primary_agents",
+    "subagents",
+    "automatic_delegation",
+    "nested_delegation",
+    "parallel_agents",
+    "agent_permissions",
+    "agent_models",
+    "mcp",
+    "hooks",
+    "commands",
+    "rules",
+    "plugin_marketplace",
+]
+
+CAP_LABELS = {
+    "agent_skills": "Agent Skills",
+    "agent_plugins": "Agent Plugins",
+    "native_custom_agents": "Native Custom Agents",
+    "primary_agents": "Primary / Default Agents",
+    "subagents": "Subagents",
+    "automatic_delegation": "Automatic Delegation",
+    "nested_delegation": "Nested Delegation",
+    "parallel_agents": "Parallel Agents",
+    "agent_permissions": "Agent Permissions",
+    "agent_models": "Agent Models",
+    "mcp": "MCP",
+    "hooks": "Hooks",
+    "commands": "Commands",
+    "rules": "Rules / Instructions",
+    "plugin_marketplace": "Plugin Marketplace",
+}
+
+
+# Human-readable cell rendering
+def fmt(val) -> str:  # noqa: ANN001
+    if val is True:
+        return "✅"
+    if val is False:
+        return "❌"
+    if val is None:
+        return "—"
+    s = str(val).strip()
+    # normalize lower
+    low = s.lower()
+    mapping = {
+        "true": "✅",
+        "false": "❌",
+        "partial": "◐ partial",
+        "unknown": "❓ unknown",
+        "unknown-blocked": "❓ unknown-blocked",
+        "native": "✅ native",
+        "native-experimental": "🧪 native-experimental",
+        "generated": "🔧 generated",
+        "bridged": "🔗 bridged",
+        "manual": "✋ manual",
+        "unsupported": "❌ unsupported",
+        "v1": "`v1`",
+        "none": "—",
+        "custom": "`custom`",
+    }
+    return mapping.get(low, s)
+
+
+def load_registry():
+    text = REGISTRY_PATH.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict) or "targets" not in data:
+        print("FAIL: registry.yaml missing 'targets' key", file=sys.stderr)
+        sys.exit(1)
+    return data
+
+
+def validate_profiles_coverage(targets):
+    """Ensure registry covers all profiles/ dirs. copilot -> copilot-cli + copilot-repository."""
+    if not PROFILES_DIR.is_dir():
+        return
+    profile_ids = sorted([p.name for p in PROFILES_DIR.iterdir() if p.is_dir()])
+    # Map profiles to expected registry ids
+    expected = set()
+    for pid in profile_ids:
+        if pid == "copilot":
+            expected.update(["copilot-cli", "copilot-repository"])
+        else:
+            expected.add(pid)
+    # agent-plugins is synthetic, not in profiles — allow it
+    registry_ids = {t["id"] for t in targets}
+    # Check coverage
+    missing = expected - registry_ids
+    extra = registry_ids - expected - {"agent-plugins"}
+    msgs = []
+    if missing:
+        msgs.append(
+            f"registry missing profiles coverage: {sorted(missing)} (profiles={profile_ids})"
+        )
+    if extra:
+        # extra synthetic is okay only for agent-plugins; otherwise warn
+        msgs.append(f"registry has extra ids not in profiles/: {sorted(extra)}")
+    if msgs:
+        for m in msgs:
+            print(f"FAIL: {m}", file=sys.stderr)
+        sys.exit(1)
+
+
+def render_md(data) -> str:
+    targets = data["targets"]
+    # preserve registry order
+    validate_profiles_coverage(targets)
+
+    lines = []
+    lines.append("# Target Capability Matrix")
+    lines.append("")
+    lines.append("> Generated from `capabilities/targets/registry.yaml` — do not hand-edit.")
+    lines.append(
+        "> Run `python3 scripts/generate-target-matrix.py` to regenerate, or `python3 scripts/generate-target-matrix.py --check` in CI."
+    )
+    lines.append("")
+    researched = data.get("researched_at") or (targets[0].get("researched_at") if targets else "")
+    if researched:
+        lines.append(f"_Researched at: {researched} — sources per target below._")
+        lines.append("")
+    # Legend
+    lines.append("## Legend")
+    lines.append("")
+    lines.append("| Symbol | Meaning |")
+    lines.append("|--------|---------|")
+    lines.append("| ✅ | Supported (native/stable) |")
+    lines.append("| ❌ | Not supported |")
+    lines.append("| ◐ partial | Partial / bridged / requires runtime |")
+    lines.append("| ❓ unknown | Could not confirm from official docs |")
+    lines.append("| `v1` | Agent Plugins 1.0 portable |")
+    lines.append("| `custom` | Tool-specific custom format |")
+    lines.append("| — | None / not applicable |")
+    lines.append("")
+
+    # Main Capability x Target table
+    lines.append("## Capability × Target")
+    lines.append("")
+    # Header row
+    header = (
+        "| Capability | " + " | ".join(t.get("display_name") or t["id"] for t in targets) + " |"
+    )
+    sep = "|---|" + "|".join(["---"] * len(targets)) + "|"
+    lines.append(header)
+    lines.append(sep)
+    caps = targets[0].get("capabilities", {}) if targets else {}
+    # Use canonical CAPABILITIES order; append any extra keys not in list
+    remaining = [k for k in caps.keys() if k not in CAPABILITIES]
+    ordered = CAPABILITIES + sorted(remaining)
+    for cap in ordered:
+        label = CAP_LABELS.get(cap, cap)
+        row = [label]
+        for t in targets:
+            v = t.get("capabilities", {}).get(cap, "—")
+            row.append(fmt(v))
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+
+    # Commands build/diff/release table (keep existing fields visible)
+    lines.append("## Build Commands")
+    lines.append("")
+    lines.append("| Target | `build` | `diff` | `release` | Maturity | Aliases |")
+    lines.append("|--------|---------|--------|-----------|----------|---------|")
+    for t in targets:
+        cmds = t.get("commands", {})
+        aliases = ", ".join(f"`{a}`" for a in t.get("aliases", [])) or "—"
+        mat = t.get("maturity", "—")
+        lines.append(
+            f"| {t.get('display_name') or t['id']} (`{t['id']}`) | {fmt(cmds.get('build'))} | {fmt(cmds.get('diff'))} | {fmt(cmds.get('release'))} | {mat} | {aliases} |"
+        )
+    lines.append("")
+
+    # Per-target details: researched_at, sources, notes, adapter
+    lines.append("## Per-Target Details")
+    lines.append("")
+    for t in targets:
+        lines.append(f"### {t.get('display_name') or t['id']} (`{t['id']}`)")
+        lines.append("")
+        lines.append(f"- **Adapter:** `{t.get('adapter', '')}`")
+        lines.append(f"- **Aliases:** {', '.join(f'`{a}`' for a in t.get('aliases', [])) or '—'}")
+        cmds = t.get("commands", {})
+        lines.append(
+            f"- **Commands:** build={fmt(cmds.get('build'))} diff={fmt(cmds.get('diff'))} release={fmt(cmds.get('release'))}"
+        )
+        lines.append(f"- **Maturity:** {t.get('maturity', '—')}")
+        lines.append(f"- **Researched at:** {t.get('researched_at', '—')}")
+        srcs = t.get("sources", [])
+        if srcs:
+            lines.append("- **Sources:**")
+            for s in srcs:
+                lines.append(f"  - {s}")
+        else:
+            lines.append("- **Sources:** —")
+        if t.get("notes"):
+            lines.append(f"- **Notes:** {t['notes']}")
+        lines.append("")
+
+    lines.append("## See also")
+    lines.append("")
+    lines.append(
+        "- `capabilities/targets/registry.yaml` — source of truth (validated by `schemas/target-capability-registry.schema.json`)"
+    )
+    lines.append("- `schemas/target-capability-registry.schema.json` — JSON schema")
+    lines.append("- `docs/TARGETS.md` — supported targets overview and install commands")
+    lines.append(
+        "- `docs/research/platform-capability-matrix.md` — prior research (2026-08-04) and capability value definitions"
+    )
+    lines.append("- `docs/research/source-ledger.md` — source URLs and dates")
+    lines.append("- `agent-toolkit build --check` — compiler drift check")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if docs/TARGET_CAPABILITY_MATRIX.md drifts from registry",
+    )
+    ap.add_argument("--output", default=str(DEFAULT_OUTPUT), help="output path")
+    args = ap.parse_args()
+    data = load_registry()
+    content = render_md(data)
+    out = Path(args.output)
+    if not out.is_absolute():
+        out = REPO_ROOT / out
+    if args.check:
+        if not out.is_file():
+            print(f"Missing matrix file: {out}", file=sys.stderr)
+            sys.exit(1)
+        existing = out.read_text(encoding="utf-8")
+        if existing != content:
+            print(f"Matrix out of date: {out} differs from {REGISTRY_PATH}", file=sys.stderr)
+            print("Run: python3 scripts/generate-target-matrix.py", file=sys.stderr)
+            # show diff hint
+            import difflib
+
+            diff = difflib.unified_diff(
+                existing.splitlines(),
+                content.splitlines(),
+                fromfile=str(out),
+                tofile="generated",
+                lineterm="",
+            )
+            for line in list(diff)[:200]:
+                print(line)
+            sys.exit(1)
+        print(f"Matrix up to date: {out}")
+        return
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(content, encoding="utf-8")
+    print(f"Wrote matrix to {out} ({len(content.splitlines())} lines)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #862

Researches all 11 harness targets (claude-code, cursor, opencode, gemini-cli, copilot-cli, copilot-repository, pi, windsurf, codex, muse-code, agent-plugins) against 2026-08-25 official docs.

- Extends `capabilities/targets/registry.yaml` with `capabilities` map (agent_skills, agent_plugins, native_custom_agents, primary_agents, subagents, automatic_delegation, nested_delegation, parallel_agents, agent_permissions, agent_models, mcp, hooks, commands, rules, plugin_marketplace), `researched_at`, `sources`, `maturity`, `notes` per target.
- Adds `schemas/target-capability-registry.schema.json` and `docs/TARGET_CAPABILITY_MATRIX.md` (generated by `scripts/generate-target-matrix.py`).
- Adds CI job `check-target-matrix` gated into Required CI.

Ghost README audit included: no `README.md` at canonical `agents/*/AGENT.md` or `skills/*/*/SKILL.md` roots; only `skills/quality/megalinter-fix/linters/README.md` (auto-generated linter index, intentional — header says do not edit).

Validation: validate-skills, catalogs --check, matrix --check, surface --check, V vet/test green locally. Invariant holds: one canonical capability architecture, many optimized harness adapters.