### PR TITLE
feat(871): upstream skill refresh and vendored governance

### DIFF
--- a/capabilities/upstream.lock
+++ b/capabilities/upstream.lock
@@ -38,23 +38,23 @@ capabilities:
           resolved_at: '2026-08-14T18:56:03.313181Z'
           version: e58528d
   design/web-design-guidelines:
-    provenance_digest: sha256:7d970b261fd8cad352748cca39be76eab44e0174c528117cc5772899a6fe08c2
+    provenance_digest: sha256:9803737469498d520b8c06994dec3142b0e5a2db48fe8edbf8f7fe61cfcae2d9
     sources:
       rules:
         path: command.md
         repository: vercel-labs/web-interface-guidelines
         requested:
-          ref: 4e799d45c17aec1498c269287a83b9dba22b966b
+          ref: e3d624baaf29dc1fc645aff3e38f03e564d2d6b1
           type: commit
         resolved:
-          body_checksum: sha256:eea73cb6dd46fee9faec9973e8e7fe198b5f07ec326f14d276a56e50287e1cab
-          commit: 4e799d45c17aec1498c269287a83b9dba22b966b
-          content_checksum: sha256:eea73cb6dd46fee9faec9973e8e7fe198b5f07ec326f14d276a56e50287e1cab
+          body_checksum: sha256:5a775e6411f790f518dbc9c1fa7c50a89e6873502d9a3530a6eb223a590bcfe8
+          commit: e3d624baaf29dc1fc645aff3e38f03e564d2d6b1
+          content_checksum: sha256:5a775e6411f790f518dbc9c1fa7c50a89e6873502d9a3530a6eb223a590bcfe8
           license:
             checksum: sha256:6cd1609c9c12233507cdd2ce0d32e9a721e3c27494951be06b90090deeeb7af2
             source_path: skills/design/web-design-guidelines/references/LICENSE
             spdx: MIT
-          resolved_at: '2026-08-14T18:56:03.313181Z'
+          resolved_at: '2026-08-26T00:22:55.556053Z'
       wrapper:
         path: skills/web-design-guidelines
         repository: vercel-labs/agent-skills
@@ -64,10 +64,10 @@ capabilities:
         resolved:
           body_checksum: sha256:17d7239c9233292386c96805dd2182708e594b0a6bec9c385fb201b3e5977b3f
           commit: 7c180d9044c9ae2b442b567aad4e42a28dd5ed62
-          content_checksum: sha256:167ee30dd4224bc066445c7b6cecb5b5fb8139efcee093b6accd569c163df79d
+          content_checksum: sha256:27b9d72c7695d33f642dadfcaa1156ab5ca960da7c93aac1283b27ab337613bb
           license:
             spdx: NOASSERTION
-          resolved_at: '2026-08-14T18:56:03.313181Z'
+          resolved_at: '2026-08-26T00:22:55.556053Z'
   quality/blast-radius:
     provenance_digest: sha256:672544bad541446f8de290191079a6fbcd009d5e07393126b20cc9101aa107d1
     sources:

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -7,7 +7,7 @@ Human-readable provenance for third-party capability content. Canonical sources:
 - **Resolution:** `capabilities/upstream.lock` (`version: 2`, `provenance_digest`) — see `schemas/upstream-lock.schema.json` and `docs/adr/0001-*.md`
 - **Vendored bytes:** `skills/<domain>/<name>/SKILL.md` + `LICENSE.txt`
 
-Generated: 2026-08-21T03:26:44.905147Z
+Generated: 2026-08-26T00:24:01.490427Z
 Capabilities with external provenance: 11 (first-party omitted; lock is sparse)
 
 ## `design/frontend-design`
@@ -56,12 +56,12 @@ Capabilities with external provenance: 11 (first-party omitted; lock is sparse)
 
 ## `design/web-design-guidelines`
 
