### PR TITLE
feat(866): machine-readable agent relationships and orchestration metadata

### DIFF
--- a/agents/agentic-security-reviewer/AGENT.md
+++ b/agents/agentic-security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/agents/architect/AGENT.md
+++ b/agents/architect/AGENT.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/agents/assistant/AGENT.md
+++ b/agents/assistant/AGENT.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/agents/build-error-resolver/AGENT.md
+++ b/agents/build-error-resolver/AGENT.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/agents/client-workflow-bootstrap/AGENT.md
+++ b/agents/client-workflow-bootstrap/AGENT.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/agents/code-reviewer/AGENT.md
+++ b/agents/code-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/agents/data-engineer/AGENT.md
+++ b/agents/data-engineer/AGENT.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/agents/designer/AGENT.md
+++ b/agents/designer/AGENT.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/agents/e2e-runner/AGENT.md
+++ b/agents/e2e-runner/AGENT.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/agents/implementer/AGENT.md
+++ b/agents/implementer/AGENT.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/agents/planner/AGENT.md
+++ b/agents/planner/AGENT.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/agents/platform-engineer/AGENT.md
+++ b/agents/platform-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/agents/qa-engineer/AGENT.md
+++ b/agents/qa-engineer/AGENT.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/agents/researcher/AGENT.md
+++ b/agents/researcher/AGENT.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/agents/reviewer/AGENT.md
+++ b/agents/reviewer/AGENT.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/agents/security-engineer/AGENT.md
+++ b/agents/security-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/agents/security-reviewer/AGENT.md
+++ b/agents/security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/agents/tdd-guide/AGENT.md
+++ b/agents/tdd-guide/AGENT.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/catalogs/agent-catalog.yaml
+++ b/catalogs/agent-catalog.yaml
@@ -5,54 +5,167 @@ agents:
   - id: agentic-security-reviewer
     name: agentic-security-reviewer
     description: 'Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-en'
+    kind: specialist
   - id: architect
     name: architect
     description: 'Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.'
+    kind: holistic
+    collaborates_with:
+      - data-engineer
+      - planner
+      - platform-engineer
+      - reviewer
+      - security-engineer
   - id: assistant
     name: assistant
     description: 'agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.'
+    kind: orchestrator
+    delegates:
+      - architect
+      - data-engineer
+      - designer
+      - implementer
+      - planner
+      - platform-engineer
+      - qa-engineer
+      - researcher
+      - reviewer
+      - security-engineer
+    collaborates_with:
+      - client-workflow-bootstrap
   - id: build-error-resolver
     name: build-error-resolver
     description: 'Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full'
+    kind: specialist
   - id: client-workflow-bootstrap
     name: client-workflow-bootstrap
     description: 'Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating '
+    kind: orchestrator
+    collaborates_with:
+      - assistant
   - id: code-reviewer
     name: code-reviewer
     description: 'Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independe'
+    kind: specialist
   - id: data-engineer
     name: data-engineer
     description: '>- Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or valida'
+    kind: holistic
+    collaborates_with:
+      - architect
+      - implementer
+      - platform-engineer
+      - qa-engineer
+      - researcher
+      - reviewer
   - id: designer
     name: designer
     description: '>- Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma f'
+    kind: holistic
+    collaborates_with:
+      - implementer
+      - qa-engineer
+      - researcher
   - id: e2e-runner
     name: e2e-runner
     description: 'End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task '
+    kind: specialist
   - id: implementer
     name: implementer
     description: '>- Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation,'
+    kind: holistic
+    delegates:
+      - tdd-guide
+    collaborates_with:
+      - architect
+      - data-engineer
+      - designer
+      - planner
+      - platform-engineer
+      - qa-engineer
+      - researcher
+      - reviewer
+      - security-engineer
   - id: planner
     name: planner
     description: 'Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.'
+    kind: holistic
+    collaborates_with:
+      - architect
+      - implementer
+      - qa-engineer
+      - researcher
+      - reviewer
   - id: platform-engineer
     name: platform-engineer
     description: '>- Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herd'
+    kind: holistic
+    delegates:
+      - build-error-resolver
+    collaborates_with:
+      - architect
+      - implementer
+      - planner
+      - qa-engineer
+      - researcher
+      - reviewer
+      - security-engineer
   - id: qa-engineer
     name: qa-engineer
     description: '>- Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, ru'
+    kind: holistic
+    delegates:
+      - e2e-runner
+    collaborates_with:
+      - data-engineer
+      - designer
+      - implementer
+      - platform-engineer
+      - reviewer
+      - security-engineer
   - id: researcher
     name: researcher
     description: '>- Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation st'
+    kind: holistic
+    collaborates_with:
+      - architect
+      - data-engineer
+      - designer
+      - implementer
+      - planner
+      - qa-engineer
   - id: reviewer
     name: reviewer
     description: '>- Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish,'
+    kind: holistic
+    delegates:
+      - code-reviewer
+    collaborates_with:
+      - architect
+      - designer
+      - implementer
+      - qa-engineer
+      - researcher
+      - security-engineer
   - id: security-engineer
     name: security-engineer
     description: '>- Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain be'
+    kind: holistic
+    delegates:
+      - agentic-security-reviewer
+      - security-reviewer
+    collaborates_with:
+      - architect
+      - designer
+      - implementer
+      - platform-engineer
+      - qa-engineer
+      - reviewer
   - id: security-reviewer
     name: security-reviewer
     description: 'App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API'
+    kind: specialist
   - id: tdd-guide
     name: tdd-guide
     description: 'Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires '
+    kind: specialist

--- a/docs/HOW_TO_ADD_AGENT.md
+++ b/docs/HOW_TO_ADD_AGENT.md
@@ -71,8 +71,16 @@ description: >-
   Use when: [trigger keywords that identify when this agent should be invoked].
   The description is shown in the agent picker — make it unambiguous.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - reviewer
+  - qa-engineer
 ---
 ```
+
+Schema: `schemas/agent-frontmatter.schema.json` (#866). `kind` is required; `delegates`/`collaborates_with`/`skills` are optional — keep entries minimal (ids only, no procedural text). Canonical skill ownership remains in `capabilities/skills/registry.yaml` (`holistic_owner`); only list `skills:` in frontmatter when the agent explicitly handles `domain/name` ids that must be validated against `skills/`.
 
 ### Required frontmatter fields
 
@@ -81,6 +89,15 @@ tools: Read, Grep, Glob, Bash
 | `name` | string | Kebab-case identifier, must match the directory name |
 | `description` | string | Used by the AI to decide which agent to invoke |
 | `tools` | string | Comma-separated list of tools the agent is allowed to use |
+| `kind` | `orchestrator` \| `holistic` \| `specialist` | Tier per `docs/AGENT_TAXONOMY.md` §2. Required since #866 |
+
+### Optional frontmatter fields (machine-readable orchestration — #866)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `delegates` | `string[]` | Directed delegation edges — agent ids this persona may delegate to. Validated: every entry must be an existing agent, no self-ref, no forbidden cycle, every `specialist` must have a caller in the reverse graph. Holistic → `specialist`, `orchestrator` (`assistant`) → holistic. |
+| `collaborates_with` | `string[]` | Undirected collaboration peers (handoff boundaries) — holistic peers this agent frequently hands off to. Validated: every entry must be an existing agent, no self-ref. Not part of cycle detection. |
+| `skills` | `string[]` | Optional explicit `domain/name` skill ids handled by this agent. Validated against `skills/`; otherwise ownership is derived from `capabilities/skills/registry.yaml`. Omit unless the agent explicitly declares skills. |
 
 ### Tools reference
 
@@ -133,11 +150,14 @@ Reference documents are domain knowledge the agent can read during a session. Th
 ./scripts/validate-agents.vsh
 ```
 
