### PR TITLE
feat(swarm): compose_role_prompt + GLOBAL_PROTOCOL + prompts per role (fixes #885)

### DIFF
--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -539,6 +539,14 @@ fn swarm_start(ws string, opts SwarmOptions) SwarmReport {
 			message: 'write approvals failed: ${err}'
 		}
 	}
+	for role in swarm_recipe_roles(recipe) {
+		prompt, manifest := swarm_compose_role_prompt(recipe, role, opts.task, '', swarm_role_skills(recipe,
+			role), rid)
+		os.write_file(os.join_path(run_dir, 'prompts', role + '.md'), prompt) or {}
+		os.write_file(os.join_path(run_dir, 'prompts', role + '.manifest.json'), json.encode(manifest) +
+			'\n') or {}
+		append_swarm_trace(run_dir, 'prompt_composed', role)
+	}
 	append_swarm_trace(run_dir, 'run_created', rid)
 	// Herdr UI spawn (ADR-008: UI is adapter, not engine). Only when --attach and not dry-run.
 	mut herdr_note := ''

--- a/modules/agent_toolkit_core/swarm_prompts.v
+++ b/modules/agent_toolkit_core/swarm_prompts.v
@@ -1,0 +1,422 @@
+module agent_toolkit_core
+
+import os
+
+const swarm_global_protocol = '# Agent Toolkit Swarm — Global Protocol\n- You are a role in a multi-agent swarm. Work only on your assigned task.\n- Do not push, do not merge to base branch, do not publish releases.\n- Transfer code only via validated Git commits on your Toolkit-owned branch.\n- Use durable handoffs via `agent-toolkit swarm handoff create` and `agent-toolkit swarm task next/complete`.\n- Stay inside your worktree when you have one. Do not write outside `.agent-toolkit/swarm/runs/<run-id>/` except your worktree.\n- Keep artifacts under 1MB, no secrets, no full transcript forwarding.\n- Record decisions in artifacts and trace events.\n'
+
+const swarm_interactive_bootstrap = '# Interactive mode — No initial task\n> This swarm was started **without an initial prompt/task**. The user will provide the first request next in this same Herdr/Tmux session.\n\n**Instructions for the first agent (planner/implementer):**\n- **Do NOT invent work** or start tasks on your own. Do not create a plan or code yet.\n- Do only a **very brief** context analysis (max 3-4 sentences / 30 seconds):\n  - If you detect a **workspace** (exists `AGENTS.md` and/or `knowledge/` or `find_workspace_root()` is not None, e.g. `~/.ai-workspace`):\n    Run `agent-toolkit workspace context` and briefly review `AGENTS.md` + `knowledge/todos/pending.md`.\n    Also check `projects/` and `loops/` if present. Summarize in 2-3 lines what workspace it is.\n  - If no workspace, briefly review the current repo (`git status`, `cat README.md` / `pyproject.toml`).\n- Then **stay on standby** and confirm with a short message:\n  "Brief analysis done — awaiting your first request. When you provide the task, I will apply `assistant` (discovery) + `workflow-generic-project` (plan -> approval -> implement -> review -> draft PR)."\n- When the user sends the request (via chat or `agent-toolkit swarm handoff create --type artifact --from planner --to implementer --artifact artifacts/task-contract.md --run-id <run-id>`), apply the full flow: discovery per `assistant` (order README -> docs/ -> AGENTS.md -> CONTRIBUTING -> PR templates -> Makefile/package.json -> devcontainer/CI), then `workflow-generic-project` with plan approval gate before implementing, and `github-cli-workflow` for draft PR.\n'
+
+pub struct SwarmPromptManifest {
+pub:
+	role               string
+	persona            string
+	policy             string
+	recipe             string
+	includes           []string
+	size_chars         int
+	model_profile_task string
+	is_interactive     bool
+}
+
+struct SwarmRoleDef {
+pub:
+	persona       string
+	policy        string
+	model_profile string
+	consumes      []string
+	produces      []string
+	skills        []string
+	worktree      string
+}
+
+fn swarm_load_persona_text(persona string) string {
+	path := 'agents/${persona}/AGENT.md'
+	if embedded_is_file(path) {
+		txt := embedded_read_file(path) or { '' }
+		if txt.len > 0 {
+			if txt.runes().len > 2000 {
+				return txt.runes()[..2000].string()
+			}
+			return txt
+		}
+	}
+	if tr := find_toolkit_root() {
+		if tr.path != 'embedded' {
+			p1 := os.join_path(tr.path, 'agents', persona, 'AGENT.md')
+			if os.is_file(p1) {
+				txt := os.read_file(p1) or { '' }
+				if txt.len > 0 {
+					if txt.runes().len > 2000 {
+						return txt.runes()[..2000].string()
+					}
+					return txt
+				}
+			}
+		}
+	} else {
+		// no root, ignore
+	}
+	p2 := os.join_path(os.getwd(), 'agents', persona, 'AGENT.md')
+	if os.is_file(p2) {
+		txt := os.read_file(p2) or { '' }
+		if txt.len > 0 {
+			if txt.runes().len > 2000 {
+				return txt.runes()[..2000].string()
+			}
+			return txt
+		}
+	}
+	return '# Persona: ${persona}\nAct as ${persona} per Toolkit guidance.'
+}
+
+fn swarm_role_def(recipe string, role string) ?SwarmRoleDef {
+	// Built-in recipes mirrored from fbb2280 recipes.py BUILTIN_RECIPES
+	match recipe {
+		'pair' {
+			match role {
+				'implementer' {
+					return SwarmRoleDef{
+						persona:       'tdd-guide'
+						policy:        'writer'
+						model_profile: 'coding'
+						consumes:      ['task-contract']
+						produces:      ['commit', 'implementation-report']
+						skills:        ['tdd']
+						worktree:      'implementer'
+					}
+				}
+				'reviewer' {
+					return SwarmRoleDef{
+						persona:       'code-reviewer'
+						policy:        'reviewer-writer'
+						model_profile: 'review'
+						consumes:      ['commit']
+						produces:      ['feedback', 'reviewed-commit']
+						skills:        ['code-review']
+						worktree:      'reviewer'
+					}
+				}
+				'integrator' {
+					return SwarmRoleDef{
+						persona:       'architect'
+						policy:        'integrator'
+						model_profile: 'architecture'
+						consumes:      ['reviewed-commit']
+						produces:      ['final-candidate', 'final-report']
+						skills:        []
+						worktree:      'integration'
+					}
+				}
+				else {
+					return none
+				}
+			}
+		}
+		'team' {
+			match role {
+				'planner' {
+					return SwarmRoleDef{
+						persona:       'planner'
+						policy:        'read-only'
+						model_profile: 'planning'
+						consumes:      []
+						produces:      ['task-contract', 'acceptance-criteria', 'risk-assessment']
+						skills:        ['planning']
+						worktree:      ''
+					}
+				}
+				'implementer' {
+					return SwarmRoleDef{
+						persona:       'tdd-guide'
+						policy:        'writer'
+						model_profile: 'coding'
+						consumes:      ['task-contract']
+						produces:      ['commit', 'implementation-report']
+						skills:        ['tdd']
+						worktree:      'implementer'
+					}
+				}
+				'reviewer' {
+					return SwarmRoleDef{
+						persona:       'code-reviewer'
+						policy:        'reviewer-writer'
+						model_profile: 'review'
+						consumes:      ['commit']
+						produces:      ['feedback', 'reviewed-commit']
+						skills:        ['code-review']
+						worktree:      'reviewer'
+					}
+				}
+				'architect' {
+					return SwarmRoleDef{
+						persona:       'architect'
+						policy:        'integrator'
+						model_profile: 'architecture'
+						consumes:      ['reviewed-commit']
+						produces:      ['final-candidate', 'final-report']
+						skills:        ['architecture']
+						worktree:      'integration'
+					}
+				}
+				else {
+					return none
+				}
+			}
+		}
+		'full' {
+			match role {
+				'planner' {
+					return SwarmRoleDef{
+						persona:       'planner'
+						policy:        'read-only'
+						model_profile: 'planning'
+						consumes:      []
+						produces:      ['task-contract']
+						skills:        ['planning']
+						worktree:      ''
+					}
+				}
+				'implementer' {
+					return SwarmRoleDef{
+						persona:       'tdd-guide'
+						policy:        'writer'
+						model_profile: 'coding'
+						consumes:      ['task-contract']
+						produces:      ['commit']
+						skills:        []
+						worktree:      'implementer'
+					}
+				}
+				'refactorer' {
+					return SwarmRoleDef{
+						persona:       'refactor-cleaner'
+						policy:        'writer'
+						model_profile: 'review'
+						consumes:      ['commit']
+						produces:      ['refactored-commit']
+						skills:        []
+						worktree:      'reviewer'
+					}
+				}
+				'architect' {
+					return SwarmRoleDef{
+						persona:       'architect'
+						policy:        'integrator'
+						model_profile: 'architecture'
+						consumes:      ['refactored-commit']
+						produces:      ['integrated-commit']
+						skills:        []
+						worktree:      'integration'
+					}
+				}
+				'hardener' {
+					return SwarmRoleDef{
+						persona:       'security-reviewer'
+						policy:        'reviewer-writer'
+						model_profile: 'hardening'
+						consumes:      ['integrated-commit']
+						produces:      ['hardened-commit']
+						skills:        []
+						worktree:      'hardener'
+					}
+				}
+				'qa' {
+					return SwarmRoleDef{
+						persona:       'e2e-runner'
+						policy:        'reviewer-writer'
+						model_profile: 'qa'
+						consumes:      ['hardened-commit']
+						produces:      ['qa-report', 'final-report']
+						skills:        []
+						worktree:      'qa'
+					}
+				}
+				else {
+					return none
+				}
+			}
+		}
+		else {
+			return none
+		}
+	}
+}
+
+fn swarm_role_skills(recipe string, role string) []string {
+	if d := swarm_role_def(recipe, role) {
+		return d.skills
+	}
+	return []
+}
+
+fn swarm_recipe_execution_text(recipe string) string {
+	return match recipe {
+		'pair', 'team', 'full' { "{'max_concurrency': 2, 'lazy_start': True, 'resumable': True, 'max_role_round_trips': 2}" }
+		else { '{}' }
+	}
+}
+
+fn swarm_recipe_workspace_text(recipe string) string {
+	return match recipe {
+		'pair', 'team', 'full' { "{'strategy': 'worktree-per-writer', 'base_ref': 'HEAD', 'integration_branch': True, 'keep_on_failure': True}" }
+		else { '{}' }
+	}
+}
+
+fn swarm_next_roles(recipe string, role string) []string {
+	// First try produces/consumes graph
+	mut next := []string{}
+	if cur := swarm_role_def(recipe, role) {
+		for other in swarm_recipe_roles(recipe) {
+			if other == role {
+				continue
+			}
+			if od := swarm_role_def(recipe, other) {
+				for p in cur.produces {
+					if p in od.consumes {
+						if other !in next {
+							next << other
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	if next.len > 0 {
+		return next
+	}
+	// Fallback chain for known recipes — mirrors prompts.py fallback
+	match recipe {
+		'pair' {
+			match role {
+				'implementer' { return ['reviewer'] }
+				'reviewer' { return ['integrator'] }
+				else { return [] }
+			}
+		}
+		'team' {
+			match role {
+				'planner' { return ['implementer'] }
+				'implementer' { return ['reviewer'] }
+				'reviewer' { return ['architect'] }
+				else { return [] }
+			}
+		}
+		'full' {
+			match role {
+				'planner' { return ['implementer'] }
+				'implementer' { return ['refactorer'] }
+				'refactorer' { return ['architect'] }
+				'architect' { return ['hardener'] }
+				'hardener' { return ['qa'] }
+				else { return [] }
+			}
+		}
+		else {
+			return []
+		}
+	}
+}
+
+// swarm_compose_role_prompt mirrors fbb2280 prompts.py:55 compose_role_prompt
+// recipe is the recipe name (pair/team/full), role is the role name, task_contract is the task text (may be empty),
+// handoff is optional handoff JSON/text (empty if none), included_skills is the role's skill list, run_id is the swarm run id for the handoff tail.
+pub fn swarm_compose_role_prompt(recipe string, role string, task_contract string, handoff string, included_skills []string, run_id string) (string, SwarmPromptManifest) {
+	def := swarm_role_def(recipe, role) or {
+		SwarmRoleDef{
+			persona:       role
+			policy:        'read-only'
+			model_profile: ''
+			consumes:      []
+			produces:      []
+			skills:        included_skills.clone()
+			worktree:      ''
+		}
+	}
+	persona := def.persona
+	policy := def.policy
+	persona_text := swarm_load_persona_text(persona)
+	recipe_name := recipe
+	mut parts := []string{}
+	parts << swarm_global_protocol
+	parts << '# Recipe: ${recipe_name} — Role: ${role}\nPolicy: ${policy}\nPersona: ${persona}\n'
+	parts << persona_text
+	// Recipe workflow snippet — mirrors Python `Execution: {spec.execution}\nWorkspace: {spec.workspace}`
+	workflow := 'Execution: ${swarm_recipe_execution_text(recipe_name)}\nWorkspace: ${swarm_recipe_workspace_text(recipe_name)}\n'
+	parts << workflow
+	is_interactive := task_contract.trim_space().len == 0
+	if is_interactive {
+		parts << swarm_interactive_bootstrap
+		if ws := find_workspace_root('') {
+			parts << '# Workspace context hint\nDetected workspace at `${ws}` — run `agent-toolkit workspace context` to see session state before waiting.'
+		}
+	} else {
+		runes := task_contract.runes()
+		tc := if runes.len > 3000 { runes[..3000].string() } else { task_contract }
+		parts << '# Task Contract\n${tc}'
+	}
+	if handoff.trim_space().len > 0 {
+		parts << '# Current Handoff\n${handoff}'
+	}
+	if included_skills.len > 0 {
+		parts << '# Skills: ${included_skills.join(', ')}'
+	}
+	// Handoff delegation tail — explicit like swarm-forge, per role
+	next_roles := swarm_next_roles(recipe_name, role)
+	if next_roles.len > 0 {
+		produces := def.produces
+		produces_str := if produces.len > 0 { produces.join(', ') } else { 'artifact' }
+		next_str := next_roles.join(', ')
+		first_next := next_roles[0]
+		rid_display := if run_id.len > 0 { run_id } else { 'see task contract' }
+		handoff_lines := [
+			'## Handoff — delegate to next role when done',
+			'Your role `${role}` produces: ${produces_str}',
+			'Next role(s): ${next_str}',
+			'When you complete your work:',
+			'1. If you created/modified code, commit it on your worktree branch (`git add` + `git commit`), then:',
+			'   `agent-toolkit swarm handoff create --type commit --from ${role} --to ${first_next} --commit <40-hex-sha> --branch <your-branch>`',
+			'2. If you created an artifact (e.g., `artifacts/review.md`), then:',
+			'   `agent-toolkit swarm handoff create --type artifact --from ${role} --to ${first_next} --artifact artifacts/<file>.md`',
+			'The next role will run `agent-toolkit swarm task next --role <next> --run-id <run_id>` to pick it up. Do not wait — the handoff is durable and the daemon will notify. The next role\'s tmux window will be auto-created by the handoff.',
+			'IMPORTANT: After you finish writing the artifact or committing code, immediately run the `handoff create` command above — do NOT ask the user for confirmation, do NOT wait for \'do the handoff\'.',
+			'Run ID for this swarm: `${rid_display}` — if the command says \'No run found\', add `--run-id <run_id>` or ensure `AGENT_TOOLKIT_SWARM_RUN_ID` is exported (it is in your tmux env).',
+		]
+		parts << handoff_lines.join('\n')
+	} else {
+		parts << '## Handoff\nWhen done, create a handoff if your work should be reviewed: `agent-toolkit swarm handoff create --type artifact --from ${role} --to <next> --artifact artifacts/<file>.md` (or `--type commit` with --commit/--branch for code).'
+	}
+	mut text := parts.join('\n\n')
+	rs := text.runes()
+	if rs.len > 12000 {
+		text = rs[..12000].string() + '\n[truncated]'
+	}
+	mut includes := []string{}
+	includes << 'global_protocol'
+	includes << 'recipe_workflow'
+	includes << 'persona'
+	if is_interactive {
+		includes << 'interactive_bootstrap'
+	}
+	if !is_interactive {
+		includes << 'task_contract'
+	}
+	if handoff.trim_space().len > 0 {
+		includes << 'handoff'
+	}
+	if included_skills.len > 0 {
+		includes << 'skills'
+	}
+	manifest := SwarmPromptManifest{
+		role:               role
+		persona:            persona
+		policy:             policy
+		recipe:             recipe_name
+		includes:           includes
+		size_chars:         text.runes().len
+		model_profile_task: def.model_profile
+		is_interactive:     is_interactive
+	}
+	return text, manifest
+}


### PR DESCRIPTION
feat(swarm): compose_role_prompt + GLOBAL_PROTOCOL + prompts/<role>.md parity — V writes state.json.task verbatim, Python fbb2280 generates per-role markdown via prompts.py


### Summary

Python `fbb2280` never passes `state.json.task` verbatim to the agent. Instead `swarm/cli.py:90-105` calls `prompts.py:55 compose_role_prompt(recipe, rname, rdef_with_run, task_text, handoff, skills)` for **every role**, which assembles `GLOBAL_PROTOCOL` + `INTERACTIVE_BOOTSTRAP` (when task empty) + `recipe.workflow` + `persona` + `task_contract` + `handoff` + `skills` + per-role handoff delegation instructions (`_run_id` injected) into `run_dir/prompts/<role>.md` (capped 12k chars) plus `run_dir/prompts/<role>.manifest.json` (`includes`, `size_chars`, `is_interactive`). `SwarmOptions.task` is *not* the agent prompt — the prompt is the composed file, and `backend.start_agent` passes `$(cat prompt_file)` / `--append-system-prompt-file` from it. V `HEAD` `modules/agent_toolkit_core/swarm.v:259 swarm_start` just stores `opts.task` verbatim in `SwarmStateFile.task` and `ensure_swarm_run_dirs` leaves `prompts/` empty; no `GLOBAL_PROTOCOL`, no `compose_role_prompt`, no `load_persona_text(agents/<persona>/AGENT.md)`, no `manifest.json`, and `swarm status` never shows prompt provenance.

### Python evidence (fbb2280 + 30ff687 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-14 00:06:27 -0300 fix(ci): always tag Docker images with VERSION file`) — `packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py:177 lines`, `cli.py:2448`, `store.py:148`; last Python before `9163c93` delete.
- `30ff687` (`2026-08-06 16:31:28 -0300 style(swarm): fix ruff check and format to make CI green`) — `packages/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py:177` at `packages/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py` (identical logic, verified `git show 30ff687:…/prompts.py | wc -l = 177`).
- `9163c93` (`2026-08-14 01:20:52 -0300 chore(pypi): drop Python CLI quarantine`) — deleted `prompts.py` + `cli.py:2448`.

#### 1. `prompts.py:8-52` — GLOBAL_PROTOCOL + INTERACTIVE_BOOTSTRAP + load_persona_text (fbb2280 verbatim, 30ff687 same)

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py:8-52
GLOBAL_PROTOCOL = """# Agent Toolkit Swarm — Global Protocol
- You are a role in a multi-agent swarm. Work only on your assigned task.
- Do not push, do not merge to base branch, do not publish releases.
- Transfer code only via validated Git commits on your Toolkit-owned branch.
- Use durable handoffs via `agent-toolkit swarm handoff create` and `agent-toolkit swarm task next/complete`.
- Stay inside your worktree when you have one. Do not write outside `.agent-toolkit/swarm/runs/<run-id>/` except your worktree.
- Keep artifacts under 1MB, no secrets, no full transcript forwarding.
- Record decisions in artifacts and trace events.
"""

# Interactive bootstrap — when swarm starts without a task, the first agent must NOT invent work.
# It does a very brief context analysis and then waits for the user to provide the first request.
INTERACTIVE_BOOTSTRAP = """# Interactive mode — No initial task
> This swarm was started **without an initial prompt/task**. The user will provide the first request next in this same Herdr/Tmux session.

**Instructions for the first agent (planner/implementer):**
- **Do NOT invent work** or start tasks on your own. Do not create a plan or code yet.
- Do only a **very brief** context analysis (max 3-4 sentences / 30 seconds):
  - If you detect a **workspace** (exists `AGENTS.md` and/or `knowledge/` or `find_workspace_root()` is not None, e.g. `~/.ai-workspace`):
    Run `agent-toolkit workspace context` and briefly review `AGENTS.md` + `knowledge/todos/pending.md`.
    Also check `projects/` and `loops/` if present. Summarize in 2-3 lines what workspace it is.
  - If no workspace, briefly review the current repo (`git status`, `cat README.md` / `pyproject.toml`).
- Then **stay on standby** and confirm with a short message:
  "Brief analysis done — awaiting your first request. When you provide the task, I will apply `assistant` (discovery) + `workflow-generic-project` (plan -> approval -> implement -> review -> draft PR)."
- When the user sends the request (via chat or `agent-toolkit swarm handoff create --type artifact --from planner --to implementer --artifact artifacts/task-contract.md --run-id <run-id>`), apply the full flow: discovery per `assistant` (order README -> docs/ -> AGENTS.md -> CONTRIBUTING -> PR templates -> Makefile/package.json -> devcontainer/CI), then `workflow-generic-project` with plan approval gate before implementing, and `github-cli-workflow` for draft PR.
"""


def load_persona_text(persona: str) -> str:
    # Load from bundled data/agents/<persona>/AGENT.md if exists
    try:
        from agent_toolkit._paths import find_toolkit_root

        root = find_toolkit_root()
        # Try package data
        candidates = [
            Path(root) / "agents" / persona / "AGENT.md",
            Path(__file__).parent.parent / "data" / "agents" / persona / "AGENT.md",
        ]
        for p in candidates:
            if p.is_file():
                return p.read_text(encoding="utf-8")[:2000]
    except Exception:
        pass
    return f"# Persona: {persona}\nAct as {persona} per Toolkit guidance."
```

Identical at `30ff687:packages/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py:8-52` (byte-equal; `git show 30ff687:…/prompts.py | sed -n '1,60p'` matches).

#### 2. `prompts.py:55-98` — compose_role_prompt signature + task_contract / handoff / skills + 12k cap + manifest (fbb2280)

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py:55-98
def compose_role_prompt(
    recipe: dict[str, Any],
    role: str,
    role_def: dict[str, Any],
    task_contract: str | None,
    handoff: dict[str, Any] | None,
    included_skills: list[str] | None = None,
) -> tuple[str, dict[str, Any]]:
    spec = recipe.get("spec", {}) if isinstance(recipe, dict) else {}
    recipe_name = recipe.get("metadata", {}).get("name", "unknown") if isinstance(recipe.get("metadata"), dict) else "unknown"
    persona = role_def.get("persona", role)
    policy = role_def.get("policy", "read-only")
    parts: list[str] = []
    parts.append(GLOBAL_PROTOCOL)
    # Persona
    parts.append(load_persona_text(persona))
    # Workflow per recipe (e.g. pair/team/full)
    parts.append(f"# Workflow: {recipe_name}\n{spec.get('workflow', '')}")
    # ... task_contract, handoff, skills appended, then handoff delegation block per role (see below)

    # Enforce size limit 12k chars
    text = "\n\n".join(parts)
    if len(text) > 12000:
        text = text[:12000] + "\n[truncated]"
    is_interactive = not task_contract or not task_contract.strip()
    manifest = {
        "role": role,
        "persona": persona,
        "policy": policy,
        "recipe": recipe_name,
        "includes": [
            "global_protocol",
            "recipe_workflow",
            "persona",
            "interactive_bootstrap" if is_interactive else None,
            "task_contract" if task_contract and task_contract.strip() else None,
            "handoff" if handoff else None,
            "skills" if included_skills else None,
        ],
        "size_chars": len(text),
        "model_profile_task": role_def.get("model_profile"),
        "is_interactive": is_interactive,
    }
    manifest["includes"] = [x for x in manifest["includes"] if x]
    return text, manifest
```

Handoff delegation tail (verbatim `prompts.py:100-130`) — shows why prompt is not just task:

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py:100-130 (excerpt)
        if next_roles:
            handoff_lines = [
                "## Handoff — delegate to next role when done",
                f"Your role `{role}` produces: {', '.join(produces) if produces else 'artifact'}",
                f"Next role(s): {', '.join(next_roles)}",
                "When you complete your work:",
                "1. If you created/modified code, commit it on your worktree branch (`git add` + `git commit`), then:",
                f"   `agent-toolkit swarm handoff create --type commit --from {role} --to {next_roles[0]} --commit <40-hex-sha> --branch <your-branch>`",
                "2. If you created an artifact (e.g., `artifacts/review.md`), then:",
                f"   `agent-toolkit swarm handoff create --type artifact --from {role} --to {next_roles[0]} --artifact artifacts/<file>.md`",
                "The next role will run `agent-toolkit swarm task next --role <next> --run-id <run_id>` to pick it up. Do not wait — the handoff is durable and the daemon will notify. The next role's tmux window will be auto-created by the handoff.",
                "IMPORTANT: After you finish writing the artifact or committing code, immediately run the `handoff create` command above — do NOT ask the user for confirmation, do NOT wait for 'do the handoff'.",
                f"Run ID for this swarm: `{role_def.get('_run_id', 'see task contract')}` — if the command says 'No run found', add `--run-id <run_id>` or ensure `AGENT_TOOLKIT_SWARM_RUN_ID` is exported (it is in your tmux env).",
            ]
            parts.append("\n".join(handoff_lines))
```

#### 3. `cli.py:88-105` — per-role prompt generation + manifest write + _run_id injection (fbb2280)

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:88-105
    roles = recipe.get("spec", {}).get("roles", {})
    for rname, rdef in roles.items():
        task_class = rdef.get("model_profile", "coding")
        model = (
            resolve_model(
                cfg.get("model_profile", "balanced"),
                task_class,
                model_profiles=cfg.get("model_profiles"),
            )
            or "unknown/model"
        )
        worktree = rdef.get("worktree")
        try:
            generate_opencode_agent(
                run_dir,
                rname,
                rdef.get("persona", rname),
                rdef.get("policy", "read-only"),
                model,
                recipe_name,
                run_id,
                worktree,
            )
        except Exception:
            pass
        # Prompt composition — inject run_id for handoff instructions
        try:
            rdef_with_run = dict(rdef)
            rdef_with_run["_run_id"] = run_id
            prompt, manifest = compose_role_prompt(
                recipe, rname, rdef_with_run, task_text, None, rdef.get("skills")
            )
            (run_dir / "prompts" / f"{rname}.md").write_text(prompt, encoding="utf-8")
            (run_dir / "prompts" / f"{rname}.manifest.json").write_text(
                json.dumps(manifest, indent=2), encoding="utf-8"
            )
        except Exception:
            pass
```

At `30ff687:cli.py:64-93` same block but without `_run_id` injection (added between `30ff687` and `fbb2280`): `prompt, manifest = compose_role_prompt(recipe, rname, rdef, task_text, None, rdef.get("skills"))` — fbb2280 added `rdef_with_run["_run_id"] = run_id` for handoff `Run ID for this swarm:` tail.

### V evidence (HEAD)

- `modules/agent_toolkit_core/swarm.v:30-38` `SwarmStateFile` — stores `task string` verbatim from `opts.task`, no `prompts/` relationship:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:30-38
struct SwarmStateFile {
	version    int
	run_id     string
	recipe     string
	backend    string
	run_state  string
	created_at string
	task       string
}
```

- `modules/agent_toolkit_core/swarm.v:188-227` `swarm_start` — writes `st.task = opts.task` directly, no `compose` call:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:202-215
	st := SwarmStateFile{
		version:    1
		run_id:     rid
		recipe:     recipe
		backend:    backend
		run_state:  initial
		created_at: time.utc().format_rfc3339()
		task:       opts.task
	}
	write_swarm_state(run_dir, st) or {
		return SwarmReport{ok: false, message: 'write state failed: ${err}'}
	}
```

- `modules/agent_toolkit_core/swarm.v:596-602` `ensure_swarm_run_dirs` — creates empty `prompts` dir, never writes `prompts/<role>.md`:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:596-602
fn ensure_swarm_run_dirs(run_dir string) ! {
	for sub in ['artifacts', 'handoffs/outbox', 'handoffs/queued', 'handoffs/active',
		'handoffs/completed', 'handoffs/failed', 'prompts', 'worktrees'] {
		os.mkdir_all(os.join_path(run_dir, sub))!
	}
}
```

- No `GLOBAL_PROTOCOL`, no `INTERACTIVE_BOOTSTRAP`, no `load_persona_text`, no `compose_role_prompt`, no `manifest.json` anywhere in `modules/`:

```bash
grep -rn "GLOBAL_PROTOCOL\|INTERACTIVE_BOOTSTRAP\|compose_role_prompt\|load_persona_text\|prompt.*manifest" modules/ 2>&1 | head
# 0 matches
grep -rn "prompt" modules/agent_toolkit_core/swarm.v 2>&1 | head
# only SwarmOptions.task reference and handoffs/outbox (not prompts)
```

- `modules/agent_toolkit_core/swarm.v:633-639` `append_swarm_trace` — traces `run_created` etc., never `prompt_composed`.

**CLI proof:**
```bash
build/agent-toolkit swarm start --recipe pair --backend headless --dry-run "Add health check" 2>&1 | head
# no prompts/ mention
ls /tmp/my-project/.agent-toolkit/swarm/runs/s*/prompts/ 2>&1 | head -n 20
# drwxr-xr-x ... prompts (empty)
cat /tmp/my-project/.agent-toolkit/swarm/runs/s*/state.json 2>&1 | jq -r .task | head
# verbatim task, not composed prompt
```

### Expected behavior

```bash
cd /tmp/my-project

# 1. Non-interactive: prompts per role with protocol + persona + task + handoff tail
agent-toolkit swarm start --recipe pair --backend headless "Add a health check endpoint with tests" 2>&1 | tail -n 5
ls .agent-toolkit/swarm/runs/s*/prompts/ 2>&1 | head -n 20
# implementer.md (exists)
# implementer.manifest.json (exists) — JSON with includes ["global_protocol","recipe_workflow","persona","task_contract"], size_chars, is_interactive=false
# reviewer.md (exists) — waiting role still gets its prompt (for when it starts via handoff)
# Optional: integrator.md for pair

cat .agent-toolkit/swarm/runs/s*/prompts/implementer.md 2>&1 | head -n 80
# # Agent Toolkit Swarm — Global Protocol
# - You are a role in a multi-agent swarm. Work only on your assigned task.
# ... (GLOBAL_PROTOCOL)
# # Persona: implementer (or loaded AGENT.md)
# # Workflow: pair
# # Task Contract
# Add a health check endpoint with tests
# ## Handoff — delegate to next role when done
# Your role `implementer` produces: commit
# Next role(s): reviewer
# When you complete your work:
# 1. If you created/modified code, commit it ... --type commit --from implementer --to reviewer --commit <sha> --branch <branch>
# Run ID for this swarm: `s20260814T123456Z`

cat .agent-toolkit/swarm/runs/s*/prompts/implementer.manifest.json 2>&1 | jq . 2>&1 | head -n 20
# {"role":"implementer","persona":"implementer","policy":"read-only","recipe":"pair","includes":["global_protocol","recipe_workflow","persona","task_contract"],"size_chars":<int>,"is_interactive":false}

# 2. Interactive (no task): GLOBAL_PROTOCOL + INTERACTIVE_BOOTSTRAP, not inventing work
agent-toolkit swarm start --recipe pair --backend headless 2>&1 | tail -n 5
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.md 2>&1 | grep -q "Interactive mode" && echo "bootstrap ok"
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.manifest.json 2>&1 | jq -r '.includes | index("interactive_bootstrap")' 2>&1 | grep -v null && echo "manifest interactive ok"
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.md 2>&1 | grep -q "Brief analysis done" && echo "standby ok"

# 3. Size cap 12k + worktree-aware handoff (when P1-03 worktrees exist, prompt still correct)

# 4. Agent pane-run (P0-01) uses prompts file, not verbatim task:
#   herdr pane run <pane> "zsh -lc '... exec claude --append-system-prompt-file <prompts/implementer.md> \"$(cat prompts/implementer.md)\"'"
```

### Proposed fix

Tiny diff, port `prompts.py:8-98` to V; no TUI/server change.

**1. New `modules/agent_toolkit_core/prompts.v` (or `swarm_prompts.v`) — verbatim port of `prompts.py:8-98`:**
```v
const global_protocol = '# Agent Toolkit Swarm — Global Protocol\n- You are a role ...'
const interactive_bootstrap = '# Interactive mode — No initial task\n> This swarm ...'

fn load_persona_text(persona string) string {
    // Try modules embedded_data or filesystem: find_toolkit_root()/agents/<persona>/AGENT.md
    // Fallback: '# Persona: ${persona}\nAct as ${persona} per Toolkit guidance.'
}
fn compose_role_prompt(recipe string, role string, task_contract string, handoff string, skills []string, run_id string) (string, map[string]string) {
    mut parts := []string{}
    parts << global_protocol
    parts << load_persona_text(persona_for_recipe_role(recipe, role))
    parts << '# Workflow: ${recipe}\n' + recipe_workflow(recipe)
    if task_contract.len == 0 { parts << interactive_bootstrap } else { parts << '# Task Contract\n' + task_contract }
    if handoff.len > 0 { parts << '# Current Handoff\n' + handoff }
    if skills.len > 0 { parts << '# Skills: ' + skills.join(', ') }
    // Handoff delegation tail per produces/consumes chain — port prompts.py:100-140 exact
    // fallback chains: pair {implementer->[reviewer], reviewer->[integrator]} etc.
    mut text := parts.join('\n\n')
    if text.len > 12000 { text = text[..12000] + '\n[truncated]' }
    manifest := {'role': role, 'recipe': recipe, 'size_chars': text.len.str(), 'is_interactive': (task_contract.len==0).str()}
    return text, manifest
}
```

Keep `HANDOFF_VERSION`-style validation out (belongs to P1-07). Hardcode `GLOBAL_PROTOCOL` / `INTERACTIVE_BOOTSTRAP` verbatim from Python to avoid divergence; include `AGENT_TOOLKIT_SWARM_RUN_ID` export hint already in `swarm_env` (P0-01) plus `Run ID for this swarm: …` tail.

**2. `modules/agent_toolkit_core/swarm.v:188-227 swarm_start` — after `ensure_swarm_run_dirs`, before `write_swarm_state`:**
```v
for role in swarm_recipe_roles(recipe) {
    prompt, manifest := compose_role_prompt(recipe, role, opts.task, '', skills_for_role(recipe, role), rid)
    os.write_file(os.join_path(run_dir, 'prompts', role + '.md'), prompt)!
    os.write_file(os.join_path(run_dir, 'prompts', role + '.manifest.json'), json.encode(manifest) + '\n')!
    if role in initial_roles {
        append_swarm_trace(run_dir, 'prompt_composed', role)
    }
}
```

For interactive (`opts.task == ''`), this writes the `INTERACTIVE_BOOTSTRAP` variant; for non-empty, the task variant. This is the file `P0-01`'s `herdr_runner_cmd` will `--append-system-prompt-file` from.

**3. `modules/agent_toolkit_core/embedded_data.v` — ensure `agents/` data available for `load_persona_text` (fallback already covers missing). No receipt change.

Gate: `build/agent-toolkit swarm start --recipe pair --backend headless "Add health" && test -f .agent-toolkit/swarm/runs/s*/prompts/implementer.md && grep -q "Global Protocol" .agent-toolkit/swarm/runs/s*/prompts/implementer.md && cat .agent-toolkit/swarm/runs/s*/prompts/implementer.manifest.json | jq -e '.includes | index("global_protocol")'` + `build/agent-toolkit swarm start --recipe pair --backend headless && grep -q "Interactive mode" .agent-toolkit/swarm/runs/s*/prompts/implementer.md`.

### Severity / Area

- **Severity:** `high` (P1) — agent behavior regression: without `GLOBAL_PROTOCOL`+persona+handoff tail, agents invent work, push to base, or never delegate; without `INTERACTIVE_BOOTSTRAP`, empty-task swarm hangs; but headless `state.json.task` still usable for manual prompt.
- **Area:** `area:swarm` + `area:prompts`
- **Kind:** `kind:parity` (regression from `fbb2280` `prompts.py:177` + `cli.py:90`)
- **Labels:** `area:swarm kind:parity severity:high`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
rm -rf .agent-toolkit/swarm/runs/s2025* 2>&1 | head

# BEFORE FIX:
build/agent-toolkit swarm start --recipe pair --backend headless "Add a health check endpoint with tests" 2>&1 | tail -n 5
ls -la .agent-toolkit/swarm/runs/s*/prompts/ 2>&1 | head -n 20
# total 0 — empty
cat .agent-toolkit/swarm/runs/s*/state.json 2>&1 | jq .task 2>&1 | head
# "Add a health check endpoint with tests" (verbatim, no protocol)
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.md 2>&1 | head
# No such file or directory

build/agent-toolkit swarm start --recipe pair --backend headless 2>&1 | tail -n 5
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.md 2>&1 | head
# No such file

# AFTER FIX:
build/agent-toolkit swarm start --recipe pair --backend headless "Add a health check endpoint with tests" 2>&1 | tail -n 5
ls .agent-toolkit/swarm/runs/s*/prompts/ 2>&1 | head -n 20
# implementer.md  implementer.manifest.json  reviewer.md  reviewer.manifest.json
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.md 2>&1 | head -n 40
# # Agent Toolkit Swarm — Global Protocol
grep -q "Handoff — delegate to next role" .agent-toolkit/swarm/runs/s*/prompts/implementer.md && echo "handoff tail ok"
grep -q "Run ID for this swarm" .agent-toolkit/swarm/runs/s*/prompts/implementer.md && echo "run_id tail ok"
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.manifest.json 2>&1 | jq . 2>&1 | head -n 20
# {"role":"implementer","recipe":"pair","includes":["global_protocol",...],"is_interactive":false}

build/agent-toolkit swarm start --recipe pair --backend headless 2>&1 | tail -n 5
cat .agent-toolkit/swarm/runs/s*/prompts/implementer.md 2>&1 | grep -q "Interactive mode — No initial task" && echo "interactive ok"

# V file proof (before):
grep -rn "GLOBAL_PROTOCOL\|compose_role" modules/ 2>&1 | head
grep -rn "prompts" modules/agent_toolkit_core/swarm.v 2>&1 | head

# Python refs:
# git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py | sed -n '8,52p'
# git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py | sed -n '55,98p'
# git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py | sed -n '88,105p'
# modules/agent_toolkit_core/swarm.v:30 SwarmStateFile + 188 swarm_start + 596 ensure_swarm_run_dirs
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py | cat -n` (lines 1-177)
- `git show 30ff687:packages/agent-toolkit-cli/src/agent_toolkit/swarm/prompts.py | cat -n` (identical)
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py | sed -n '88,105p'`
- `modules/agent_toolkit_core/swarm.v:30` `SwarmStateFile.task` + `modules/agent_toolkit_core/swarm.v:596` `ensure_swarm_run_dirs` (empty)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§2.2 start prompts`, `§3.1 A1.04`, `§4.3 P1-04`.

