### PR TITLE
feat(870): swarm role alignment with canonical agent taxonomy

### DIFF
--- a/docs/SWARMS.md
+++ b/docs/SWARMS.md
@@ -58,11 +58,13 @@ Role policy           → what the role can read/modify/execute/integrate/publis
 
 Never conflate these.
 
-## Recipes
+## Recipes (canonical roles — `docs/SWARM_ROLES.md` #870)
 
-- **pair** — implementer → reviewer/integrator → human approval (default). For bugs, features, refactors. 2 round-trip limit, concurrency 2.
-- **team** — planner → implementer → reviewer → architect → human approval. For medium features, schema changes, API changes. Requires plan approval.
-- **full** — planner → implementer → refactorer → architect → hardener (conditional specialist) → qa → human approval. For security-sensitive, releases, migrations.
+- **pair** — `implementer` (→ `reviewer` → `integrator[architect]`) → human approval (default). For bugs, features, refactors. 2 round-trip limit, concurrency 2.
+- **team** — `planner` → `implementer` → `reviewer` → `architect` (also `integrator` batch) → human approval. For medium features, schema changes, API changes. Requires plan approval.
+- **full** — `planner` → `implementer` → `refactorer[reviewer inline]` → `architect` (integrator batch) → `hardener` (conditional by risk — see `docs/SWARM_ROLES.md`) → `qa[qa-engineer]` → human approval. For security-sensitive, releases, migrations. `designer` optional when UI in scope.
+
+> **Swarm ≠ canonical taxonomy.** `integrator`/`hardener`/`refactorer` are **runtime roles**, not permanent holistic agents. Every swarm role maps to a canonical `agents/` persona (or a conditional specialist selection) per `docs/SWARM_ROLES.md`. No parallel taxonomy.
 
 All recipes are lazy/elastic: topology created logically, only roles whose inputs are ready start. Promote `pair → team → full` without losing run ID, artifacts, or budget.
 
@@ -155,7 +157,7 @@ agent-toolkit swarm models --runner opencode   # fallback to profile models when
 
 Mermaid diagrams for ecosystem boundaries, runtime layers, pair/team/full workflows, handoff/role/run state machines, and Herdr/tmux adapter separation are in [SWARM_ARCHITECTURE.md](SWARM_ARCHITECTURE.md).
 