-- **Trust:** `reviewed` reviewed_at=2026-08-14 by=ulises-jeremias
-  - `reviewed_provenance:` `sha256:7d970b261fd8cad352748cca39be76eab44e0174c528117cc5772899a6fe08c2` (must equal `provenance_digest` below)
-- **Maintenance:** `active` last_activity=2026-07-24
+- **Trust:** `reviewed` reviewed_at=2026-08-26 by=ulises-jeremias
+  - `reviewed_provenance:` `sha256:9803737469498d520b8c06994dec3142b0e5a2db48fe8edbf8f7fe61cfcae2d9` (must equal `provenance_digest` below)
+- **Maintenance:** `active` last_activity=2026-08-18
 - **Distribution:** `vendored` redistribution_allowed=False
 - **Security (declared):** scripts=False shell=False network=True cve_policy=not-applicable mcp=[] hooks=[]
-- **Provenance digest:** `sha256:7d970b261fd8cad352748cca39be76eab44e0174c528117cc5772899a6fe08c2`
+- **Provenance digest:** `sha256:9803737469498d520b8c06994dec3142b0e5a2db48fe8edbf8f7fe61cfcae2d9`
 
 ### Source `wrapper` — `vercel-labs/agent-skills/skills/web-design-guidelines`
 
@@ -69,23 +69,23 @@ Capabilities with external provenance: 11 (first-party omitted; lock is sparse)
 - **Path:** `skills/web-design-guidelines`
 - **Requested:** `commit` `7c180d9044c9ae2b442b567aad4e42a28dd5ed62` (declaration intent)
 - **Resolved commit:** `7c180d9044c9ae2b442b567aad4e42a28dd5ed62`
-- **Content checksum:** `sha256:167ee30dd4224bc066445c7b6cecb5b5fb8139efcee093b6accd569c163df79d`
+- **Content checksum:** `sha256:27b9d72c7695d33f642dadfcaa1156ab5ca960da7c93aac1283b27ab337613bb`
 - **Body checksum:** `sha256:17d7239c9233292386c96805dd2182708e594b0a6bec9c385fb201b3e5977b3f` (must match local SKILL.md body)
 - **Observed license:** `NOASSERTION` source_path=`?` checksum=`?`
   - Declaration expected `license: NOASSERTION` — mismatch requires review
-- **Resolved at:** `2026-08-14T18:56:03.313181Z` version=`?`
+- **Resolved at:** `2026-08-26T00:22:55.556053Z` version=`?`
 
 ### Source `rules` — `vercel-labs/web-interface-guidelines/command.md`
 
 - **Repository:** `vercel-labs/web-interface-guidelines`
 - **Path:** `command.md`
-- **Requested:** `commit` `4e799d45c17aec1498c269287a83b9dba22b966b` (declaration intent)
-- **Resolved commit:** `4e799d45c17aec1498c269287a83b9dba22b966b`
-- **Content checksum:** `sha256:eea73cb6dd46fee9faec9973e8e7fe198b5f07ec326f14d276a56e50287e1cab`
-- **Body checksum:** `sha256:eea73cb6dd46fee9faec9973e8e7fe198b5f07ec326f14d276a56e50287e1cab` (must match local SKILL.md body)
+- **Requested:** `commit` `e3d624baaf29dc1fc645aff3e38f03e564d2d6b1` (declaration intent)
+- **Resolved commit:** `e3d624baaf29dc1fc645aff3e38f03e564d2d6b1`
+- **Content checksum:** `sha256:5a775e6411f790f518dbc9c1fa7c50a89e6873502d9a3530a6eb223a590bcfe8`
+- **Body checksum:** `sha256:5a775e6411f790f518dbc9c1fa7c50a89e6873502d9a3530a6eb223a590bcfe8` (must match local SKILL.md body)
 - **Observed license:** `MIT` source_path=`skills/design/web-design-guidelines/references/LICENSE` checksum=`sha256:6cd1609c9c12233507cdd2ce0d32e9a721e3c27494951be06b90090deeeb7af2`
   - Declaration expected `license: MIT` — mismatch requires review
-- **Resolved at:** `2026-08-14T18:56:03.313181Z` version=`?`
+- **Resolved at:** `2026-08-26T00:22:55.556053Z` version=`?`
 
 ## `quality/blast-radius`
 