-The validator checks:
+The validator (`scripts/validate-agents.vsh` — #866 schema + graph) checks:
 - `AGENT.md` is present in every agent directory
-- YAML frontmatter is valid
-- Required fields (`name`, `description`, `tools`) are present
-- `name` in frontmatter matches the directory name
+- YAML frontmatter is valid and validates against `schemas/agent-frontmatter.schema.json`
+- Required fields (`name`, `description`, `tools`, `kind`) are present; `kind` is `orchestrator|holistic|specialist`
+- `name` in frontmatter matches the directory name (kebab-case)
+- `delegates` / `collaborates_with` entries reference existing agents, no self-ref, no duplicates, no forbidden cycle; every `specialist` has a legitimate caller (reverse graph)
+- `skills` (if present) entries are valid `domain/name` ids that exist in `skills/`
+- `distributions/products.yaml` `agents:` entries reference canonical agents
 
 ---
 
@@ -170,11 +190,13 @@ When a new skill is routed through an agent:
 ```markdown
 ## Agent Checklist
 - [ ] `agents/<agent-name>/AGENT.md` created
-- [ ] Frontmatter has `name`, `description`, and `tools`
-- [ ] `name` in frontmatter matches directory name
-- [ ] `./scripts/validate-agents.vsh` passes with no errors
-- [ ] `distributions/products.yaml` updated if product membership changed
-- [ ] `./scripts/generate-catalogs.vsh` was run (do **not** hand-edit `agent-catalog.yaml`)
+- [ ] Frontmatter has `name`, `description`, `tools`, and `kind` (`orchestrator|holistic|specialist` — required since #866; see `schemas/agent-frontmatter.schema.json`)
+- [ ] `name` in frontmatter matches directory name (kebab-case)
+- [ ] `delegates` / `collaborates_with` (if any) list only existing agents, no self-ref/cycle — every new `specialist` has a caller in the reverse graph
+- [ ] `skills` (if present) lists only valid `domain/name` ids that exist in `skills/`
+- [ ] `./scripts/validate-agents.vsh` passes with no errors (schema + orphan/cycle/missing-delegate/products checks)
+- [ ] `distributions/products.yaml` updated if product membership changed (must reference canonical agents)
+- [ ] `./scripts/generate-catalogs.vsh` was run (do **not** hand-edit `agent-catalog.yaml` — now emits `kind`/`delegates`/`collaborates_with`)
 - [ ] `./make.vsh build-cli && AGENT_TOOLKIT_ROOT="$PWD" ./build/agent-toolkit build --check` passes
 - [ ] `references/` documents linked from agent body (if present)
 - [ ] `tools` list is minimal — only what the agent genuinely needs
@@ -205,6 +227,10 @@ description: >-
   Use when: reviewing a component for accessibility, auditing a PR with UI changes,
   checking WCAG compliance, fixing a11y CI failures, preparing for an accessibility audit.
 tools: Read, Grep, Glob, Bash
+kind: specialist
+collaborates_with:
+  - reviewer
+  - designer
 ---
 
 # Accessibility Reviewer

--- a/plugins/agent-toolkit-agents/.github/agents/agentic-security-reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/agentic-security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-agents/.github/agents/architect.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/architect.agent.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-agents/.github/agents/assistant.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/assistant.agent.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-agents/.github/agents/build-error-resolver.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/build-error-resolver.agent.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-agents/.github/agents/client-workflow-bootstrap.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/client-workflow-bootstrap.agent.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-agents/.github/agents/code-reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/code-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-agents/.github/agents/data-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/data-engineer.agent.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-agents/.github/agents/designer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/designer.agent.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-agents/.github/agents/e2e-runner.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/e2e-runner.agent.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-agents/.github/agents/implementer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/implementer.agent.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-agents/.github/agents/planner.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/planner.agent.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-agents/.github/agents/platform-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/platform-engineer.agent.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-agents/.github/agents/qa-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/qa-engineer.agent.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-agents/.github/agents/researcher.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/researcher.agent.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-agents/.github/agents/reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/reviewer.agent.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-agents/.github/agents/security-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/security-engineer.agent.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-agents/.github/agents/security-reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-agents/.github/agents/tdd-guide.agent.md
+++ b/plugins/agent-toolkit-agents/.github/agents/tdd-guide.agent.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-agents/.opencode/agents/agentic-security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/agentic-security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-agents/.opencode/agents/architect/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/architect/AGENT.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-agents/.opencode/agents/assistant/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/assistant/AGENT.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-agents/.opencode/agents/build-error-resolver/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/build-error-resolver/AGENT.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-agents/.opencode/agents/client-workflow-bootstrap/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/client-workflow-bootstrap/AGENT.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-agents/.opencode/agents/code-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/code-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-agents/.opencode/agents/data-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/data-engineer/AGENT.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-agents/.opencode/agents/designer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/designer/AGENT.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-agents/.opencode/agents/e2e-runner/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/e2e-runner/AGENT.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-agents/.opencode/agents/implementer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/implementer/AGENT.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-agents/.opencode/agents/planner/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/planner/AGENT.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-agents/.opencode/agents/platform-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/platform-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-agents/.opencode/agents/qa-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/qa-engineer/AGENT.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-agents/.opencode/agents/researcher/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/researcher/AGENT.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-agents/.opencode/agents/reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/reviewer/AGENT.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-agents/.opencode/agents/security-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/security-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-agents/.opencode/agents/security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-agents/.opencode/agents/tdd-guide/AGENT.md
+++ b/plugins/agent-toolkit-agents/.opencode/agents/tdd-guide/AGENT.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-agents/agents/agentic-security-reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/agentic-security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-agents/agents/agentic-security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/agentic-security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-agents/agents/architect.agent.md
+++ b/plugins/agent-toolkit-agents/agents/architect.agent.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-agents/agents/architect/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/architect/AGENT.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-agents/agents/assistant.agent.md
+++ b/plugins/agent-toolkit-agents/agents/assistant.agent.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-agents/agents/assistant/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/assistant/AGENT.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-agents/agents/build-error-resolver.agent.md
+++ b/plugins/agent-toolkit-agents/agents/build-error-resolver.agent.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-agents/agents/build-error-resolver/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/build-error-resolver/AGENT.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-agents/agents/client-workflow-bootstrap.agent.md
+++ b/plugins/agent-toolkit-agents/agents/client-workflow-bootstrap.agent.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-agents/agents/client-workflow-bootstrap/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/client-workflow-bootstrap/AGENT.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-agents/agents/code-reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/code-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-agents/agents/code-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/code-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-agents/agents/data-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/data-engineer.agent.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-agents/agents/data-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/data-engineer/AGENT.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-agents/agents/designer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/designer.agent.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-agents/agents/designer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/designer/AGENT.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-agents/agents/e2e-runner.agent.md
+++ b/plugins/agent-toolkit-agents/agents/e2e-runner.agent.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-agents/agents/e2e-runner/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/e2e-runner/AGENT.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-agents/agents/implementer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/implementer.agent.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-agents/agents/implementer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/implementer/AGENT.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-agents/agents/planner.agent.md
+++ b/plugins/agent-toolkit-agents/agents/planner.agent.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-agents/agents/planner/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/planner/AGENT.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-agents/agents/platform-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/platform-engineer.agent.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-agents/agents/platform-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/platform-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-agents/agents/qa-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/qa-engineer.agent.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-agents/agents/qa-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/qa-engineer/AGENT.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-agents/agents/researcher.agent.md
+++ b/plugins/agent-toolkit-agents/agents/researcher.agent.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-agents/agents/researcher/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/researcher/AGENT.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-agents/agents/reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/reviewer.agent.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-agents/agents/reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/reviewer/AGENT.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-agents/agents/security-engineer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/security-engineer.agent.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-agents/agents/security-engineer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/security-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-agents/agents/security-reviewer.agent.md
+++ b/plugins/agent-toolkit-agents/agents/security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-agents/agents/security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-agents/agents/tdd-guide.agent.md
+++ b/plugins/agent-toolkit-agents/agents/tdd-guide.agent.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-agents/agents/tdd-guide/AGENT.md
+++ b/plugins/agent-toolkit-agents/agents/tdd-guide/AGENT.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-agents/context/agentic-security-reviewer.md
+++ b/plugins/agent-toolkit-agents/context/agentic-security-reviewer.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-agents/context/architect.md
+++ b/plugins/agent-toolkit-agents/context/architect.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-agents/context/assistant.md
+++ b/plugins/agent-toolkit-agents/context/assistant.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-agents/context/build-error-resolver.md
+++ b/plugins/agent-toolkit-agents/context/build-error-resolver.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-agents/context/client-workflow-bootstrap.md
+++ b/plugins/agent-toolkit-agents/context/client-workflow-bootstrap.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-agents/context/code-reviewer.md
+++ b/plugins/agent-toolkit-agents/context/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-agents/context/data-engineer.md
+++ b/plugins/agent-toolkit-agents/context/data-engineer.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-agents/context/designer.md
+++ b/plugins/agent-toolkit-agents/context/designer.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-agents/context/e2e-runner.md
+++ b/plugins/agent-toolkit-agents/context/e2e-runner.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-agents/context/implementer.md
+++ b/plugins/agent-toolkit-agents/context/implementer.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-agents/context/planner.md
+++ b/plugins/agent-toolkit-agents/context/planner.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-agents/context/platform-engineer.md
+++ b/plugins/agent-toolkit-agents/context/platform-engineer.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-agents/context/qa-engineer.md
+++ b/plugins/agent-toolkit-agents/context/qa-engineer.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-agents/context/researcher.md
+++ b/plugins/agent-toolkit-agents/context/researcher.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-agents/context/reviewer.md
+++ b/plugins/agent-toolkit-agents/context/reviewer.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-agents/context/security-engineer.md
+++ b/plugins/agent-toolkit-agents/context/security-engineer.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-agents/context/security-reviewer.md
+++ b/plugins/agent-toolkit-agents/context/security-reviewer.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-agents/context/tdd-guide.md
+++ b/plugins/agent-toolkit-agents/context/tdd-guide.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-agents/rules/agentic-security-reviewer.mdc
+++ b/plugins/agent-toolkit-agents/rules/agentic-security-reviewer.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-agents/rules/architect.mdc
+++ b/plugins/agent-toolkit-agents/rules/architect.mdc
@@ -7,6 +7,13 @@ alwaysApply: true
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-agents/rules/assistant.mdc
+++ b/plugins/agent-toolkit-agents/rules/assistant.mdc
@@ -7,6 +7,20 @@ alwaysApply: true
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-agents/rules/build-error-resolver.mdc
+++ b/plugins/agent-toolkit-agents/rules/build-error-resolver.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-agents/rules/client-workflow-bootstrap.mdc
+++ b/plugins/agent-toolkit-agents/rules/client-workflow-bootstrap.mdc
@@ -7,6 +7,9 @@ alwaysApply: true
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-agents/rules/code-reviewer.mdc
+++ b/plugins/agent-toolkit-agents/rules/code-reviewer.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-agents/rules/data-engineer.mdc
+++ b/plugins/agent-toolkit-agents/rules/data-engineer.mdc
@@ -8,6 +8,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-agents/rules/designer.mdc
+++ b/plugins/agent-toolkit-agents/rules/designer.mdc
@@ -8,6 +8,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-agents/rules/e2e-runner.mdc
+++ b/plugins/agent-toolkit-agents/rules/e2e-runner.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-agents/rules/implementer.mdc
+++ b/plugins/agent-toolkit-agents/rules/implementer.mdc
@@ -8,6 +8,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-agents/rules/planner.mdc
+++ b/plugins/agent-toolkit-agents/rules/planner.mdc
@@ -7,6 +7,13 @@ alwaysApply: true
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-agents/rules/platform-engineer.mdc
+++ b/plugins/agent-toolkit-agents/rules/platform-engineer.mdc
@@ -8,6 +8,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-agents/rules/qa-engineer.mdc
+++ b/plugins/agent-toolkit-agents/rules/qa-engineer.mdc
@@ -8,6 +8,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-agents/rules/researcher.mdc
+++ b/plugins/agent-toolkit-agents/rules/researcher.mdc
@@ -8,6 +8,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-agents/rules/reviewer.mdc
+++ b/plugins/agent-toolkit-agents/rules/reviewer.mdc
@@ -8,6 +8,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-agents/rules/security-engineer.mdc
+++ b/plugins/agent-toolkit-agents/rules/security-engineer.mdc
@@ -8,6 +8,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-agents/rules/security-reviewer.mdc
+++ b/plugins/agent-toolkit-agents/rules/security-reviewer.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-agents/rules/tdd-guide.mdc
+++ b/plugins/agent-toolkit-agents/rules/tdd-guide.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-complete/.github/agents/agentic-security-reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/agentic-security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-complete/.github/agents/architect.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/architect.agent.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-complete/.github/agents/assistant.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/assistant.agent.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-complete/.github/agents/build-error-resolver.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/build-error-resolver.agent.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-complete/.github/agents/client-workflow-bootstrap.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/client-workflow-bootstrap.agent.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-complete/.github/agents/code-reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/code-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-complete/.github/agents/data-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/data-engineer.agent.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-complete/.github/agents/designer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/designer.agent.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-complete/.github/agents/e2e-runner.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/e2e-runner.agent.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-complete/.github/agents/implementer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/implementer.agent.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-complete/.github/agents/planner.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/planner.agent.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-complete/.github/agents/platform-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/platform-engineer.agent.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-complete/.github/agents/qa-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/qa-engineer.agent.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-complete/.github/agents/researcher.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/researcher.agent.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-complete/.github/agents/reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/reviewer.agent.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-complete/.github/agents/security-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/security-engineer.agent.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-complete/.github/agents/security-reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-complete/.github/agents/tdd-guide.agent.md
+++ b/plugins/agent-toolkit-complete/.github/agents/tdd-guide.agent.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-complete/.opencode/agents/agentic-security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/agentic-security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-complete/.opencode/agents/architect/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/architect/AGENT.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-complete/.opencode/agents/assistant/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/assistant/AGENT.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-complete/.opencode/agents/build-error-resolver/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/build-error-resolver/AGENT.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-complete/.opencode/agents/client-workflow-bootstrap/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/client-workflow-bootstrap/AGENT.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-complete/.opencode/agents/code-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/code-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-complete/.opencode/agents/data-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/data-engineer/AGENT.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-complete/.opencode/agents/designer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/designer/AGENT.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-complete/.opencode/agents/e2e-runner/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/e2e-runner/AGENT.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-complete/.opencode/agents/implementer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/implementer/AGENT.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-complete/.opencode/agents/planner/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/planner/AGENT.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-complete/.opencode/agents/platform-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/platform-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-complete/.opencode/agents/qa-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/qa-engineer/AGENT.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-complete/.opencode/agents/researcher/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/researcher/AGENT.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-complete/.opencode/agents/reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/reviewer/AGENT.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-complete/.opencode/agents/security-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/security-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-complete/.opencode/agents/security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-complete/.opencode/agents/tdd-guide/AGENT.md
+++ b/plugins/agent-toolkit-complete/.opencode/agents/tdd-guide/AGENT.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-complete/agents/agentic-security-reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/agentic-security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-complete/agents/agentic-security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/agentic-security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-complete/agents/architect.agent.md
+++ b/plugins/agent-toolkit-complete/agents/architect.agent.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-complete/agents/architect/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/architect/AGENT.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-complete/agents/assistant.agent.md
+++ b/plugins/agent-toolkit-complete/agents/assistant.agent.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-complete/agents/assistant/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/assistant/AGENT.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-complete/agents/build-error-resolver.agent.md
+++ b/plugins/agent-toolkit-complete/agents/build-error-resolver.agent.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-complete/agents/build-error-resolver/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/build-error-resolver/AGENT.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-complete/agents/client-workflow-bootstrap.agent.md
+++ b/plugins/agent-toolkit-complete/agents/client-workflow-bootstrap.agent.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-complete/agents/client-workflow-bootstrap/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/client-workflow-bootstrap/AGENT.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-complete/agents/code-reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/code-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-complete/agents/code-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/code-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-complete/agents/data-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/data-engineer.agent.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-complete/agents/data-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/data-engineer/AGENT.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-complete/agents/designer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/designer.agent.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-complete/agents/designer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/designer/AGENT.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-complete/agents/e2e-runner.agent.md
+++ b/plugins/agent-toolkit-complete/agents/e2e-runner.agent.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-complete/agents/e2e-runner/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/e2e-runner/AGENT.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-complete/agents/implementer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/implementer.agent.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-complete/agents/implementer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/implementer/AGENT.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-complete/agents/planner.agent.md
+++ b/plugins/agent-toolkit-complete/agents/planner.agent.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-complete/agents/planner/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/planner/AGENT.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-complete/agents/platform-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/platform-engineer.agent.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-complete/agents/platform-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/platform-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-complete/agents/qa-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/qa-engineer.agent.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-complete/agents/qa-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/qa-engineer/AGENT.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-complete/agents/researcher.agent.md
+++ b/plugins/agent-toolkit-complete/agents/researcher.agent.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-complete/agents/researcher/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/researcher/AGENT.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-complete/agents/reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/reviewer.agent.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-complete/agents/reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/reviewer/AGENT.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-complete/agents/security-engineer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/security-engineer.agent.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-complete/agents/security-engineer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/security-engineer/AGENT.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-complete/agents/security-reviewer.agent.md
+++ b/plugins/agent-toolkit-complete/agents/security-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-complete/agents/security-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/security-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-complete/agents/tdd-guide.agent.md
+++ b/plugins/agent-toolkit-complete/agents/tdd-guide.agent.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-complete/agents/tdd-guide/AGENT.md
+++ b/plugins/agent-toolkit-complete/agents/tdd-guide/AGENT.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-complete/context/agentic-security-reviewer.md
+++ b/plugins/agent-toolkit-complete/context/agentic-security-reviewer.md
@@ -2,6 +2,7 @@
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-complete/context/architect.md
+++ b/plugins/agent-toolkit-complete/context/architect.md
@@ -2,6 +2,13 @@
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-complete/context/assistant.md
+++ b/plugins/agent-toolkit-complete/context/assistant.md
@@ -2,6 +2,20 @@
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-complete/context/build-error-resolver.md
+++ b/plugins/agent-toolkit-complete/context/build-error-resolver.md
@@ -2,6 +2,7 @@
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-complete/context/client-workflow-bootstrap.md
+++ b/plugins/agent-toolkit-complete/context/client-workflow-bootstrap.md
@@ -2,6 +2,9 @@
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-complete/context/code-reviewer.md
+++ b/plugins/agent-toolkit-complete/context/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-complete/context/data-engineer.md
+++ b/plugins/agent-toolkit-complete/context/data-engineer.md
@@ -3,6 +3,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-complete/context/designer.md
+++ b/plugins/agent-toolkit-complete/context/designer.md
@@ -3,6 +3,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-complete/context/e2e-runner.md
+++ b/plugins/agent-toolkit-complete/context/e2e-runner.md
@@ -2,6 +2,7 @@
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-complete/context/implementer.md
+++ b/plugins/agent-toolkit-complete/context/implementer.md
@@ -3,6 +3,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-complete/context/planner.md
+++ b/plugins/agent-toolkit-complete/context/planner.md
@@ -2,6 +2,13 @@
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-complete/context/platform-engineer.md
+++ b/plugins/agent-toolkit-complete/context/platform-engineer.md
@@ -3,6 +3,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-complete/context/qa-engineer.md
+++ b/plugins/agent-toolkit-complete/context/qa-engineer.md
@@ -3,6 +3,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-complete/context/researcher.md
+++ b/plugins/agent-toolkit-complete/context/researcher.md
@@ -3,6 +3,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-complete/context/reviewer.md
+++ b/plugins/agent-toolkit-complete/context/reviewer.md
@@ -3,6 +3,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-complete/context/security-engineer.md
+++ b/plugins/agent-toolkit-complete/context/security-engineer.md
@@ -3,6 +3,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-complete/context/security-reviewer.md
+++ b/plugins/agent-toolkit-complete/context/security-reviewer.md
@@ -2,6 +2,7 @@
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-complete/context/tdd-guide.md
+++ b/plugins/agent-toolkit-complete/context/tdd-guide.md
@@ -2,6 +2,7 @@
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-complete/rules/agentic-security-reviewer.mdc
+++ b/plugins/agent-toolkit-complete/rules/agentic-security-reviewer.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: agentic-security-reviewer
 description: Agentic security review specialist — prompt injection, tool poisoning, excessive agency, credential exposure, supply-chain, MCP/plugin hardening with OWASP LLM01-10 + AGNT01-06. Use when security-engineer delegates agentic surface or skill/MCP/hook changes warrant isolated audit; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **agentic-security-reviewer** at agent-toolkit. Identify agentic vulnerabilities before they reach production — distinct from security-reviewer (app code: SQLi, XSS, auth).

--- a/plugins/agent-toolkit-complete/rules/architect.mdc
+++ b/plugins/agent-toolkit-complete/rules/architect.mdc
@@ -7,6 +7,13 @@ alwaysApply: true
 name: architect
 description: Software architecture and system design specialist. Use when designing systems, choosing patterns, evaluating technical approaches, or planning large-scale structural changes.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - data-engineer
+  - planner
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 You are a software architect at agent-toolkit. Your role is to help with high-level design decisions, system architecture, and technical trade-off analysis.

--- a/plugins/agent-toolkit-complete/rules/assistant.mdc
+++ b/plugins/agent-toolkit-complete/rules/assistant.mdc
@@ -7,6 +7,20 @@ alwaysApply: true
 name: assistant
 description: agent-toolkit Dev Companion — follows internal conventions and best practices. Use for any work in agent-toolkit or client repositories to ensure compliance with agent-toolkit standards.
 tools: Read, Grep, Glob, Bash
+kind: orchestrator
+delegates:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
+collaborates_with:
+  - client-workflow-bootstrap
 ---
 
 You are the agent-toolkit Dev Companion. Ensure all work follows agent-toolkit standards and conventions.

--- a/plugins/agent-toolkit-complete/rules/build-error-resolver.mdc
+++ b/plugins/agent-toolkit-complete/rules/build-error-resolver.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: build-error-resolver
 description: Build and TypeScript error resolution specialist — large diagnostic context, root-cause triage across tsc/lint/webpack/vite. Use when platform-engineer delegates CI failure logs or fix requires full error/stack analysis; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **build-error-resolver** at agent-toolkit — the opt-in build/type/lint diagnostic specialist.

--- a/plugins/agent-toolkit-complete/rules/client-workflow-bootstrap.mdc
+++ b/plugins/agent-toolkit-complete/rules/client-workflow-bootstrap.mdc
@@ -7,6 +7,9 @@ alwaysApply: true
 name: client-workflow-bootstrap
 description: "Meta-generator / orchestrator — onboarding interview that meta-generates <client>-workflow + <client>-dev-companion skills and opens a draft PR. Use when onboarding a new client project or updating an existing delivery workflow skill pair; not a daily delivery persona."
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: orchestrator
+collaborates_with:
+  - assistant
 ---
 
 You are the **client-workflow-bootstrap** orchestrator at agent-toolkit — the meta-generator that interviews then scaffolds a client delivery workflow (not a daily delivery persona).

--- a/plugins/agent-toolkit-complete/rules/code-reviewer.mdc
+++ b/plugins/agent-toolkit-complete/rules/code-reviewer.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-complete/rules/data-engineer.mdc
+++ b/plugins/agent-toolkit-complete/rules/data-engineer.mdc
@@ -8,6 +8,14 @@ name: data-engineer
 description: >-
   Data engineering specialist — dbt/Snowflake validation, Jupyter notebooks, data artifact stewardship. Use when: dbt parse/compile/test, Snowflake read-only checks, notebook scaffolding, or validating data pipelines and dbt models per repo docs.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 # Data Engineer

--- a/plugins/agent-toolkit-complete/rules/designer.mdc
+++ b/plugins/agent-toolkit-complete/rules/designer.mdc
@@ -8,6 +8,11 @@ name: designer
 description: >-
   Design routing and UI/UX specialist — owns contextual selection among design skills (frontend-design, frontend-design-review, web-design-guidelines, design-assessment, design-improvement, Figma family, accessibility/review). Use when: new visual direction, design review, WIG audit, holistic UX diagnosis, browser-grounded improvement, Figma-driven work, or accessibility-sensitive UI.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - implementer
+  - qa-engineer
+  - researcher
 ---
 
 # Designer

--- a/plugins/agent-toolkit-complete/rules/e2e-runner.mdc
+++ b/plugins/agent-toolkit-complete/rules/e2e-runner.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: e2e-runner
 description: End-to-end testing specialist using Playwright — selector discipline, POM, and flake avoidance with explicit browser-output isolation. Use when qa-engineer delegates E2E authoring/debugging or task explicitly requires Playwright specs; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **e2e-runner** at agent-toolkit — the opt-in Playwright E2E authoring specialist.

--- a/plugins/agent-toolkit-complete/rules/implementer.mdc
+++ b/plugins/agent-toolkit-complete/rules/implementer.mdc
@@ -8,6 +8,19 @@ name: implementer
 description: >-
   Implementation specialist — feature/bug/refactoring delivery, build/test loop, TDD-aware scaffolding and docs generation. Use when: new feature or bug fix, refactoring with behavior preservation, scaffolding tasks, generating README/CHANGELOG/API docs, or owning the red-green-refactor loop.
 tools: Read, Grep, Glob, Bash, Write, Edit
+kind: holistic
+delegates:
+  - tdd-guide
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - planner
+  - platform-engineer
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Implementer

--- a/plugins/agent-toolkit-complete/rules/planner.mdc
+++ b/plugins/agent-toolkit-complete/rules/planner.mdc
@@ -7,6 +7,13 @@ alwaysApply: true
 name: planner
 description: Expert planning specialist for complex features and refactoring. Use before starting any significant implementation to break down work, identify risks, and create an actionable plan.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+collaborates_with:
+  - architect
+  - implementer
+  - qa-engineer
+  - researcher
+  - reviewer
 ---
 
 You are a technical planning specialist at agent-toolkit. Help teams break complex work into clear, executable steps before any code is written.

--- a/plugins/agent-toolkit-complete/rules/platform-engineer.mdc
+++ b/plugins/agent-toolkit-complete/rules/platform-engineer.mdc
@@ -8,6 +8,17 @@ name: platform-engineer
 description: >-
   Platform and forge specialist — CI/CD, GitHub/GitLab PR lifecycle, merge-conflicts, worktrees, integrations (Slack/Linear/ClickUp/MCP), loops/swarm, triage, llm-cost-advisor, cli-for-agents, herdr. Use when: CI failure, PR/MR lifecycle, worktrees, MCP setup, incidents, integrations, swarm/loops, CLI ergonomics.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - build-error-resolver
+collaborates_with:
+  - architect
+  - implementer
+  - planner
+  - qa-engineer
+  - researcher
+  - reviewer
+  - security-engineer
 ---
 
 # Platform Engineer

--- a/plugins/agent-toolkit-complete/rules/qa-engineer.mdc
+++ b/plugins/agent-toolkit-complete/rules/qa-engineer.mdc
@@ -8,6 +8,16 @@ name: qa-engineer
 description: >-
   Quality-assurance and verification specialist — lint gates, browser automation, E2E, behavioral verification, bug triage. Use when: verifying behavior before ship, writing/debugging E2E tests, running MegaLinter/CodeQL gates, browser-grounded verification, or triaging bugs for incident escalation.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - e2e-runner
+collaborates_with:
+  - data-engineer
+  - designer
+  - implementer
+  - platform-engineer
+  - reviewer
+  - security-engineer
 ---
 
 # QA Engineer

--- a/plugins/agent-toolkit-complete/rules/researcher.mdc
+++ b/plugins/agent-toolkit-complete/rules/researcher.mdc
@@ -8,6 +8,14 @@ name: researcher
 description: >-
   Research and discovery specialist — spike findings, evidence-intake, framework/docs exploration, inventory, reference examples. Use when: unknown needs time-boxed investigation, implementation strategy/risks/tradeoffs, upstream/framework docs lookup, project-assessment evidence map, or discovering installed toolkit capabilities.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
+kind: holistic
+collaborates_with:
+  - architect
+  - data-engineer
+  - designer
+  - implementer
+  - planner
+  - qa-engineer
 ---
 
 # Researcher

--- a/plugins/agent-toolkit-complete/rules/reviewer.mdc
+++ b/plugins/agent-toolkit-complete/rules/reviewer.mdc
@@ -8,6 +8,16 @@ name: reviewer
 description: >-
   Independent quality/craft reviewer — owns change impact, deep review, anti-slop (code + prose), and verification separation. Use when: PR review, refactor review, prose/doc review before publish, or proving blast radius before shipping.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - code-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - qa-engineer
+  - researcher
+  - security-engineer
 ---
 
 # Reviewer

--- a/plugins/agent-toolkit-complete/rules/security-engineer.mdc
+++ b/plugins/agent-toolkit-complete/rules/security-engineer.mdc
@@ -8,6 +8,17 @@ name: security-engineer
 description: >-
   Security hardening specialist — app + agentic security, threat modeling, supply-chain/MCP audit, SARIF triage. Use when: security-sensitive PR/endpoint, agentic/MCP/plugin change, supply-chain before adoption, STRIDE/threat model, or CodeQL/SARIF triage.
 tools: Read, Grep, Glob, Bash
+kind: holistic
+delegates:
+  - agentic-security-reviewer
+  - security-reviewer
+collaborates_with:
+  - architect
+  - designer
+  - implementer
+  - platform-engineer
+  - qa-engineer
+  - reviewer
 ---
 
 # Security Engineer

--- a/plugins/agent-toolkit-complete/rules/security-reviewer.mdc
+++ b/plugins/agent-toolkit-complete/rules/security-reviewer.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: security-reviewer
 description: App-code security review specialist — OWASP Top 10 (injection, auth, data exposure, deps), CVE-mapped. Use when security-engineer delegates app-surface hardening or code change touches auth/data/API; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **security-reviewer** at agent-toolkit — the app-code security specialist. Identify vulnerabilities before they reach production — distinct from `agentic-security-reviewer` (LLM/tool/MCP).

--- a/plugins/agent-toolkit-complete/rules/tdd-guide.mdc
+++ b/plugins/agent-toolkit-complete/rules/tdd-guide.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: tdd-guide
 description: Test-Driven Development specialist — enforces red-green-refactor with AAA, test doubles and behavior-first coverage. Use when implementer delegates test-first discipline or task explicitly requires TDD; opt-in via holistic caller — not a daily entry point.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **tdd-guide** at agent-toolkit — the opt-in TDD discipline specialist. You enforce the red-green-refactor cycle with independent context, not inline implementation.

--- a/plugins/agent-toolkit-core/.github/agents/code-reviewer.agent.md
+++ b/plugins/agent-toolkit-core/.github/agents/code-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-core/.opencode/agents/code-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-core/.opencode/agents/code-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-core/agents/code-reviewer.agent.md
+++ b/plugins/agent-toolkit-core/agents/code-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-core/agents/code-reviewer/AGENT.md
+++ b/plugins/agent-toolkit-core/agents/code-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-core/context/code-reviewer.md
+++ b/plugins/agent-toolkit-core/context/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/plugins/agent-toolkit-core/rules/code-reviewer.mdc
+++ b/plugins/agent-toolkit-core/rules/code-reviewer.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 name: code-reviewer
 description: Expert code review specialist — quality/correctness/security/performance/testing with severity-ranked findings. Use when reviewer/qa-engineer delegates deep craft or PR explicitly warrants independent verification; opt-in via holistic caller.
 tools: Read, Grep, Glob, Bash
+kind: specialist
 ---
 
 You are **code-reviewer** at agent-toolkit. Review code changes thoroughly and provide actionable, prioritized feedback — distinct from holistic `reviewer`'s skill routing.

--- a/schemas/agent-frontmatter.schema.json
+++ b/schemas/agent-frontmatter.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ulises-jeremias/agent-toolkit/main/schemas/agent-frontmatter.schema.json",
+  "title": "Agent Frontmatter — Machine-readable Agent Persona Metadata",
+  "description": "Validates agents/*/AGENT.md YAML frontmatter. Extends minimal name/description/tools with kind, delegates, and collaborates_with for machine-readable orchestration graph (#866). Skills ownership is canonical in capabilities/skills/registry.yaml (holistic_owner); frontmatter does not duplicate skill lists unless explicitly declared. Enables validation, catalog/graph generation, assistant routing, and orphan/cycle detection.",
+  "type": "object",
+  "required": ["name", "description", "tools", "kind"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Kebab-case agent identifier; must match the directory name agents/<name>/."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Selection text for the AI tool's agent picker; include when-to-use triggers."
+    },
+    "tools": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Comma-separated allowlist of tools the persona may use (e.g. 'Read, Grep, Glob, Bash'). Kept as string for backwards compat with validate-agents.vsh and existing agents."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["orchestrator", "holistic", "specialist"],
+      "description": "Tier per docs/AGENT_TAXONOMY.md §2: orchestrator (default entry/meta-generator), holistic (owns contextual routing among a coherent skill group), specialist (opt-in narrow technique with separate context/isolation). Required after #866."
+    },
+    "delegates": {
+      "type": "array",
+      "description": "Directed delegation edges: agents this persona may delegate to. Validated: every entry must be an existing agent id, no self-delegation, no forbidden cycles, every specialist must have at least one caller in the reverse graph.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "collaborates_with": {
+      "type": "array",
+      "description": "Undirected collaboration peers (hand-off boundaries) — holistic peers this agent frequently hands off to for cross-domain work. Validated: every entry must be an existing agent id, no self-reference. Not part of cycle detection (delegates is directed).",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "skills": {
+      "type": "array",
+      "description": "Optional explicit skill ids (domain/name) this agent directly handles. When omitted, ownership is derived from capabilities/skills/registry.yaml holistic_owner. If present, every id must exist in skills/. Minimal metadata keeps procedural instructions out of frontmatter.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+      },
+      "uniqueItems": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "kind": { "const": "specialist" } }
+      },
+      "then": {
+        "description": "Specialists are opt-in and should not delegate further by default; delegates if present is usually empty."
+      }
+    }
+  ]
+}

--- a/scripts/generate-catalogs.vsh
+++ b/scripts/generate-catalogs.vsh
@@ -68,6 +68,69 @@ fn fm_field(fm string, key string) string {
 	return ''
 }
 
+fn fm_list(fm string, key string) []string {
+	prefix := '${key}:'
+	lines := fm.split_into_lines()
+	mut i := 0
+	for i < lines.len {
+		line := lines[i]
+		trimmed := line.trim_space()
+		if trimmed.starts_with(prefix) {
+			mut rest := trimmed[prefix.len..].trim_space()
+			if rest.len > 0 && rest.starts_with('[') {
+				mut inner := rest
+				if inner.contains(']') {
+					end := inner.index(']') or { inner.len - 1 }
+					inner = inner[1..end]
+				} else {
+					inner = inner[1..]
+				}
+				inner = inner.trim_space()
+				if inner.len == 0 {
+					return []string{}
+				}
+				mut out := []string{}
+				parts := inner.split(',')
+				for pp in parts {
+					mut v := pp.trim_space()
+					if v.len >= 2 && ((v[0] == `'` && v[v.len - 1] == `'`) || (v[0] == `"` && v[v.len - 1] == `"`)) {
+						v = v[1..v.len - 1]
+					}
+					if v.len > 0 {
+						out << v.trim_space()
+					}
+				}
+				return out
+			}
+			mut out := []string{}
+			i++
+			for i < lines.len {
+				l := lines[i]
+				tt := l.trim_space()
+				if tt.len == 0 {
+					i++
+					continue
+				}
+				if tt.starts_with('-') {
+					mut v := tt[1..].trim_space()
+					if v.len >= 2 && ((v[0] == `'` && v[v.len - 1] == `'`) || (v[0] == `"` && v[v.len - 1] == `"`)) {
+						v = v[1..v.len - 1]
+					}
+					if v.len > 0 {
+						out << v
+					}
+					i++
+					continue
+				}
+				break
+			}
+			return out
+		}
+		i++
+	}
+	return []string{}
+}
+
 fn truncate(s string, n int) string {
 	if s.len <= n {
 		return s
@@ -103,9 +166,12 @@ struct SkillEntry {
 }
 
 struct AgentEntry {
-	id          string
-	name        string
-	description string
+	id                string
+	name              string
+	description       string
+	kind              string
+	delegates         []string
+	collaborates_with []string
 }
 
 struct LoopEntry {
@@ -143,6 +209,19 @@ fn dump_agents(entries []AgentEntry) string {
 		s += '  - id: ${yaml_escape_scalar(e.id)}\n'
 		s += yaml_kv(4, 'name', e.name)
 		s += yaml_kv(4, 'description', e.description)
+		s += yaml_kv(4, 'kind', e.kind)
+		if e.delegates.len > 0 {
+			s += '    delegates:\n'
+			for d in e.delegates {
+				s += '      - ${yaml_escape_scalar(d)}\n'
+			}
+		}
+		if e.collaborates_with.len > 0 {
+			s += '    collaborates_with:\n'
+			for c in e.collaborates_with {
+				s += '      - ${yaml_escape_scalar(c)}\n'
+			}
+		}
 	}
 	return s
 }
@@ -210,10 +289,16 @@ fn gen_agents(root string) []AgentEntry {
 		fm := extract_frontmatter(read_file(agent_md) or { '' })
 		nm := fm_field(fm, 'name')
 		desc := fm_field(fm, 'description')
+		kind := fm_field(fm, 'kind')
+		delegates := fm_list(fm, 'delegates')
+		collab := fm_list(fm, 'collaborates_with')
 		agents << AgentEntry{
-			id:          name
-			name:        if nm.len > 0 { nm } else { name }
-			description: truncate(desc, 200)
+			id:                name
+			name:              if nm.len > 0 { nm } else { name }
+			description:       truncate(desc, 200)
+			kind:              if kind.len > 0 { kind } else { 'holistic' }
+			delegates:         delegates
+			collaborates_with: collab
 		}
 	}
 	return agents

--- a/scripts/validate-agents.vsh
+++ b/scripts/validate-agents.vsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env -S v run
-// Validate AGENT.md frontmatter across all agents.
+// Validate AGENT.md frontmatter across all agents (#866).
+// Extends minimal name/description/tools checks with kind, delegates,
+// collaborates_with, skills and graph invariants (orphan, cycle, missing ref).
 // Usage: ./scripts/validate-agents.vsh
 
 fn repo_root() string {
@@ -35,8 +37,9 @@ fn fm_field(fm string, key string) ?string {
 	mut i := 0
 	for i < lines.len {
 		line := lines[i]
-		if line.starts_with(prefix) {
-			mut val := line[prefix.len..].trim_space()
+		trimmed := line.trim_space()
+		if trimmed.starts_with(prefix) {
+			mut val := trimmed[prefix.len..].trim_space()
 			if val.len >= 2 {
 				if (val[0] == `'` && val[val.len - 1] == `'`)
 					|| (val[0] == `"` && val[val.len - 1] == `"`) {
@@ -68,24 +71,207 @@ fn fm_field(fm string, key string) ?string {
 	return none
 }
 
+fn fm_list(fm string, key string) ?[]string {
+	prefix := '${key}:'
+	lines := fm.split_into_lines()
+	mut i := 0
+	for i < lines.len {
+		line := lines[i]
+		trimmed := line.trim_space()
+		if trimmed.starts_with(prefix) {
+			mut rest := trimmed[prefix.len..].trim_space()
+			// inline flow list: delegates: [a, b]
+			if rest.len > 0 && rest.starts_with('[') {
+				// find closing ]
+				// rest is like "[a, b]" or "[a, b] # comment"
+				mut inner := rest
+				// strip comment after ]
+				if inner.contains(']') {
+					end := inner.index(']') or { inner.len - 1 }
+					inner = inner[1..end]
+				} else {
+					inner = inner[1..]
+				}
+				inner = inner.trim_space()
+				if inner.len == 0 {
+					return []string{}
+				}
+				mut out := []string{}
+				parts := inner.split(',')
+				for p in parts {
+					mut v := p.trim_space()
+					if v.len >= 2 && ((v[0] == `'` && v[v.len - 1] == `'`)
+						|| (v[0] == `"` && v[v.len - 1] == `"`)) {
+						v = v[1..v.len - 1]
+					}
+					if v.len > 0 {
+						out << v.trim_space()
+					}
+				}
+				return out
+			}
+			if rest.len > 0 {
+				// single scalar on same line — treat as one-element list (defensive)
+				mut v := rest
+				if v.len >= 2 && ((v[0] == `'` && v[v.len - 1] == `'`)
+					|| (v[0] == `"` && v[v.len - 1] == `"`)) {
+					v = v[1..v.len - 1]
+				}
+				// if value looks like a scalar that shouldn't be a list, return it anyway
+				// for kind/skill single-value cases, callers use fm_field; fm_list should not be used there.
+				// For delegates/collaborates_with we expect block list; single value is still collected.
+				v = v.trim_space()
+				if v.len > 0 && !v.contains(' ') {
+					return [v]
+				}
+				// otherwise treat as empty and fall through to block collection
+			}
+			// block list: next lines are "- item"
+			mut out := []string{}
+			i++
+			for i < lines.len {
+				l := lines[i]
+				t := l.trim_space()
+				if t.len == 0 {
+					i++
+					continue
+				}
+				if t.starts_with('-') {
+					mut v := t[1..].trim_space()
+					if v.len >= 2 && ((v[0] == `'` && v[v.len - 1] == `'`)
+						|| (v[0] == `"` && v[v.len - 1] == `"`)) {
+						v = v[1..v.len - 1]
+					}
+					if v.len > 0 {
+						out << v
+					}
+					i++
+					continue
+				}
+				break
+			}
+			return out
+		}
+		i++
+	}
+	return none
+}
+
+fn is_kebab(s string) bool {
+	if s.len == 0 {
+		return false
+	}
+	if s[0] == `-` || s[s.len - 1] == `-` {
+		return false
+	}
+	if s.contains('--') {
+		return false
+	}
+	for c in s {
+		if !((c >= `a` && c <= `z`) || (c >= `0` && c <= `9`) || c == `-`) {
+			return false
+		}
+	}
+	return true
+}
+
+fn is_skill_id(s string) bool {
+	if !s.contains('/') {
+		return false
+	}
+	parts := s.split('/')
+	if parts.len != 2 {
+		return false
+	}
+	for p in parts {
+		if p.len == 0 || !is_kebab(p) {
+			return false
+		}
+	}
+	return true
+}
+
+fn dfs_cycle(node string, graph map[string][]string, mut visited map[string]int, mut stack []string) ?string {
+	visited[node] = 1
+	stack << node
+	for nb in graph[node] {
+		if nb !in visited || visited[nb] == 0 {
+			if msg := dfs_cycle(nb, graph, mut visited, mut stack) {
+				return msg
+			}
+		} else if visited[nb] == 1 {
+			mut idx := -1
+			for i, v in stack {
+				if v == nb {
+					idx = i
+					break
+				}
+			}
+			mut cyc := []string{}
+			if idx >= 0 {
+				for i := idx; i < stack.len; i++ {
+					cyc << stack[i]
+				}
+				cyc << nb
+			} else {
+				cyc = [nb, node, nb]
+			}
+			return cyc.join(' -> ')
+		}
+	}
+	stack.pop()
+	visited[node] = 2
+	return none
+}
+
+fn has_cycle(graph map[string][]string) ?string {
+	mut visited := map[string]int{}
+	mut stack := []string{}
+	for node in graph.keys() {
+		if visited[node] == 0 {
+			if msg := dfs_cycle(node, graph, mut visited, mut stack) {
+				return msg
+			}
+		}
+	}
+	return none
+}
+
+struct AgentMeta {
+	name              string
+	kind              string
+	delegates       []string
+	collaborates_with []string
+	skills            []string
+}
+
 fn main() {
 	root := repo_root()
 	agents_dir := join_path(root, 'agents')
+	skills_dir := join_path(root, 'skills')
 	mut errors := []string{}
-	println('\n🔍 Validating AGENT.md frontmatter...\n')
+	mut warnings := []string{}
+	println('\n🔍 Validating AGENT.md frontmatter (#866 graph)...\n')
 	mut count := 0
-	agents := ls(agents_dir) or { []string{} }
-	for agent in agents.sorted() {
+	mut metas := map[string]AgentMeta{}
+	mut known := []string{}
+	// collect known agents first
+	tmp := ls(agents_dir) or { []string{} }
+	for agent in tmp.sorted() {
+		p := join_path(agents_dir, agent)
+		if is_dir(p) && is_file(join_path(p, 'AGENT.md')) {
+			known << agent
+		}
+	}
+	known.sort()
+	mut known_set := map[string]bool{}
+	for k in known {
+		known_set[k] = true
+	}
+
+	for agent in known {
 		agent_path := join_path(agents_dir, agent)
-		if !is_dir(agent_path) {
-			continue
-		}
 		agent_md := join_path(agent_path, 'AGENT.md')
-		if !is_file(agent_md) {
-			errors << '${agent}: missing AGENT.md'
-			println('  ✗ ${agent}: missing AGENT.md')
-			continue
-		}
 		content := read_file(agent_md) or {
 			errors << '${agent}/AGENT.md: cannot read'
 			println('  ✗ ${agent}/AGENT.md: cannot read')
@@ -96,20 +282,252 @@ fn main() {
 			println('  ✗ ${agent}/AGENT.md: no YAML frontmatter')
 			continue
 		}
-		if fm_field(fm, 'name') or { '' } == '' {
+		mut ok := true
+		name := fm_field(fm, 'name') or { '' }
+		desc := fm_field(fm, 'description') or { '' }
+		tools_str := fm_field(fm, 'tools') or { '' }
+		kind := fm_field(fm, 'kind') or { '' }
+		if name == '' {
 			errors << "${agent}/AGENT.md: missing 'name'"
 			println("  ✗ ${agent}/AGENT.md: missing 'name'")
+			ok = false
+		} else if name != agent {
+			errors << "${agent}/AGENT.md: name '${name}' != directory '${agent}'"
+			println("  ✗ ${agent}/AGENT.md: name '${name}' != directory '${agent}'")
+			ok = false
+		} else if !is_kebab(name) {
+			errors << "${agent}/AGENT.md: name '${name}' not kebab-case"
+			println("  ✗ ${agent}/AGENT.md: name '${name}' not kebab-case")
+			ok = false
 		}
-		if fm_field(fm, 'description') or { '' } == '' {
+		if desc == '' {
 			errors << "${agent}/AGENT.md: missing 'description'"
 			println("  ✗ ${agent}/AGENT.md: missing 'description'")
+			ok = false
+		}
+		if tools_str == '' {
+			errors << "${agent}/AGENT.md: missing 'tools'"
+			println("  ✗ ${agent}/AGENT.md: missing 'tools'")
+			ok = false
+		}
+		if kind == '' {
+			errors << "${agent}/AGENT.md: missing 'kind' (orchestrator|holistic|specialist) — required since #866"
+			println("  ✗ ${agent}/AGENT.md: missing 'kind' (orchestrator|holistic|specialist)")
+			ok = false
+		} else if kind !in ['orchestrator', 'holistic', 'specialist'] {
+			errors << "${agent}/AGENT.md: invalid kind '${kind}' (expected orchestrator|holistic|specialist)"
+			println("  ✗ ${agent}/AGENT.md: invalid kind '${kind}'")
+			ok = false
+		}
+
+		// delegates
+		delegates := fm_list(fm, 'delegates') or { []string{} }
+		collaborates := fm_list(fm, 'collaborates_with') or { []string{} }
+		skills_list := fm_list(fm, 'skills') or { []string{} }
+
+		// validate delegates
+		mut seen_d := map[string]bool{}
+		for d in delegates {
+			if d == agent {
+				errors << "${agent}/AGENT.md: delegates contains self-reference '${d}'"
+				println("  ✗ ${agent}/AGENT.md: delegates contains self-reference '${d}'")
+				ok = false
+			}
+			if !is_kebab(d) {
+				errors << "${agent}/AGENT.md: delegates entry '${d}' not kebab-case"
+				println("  ✗ ${agent}/AGENT.md: delegates entry '${d}' not kebab-case")
+				ok = false
+			}
+			if d !in known_set {
+				errors << "${agent}/AGENT.md: delegates references unknown agent '${d}'"
+				println("  ✗ ${agent}/AGENT.md: delegates references unknown agent '${d}'")
+				ok = false
+			}
+			if d in seen_d {
+				errors << "${agent}/AGENT.md: delegates duplicate '${d}'"
+				println("  ✗ ${agent}/AGENT.md: delegates duplicate '${d}'")
+				ok = false
+			}
+			seen_d[d] = true
+		}
+		// validate collaborates_with
+		mut seen_c := map[string]bool{}
+		for c in collaborates {
+			if c == agent {
+				errors << "${agent}/AGENT.md: collaborates_with contains self-reference '${c}'"
+				println("  ✗ ${agent}/AGENT.md: collaborates_with self '${c}'")
+				ok = false
+			}
+			if !is_kebab(c) {
+				errors << "${agent}/AGENT.md: collaborates_with entry '${c}' not kebab-case"
+				println("  ✗ ${agent}/AGENT.md: collaborates_with entry '${c}' not kebab-case")
+				ok = false
+			}
+			if c !in known_set {
+				errors << "${agent}/AGENT.md: collaborates_with references unknown agent '${c}'"
+				println("  ✗ ${agent}/AGENT.md: collaborates_with unknown '${c}'")
+				ok = false
+			}
+			if c in seen_c {
+				errors << "${agent}/AGENT.md: collaborates_with duplicate '${c}'"
+				println("  ✗ ${agent}/AGENT.md: collaborates_with duplicate '${c}'")
+				ok = false
+			}
+			seen_c[c] = true
+		}
+		// validate skills (if present)
+		mut seen_s := map[string]bool{}
+		for s in skills_list {
+			if !is_skill_id(s) {
+				errors << "${agent}/AGENT.md: skills entry '${s}' invalid (expected domain/name kebab)"
+				println("  ✗ ${agent}/AGENT.md: skills entry '${s}' invalid")
+				ok = false
+				continue
+			}
+			if s in seen_s {
+				errors << "${agent}/AGENT.md: skills duplicate '${s}'"
+				println("  ✗ ${agent}/AGENT.md: skills duplicate '${s}'")
+				ok = false
+			}
+			seen_s[s] = true
+			parts := s.split('/')
+			skill_path := join_path(skills_dir, parts[0], parts[1], 'SKILL.md')
+			if !is_file(skill_path) {
+				errors << "${agent}/AGENT.md: skills references unknown skill '${s}' (no ${skill_path})"
+				println("  ✗ ${agent}/AGENT.md: skills references unknown skill '${s}'")
+				ok = false
+			}
+		}
+		// soft warn if specialist has delegates (unusual)
+		if kind == 'specialist' && delegates.len > 0 {
+			warnings << "${agent}: specialist has delegates ${delegates} — specialists should rarely delegate"
+			println("  ⚠ ${agent}: specialist delegates ${delegates} — specialists should rarely delegate")
+		}
+
+		if ok {
+			println('  ✓ ${agent} (kind=${kind})')
+		}
+		metas[agent] = AgentMeta{
+			name:              name
+			kind:              kind
+			delegates:       delegates
+			collaborates_with: collaborates
+			skills:            skills_list
 		}
 		count++
 	}
-	println('\nAgents validated: ${count}')
+
+	// ── graph invariants ──
+	// build delegates graph
+	mut graph := map[string][]string{}
+	for k, m in metas {
+		graph[k] = m.delegates
+	}
+	// orphan: every specialist must have at least one caller
+	for k, m in metas {
+		if m.kind == 'specialist' {
+			mut has_caller := false
+			for caller, cm in metas {
+				if k in cm.delegates {
+					has_caller = true
+					break
+				}
+			}
+			if !has_caller {
+				errors << "orphan specialist '${k}' has no caller — every specialist must have a legitimate caller (delegates reverse)"
+				println("  ✗ orphan specialist '${k}' has no caller")
+			}
+		}
+	}
+	// cycle detection on delegates (directed)
+	if cycle := has_cycle(graph) {
+		errors << "forbidden cycle in delegates graph: ${cycle}"
+		println("  ✗ forbidden delegates cycle: ${cycle}")
+	} else {
+		println('  ✓ no forbidden delegates cycle')
+	}
+
+	// products.yaml references canonical agents
+	products_path := join_path(root, 'distributions', 'products.yaml')
+	if is_file(products_path) {
+		text := read_file(products_path) or { '' }
+		lines := text.split_into_lines()
+		mut in_agents := false
+		mut agents_indent := -1
+		mut product_line_no := 0
+		for idx, line in lines {
+			trimmed := line.trim_space()
+			if trimmed.len == 0 || trimmed.starts_with('#') {
+				continue
+			}
+			// count leading spaces
+			mut indent := 0
+			for c in line {
+				if c == ` ` {
+					indent++
+				} else if c == `\t` {
+					indent += 2
+				} else {
+					break
+				}
+			}
+			if trimmed.starts_with('agents:') {
+				in_agents = true
+				agents_indent = indent
+				continue
+			}
+			if in_agents {
+				if trimmed.starts_with('- ') {
+					if indent <= agents_indent {
+						in_agents = false
+						continue
+					}
+					mut val := trimmed[2..].trim_space()
+					// strip inline comment
+					if val.contains('#') {
+						val = val.all_before('#').trim_space()
+					}
+					if val.len >= 2 && ((val[0] == `'` && val[val.len - 1] == `'`)
+						|| (val[0] == `"` && val[val.len - 1] == `"`)) {
+						val = val[1..val.len - 1]
+					}
+					val = val.trim_space()
+					if val.len > 0 {
+						if val !in known_set {
+							errors << "distributions/products.yaml:${idx + 1}: references unknown agent '${val}'"
+							println("  ✗ distributions/products.yaml:${idx + 1}: unknown agent '${val}'")
+						}
+						// also track duplicate product agent refs if needed; skipped — product ids are unique
+					}
+					continue
+				}
+				// non-list line
+				if indent <= agents_indent && !trimmed.starts_with('-') {
+					in_agents = false
+				}
+			}
+		}
+		println('  ✓ products.yaml agent refs checked')
+	}
+
+	// duplicate generated IDs: agents are dir names, already unique; catalog will enforce count vs entries
+	if known.len != count {
+		errors << "agent count mismatch: dirs ${known.len} vs validated ${count}"
+	}
+
+	println('\nAgents validated: ${count} (orchestrator/holistic/specialist)')
+	if warnings.len > 0 {
+		println('Warnings: ${warnings.len}')
+		for w in warnings {
+			println('  ⚠ ${w}')
+		}
+	}
 	if errors.len > 0 {
 		println('\n❌ ${errors.len} error(s)')
+		for e in errors {
+			println('  ✗ ${e}')
+		}
 		exit(1)
 	}
-	println('\n✅ All AGENT.md files are valid!')
+	println('\n✅ All AGENT.md files are valid (schema + graph invariants)!')
 }


### PR DESCRIPTION
Closes #866

## Summary

Introduce **canonical machine-readable agent relationships** — minimal schema providing validation, catalog/graph generation, assistant routing, and orphan/cycle detection.

## What was added

### Schema (`schemas/agent-frontmatter.schema.json` — new)
- `kind: orchestrator | holistic | specialist` — **required** since #866 (per `docs/AGENT_TAXONOMY.md` §2 tiering). 18 agents: 2 orchestrators, 10 holistic, 6 specialists.
- `delegates: string[]` — directed delegation edges (holistic → specialist, orchestrator → holistic). Validated: existing agent, no self-ref, no duplicate, no forbidden cycle; every `specialist` must have a caller in the reverse graph.
- `collaborates_with: string[]` — undirected collaboration peers (handoff boundaries). Holistic ↔ holistic derived from `## Collaborators` sections + `AGENT_TAXONOMY.md`. Not part of cycle detection.
- `skills: string[]` — optional explicit `domain/name` ids; validated against `skills/` when present. Otherwise ownership is canonical in `capabilities/skills/registry.yaml` (`holistic_owner`) — no duplication.
- No long procedural instructions in metadata — identifiers only.

### Validators
- **`scripts/validate-agents.vsh`** — extended from minimal `name/description/tools` to full schema + graph invariants: kebab-case, invalid kind, missing delegate → existing-agent check, orphan specialist (no caller), forbidden DFS cycle, `skills` → valid `domain/name` + exists in `skills/`, `distributions/products.yaml` `agents:` → canonical agent, duplicate generated IDs. Soft warn if `specialist` has delegates (rare). `build --check` drift disjoint: `validate-agents.vsh` owns schema/graph; `build --check` owns Tier-1 compile + `plugins/` digest parity.
- **`scripts/generate-catalogs.vsh`** — now emits `kind` + `delegates` + `collaborates_with` into `catalogs/agent-catalog.yaml` (routing table / relationship graph). Also parses `fm_list` (block + flow list) for `delegates`/`collaborates_with`.

### Agents (`agents/*/AGENT.md` — all 18)
Every frontmatter now includes `kind` + relationship edges derived from `docs/AGENT_TAXONOMY.md` + existing `## Caller / skills / handoff` / `## Collaborators`:

| Agent | kind | delegates | collaborates_with |
|---|---|---|---|
| `assistant` | orchestrator | 10 holistic (planner/architect/designer/data-engineer/implementer/reviewer/qa-engineer/security-engineer/platform-engineer/researcher) | `client-workflow-bootstrap` |
| `client-workflow-bootstrap` | orchestrator | — | `assistant` |
| `implementer` | holistic | `tdd-guide` | 9 holistic peers |
| `reviewer` | holistic | `code-reviewer` | 6 holistic peers |
| `qa-engineer` | holistic | `e2e-runner` | 6 peers |
| `security-engineer` | holistic | `agentic-security-reviewer`, `security-reviewer` | 6 peers |
| `platform-engineer` | holistic | `build-error-resolver` | 7 peers |
| `planner`/`architect`/`designer`/`researcher`/`data-engineer` | holistic | — (holistic, collaborator edges only) | per body tables |
| `tdd-guide`/`code-reviewer`/`e2e-runner`/`build-error-resolver`/`agentic-security-reviewer`/`security-reviewer` | specialist | — | — |

Every specialist has a legitimate caller (reverse graph) — `validate-agents.vsh` enforces orphan check.

### Catalog & routing
- `catalogs/agent-catalog.yaml` — regenerated (18 entries, each with `kind` + `delegates`/`collaborates_with`). Serves as the **relationship graph / routing table** (`assistant` routing can be driven from catalog without duplicating config).
- No new SSOT file needed — checked compiler/distribution model (`modules/agent_toolkit_core/loader.v` → `distributions/products.yaml` + `agents/` tree, `AGENT_TOOLKIT_ROOT` / embedded_data, `build --check` drift). Frontmatter extension + catalog emission is the minimal that validates; a central `capabilities/agents/relationships.yaml` SSOT would duplicate the same edges and require a new compiler loader — inspected and rejected as over-engineering per #866 ("inspect whether the compiler/distribution model can be extended before adding a new SSOT file").

### Docs
- `docs/HOW_TO_ADD_AGENT.md` §3/§5/§7 — documents new required `kind` + optional `delegates`/`collaborates_with`/`skills`, schema ref, validator graph checks, product-agent refs, and updated checklist/catalog notes. Example now shows `kind` + edges.

### Compiler / dist
- `plugins/` — regenerated via `AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build` + `modules/agent_toolkit_core/embedded_data.v` (`./scripts/generate-embedded-data.vsh` — 1431 files) so `build --check` passes (Tier-1 compile + plugin digest parity covers the new frontmatter digest).

## Validation

```bash
./scripts/validate-agents.vsh          # ✅ 18 agents, schema + orphan/cycle/missing-delegate/products — fails on invalid kind / missing delegate / orphan / cycle
./scripts/generate-catalogs.vsh --check # ✅ catalogs in sync (18)
python3 scripts/validate-skill-capability.py --check # ✅ 85 skills, no orphans
./make.vsh build-cli && AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check # ✅ Tier-1 compile + plugin drift OK (after regenerate)
```

Negative tests (temporary mutations, reverted before commit): `kind=invalid` → fail, `delegates: [nonexistent-agent]` → fail, added orphan specialist → fail, planner↔architect delegates cycle → fail (`architect -> planner -> architect`).

## Design decisions

- **Frontmatter vs central catalog:** Extended `AGENT.md` frontmatter (single source; already the canonical persona definition) and generated `agent-catalog.yaml` view. A separate `capabilities/agents/relationships.yaml` SSOT would duplicate the same edges and require a new compiler loader — inspected and rejected as over-engineering per #866 ("inspect whether the compiler/distribution model can be extended before adding a new SSOT file").
- **No duplicate skill ownership:** `skills:` in frontmatter is optional and validated only when present; canonical ownership stays in `capabilities/skills/registry.yaml` (`holistic_owner`) to avoid split-brain.

## Checklist

- [x] Schema exists and validates all agents.
- [x] `validate-agents.vsh` and `build --check` fail on orphan, cycle, or missing delegate.
- [x] Catalog generation emits a relationship graph / routing table (`kind`/`delegates`/`collaborates_with`).
- [x] Assistant routing can be driven from the same metadata without duplicating config (catalog is the machine-readable view of `agents/*/AGENT.md` frontmatter + `capabilities/skills/registry.yaml`).