### PR TITLE
feat(swarm): recipes detail parity (fixes #894)

### DIFF
--- a/modules/agent_toolkit_cli/commands.v
+++ b/modules/agent_toolkit_cli/commands.v
@@ -854,6 +854,18 @@ fn swarm_command() cli.Command {
 				execute:     atk_exec
 			},
 			cli.Command{
+				name:        'recipe'
+				description: 'Show recipe details (alias for recipes)'
+				execute:     atk_exec
+				commands:    [
+					cli.Command{
+						name:        'show'
+						description: 'Show a single recipe'
+						execute:     atk_exec
+					},
+				]
+			},
+			cli.Command{
 				name:        'backends'
 				description: 'List backends'
 				execute:     atk_exec

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -252,6 +252,15 @@ fn execute_command(cmd_name string, rest []string, mode agent_toolkit_core.Rende
 			println(report.message)
 			return 0
 		}
+		// For `swarm recipes --json` / `swarm recipe show --json`, emit raw recipe JSON
+		// (Python parity: `json.dumps(recipe)` directly, not wrapped in CommandResult).
+		if opts.json_output && opts.subcommand in ['recipes', 'recipe'] {
+			println(report.message)
+			if report.ok {
+				return 0
+			}
+			return agent_toolkit_core.err_user('command.failed', report.message).exit_code()
+		}
 		return render(agent_toolkit_core.swarm_result(report), mode)
 	}
 	if cmd_name == 'tui' {

--- a/modules/agent_toolkit_cli/options.v
+++ b/modules/agent_toolkit_cli/options.v
@@ -1110,6 +1110,26 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 	} else if task.len == 0 && issue_ref.len > 0 {
 		task = 'Implement issue ${issue_ref}'
 	}
+	// Normalize `swarm recipe show <name>` alias to `swarm recipes <name>` (Python parity)
+	if sub == 'recipe' {
+		if run_id == 'show' {
+			if task.len > 0 {
+				run_id = task
+				task = ''
+			} else if gate_id.len > 0 {
+				run_id = gate_id
+				gate_id = ''
+			} else {
+				run_id = ''
+			}
+		}
+		sub = 'recipes'
+	}
+	// also handle `swarm recipes show <name>` typo alias
+	if sub == 'recipes' && run_id == 'show' && task.len > 0 {
+		run_id = task
+		task = ''
+	}
 	// attach defaults to true for start unless explicitly disabled
 	if sub == 'start' && !attach_set && !dry_run {
 		attach = true

--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -88,8 +88,29 @@ pub fn run_swarm(opts SwarmOptions) SwarmReport {
 	}
 	ws := find_swarm_workspace(opts.workspace_path)
 	return match sub {
-		'recipes' {
-			swarm_recipes(opts)
+		'recipes', 'recipe' {
+			mut r_opts := opts
+			if sub == 'recipe' && r_opts.run_id == 'show' {
+				if r_opts.task.len > 0 {
+					r_opts = SwarmOptions{
+						...r_opts
+						run_id: r_opts.task
+						task: ''
+					}
+				} else if r_opts.gate_id.len > 0 {
+					r_opts = SwarmOptions{
+						...r_opts
+						run_id: r_opts.gate_id
+						gate_id: ''
+					}
+				} else {
+					r_opts = SwarmOptions{
+						...r_opts
+						run_id: ''
+					}
+				}
+			}
+			swarm_recipes(r_opts)
 		}
 		'backends' {
 			swarm_backends()
@@ -303,17 +324,30 @@ fn swarm_recipes(opts SwarmOptions) SwarmReport {
 	names := ['full', 'pair', 'team']
 	if opts.run_id.len > 0 {
 		name := opts.run_id
-		desc := swarm_recipe_description(name)
-		if desc.len == 0 {
+		recipe := builtin_recipes[name] or {
 			return SwarmReport{
 				ok:      false
 				message: "Unknown recipe '${name}'. Built-ins: pair, team, full"
 			}
 		}
-		roles := swarm_recipe_roles(name).join(',')
+		if opts.json_output {
+			txt := json.encode(recipe)
+			return SwarmReport{
+				ok:      true
+				message: txt
+				data:    {
+					'subcommand': 'recipes'
+					'recipe':     name
+				}
+			}
+		}
+		roles := swarm_recipe_roles(name).join(', ')
+		gates_str := if recipe.gates.len > 0 { recipe.gates.join(', ') } else { 'none' }
+		execution_str := 'max_concurrency=${recipe.execution.max_concurrency} lazy_start=${recipe.execution.lazy_start}'
+		budget_str := '${recipe.budget.max_total_tokens} tokens / \$${recipe.budget.max_cost_usd:.2f} / ${recipe.budget.max_wall_seconds}s'
 		return SwarmReport{
 			ok:      true
-			message: '${name}\t${desc}\nroles: ${roles}'
+			message: '${name}\t${recipe.description}\nroles: ${roles}\nexecution: ${execution_str}\ngates: ${gates_str}\nbudget: ${budget_str}'
 			data:    {
 				'subcommand': 'recipes'
 				'recipe':     name
@@ -321,9 +355,24 @@ fn swarm_recipes(opts SwarmOptions) SwarmReport {
 			}
 		}
 	}
+	if opts.json_output {
+		txt := json.encode(builtin_recipes)
+		return SwarmReport{
+			ok:      true
+			message: txt
+			data:    {
+				'subcommand': 'recipes'
+				'recipes':    names.join(',')
+			}
+		}
+	}
 	mut lines := []string{}
 	for n in names {
-		lines << '${n}\t${swarm_recipe_description(n)}'
+		if r := builtin_recipes[n] {
+			lines << '${n}\t${r.description}'
+		} else {
+			lines << '${n}\t${swarm_recipe_description(n)}'
+		}
 	}
 	return SwarmReport{
 		ok:      true

--- a/modules/agent_toolkit_core/swarm_state.v
+++ b/modules/agent_toolkit_core/swarm_state.v
@@ -181,3 +181,204 @@ pub fn swarm_valid_run_id(id string) bool {
 	}
 	return true
 }
+
+// Swarm recipe detail parity — mirrors Python fbb2280 recipes.py BUILTIN_RECIPES.
+
+pub struct SwarmRoleSpec {
+pub:
+	persona       string
+	policy        string
+	worktree      string
+	consumes      []string
+	produces      []string
+	model_profile string
+}
+
+pub struct SwarmExecutionSpec {
+pub:
+	max_concurrency int
+	lazy_start      bool
+}
+
+pub struct SwarmBudgetSpec {
+pub:
+	max_total_tokens int
+	max_cost_usd     f64
+	max_wall_seconds int
+}
+
+pub struct SwarmSpecDetail {
+pub:
+	roles map[string]SwarmRoleSpec
+}
+
+pub struct SwarmRecipeSpec {
+pub:
+	description string
+	spec        SwarmSpecDetail
+	execution   SwarmExecutionSpec
+	gates       []string
+	budget      SwarmBudgetSpec
+	ui_backend  string
+}
+
+pub const builtin_recipes = {
+	'pair': SwarmRecipeSpec{
+		description: 'Two-role implementer + reviewer/integrator workflow'
+		spec: SwarmSpecDetail{
+			roles: {
+				'implementer': SwarmRoleSpec{
+					persona: 'tdd-guide'
+					policy: 'writer'
+					worktree: 'implementer'
+					consumes: ['task-contract']
+					produces: ['commit', 'implementation-report']
+					model_profile: 'coding'
+				}
+				'reviewer':    SwarmRoleSpec{
+					persona: 'code-reviewer'
+					policy: 'reviewer-writer'
+					worktree: 'reviewer'
+					consumes: ['commit']
+					produces: ['feedback', 'reviewed-commit']
+					model_profile: 'review'
+				}
+				'integrator':  SwarmRoleSpec{
+					persona: 'architect'
+					policy: 'integrator'
+					worktree: 'integration'
+					consumes: ['reviewed-commit']
+					produces: ['final-candidate', 'final-report']
+					model_profile: 'architecture'
+				}
+			}
+		}
+		execution: SwarmExecutionSpec{
+			max_concurrency: 1
+			lazy_start: true
+		}
+		gates: ['final']
+		budget: SwarmBudgetSpec{
+			max_total_tokens: 900000
+			max_cost_usd: 4.0
+			max_wall_seconds: 7200
+		}
+		ui_backend: 'herdr'
+	}
+	'team': SwarmRecipeSpec{
+		description: 'Four-role planner → implementer → reviewer → architect workflow'
+		spec: SwarmSpecDetail{
+			roles: {
+				'planner':     SwarmRoleSpec{
+					persona: 'planner'
+					policy: 'read-only'
+					worktree: ''
+					consumes: []
+					produces: ['task-contract', 'acceptance-criteria', 'risk-assessment']
+					model_profile: 'planning'
+				}
+				'implementer': SwarmRoleSpec{
+					persona: 'tdd-guide'
+					policy: 'writer'
+					worktree: 'implementer'
+					consumes: ['task-contract']
+					produces: ['commit', 'implementation-report']
+					model_profile: 'coding'
+				}
+				'reviewer':    SwarmRoleSpec{
+					persona: 'code-reviewer'
+					policy: 'reviewer-writer'
+					worktree: 'reviewer'
+					consumes: ['commit']
+					produces: ['feedback', 'reviewed-commit']
+					model_profile: 'review'
+				}
+				'architect':   SwarmRoleSpec{
+					persona: 'architect'
+					policy: 'integrator'
+					worktree: 'integration'
+					consumes: ['reviewed-commit']
+					produces: ['final-candidate', 'final-report']
+					model_profile: 'architecture'
+				}
+			}
+		}
+		execution: SwarmExecutionSpec{
+			max_concurrency: 2
+			lazy_start: true
+		}
+		gates: ['plan', 'final']
+		budget: SwarmBudgetSpec{
+			max_total_tokens: 900000
+			max_cost_usd: 4.0
+			max_wall_seconds: 7200
+		}
+		ui_backend: 'herdr'
+	}
+	'full': SwarmRecipeSpec{
+		description: 'Six-role planner → implementer → refactorer → architect → hardener → qa workflow'
+		spec: SwarmSpecDetail{
+			roles: {
+				'planner':     SwarmRoleSpec{
+					persona: 'planner'
+					policy: 'read-only'
+					worktree: ''
+					consumes: []
+					produces: ['task-contract']
+					model_profile: 'planning'
+				}
+				'implementer': SwarmRoleSpec{
+					persona: 'tdd-guide'
+					policy: 'writer'
+					worktree: 'implementer'
+					consumes: ['task-contract']
+					produces: ['commit']
+					model_profile: 'coding'
+				}
+				'refactorer':  SwarmRoleSpec{
+					persona: 'refactor-cleaner'
+					policy: 'writer'
+					worktree: 'reviewer'
+					consumes: ['commit']
+					produces: ['refactored-commit']
+					model_profile: 'review'
+				}
+				'architect':   SwarmRoleSpec{
+					persona: 'architect'
+					policy: 'integrator'
+					worktree: 'integration'
+					consumes: ['refactored-commit']
+					produces: ['integrated-commit']
+					model_profile: 'architecture'
+				}
+				'hardener':    SwarmRoleSpec{
+					persona: 'security-reviewer'
+					policy: 'reviewer-writer'
+					worktree: 'hardener'
+					consumes: ['integrated-commit']
+					produces: ['hardened-commit']
+					model_profile: 'hardening'
+				}
+				'qa':          SwarmRoleSpec{
+					persona: 'e2e-runner'
+					policy: 'reviewer-writer'
+					worktree: 'qa'
+					consumes: ['hardened-commit']
+					produces: ['qa-report', 'final-report']
+					model_profile: 'qa'
+				}
+			}
+		}
+		execution: SwarmExecutionSpec{
+			max_concurrency: 2
+			lazy_start: true
+		}
+		gates: ['plan', 'final']
+		budget: SwarmBudgetSpec{
+			max_total_tokens: 1200000
+			max_cost_usd: 8.0
+			max_wall_seconds: 10800
+		}
+		ui_backend: 'herdr'
+	}
+}


### PR DESCRIPTION
TITLE: feat(swarm): `swarm recipes` detail parity — Python fbb2280 shows roles/execution/budget/gates per recipe, V shows one-line desc + roles only

### Summary

Python `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:127` `swarm recipes --json` dumps the full `recipes.py:30` `BUILTIN_RECIPES` spec (`roles{persona,policy,consumes,produces,worktree}`, `execution{max_concurrency, lazy_start}`, `gates`, `budget{900k/4.00/7200}`, `ui_backend`) and `:147` `swarm recipes <name> --json` (aliased `recipe show`) prints the single recipe; human mode prints `roles:..., execution:..., gates:..., budget:...`. `workflow-generic-project` validates tier via `recipes --json`. V `HEAD` `modules/agent_toolkit_core/swarm.v:165-198` `swarm_recipes(opts)` only does `names=['full','pair','team'] → desc one-liner + roles.join(',')`; `--json` is global mode, not per-recipes structured JSON, and the per-recipe budgets/gates/execution are lost. `config.py:60` `resolve_config` persona/policy/gates are therefore invisible and `swarm start --help` `Runners:` line is decoupled from recipe data.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `swarm/recipes.py:304`, `cli.py:2448`.
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — same recipes at old prefix `packages/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:304`.
- `0e6d276` (`2026-08-06 feat(swarm): backend-neutral (#331)`) — origin `BUILTIN_RECIPES` spec.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes `recipes.py`.

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:30-80`

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:30-80
BUILTIN_RECIPES = {
    "pair": {
        "description": "Two-role implementer + reviewer/integrator workflow",
        "spec": {"roles": {"implementer": {"persona": "implementer", "worktree": "implementer", "consumes": [], "produces": ["code"]},
                           "reviewer": {"persona": "reviewer", "consumes": ["code"], "produces": ["review"]},
                           "integrator": {"persona": "integrator", "consumes": ["review"], "produces": ["merged"]}}},
        "execution": {"max_concurrency": 1, "lazy_start": True},
        "gates": ["final"],
        "budget": {"max_total_tokens": 900_000, "max_cost_usd": 4.00, "max_wall_seconds": 7200},
        "ui_backend": "herdr",
    },
    # team/full similar with gates ["plan","final"] and roles 4/6
}
```

`30ff687:recipes.py:30` identical budget values.

#### 2. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:127-160`

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:127-160
def cmd_recipes(args: list[str]) -> int:
    parser = argparse.ArgumentParser(prog="agent-toolkit swarm recipes")
    parser.add_argument("name", nargs="?", default=None)
    parser.add_argument("--json", action="store_true")
    parser.add_argument("--workspace", default=None)
    ns = parser.parse_args(args)
    if ns.name:
        recipe = BUILTIN_RECIPES.get(ns.name)
        if not recipe: return _error(f"Unknown recipe '{ns.name}'")
        if ns.json: print(json.dumps(recipe, indent=2)); return 0
        print(f"{ns.name}\t{recipe['description']}\nroles: {', '.join(recipe['spec']['roles'].keys())}\nexecution: {recipe['execution']}\ngates: {recipe['gates']}\nbudget: {recipe['budget']}")
    else:
        if ns.json: print(json.dumps(BUILTIN_RECIPES, indent=2)); return 0
        for name, spec in BUILTIN_RECIPES.items():
            print(f"{name}\t{spec['description']} (roles: {', '.join(spec['spec']['roles'].keys())})")
    return 0

def cmd_recipe_show(args: list[str]) -> int:  # alias
    return cmd_recipes(args)
```

`30ff687:cli.py:127` same but without `--workspace`; logic identical.

### V evidence (HEAD)

- `modules/agent_toolkit_core/swarm_state.v:55-87` flat roles/descriptions only:

```v
// HEAD:modules/agent_toolkit_core/swarm_state.v:55-87
pub fn swarm_recipe_roles(recipe string) []string {
    return match recipe {'pair'{['implementer','reviewer','integrator']} 'team'{['planner','implementer','reviewer','architect']} 'full'{['planner','implementer','refactorer','architect','hardener','qa']} else {[]}}
}
pub fn swarm_recipe_description(recipe string) string {
    return match recipe {'pair'{'Two-role implementer + reviewer/integrator workflow'} 'team'{'Four-role planner → implementer → reviewer → architect workflow'} 'full'{'Six-role planner → implementer → refactorer → architect → hardener → qa workflow'} else {''}}
}
pub fn swarm_require_plan_approval(recipe string) bool { return recipe in ['team','full'] }
pub fn swarm_default_gates(recipe string) []SwarmGate { mut gates:=[]SwarmGate{}; if swarm_require_plan_approval(recipe){gates<<SwarmGate{id:'plan'}}; gates<<SwarmGate{id:'final'}; return gates }
```

No `execution`, no `budget`, no `persona/worktree`.

- `modules/agent_toolkit_core/swarm.v:165-198` recipes handler minimal:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:165-198
fn swarm_recipes(opts SwarmOptions) SwarmReport {
    names := ['full', 'pair', 'team']
    if opts.run_id.len > 0 {
        name := opts.run_id
        desc := swarm_recipe_description(name)
        if desc.len == 0 { return SwarmReport{ok:false, message:"Unknown recipe '${name}'. Built-ins: pair, team, full"} }
        roles := swarm_recipe_roles(name).join(',')
        return SwarmReport{ok:true, message:'${name}\t${desc}\nroles: ${roles}', data:{'subcommand':'recipes','recipe':name,'roles':roles}}
    }
    mut lines := []string{}; for n in names { lines << '${n}\t${swarm_recipe_description(n)}' }
    return SwarmReport{ok:true, message:lines.join('\n'), data:{'subcommand':'recipes','recipes':names.join(',')}}
}
```

`opts.run_id` is abused as recipe name (positional); no `--json` per-command, no budget/gates.

- `modules/agent_toolkit_cli/commands.v:836-838` single handler:

```v
cli.Command{name: 'recipes', description: 'List or show recipes'}
```

No `recipe show` alias.

**CLI proof:**
```bash
build/agent-toolkit swarm recipes --json 2>&1 | head -n 20  # only global JSON mode wrapper, not recipe JSON
build/agent-toolkit swarm recipes pair --json 2>&1 | head -n 20  # same
grep -n "swarm_recipe_roles\|BUILTIN" modules/agent_toolkit_core/swarm_state.v 2>&1 | head
# only flat functions, no budget map
```

### Expected behavior

```bash
# Playground /tmp/my-project
cd /tmp/my-project
agent-toolkit swarm recipes --json 2>&1 | head -n 60
# Expected: {"pair":{"description":"Two-role ...","spec":{"roles":{"implementer":{"persona":"implementer","worktree":"implementer","consumes":[],"produces":["code"]},...}},"execution":{"max_concurrency":1,"lazy_start":true},"gates":["final"],"budget":{"max_total_tokens":900000,"max_cost_usd":4.0,"max_wall_seconds":7200}},"team":{...},"full":{...}}
agent-toolkit swarm recipes pair --json 2>&1 | jq .budget.max_total_tokens | grep -q 900000 && echo "budget ok"
agent-toolkit swarm recipes pair --json 2>&1 | jq .spec.roles.implementer.worktree | grep -q implementer && echo "worktree ok"
agent-toolkit swarm recipes pair 2>&1 | head -n 20
# Expected human: pair   Two-role ... 
# roles: implementer, reviewer, integrator
# execution: max_concurrency=1 lazy_start=true
# gates: final
# budget: 900k tokens / $4.00 / 7200s
agent-toolkit swarm recipes pair --json 2>&1 | jq .execution.max_concurrency | grep -q 1 && echo "execution ok"
```

### Proposed fix

**1. `modules/agent_toolkit_core/recipes.v` (new) or extend `swarm_state.v`**

```v
pub struct RoleSpec { persona string, worktree string, consumes []string, produces []string }
pub struct ExecutionSpec { max_concurrency int, lazy_start bool }
pub struct RecipeSpec { description string, spec map[string]RoleSpec, execution ExecutionSpec, gates []string, budget Budget }
pub const builtin_recipes = {
    'pair': RecipeSpec{description: 'Two-role ...', spec: {'implementer': RoleSpec{persona:'implementer', worktree:'implementer'}, ...}, execution: ExecutionSpec{1,true}, gates:['final'], budget:Budget{900_000,4.0,7200,1}},
    'team': RecipeSpec{... gates:['plan','final'], budget:Budget{900_000,4.0,7200,1}},
    'full': RecipeSpec{... max_concurrency:2 ...}
}
```

**2. `modules/agent_toolkit_core/swarm.v:165` — `--json` branching**

```v
fn swarm_recipes(opts SwarmOptions) SwarmReport {
    // opts.run_id is positional name, opts.json_output is global/ per-command flag
    if opts.run_id.len>0 {
        spec := builtin_recipes[opts.run_id] or {return error}
        if opts.json_output { return SwarmReport{message: json.encode(spec)} }
        return SwarmReport{message: '${opts.run_id}\t${spec.description}\nroles: ${spec.spec.keys().join(', ')}\nexecution: ${spec.execution}\ngates: ${spec.gates.join(', ')}\nbudget: ${spec.budget.max_total_tokens} / ${spec.budget.max_cost_usd} / ${spec.budget.max_wall_seconds}'}
    }
    if opts.json_output { return SwarmReport{message: json.encode(builtin_recipes)} }
    // human list
}
```

**3. `modules/agent_toolkit_cli/options.v:743` — capture `--json` for recipes subcommand into `SwarmOptions.json_output` (already global but stash).**

Gate: `swarm recipes --json | jq .pair.budget.max_total_tokens` 900000 + `swarm recipes pair --json | jq .spec` present.

### Severity / Area

- **Severity:** `medium` (P2) — observability/API contract but not blocker for headless start.
- **Area:** `area:swarm`
- **Kind:** `kind:parity`
- **Labels:** `area:swarm kind:parity severity:medium`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
build/agent-toolkit swarm recipes --json 2>&1 | head -n 20 || echo "no --json (bug)"
build/agent-toolkit swarm recipes pair --json 2>&1 | head -n 20 || echo "no detail (bug)"
cat modules/agent_toolkit_core/swarm.v | sed -n '165,200p' | head -n 40
grep -n "builtin_recipes\|BUILTIN" modules/agent_toolkit_core/*.v 2>&1 | head -n 20
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py | sed -n '30,80p'`
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py | sed -n '127,160p'`
- `modules/agent_toolkit_core/swarm_state.v:55` `swarm_recipe_roles` + `modules/agent_toolkit_core/swarm.v:165` `swarm_recipes` (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§3.1 A1.09/A1.11`, `§4.4 P2-02`.