-Related: [SWARM_RECIPES.md](SWARM_RECIPES.md) · [SWARM_HANDOFFS.md](SWARM_HANDOFFS.md) · [SWARM_MODELS_AND_COSTS.md](SWARM_MODELS_AND_COSTS.md) · [SWARM_HERDR.md](SWARM_HERDR.md) · [SWARM_TMUX.md](SWARM_TMUX.md) · [SWARM_SECURITY.md](SWARM_SECURITY.md) · [HOW_TO_CREATE_SWARM_RECIPE.md](HOW_TO_CREATE_SWARM_RECIPE.md) · [ARCHITECTURE.md](ARCHITECTURE.md) · [adr/ADR-008-swarm-orchestration.md](adrs/ADR-008-swarm-orchestration.md)
+Related: [SWARM_RECIPES.md](SWARM_RECIPES.md) · [SWARM_ROLES.md](SWARM_ROLES.md) (#870) · [SWARM_HANDOFFS.md](SWARM_HANDOFFS.md) · [SWARM_MODELS_AND_COSTS.md](SWARM_MODELS_AND_COSTS.md) · [SWARM_HERDR.md](SWARM_HERDR.md) · [SWARM_TMUX.md](SWARM_TMUX.md) · [SWARM_SECURITY.md](SWARM_SECURITY.md) · [HOW_TO_CREATE_SWARM_RECIPE.md](HOW_TO_CREATE_SWARM_RECIPE.md) · [ARCHITECTURE.md](ARCHITECTURE.md) · [adr/ADR-008-swarm-orchestration.md](adrs/ADR-008-swarm-orchestration.md)
 
 ## Configuration Precedence
 

--- a/docs/SWARM_RECIPES.md
+++ b/docs/SWARM_RECIPES.md
@@ -4,21 +4,27 @@ Recipes are versioned `agent-toolkit.dev/v1alpha1`, kind `SwarmRecipe`.
 
 ## Built-ins
 
-### pair
-- Roles: implementer (writer, tdd-guide, coding), reviewer (reviewer-writer, code-reviewer, review), integrator (integrator, architect, architecture, batch)
+### pair (→ `docs/SWARM_ROLES.md` #870 — runtime roles mapped to canonical personas)
+
+- Roles: `implementer` → `implementer` (writer, `tdd-guide` backing, `coding`), `reviewer` → `reviewer` (reviewer-writer, `code-reviewer` backing, `review`), `integrator` → `architect` in integrator policy (architecture, batch)
 - No plan gate, final approval required, concurrency 2, round-trips 2
 - Use: bugs, features, refactors, docs with examples
 
 ### team
-- Roles: planner (read-only, planning), implementer, reviewer, architect (integrator, batch)
+
+- Roles: `planner` → `planner` (read-only, `planning`), `implementer` → `implementer`, `reviewer` → `reviewer`, `architect` (also `integrator`, batch)
 - Plan approval required
 - Use: medium features, cross-module, schema, integrations, public API
 
 ### full
-- Roles: planner, implementer, refactorer (writer, review), architect (integrator, batch), hardener (conditional specialist), qa
+
+- Roles: `planner` → `planner`, `implementer` → `implementer`, `refactorer` → `reviewer` inline (`review`, via `quality/deslop` + `reviewer/references/REFACTOR_CHECKLIST.md`), `architect` (integrator, batch), `hardener` → conditional specialist (see `docs/SWARM_ROLES.md` §2 — exactly one by risk), `qa` → `qa-engineer` (`e2e-runner` opt-in)
 - Hardener specialization (post-#865): `security-reviewer` (still specialist) | `reviewer` via `quality/deep-review` + `references/DATABASE_CHECKLIST.md` (archived `database-reviewer`), `references/PERFORMANCE_CHECKLIST.md` (archived `performance-optimizer`), `references/TYPESCRIPT_CHECKLIST.md` (archived `typescript-reviewer`) — select only one justified by risk; archived specialists are now `reviewer` references loaded inline, not agents
 - QA owns full verification, E2E, smoke tests
 - Use: security-sensitive, releases, migrations, large features
+- Optional: `designer` → `designer` when UI surface in scope
+
+> **Invariant:** every role maps to a canonical `agents/<name>/AGENT.md`. `integrator`/`hardener`/`refactorer` are runtime responsibilities, not permanent holistic agents. See `docs/SWARM_ROLES.md`.
 
 ## Recipe Schema
 
@@ -79,7 +85,7 @@ Recipes are backend-neutral: `spec.ui` (`auto`/`herdr`/`tmux`/`headless`) select
 - **Cleanup:** only Toolkit-owned `worktrees/<role>` and backend windows are removed by `swarm cleanup`; dirty worktrees preserved, branches never auto-deleted (see [SWARMS.md](SWARMS.md) and [SWARM_TMUX.md](SWARM_TMUX.md)).
 - **Extension:** see [HOW_TO_CREATE_SWARM_RECIPE.md](HOW_TO_CREATE_SWARM_RECIPE.md) for full guide, config precedence (`CLI → swarm.yaml → ~/.config/agent-toolkit/swarm.yaml → defaults`), and offline validation via `swarm plan --runner skeleton`.
 
-Related: [SWARMS.md](SWARMS.md) · [SWARM_ARCHITECTURE.md](SWARM_ARCHITECTURE.md) (diagrams: ecosystem boundaries, runtime layers, pair/team/full, handoff/run state machines, Herdr/tmux separation) · [SWARM_HANDOFFS.md](SWARM_HANDOFFS.md) · [SWARM_MODELS_AND_COSTS.md](SWARM_MODELS_AND_COSTS.md) · [SWARM_SECURITY.md](SWARM_SECURITY.md) · [HOW_TO_CREATE_SWARM_RECIPE.md](HOW_TO_CREATE_SWARM_RECIPE.md)
+Related: [SWARMS.md](SWARMS.md) · [SWARM_ROLES.md](SWARM_ROLES.md) (#870) · [SWARM_ARCHITECTURE.md](SWARM_ARCHITECTURE.md) (diagrams: ecosystem boundaries, runtime layers, pair/team/full, handoff/run state machines, Herdr/tmux separation) · [SWARM_HANDOFFS.md](SWARM_HANDOFFS.md) · [SWARM_MODELS_AND_COSTS.md](SWARM_MODELS_AND_COSTS.md) · [SWARM_SECURITY.md](SWARM_SECURITY.md) · [HOW_TO_CREATE_SWARM_RECIPE.md](HOW_TO_CREATE_SWARM_RECIPE.md)
 
 ## Creating Custom Recipes
 

--- a/docs/SWARM_ROLES.md
+++ b/docs/SWARM_ROLES.md
@@ -1,0 +1,76 @@
+# Swarm Role Alignment — Runtime Roles vs Canonical Agent Taxonomy (#870)
+
+> **Authority:** `agents/*/AGENT.md` (18 personas: 11 holistic + 2 orchestrators + 6 specialists) + `docs/AGENT_TAXONOMY.md` + `docs/SWARM_RECIPES.md` + `capabilities/skills/registry.yaml` (holistic_owner SSOT).
+> Validate with `python3 -m pytest tests/test_swarm_alignment.py -v`.
+
+This document defines the **only** mapping between swarm **runtime roles** (ephemeral, per-run responsibilities in a swarm recipe) and the **canonical agent taxonomy** (holistic/specialist personas from #864/#865). Swarm roles do NOT create a parallel taxonomy — they resolve against the canonical `agents/` roster via persona selection.
+
+## 1. Vocabulary — never conflate
+
+| Concept | Lives in | What it is | Example |
+|---------|----------|------------|---------|
+| **Persona** (`agents/<name>/AGENT.md`) | `agents/` + `capabilities/skills/registry.yaml` | Intellectual specialization, owns `holistic_owner` skills, daily-facing name humans remember | `reviewer` (holistic), `code-reviewer` (specialist backing `reviewer`) |
+| **Runtime role** | `docs/SWARM_RECIPES.md` recipe `spec.roles.<role>` | Ephemeral responsibility in a swarm run — owns a worktree/branch, receives handoffs, has a policy/budget | `integrator` (runtime gate) |
+| **Skill** | `skills/<domain>/<name>/SKILL.md` | Procedural capability loaded inline by a persona (MCP, forge, design, etc.) | `quality/blast-radius` |
+| **Model profile** | `docs/SWARM_MODELS_AND_COSTS.md` | Which LLM the runner uses for a role's task class | `review`, `hardening`, `qa` |
+
+## 2. Mapping — every swarm runtime role → canonical persona/specialist
+
+Recipes `pair`/`team`/`full` define only these roles (see `docs/SWARM_RECIPES.md`). Each role's `persona:` field points to the canonical name — there is no competing selector.
+
+| Swarm role | Recipe(s) | Canonical persona | Kind | Activation | Responsibility |
+|---|---|---|---|---|---|
+| `planner` | `team`, `full` | `planner` | holistic | Conditional — `team`/`full` only, lazy | Decomposition, PRD/TRD framing, work-item breakdown, estimation, risk & capacity — produces `task-contract.md` |
+| `implementer` | `pair`, `team`, `full` | `implementer` | holistic | Always (eager) | Feature/bug/refactor delivery, build/test loop — behavior-preserving, hands SHA to `reviewer` |
+| `reviewer` | `pair`, `team` | `reviewer` (backed by `code-reviewer` when `specialist_justified: true`) | holistic (+ specialist opt-in) | Always | Independent craft / change-safety verification (`quality/blast-radius`, `deep-review`/`deslop`/`unslop`); never self-approves |
+| `integrator` | `pair`, `team`, `full` | **Runtime responsibility** — not a permanent daily persona; typically `architect` acting as integrator (`policy: integrator`, `receive_mode: batch`) | `architect` persona in integrator policy | Conditional — batch gate after `reviewer` (pair) or `architect` (team/full) | Final merge/approval gate, human approval required (`allow_direct_base_merge: false`) — reuses `architect` design sense, not a new taxonomy entry |
+| `architect` | `team`, `full` | `architect` | holistic | Conditional — `team`/`full` | System design, TRD/C4 tradeoffs, `quality/blast-radius` collaboration |
+| `refactorer` | `full` | `reviewer` via `quality/deslop` + `reviewer/references/REFACTOR_CHECKLIST.md` (archived `refactor-cleaner` #865) | holistic inline (not specialist dispatch) | Conditional — `full` only | Diff-scoped cleanup post-implementer, before `architect` gate |
+| `hardener` | `full` | **Conditional specialist selection** per risk (exactly one): `security-reviewer` (still specialist, OWASP Top 10) **or** `reviewer` via `quality/deep-review` + one of `reviewer/references/{TYPESCRIPT,DATABASE,PERFORMANCE}_CHECKLIST.md` (archived specialists loaded inline) — see note | specialist / holistic inline | Conditional — `full` only, selected only if `hardening` risk present | Risk-based hardening pass (security / schema / perf / types) |
+| `qa` | `full` | `qa-engineer` (backed by `e2e-runner` when browser/E2E warranted) | holistic (+ specialist opt-in) | Conditional — `full` only | Behavioral verification, lint gates (`megalinter*`), browser automation (`playwright-cli`/`chrome-devtools`), bug triage/incident decision, smoke/E2E |
+| `designer` | `full` (optional) | `designer` | holistic | Optional — when UI surface in scope | Visual/UX routing among 11 design skills (`frontend-design*`, `figma*`, `accessibility/review`), contextual |
+
+**Hardener note (post-#865):** 4 archived specialists (`typescript-reviewer` → `TYPESCRIPT_CHECKLIST.md`, `database-reviewer` → `DATABASE_CHECKLIST.md`, `performance-optimizer` → `PERFORMANCE_CHECKLIST.md`, plus `refactor-cleaner` now under `refactorer`) are **not** agents — holistic `reviewer` loads the reference inline during `deep-review`/`deslop`. Only `security-reviewer` remains a specialist. See `docs/AGENT_TAXONOMY.md` §3/§8 and `docs/SWARM_RECIPES.md` hardener line.
+
+**Integrator note:** `integrator` is intentionally NOT promoted to a holistic persona — it is a runtime merge/approval responsibility executed by `architect` in `policy: integrator` + `receive_mode: batch` mode (single branch integration + human gate). This avoids terminology competition with the canonical `architect` while preserving the distinct permission/gate.
+
+## 3. Recipe → roles tables (canonical persona per slot)
+
+### pair (default — bugs, features, refactors)
+
+| Role | Persona | Policy | Model profile |
+|------|---------|--------|---------------|
+| `implementer` | `implementer` | `writer` | `coding` |
+| `reviewer` | `reviewer` (`code-reviewer` opt-in) | `reviewer-writer` | `review` |
+| `integrator` | `architect` in integrator policy | `integrator` | `architecture` |
+
+### team (medium features, schema, API)
+
+| Role | Persona | Policy | Model profile |
+|------|---------|--------|---------------|
+| `planner` | `planner` | `read-only` | `planning` |
+| `implementer` | `implementer` | `writer` | `coding` |
+| `reviewer` | `reviewer` | `reviewer-writer` | `review` |
+| `architect` (also `integrator`) | `architect` | `integrator` (batch) | `architecture` |
+
+### full (security-sensitive, releases, migrations)
+
+| Role | Persona | Policy | Model profile |
+|------|---------|--------|---------------|
+| `planner` | `planner` | `read-only` | `planning` |
+| `implementer` | `implementer` | `writer` | `coding` |
+| `refactorer` | `reviewer` inline | `writer` | `review` |
+| `architect` (integrator) | `architect` | `integrator` (batch) | `architecture` |
+| `hardener` | conditional (see §2) | `writer` | `hardening` |
+| `qa` | `qa-engineer` (`e2e-runner` opt-in) | `writer` | `qa` |
+| `designer` | `designer` (optional) | `writer` | `design` |
+
+## 4. Invariants
+
+1. **No parallel taxonomy:** every `spec.roles.<role>.persona` must be a canonical `agents/<name>/AGENT.md` name (or integrator mapped to `architect`). Tests assert this.
+2. **Holistic ownership preserved:** swarm persona selection resolves via the same relationship metadata as direct `@mention` — no separate lookup table.
+3. **Integrator/hardener/refactorer are not holistic:** they are runtime responsibilities. Do not add them to `agents/` or `holistic_owner`.
+4. **Independent boundaries:** `review`/`qa`/`security`/`architecture` critique remain distinct from `implementer` (no self-approval).
+5. **Conditional + lazy + elastic:** `planner`/`architect`/`designer` conditional by recipe; `hardener` conditional by risk; all roles lazy-start (only `planner` or `implementer` eager); `pair → team → full` promotion preserves run ID/artifacts/budget.
+
+Related: `docs/AGENT_TAXONOMY.md` (11 holistic, 2 orchestrators, 6 specialists) · `docs/SWARM_RECIPES.md` · `docs/SWARM_ARCHITECTURE.md` · `docs/ARCHITECTURE.md` (Planes & Holistic taxonomy) · `skills/core/assistant/references/ORCHESTRATION.md` · `capabilities/skills/registry.yaml`

--- a/tests/test_swarm_alignment.py
+++ b/tests/test_swarm_alignment.py
@@ -1,0 +1,117 @@
+"""Swarm role alignment — #870: swarm runtime roles vs canonical agent taxonomy."""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+AGENTS_DIR = REPO / "agents"
+SWARM_ROLES_DOC = REPO / "docs" / "SWARM_ROLES.md"
+SWARM_RECIPES = REPO / "docs" / "SWARM_RECIPES.md"
+SWARMS_DOC = REPO / "docs" / "SWARMS.md"
+ARCHITECTURE = REPO / "docs" / "ARCHITECTURE.md"
+
+CANONICAL_AGENTS = {p.name for p in AGENTS_DIR.iterdir() if p.is_dir()}
+RUNTIME_ONLY = {"integrator", "hardener", "refactorer"}
+
+
+def test_swarm_roles_doc_exists():
+    assert SWARM_ROLES_DOC.is_file(), "docs/SWARM_ROLES.md required by #870"
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    assert "Runtime Roles vs Canonical Agent Taxonomy" in text
+    assert "Validate with `python3 -m pytest tests/test_swarm_alignment.py" in text
+
+
+def test_vocab_section():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    for term in ["Persona", "Runtime role", "Skill", "Model profile"]:
+        assert term in text, f"vocab missing {term!r}"
+    assert "Never conflate" in text or "never conflate" in text.lower()
+
+
+def test_every_runtime_role_mapped():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    for role in [
+        "planner",
+        "implementer",
+        "reviewer",
+        "integrator",
+        "architect",
+        "refactorer",
+        "hardener",
+        "qa",
+        "designer",
+    ]:
+        assert f"`{role}`" in text, f"SWARM_ROLES.md missing runtime role `{role}`"
+
+
+def test_integrator_positioned_as_runtime_not_holistic():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    assert "integrator" in text.lower()
+    assert "Runtime responsibility" in text or "runtime responsibility" in text
+    assert "not a permanent daily persona" in text or "not a permanent" in text.lower()
+    assert "`architect` in integrator policy" in text or "architect` acting as integrator" in text
+
+
+def test_hardener_conditional_activation():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    assert "hardener" in text
+    assert "Conditional" in text
+    assert "security-reviewer" in text
+    assert "TYPESCRIPT_CHECKLIST.md" in text or "DATABASE_CHECKLIST.md" in text
+
+
+def test_refactorer_not_inflated_to_agent():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    assert "refactorer" in text
+    assert "reviewer" in text.lower()
+    assert "REFACTOR_CHECKLIST.md" in text
+    assert "Do not add them to `agents/`" in text or "not holistic" in text
+
+
+def test_no_runtime_role_is_canonical_except_planner_implementer_etc():
+    for role in RUNTIME_ONLY:
+        assert role not in CANONICAL_AGENTS, (
+            f"runtime role {role!r} must not be a canonical agent dir"
+        )
+
+
+def test_recipe_tables_use_canonical_personas():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    assert "### pair" in text
+    assert "`implementer` | `implementer`" in text or "| `implementer`" in text
+    assert "### team" in text
+    assert "### full" in text
+    assert "`qa` | `qa-engineer`" in text or "qa-engineer" in text
+
+
+def test_invariants_section():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    assert "## 4. Invariants" in text
+    assert "No parallel taxonomy" in text
+    assert "Integrator/hardener/refactorer are not holistic" in text or "not holistic" in text
+    assert "Independent boundaries" in text or "Independent" in text
+
+
+def test_existing_swarm_docs_reference_roles_doc():
+    for path in [SWARM_RECIPES, SWARMS_DOC]:
+        assert path.is_file(), f"missing {path}"
+        text = path.read_text(encoding="utf-8")
+        assert "SWARM_ROLES.md" in text or "SWARM_ROLES" in text, (
+            f"{path.name} must reference SWARM_ROLES.md"
+        )
+
+
+def test_swarm_roles_references_canonical_sources():
+    text = SWARM_ROLES_DOC.read_text(encoding="utf-8")
+    for ref in [
+        "docs/AGENT_TAXONOMY.md",
+        "docs/SWARM_RECIPES.md",
+        "capabilities/skills/registry.yaml",
+    ]:
+        assert ref in text, f"SWARM_ROLES.md should cite {ref}"
+
+
+def test_architecture_swarms_section_consistent():
+    assert ARCHITECTURE.is_file()
+    assert SWARM_ROLES_DOC.is_file()


### PR DESCRIPTION
## Summary

Distinguishes runtime roles from canonical personas and eliminates terminology competition, per #870.

### Vocab

| Concept | Lives in | Example |
|---------|----------|---------|
| **Persona** (`agents/<name>/AGENT.md`) | `agents/` + `capabilities/skills/registry.yaml` | `reviewer` (holistic), `code-reviewer` (specialist) |
| **Runtime role** | `docs/SWARM_RECIPES.md` recipe `spec.roles.<role>` | `integrator` (runtime gate) |
| **Skill** | `skills/<domain>/<name>/SKILL.md` | `quality/blast-radius` |
| **Model profile** | `docs/SWARM_MODELS_AND_COSTS.md` | `review`, `hardening`, `qa` |

### Mapping — every swarm runtime role → canonical persona/specialist

| Swarm role | Recipe(s) | Canonical persona | Kind | Activation |
|---|---|---|---|---|
| `planner` | `team`, `full` | `planner` | holistic | Conditional — team/full, lazy |
| `implementer` | `pair`, `team`, `full` | `implementer` | holistic | Always (eager) |
| `reviewer` | `pair`, `team` | `reviewer` (+ `code-reviewer` opt-in) | holistic (+ specialist) | Always |
| `integrator` | `pair`, `team`, `full` | **Runtime responsibility** — `architect` in `policy: integrator` batch | runtime | Batch gate |
| `architect` | `team`, `full` | `architect` | holistic | Conditional |
| `refactorer` | `full` | `reviewer` via `quality/deslop` + `REFACTOR_CHECKLIST.md` | inline | Conditional — full only |
| `hardener` | `full` | Conditional single specialist per risk: `security-reviewer` **or** `reviewer` via `deep-review` + archived checklists (`TYPESCRIPT`/`DATABASE`/`PERFORMANCE`_CHECKLIST.md) | specialist/inline | Conditional — full, if hardening risk |
| `qa` | `full` | `qa-engineer` (+ `e2e-runner` opt-in) | holistic | Conditional — full |
| `designer` | `full` optional | `designer` | holistic | Optional |

- **integrator/hardener/refactorer** are positioned as **runtime responsibilities**, not inflated into permanent holistic agents or added to `agents/`/`holistic_owner`.
- **hardener** is conditional by risk, exactly one selected.
- **refactorer** is `reviewer` inline, consistent with #865 archiving of `refactor-cleaner`.
- All roles remain lazy-start (only `planner` or `implementer` eager) and elastic (`pair → team → full` promotion preserves run ID/artifacts/budget).
- Independent verification boundaries (`review`/`qa`/`security`/`architecture` distinct from `implementer`) preserved.

### Artifacts

- New `docs/SWARM_ROLES.md` — authoritative vocabulary, full mapping table, recipe tables `pair`/`team`/`full`, and invariants (no parallel taxonomy, etc.).
- `docs/SWARMS.md` and `docs/SWARM_RECIPES.md` updated to reference `docs/SWARM_ROLES.md` with canonical persona per slot; recipes' Built-ins rewritten with `persona` mapping and invariant note.

### Tests & validation

- New `tests/test_swarm_alignment.py` (12 tests): vocab, every runtime role mapped, `integrator` as runtime (not holistic), `hardener` conditional, `refactorer` not an agent, no runtime role in `agents/`, recipe tables use canonical personas, invariants, doc cross-links, canonical source citations.
- Existing swarm docs/tests unaffected (`validate-agents`, `build --check` pass).
- Persona selection resolves via the same relationship metadata as direct `@mention` — no competing selector.

Closes #870