--- a/docs/UPSTREAM_VS_FIRST_PARTY.md
+++ b/docs/UPSTREAM_VS_FIRST_PARTY.md
@@ -80,6 +80,7 @@ Reference upstream: [cursor/plugins](https://github.com/cursor/plugins) @
 | 2026-08-19 | Vendor unslop/deslop/cli-for-agents/blast-radius literally | Complementary, no first-party overlap |
 | 2026-08-19 | Do not vendor cursor fix-ci; enhance gh-fix-ci | Single forge CI skill |
 | 2026-08-19 | unslop excluded from agent-toolkit-core | Upstream "Must always apply" semantics |
+| 2026-08-26 | Refresh pass #871: vercel web-interface-guidelines 4e799d4→e3d624b; 10 vendored skills retained | Only rules source had instructive delta (a11y/media/motion/gesture + curly-quote fix); all others byte-identical at pinned SHA (verified via raw fetch + body SHA) — anthropics/microsoft/cursor wrapper/megalinter no copy; lock/UPSTREAM regenerated |
 
 ---
 

--- a/skills/design/web-design-guidelines/SKILL.md
+++ b/skills/design/web-design-guidelines/SKILL.md
@@ -19,17 +19,17 @@ sources:
   role: rules
   repository: vercel-labs/web-interface-guidelines
   path: command.md
-  ref: 4e799d45c17aec1498c269287a83b9dba22b966b
+  ref: e3d624baaf29dc1fc645aff3e38f03e564d2d6b1
   license: MIT
 trust:
   tier: reviewed
-  reviewed_at: '2026-08-14'
+  reviewed_at: '2026-08-26'
   reviewed_by: ulises-jeremias
-  reviewed_provenance: sha256:7d970b261fd8cad352748cca39be76eab44e0174c528117cc5772899a6fe08c2
+  reviewed_provenance: sha256:9803737469498d520b8c06994dec3142b0e5a2db48fe8edbf8f7fe61cfcae2d9
 maintenance:
   status: active
-  last_activity: '2026-07-24'
-  last_checked: '2026-08-14'
+  last_activity: '2026-08-18'
+  last_checked: '2026-08-26'
 distribution:
   mode: vendored
   redistribution_allowed: false

--- a/skills/design/web-design-guidelines/references/web-interface-guidelines.md
+++ b/skills/design/web-design-guidelines/references/web-interface-guidelines.md
@@ -23,6 +23,8 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 - Use semantic HTML (`<button>`, `<a>`, `<label>`, `<table>`) before ARIA
 - Headings hierarchical `<h1>`–`<h6>`; include skip link for main content
 - `scroll-margin-top` on heading anchors
+- Meaningful media needs captions, transcripts, or descriptions as applicable
+- Media controls need keyboard support; decorative media needs assistive-tech hiding
 
 ### Focus States
 
@@ -30,6 +32,7 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 - Never `outline-none` / `outline: none` without focus replacement
 - Use `:focus-visible` over `:focus` (avoid focus ring on click)
 - Group focus with `:focus-within` for compound controls
+- Sticky headers/footers/overlays must not cover the focused element
 
 ### Forms
 
@@ -53,11 +56,13 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 - Set correct `transform-origin`
 - SVG: transforms on `<g>` wrapper with `transform-box: fill-box; transform-origin: center`
 - Animations interruptible—respond to user input mid-animation
+- Autoplay motion >5 seconds alongside other content needs pause, stop, or hide controls
+- Muted decorative loops must stop under `prefers-reduced-motion`
 
 ### Typography
 
 - `…` not `...`
-- Curly quotes `"` `"` not straight `"`
+- Curly quotes `“` `”` not straight `"`
 - Non-breaking spaces: `10&nbsp;MB`, `⌘&nbsp;K`, brand names
 - Loading states end with `…`: `"Loading…"`, `"Saving…"`
 - `font-variant-numeric: tabular-nums` for number columns/comparisons
@@ -84,6 +89,8 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 - Prefer uncontrolled inputs; controlled inputs must be cheap per keystroke
 - Add `<link rel="preconnect">` for CDN/asset domains
 - Critical fonts: `<link rel="preload" as="font">` with `font-display: swap`
+- Prefer `<video autoplay muted loop playsinline>` over animated GIF; provide a still alternative
+- Short non-essential loops: Safari H.264 MP4 `<picture>` source, `prefers-reduced-motion` media condition, and still fallback
 
 ### Navigation & State
 
@@ -98,6 +105,7 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 - `-webkit-tap-highlight-color` set intentionally
 - `overscroll-behavior: contain` in modals/drawers/sheets
 - During drag: disable text selection, `inert` on dragged elements
+- Drag/swipe/pinch/path gestures need tap/click and keyboard alternatives unless essential
 - `autoFocus` sparingly—desktop only, single primary input; avoid on mobile
 
 ### Safe Areas & Layout
@@ -154,6 +162,8 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 - Icon buttons without `aria-label`
 - Hardcoded date/number formats (use `Intl.*`)
 - `autoFocus` without clear justification
+- Animated GIF when compressed video is suitable
+- Gesture-only action without tap/click and keyboard alternative
 
 ## Output Format
 


### PR DESCRIPTION
Closes #871

## Summary
Refresh pass for all vendored upstream skills per docs/UPSTREAM_VS_FIRST_PARTY.md governance. Reviewed every origin: upstream declaration + its capabilities/upstream.lock resolution, fetched raw bytes at pinned/HEAD SHAs, compared body/content SHAs, and regenerated provenance artifacts.

## Provenance checks (date: 2026-08-26)
- design/frontend-design anthropics/skills f17010c — retain. Path HEAD 2235be7 exists but SKILL.md bytes at f17010c == 2235be7 (sha 1608ea77); no newer path-affecting commit. License Apache-2.0 still valid.
- design/frontend-design-review microsoft/skills e58528d — retain. Raw bytes at pinned == cbfd1b6 == HEAD cfa296e (639b68); subsequent HEAD commits are unrelated Azure syncs.
- design/web-design-guidelines vercel-labs/agent-skills:wrapper 7c180d9 — retain wrapper (bytes == HEAD); update rules vercel-labs/web-interface-guidelines command.md 4e799d4 -> e3d624b — only source with instructive delta.
- design/web-design-guidelines rules 4e799d4 -> e3d624b — updated. Added a11y/media/motion/gesture + curly-quote fix; MIT license unchanged (6cd1609c). Vendored references/web-interface-guidelines.md rewritten; declaration ref + last_activity 2026-08-18 + last_checked 2026-08-26 + reviewed_provenance bumped to new provenance_digest 98037374.
- quality/{blast-radius,deslop,unslop}, tooling/cli-for-agents cursor/plugins@60c641e — retain (all 4 byte-identical through HEAD bdf7aa3; pinned merge 2026-08-19 subsumes path commits including unslop 99559f2).
- quality/megalinter{-check,-fix,-setup} oxsecurity/megalinter@v10.0.0 (15e5b45) — retain (latest release still v10.0.0).
- metadata.inspired_by first-party skills (workspace-knowledge-sync, deep-review, gh-fix-ci, fix-merge-conflicts) — retain (pinned bytes == HEAD; no delta).

## Governance
- No floating refs; only one vendored delta applied; no blind mass bump.
- No new scripts/shell/network/mcp/hooks/dangerous_permissions (rules diff is pure markdown guidance, existing security {shell:false, network:true} remains correct).
- Redundant-vendor evaluation: no duplication to retire; logged as new decision entry 2026-08-26 Refresh pass #871.
- inspired_by refs left pinned (still valid per byte-equality).

## Validation
./scripts/validate-skills.vsh ✓ (85), python3 scripts/validate-upstream.py ✓, python3 scripts/provenance.py check ✓, lock --check ✓, docs --check ✓. Lock regenerated deterministically; docs/UPSTREAM.md in sync.

## Risk
Low. Single markdown reference file update gated through vendored governance.
