### PR TITLE
feat(swarm): git worktree per writer lazy initial_roles (fixes #884)

### DIFF
--- a/modules/agent_toolkit_cli/options.v
+++ b/modules/agent_toolkit_cli/options.v
@@ -1019,6 +1019,11 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 			i++
 			continue
 		}
+		if a.starts_with('--base-ref=') {
+			base_ref = a.all_after('=')
+			i++
+			continue
+		}
 		if a.starts_with('-') {
 			i++
 			continue

--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -58,6 +58,7 @@ struct SwarmStateFile {
 	created_at    string
 	task          string
 	active_roles []string
+	worktrees  []SwarmWorktree
 }
 
 struct SwarmApprovalsFile {
@@ -469,7 +470,51 @@ fn swarm_start(ws string, opts SwarmOptions) SwarmReport {
 	} else {
 		'running'
 	}
-	st := SwarmStateFile{
+	// Lazy worktree per writer — port fbb2280 cli.py:688-750 initial_roles + create_worktree.
+	// Determine initial roles: planner > implementer > first role.
+	roles_all := swarm_recipe_roles(recipe)
+	mut initial_roles := []string{}
+	if 'planner' in roles_all {
+		initial_roles = ['planner']
+	} else if 'implementer' in roles_all {
+		initial_roles = ['implementer']
+	} else if roles_all.len > 0 {
+		initial_roles = [roles_all[0]]
+	}
+	lazy := swarm_recipe_lazy_start(recipe)
+	repo_root := find_git_root(ws) or { ws }
+	base_ref := if opts.base_ref != '' { opts.base_ref } else { 'HEAD' }
+	mut created_wts := []SwarmWorktree{}
+	for role in roles_all {
+		if !swarm_role_has_worktree(recipe, role) {
+			continue
+		}
+		if lazy && role !in initial_roles {
+			continue
+		}
+		wt := swarm_create_worktree(repo_root, run_dir, role, rid, base_ref) or {
+			append_swarm_trace(run_dir, 'worktree_failed', role + ':' + err.msg())
+			continue
+		}
+		created_wts << wt
+		// Copy opencode agent into worktree if a runner agent exists for that role
+		// Mirrors cli.py:709 ff: runner/opencode/agents/<role>.md -> wt/.opencode/agents/<role>.md
+		agent_src := os.join_path(run_dir, 'runner', 'opencode', 'agents', role + '.md')
+		if os.is_file(agent_src) {
+			wt_agents := os.join_path(wt.path, '.opencode', 'agents')
+			os.mkdir_all(wt_agents) or {}
+			agent_content := os.read_file(agent_src) or { '' }
+			os.write_file(os.join_path(wt_agents, role + '.md'), agent_content) or {}
+			prompt_src := os.join_path(run_dir, 'prompts', role + '.md')
+			if os.is_file(prompt_src) {
+				prompt_content := os.read_file(prompt_src) or { '' }
+				os.write_file(os.join_path(wt.path, '.agent-toolkit-prompt-' + role + '.md'),
+					prompt_content) or {}
+			}
+		}
+		append_swarm_trace(run_dir, 'worktree_created', role + ':' + wt.branch + ':' + wt.path)
+	}
+	mut st := SwarmStateFile{
 		version:       1
 		run_id:        rid
 		recipe:        recipe
@@ -479,6 +524,8 @@ fn swarm_start(ws string, opts SwarmOptions) SwarmReport {
 		run_state:     initial
 		created_at:    time.utc().format_rfc3339()
 		task:          opts.task
+		active_roles:  []string{}
+		worktrees:     created_wts
 	}
 	write_swarm_state(run_dir, st) or {
 		return SwarmReport{
@@ -776,9 +823,41 @@ fn swarm_status(ws string, opts SwarmOptions) SwarmReport {
 		}
 		gtxt << '${g.id}:${mark}'
 	}
+	mut wlines := []string{}
+	for wt in st.worktrees {
+		wlines << '${wt.role}:${wt.branch}@${wt.path}'
+	}
+	mut wt_detail := gtxt.join(', ')
+	if wlines.len > 0 {
+		wt_detail += '\nworktrees: ' + wlines.join(', ')
+	}
+	// Also reflect owned worktrees not in state but on disk
+	if st.worktrees.len == 0 {
+		wt_root := os.join_path(swarm_run_dir(ws, st.run_id), 'worktrees')
+		if os.is_dir(wt_root) {
+			entries := os.ls(wt_root) or { []string{} }
+			if entries.len > 0 {
+				wt_detail += if wt_detail.len > 0 { '; ' } else { '' } + 'worktrees(dir): ' + entries.join(', ')
+			}
+		}
+	}
+	mut msg := 'run ${st.run_id} recipe=${st.recipe} backend=${st.backend} state=${st.run_state}\ngates: ${gtxt.join(', ')}'
+	if wlines.len > 0 {
+		msg += '\nworktrees: ' + wlines.join(', ')
+	}
+	mut wt_data := wlines.join(',')
+	if wt_data.len == 0 && st.worktrees.len == 0 {
+		wt_root2 := os.join_path(swarm_run_dir(ws, st.run_id), 'worktrees')
+		if os.is_dir(wt_root2) {
+			el := os.ls(wt_root2) or { []string{} }
+			if el.len > 0 {
+				wt_data = el.join(',')
+			}
+		}
+	}
 	return SwarmReport{
 		ok:      true
-		message: 'run ${st.run_id} recipe=${st.recipe} backend=${st.backend} state=${st.run_state}\ngates: ${gtxt.join(', ')}'
+		message: msg
 		data:    {
 			'subcommand': 'status'
 			'run_id':     st.run_id
@@ -786,6 +865,7 @@ fn swarm_status(ws string, opts SwarmOptions) SwarmReport {
 			'backend':    st.backend
 			'run_state':  st.run_state
 			'gates':      gtxt.join(',')
+			'worktrees':  wt_data
 		}
 	}
 }
@@ -1237,23 +1317,6 @@ fn swarm_branch_for_role(run_id string, role string) string {
 
 fn swarm_worktree_path(run_dir string, role string) string {
 	return os.join_path(run_dir, 'worktrees', role)
-}
-
-fn swarm_is_worktree_dirty(path string) bool {
-	if !os.is_dir(path) && !os.is_file(path) {
-		return false
-	}
-	mut check_dir := path
-	if !os.is_dir(path) {
-		check_dir = os.dir(path)
-	}
-	ps := new_process_service()
-	res := ps.run(RunOptions{
-		argv:    ['git', 'status', '--porcelain']
-		cwd:     check_dir
-		timeout: 5 * time.second
-	}) or { return false }
-	return res.stdout.trim_space().len > 0
 }
 
 fn swarm_promote(ws string, opts SwarmOptions) SwarmReport {
@@ -1775,7 +1838,7 @@ fn swarm_role_receive_mode(recipe string, role string) string {
 
 fn ensure_swarm_run_dirs(run_dir string) ! {
 	for sub in ['artifacts', 'handoffs/outbox', 'handoffs/queued', 'handoffs/active',
-		'handoffs/completed', 'handoffs/failed', 'prompts', 'worktrees'] {
+		'handoffs/completed', 'handoffs/failed', 'prompts', 'worktrees', 'runner/opencode/agents'] {
 		os.mkdir_all(os.join_path(run_dir, sub))!
 	}
 }

--- a/modules/agent_toolkit_core/swarm_worktree.v
+++ b/modules/agent_toolkit_core/swarm_worktree.v
@@ -1,0 +1,162 @@
+module agent_toolkit_core
+
+import os
+import time
+
+// SwarmWorktree mirrors Python state["worktrees"] entries.
+pub struct SwarmWorktree {
+pub mut:
+	role   string
+	branch string
+	path   string
+	exists bool
+}
+
+pub fn swarm_is_valid_role(role string) bool {
+	if role.len < 2 || role.len > 32 {
+		return false
+	}
+	first := role[0]
+	if !(first >= `a` && first <= `z`) {
+		return false
+	}
+	for i in 1 .. role.len {
+		c := role[i]
+		if !((c >= `a` && c <= `z`) || (c >= `0` && c <= `9`) || c == `_` || c == `-`) {
+			return false
+		}
+	}
+	return true
+}
+
+fn swarm_sanitize_run_id(run_id string) string {
+	mut res := ''
+	for i in 0 .. run_id.len {
+		b := run_id[i]
+		is_ok := (b >= `a` && b <= `z`) || (b >= `A` && b <= `Z`) || (b >= `0` && b <= `9`)
+			|| b == `.` || b == `_` || b == `-`
+		if is_ok {
+			res += run_id[i..i + 1]
+		} else {
+			res += '-'
+		}
+	}
+	if res.len > 32 {
+		return res[..32]
+	}
+	return res
+}
+
+pub fn swarm_branch_for_run_role(run_id string, role string) !string {
+	if !swarm_is_valid_role(role) {
+		return error('Invalid role: ${role}')
+	}
+	safe := swarm_sanitize_run_id(run_id)
+	return 'agent-toolkit-swarm/${safe}/${role}'
+}
+
+pub fn swarm_worktree_path_for(run_dir string, role string) !string {
+	if !swarm_is_valid_role(role) {
+		return error('Invalid role: ${role}')
+	}
+	return os.join_path(run_dir, 'worktrees', role)
+}
+
+pub fn swarm_role_has_worktree(recipe string, role string) bool {
+	if role == 'planner' {
+		return false
+	}
+	roles := swarm_recipe_roles(recipe)
+	if roles.len == 0 {
+		return role != 'planner'
+	}
+	if role !in roles {
+		return false
+	}
+	return role != 'planner'
+}
+
+pub fn swarm_recipe_lazy_start(recipe string) bool {
+	return true
+}
+
+fn swarm_git_run(args []string, cwd string) RunResult {
+	mut argv := ['git']
+	argv << args
+	ps := new_process_service()
+	res := ps.run(RunOptions{
+		argv:    argv
+		cwd:     cwd
+		timeout: 15 * time.second
+	}) or {
+		return RunResult{
+			exit_code: -1
+			stderr:    err.msg()
+		}
+	}
+	return res
+}
+
+pub fn swarm_create_worktree(repo_root string, run_dir string, role string, run_id string, base_ref string) !SwarmWorktree {
+	branch := swarm_branch_for_run_role(run_id, role)!
+	wt_path := swarm_worktree_path_for(run_dir, role)!
+	if os.exists(wt_path) {
+		return SwarmWorktree{
+			role:   role
+			branch: branch
+			path:   wt_path
+			exists: true
+		}
+	}
+	br_ref := if base_ref != '' { base_ref } else { 'HEAD' }
+	rev := swarm_git_run(['rev-parse', '--verify', branch], repo_root)
+	if rev.exit_code != 0 {
+		cre := swarm_git_run(['branch', branch, br_ref], repo_root)
+		if cre.exit_code != 0 {
+			msg := cre.stderr.trim_space()
+			extra := if msg.len > 0 { msg } else { cre.stdout.trim_space() }
+			return error('Failed to create branch ${branch}: ${extra}')
+		}
+	}
+	os.mkdir_all(os.dir(wt_path)) or {
+		return error('mkdir worktree parent failed: ${err.msg()}')
+	}
+	wt_res := swarm_git_run(['worktree', 'add', wt_path, branch], repo_root)
+	if wt_res.exit_code != 0 {
+		msg := wt_res.stderr.trim_space()
+		extra := if msg.len > 0 { msg } else { wt_res.stdout.trim_space() }
+		return error('Failed to create worktree ${wt_path}: ${extra}')
+	}
+	return SwarmWorktree{
+		role:   role
+		branch: branch
+		path:   wt_path
+		exists: false
+	}
+}
+
+pub fn swarm_is_worktree_dirty(wt_path string) bool {
+	res := swarm_git_run(['status', '--porcelain'], wt_path)
+	if res.exit_code != 0 {
+		return false
+	}
+	return res.stdout.trim_space().len > 0
+}
+
+pub fn swarm_remove_worktree(repo_root string, wt_path string, force bool) !bool {
+	if !os.exists(wt_path) {
+		return false
+	}
+	if !force && swarm_is_worktree_dirty(wt_path) {
+		return error('Worktree dirty, refusing removal without --force: ${wt_path}')
+	}
+	mut args := ['worktree', 'remove', wt_path]
+	if force {
+		args << '--force'
+	}
+	swarm_git_run(args, repo_root)
+	if os.exists(wt_path) {
+		os.rmdir_all(wt_path) or {}
+	}
+	return true
+}


### PR DESCRIPTION

### Summary

Python `fbb2280` isolates each **writing role** (those with `worktree:` in `recipes.py` spec) on its own `git worktree` + branch `agent-toolkit-swarm/<safe-run>/<role>` via `worktree.py:33 create_worktree(repo, run_dir, role, run_id, base_ref)` (`git branch <branch> <base_ref>` then `git worktree add <run_dir/worktrees/<role>> <branch>`). `cli.py:48-65` lazily creates worktrees **only for `initial_roles`** ( `["planner"]` → `["implementer"]` fallback ) when `spec.execution.lazy_start == true` (default), tracks them in `state["worktrees"]`, copies `runner/opencode/agents/<role>.md` into the worktree's `.opencode/agents/`, and appends `worktree_created / worktree_failed` to `trace.jsonl`. V `HEAD` `modules/agent_toolkit_core/swarm.v:596 ensure_swarm_run_dirs` only `os.mkdir_all(worktrees)` (empty), `swarm_start:259` never calls `git`, and `swarm_state.v:55 swarm_recipe_roles` lists roles without `worktree:` metadata — all runs share `cwd` and risk concurrent file collisions; `agent-toolkit swarm status` never shows `worktrees`.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-14 00:06:27 -0300 fix(ci): always tag Docker images with VERSION file`) — `packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/worktree.py:105 lines`, `cli.py:2448`, `recipes.py:304`, `store.py:148` canonical after `2fbb503 pypi layout`.
- `30ff687` (`2026-08-06 16:31:28 -0300 style(swarm): fix ruff check and format`) — same files at `packages/agent-toolkit-cli/src/agent_toolkit/swarm/worktree.py:105` (`git show 30ff687:…/swarm/cli.py | wc -l = 1691`).
- `0e6d276` (`2026-08-06 16:24:08 -0300 feat(swarm): backend-neutral local multi-agent swarm orchestration (#331)`) — introduced `branch_for_run_role` + `create_worktree`.
- `9163c93` (`2026-08-14 01:20:52 -0300 chore(pypi): drop Python CLI quarantine`) — deleted `14 packages/pypi/.../swarm` files including `worktree.py`.

#### 1. `worktree.py:14-52` — branch naming + worktree creation (fbb2280 verbatim, identical at 30ff687)

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/worktree.py:14-52
def branch_for_run_role(run_id: str, role: str) -> str:
    if not ROLE_RE.match(role):
        raise ValueError(f"Invalid role: {role!r}")
    # Safe short prefix if too long (git branch limit ~ 255, filesystem limits)
    safe_run = re.sub(r"[^a-zA-Z0-9._-]", "-", run_id)[:32]
    return f"agent-toolkit-swarm/{safe_run}/{role}"


def worktree_path_for(run_dir: Path, role: str) -> Path:
    if not ROLE_RE.match(role):
        raise ValueError(f"Invalid role: {role!r}")
    return run_dir / "worktrees" / role


def git_run(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
    # Safe arg handling — no shell
    return subprocess.run(["git"] + args, cwd=str(cwd), capture_output=True, text=True, check=False)


def create_worktree(
    repo_root: Path, run_dir: Path, role: str, run_id: str, base_ref: str = "HEAD"
) -> dict[str, Any]:
    branch = branch_for_run_role(run_id, role)
    wt_path = worktree_path_for(run_dir, role)
    if wt_path.exists():
        return {"branch": branch, "path": str(wt_path), "exists": True}
    # Create branch if not exists
    res = git_run(["rev-parse", "--verify", branch], cwd=repo_root, check=False)
    if res.returncode != 0:
        # create branch from base_ref
        cre = git_run(["branch", branch, base_ref], cwd=repo_root, check=False)
        if cre.returncode != 0:
            raise RuntimeError(f"Failed to create branch {branch}: {cre.stderr}")
    # Create worktree
    wt_path.parent.mkdir(parents=True, exist_ok=True)
    res2 = git_run(["worktree", "add", str(wt_path), branch], cwd=repo_root, check=False)
    if res2.returncode != 0:
        raise RuntimeError(f"Failed to create worktree {wt_path}: {res2.stderr}")
    return {"branch": branch, "path": str(wt_path), "exists": False}
```

`30ff687:packages/agent-toolkit-cli/src/agent_toolkit/swarm/worktree.py` is byte-identical (verified `git show 30ff687:…/worktree.py | diff - fbb2280:…` → only import order).

Also `worktree.py:55-77`:

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/worktree.py:55-77
def remove_worktree(repo_root: Path, wt_path: Path, force: bool = False) -> bool:
    if not wt_path.exists():
        return False
    # Check dirty
    res = git_run(["status", "--porcelain"], cwd=wt_path, check=False)
    if res.returncode == 0 and res.stdout.strip() and not force:
        raise RuntimeError(f"Worktree dirty, refusing removal without --force: {wt_path}")
    # Remove worktree
    git_run(
        ["worktree", "remove", str(wt_path), "--force" if force else str(wt_path)],
        cwd=repo_root,
        check=False,
    )
    # Clean up directory if still exists
    if wt_path.exists():
        shutil.rmtree(wt_path, ignore_errors=True)
    return True


def is_worktree_dirty(wt_path: Path) -> bool:
    res = git_run(["status", "--porcelain"], cwd=wt_path, check=False)
    return bool(res.stdout.strip())
```

#### 2. `cli.py:48-115` — lazy worktree loop + initial_roles + state + opencode-agent copy (fbb2280)

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:48-115 (abridged, lines 48-115 in worktree section)
    # Determine initially active roles: planner or implementer
    initial_roles = []
    if "planner" in roles:
        initial_roles = ["planner"]
    elif "implementer" in roles:
        initial_roles = ["implementer"]
    else:
        initial_roles = list(roles.keys())[:1]
    created_wts = []
    for rname in roles:
        rdef = roles[rname]
        wt_name = rdef.get("worktree")
        if wt_name:
            # lazy: only create for initially active roles now
            if lazy and rname not in initial_roles:
                continue
            try:
                info = create_worktree(repo, run_dir, rname, run_id, ns.base_ref)
                info["role"] = rname
                created_wts.append(info)
                # Ensure opencode agent is discoverable from worktree (copy to .opencode/agents)
                try:
                    _agent_src = run_dir / "runner" / "opencode" / "agents" / f"{rname}.md"
                    if _agent_src.exists():
                        _wt_agents = Path(info["path"]) / ".opencode" / "agents"
                        _wt_agents.mkdir(parents=True, exist_ok=True)
                        import shutil as _shutil

                        _shutil.copy2(_agent_src, _wt_agents / f"{rname}.md")
                        # Also copy prompt as context if needed
                        _prompt_src = run_dir / "prompts" / f"{rname}.md"
                        if _prompt_src.exists():
                            _shutil.copy2(
                                _prompt_src,
                                Path(info["path"]) / f".agent-toolkit-prompt-{rname}.md",
                            )
                except Exception:
                    pass
                append_trace(
                    run_dir,
                    {
                        "ts": now_ts(),
                        "kind": "worktree_created",
                        "role": rname,
                        "path": info["path"],
                        "branch": info["branch"],
                    },
                )
            except Exception as e:
                # Log but continue
                append_trace(
                    run_dir,
                    {
                        "ts": now_ts(),
                        "kind": "worktree_failed",
                        "role": rname,
                        "error": str(e)[:500],
                    },
                )
    # Update state worktrees
    state = read_state(run_dir) or {}
    state["worktrees"] = created_wts
```

Also `recipes.py:spec.roles[*].worktree` (e.g. `implementer` with `worktree: implementer`, `planner` without) — `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:120-180` defines `BUILTIN_RECIPES` with `execution.lazy_start: true`, `max_concurrency: 1`, `gates`, `budget`.

#### 3. `store.py:34-47 ensure_run_dirs` + `state["worktrees"]` (fbb2280)

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/store.py:34-47
def ensure_run_dirs(run_dir: Path) -> None:
    for sub in [
        "artifacts",
        "handoffs/outbox",
        "handoffs/queued",
        "handoffs/active",
        "handoffs/completed",
        "handoffs/failed",
        "prompts",
        "worktrees",
        "runner/opencode/agents",
    ]:
        (run_dir / sub).mkdir(parents=True, exist_ok=True)
```

Note `runner/opencode/agents` dir created eagerly then `generate_opencode_agent` writes there before copy to worktree.

### V evidence (HEAD)

- `modules/agent_toolkit_core/swarm.v:596-602` `fn ensure_swarm_run_dirs(run_dir string) !` — mirrors `store.py:34` but **without** `runner/opencode/agents` and without any `git` call:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:596-602
fn ensure_swarm_run_dirs(run_dir string) ! {
	for sub in ['artifacts', 'handoffs/outbox', 'handoffs/queued', 'handoffs/active',
		'handoffs/completed', 'handoffs/failed', 'prompts', 'worktrees'] {
		os.mkdir_all(os.join_path(run_dir, sub))!
	}
}
```

`worktrees/` is created empty; no `branch_for_run_role`, no `git branch`, no `git worktree add`, no `is_worktree_dirty`, no `remove_worktree`.

- `modules/agent_toolkit_core/swarm.v:259-347` `fn swarm_start(...) SwarmReport` — after `ensure_swarm_run_dirs` writes `state.json`/`approvals.json`/`trace.jsonl` and returns. Zero worktree logic. No `lazy_start`, no `initial_roles`, no `create_worktree`, no `worktree_created` trace, no `state.worktrees` field. `SwarmStateFile` at `swarm.v:30-38` has `version/run_id/recipe/backend/run_state/created_at/task` — **no** `worktrees` array (Python `state["worktrees"] = created_wts` at `cli.py:110`).

```v
// HEAD:modules/agent_toolkit_core/swarm.v:30-38
struct SwarmStateFile {
	version    int
	run_id     string
	recipe     string
	backend    string
	run_state  string
	created_at string
	task       string
}
```

```v
// HEAD:modules/agent_toolkit_core/swarm.v:188-227 (swarm_start excerpt)
	initial := if swarm_require_plan_approval(recipe) {
		'awaiting_plan_approval'
	} else {
		'running'
	}
	st := SwarmStateFile{
		version:    1
		run_id:     rid
		recipe:     recipe
		backend:    backend
		run_state:  initial
		created_at: time.utc().format_rfc3339()
		task:       opts.task
	}
	write_swarm_state(run_dir, st) or {
		return SwarmReport{ok: false, message: 'write state failed: ${err}'}
	}
	write_swarm_approvals(run_dir, swarm_default_gates(recipe)) or { … }
	append_swarm_trace(run_dir, 'run_created', rid)
	return SwarmReport{
		ok:      true
		message: '[swarm] started ${rid} recipe=${recipe} backend=${backend} state=${initial}\n  ${run_dir}\n  UI spawn fail-closed (ADR-020); filesystem state is authoritative (ADR-008).'
	}
```

No `append_swarm_trace('worktree_created',…)` anywhere in `swarm.v` (`grep -n worktree swarm.v` → only `ensure_swarm_run_dirs`'s `'worktrees'` string).

- `modules/agent_toolkit_core/swarm_state.v:55-70` `pub fn swarm_recipe_roles(recipe string) []string` — plain lists `['implementer','reviewer','integrator']` etc., no `worktree:`/`consumes`/`produces`/`persona`/`policy` metadata (vs Python `recipes.py:BUILTIN_RECIPES` with per-role `worktree` presence driving lazy logic).

- `modules/agent_toolkit_core/swarm.v:603-606` `fn write_swarm_state` — `os.write_file(path, json.encode(st)+'\n')` non-atomic (Python `store.py:49 atomic_write_json` via `tmpfile+os.replace`).

- No `is_worktree_dirty` guard for `swarm cleanup` (P1-06) — V `swarm_cancel:554` just flips `cancelled` without checking dirty.

**CLI proof:**
```bash
grep -rn "worktree\|branch_for_run" modules/ 2>&1 | head
# only modules/agent_toolkit_core/swarm.v:598 'worktrees' dir name
grep -rn "git.*worktree\|git.*branch" modules/ 2>&1 | head
# 0 matches — confirms gap
./make.vsh build-cli && build/agent-toolkit swarm start --recipe pair --dry-run "task with worktree" 2>&1 | head
# dry-run mentions roles but no branches
ls -la /tmp/my-project/.agent-toolkit/swarm/runs/s*/worktrees/ 2>&1 | head
# empty after real start
```

### Expected behavior

```bash
# Playground /tmp/my-project (git repo, main branch at HEAD)
cd /tmp/my-project
# Clean prior runs for isolation
git worktree list --porcelain 2>&1 | head -n 20
ls .agent-toolkit/swarm/runs/ 2>&1 | head

# Non-dry-run start with default lazy_start=true, recipe=pair (implementer is initial, has worktree)
agent-toolkit swarm start --recipe pair --backend headless "Add health check endpoint with tests" 2>&1 | tail -n 10
# Expected stdout:
#   Swarm run created: s20260814T123456Z
#     recipe: pair
#     run_dir: /tmp/my-project/.agent-toolkit/swarm/runs/s20260814T123456Z
#     backend: headless
#     runner: opencode
#     task: Add health check endpoint with tests
#     initial roles: implementer
#   run s20260814T123456Z state=running

# Filesystem side effects (must hold):
# 1. Branch created from --base-ref (default HEAD)
git branch --list "agent-toolkit-swarm/s20260814T123456Z/implementer" | grep -q agent-toolkit-swarm && echo "branch ok"
# 2. Worktree mounted at worktrees/implementer
test -d .agent-toolkit/swarm/runs/s20260814T123456Z/worktrees/implementer/.git && echo "worktree mounted"
git -C .agent-toolkit/swarm/runs/s20260814T123456Z/worktrees/implementer rev-parse --abbrev-ref HEAD 2>&1 | grep -q "agent-toolkit-swarm" && echo "branch checked out"
# 3. Reviewer worktree NOT created yet (lazy) — only implementer eagerly
test ! -d .agent-toolkit/swarm/runs/s20260814T123456Z/worktrees/reviewer && echo "lazy ok (reviewer absent)"
# 4. Lazy disabled path (if spec.execution.lazy_start==false): all writing roles have worktrees — test via custom recipe
# 5. worktree_created trace exists
cat .agent-toolkit/swarm/runs/s20260814T123456Z/trace.jsonl | grep -q "worktree_created.*implementer" && echo "trace ok"
# 6. Opencode agent copied into worktree (if runner/opencode)
test -f .agent-toolkit/swarm/runs/s20260814T123456Z/worktrees/implementer/.opencode/agents/implementer.md && echo "agent copied" || echo "agent copy missing (runner not opencode — ok)"
# 7. state.worktrees array populated (when implemented as JSON with worktrees)
cat .agent-toolkit/swarm/runs/s20260814T123456Z/state.json | jq '.worktrees | length' 2>&1 | grep -q "1" && echo "state worktrees ok"

# After handoff create for reviewer (P1-07), reviewer worktree should be lazily created then:
#   git branch --list "agent-toolkit-swarm/s…/reviewer" && test -d .../worktrees/reviewer

# --base-ref HEAD~1 should base branch there:
git log --oneline HEAD~1 -1 | head
agent-toolkit swarm start --recipe pair --base-ref HEAD~1 --backend headless "task base" 2>&1 | grep run
git branch --list "agent-toolkit-swarm/s*/implementer" --verbose | head
# branch should contain HEAD~1 commit, not latest if HEAD moved

# Dirty guard (remove_worktree): if worktree dirty, cleanup without --force must refuse
echo "dirty" > .agent-toolkit/swarm/runs/s…/worktrees/implementer/dirty.txt
agent-toolkit swarm cleanup s… 2>&1 | grep -q "dirty.*--force" && echo "dirty guard ok"
```

### Proposed fix

Tiny diff, files + functions (minimal worktree isolation without full handoff daemon):

**1. `modules/agent_toolkit_core/swarm.v:11` extend `SwarmStateFile`:**
```v
struct SwarmWorktree {
	role   string
	branch string
	path   string
	exists bool
}
struct SwarmStateFile {
	version    int
	run_id     string
	recipe     string
	backend    string
	run_state  string
	created_at string
	task       string
	worktrees  []SwarmWorktree // new — mirrors Python state["worktrees"]
}
```

**2. New `modules/agent_toolkit_core/worktree.v` (or inline in `swarm.v` for minimal diff) — port `worktree.py:14-77`:**
```v
fn branch_for_run_role(run_id string, role string) !string // ROLE_RE check + safe_run[:32]
fn worktree_path_for(run_dir string, role string) !string
fn git_run(args []string, cwd string) !RunResult // via process.v new_process_service() + RunOptions
fn create_worktree(repo_root string, run_dir string, role string, run_id string, base_ref string) !SwarmWorktree
//  if exists return exists