### PR TITLE
feat(swarm): list --json/--workspace/-C + list_all_runs aggregator (fixes #895)

### DIFF
--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -243,9 +243,15 @@ fn execute_command(cmd_name string, rest []string, mode agent_toolkit_core.Rende
 		return render(agent_toolkit_core.loop_result(report), mode)
 	}
 	if cmd_name == 'swarm' {
-		opts := parse_swarm_options(rest) or {
+		mut opts := parse_swarm_options(rest) or {
 			e := agent_toolkit_core.err_usage_flags('flag.invalid', err.msg())
 			return render_error(e, mode)
+		}
+		if opts.subcommand == 'list' && mode == .json && !opts.json_output {
+			opts = agent_toolkit_core.SwarmOptions{
+				...opts
+				json_output: true
+			}
 		}
 		report := agent_toolkit_core.run_swarm(opts)
 		if mode == .json && opts.subcommand in ['runners', 'models'] && report.ok {
@@ -260,6 +266,10 @@ fn execute_command(cmd_name string, rest []string, mode agent_toolkit_core.Rende
 				return 0
 			}
 			return agent_toolkit_core.err_user('command.failed', report.message).exit_code()
+		}
+		if opts.subcommand == 'list' && opts.json_output {
+			println(report.message)
+			return if report.ok { 0 } else { 1 }
 		}
 		return render(agent_toolkit_core.swarm_result(report), mode)
 	}

--- a/modules/agent_toolkit_cli/options.v
+++ b/modules/agent_toolkit_cli/options.v
@@ -966,9 +966,9 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 			i++
 			continue
 		}
-		if a == '-C' || a == '--C' {
+		if a in ['-C', '--C'] {
 			if i + 1 >= args.len {
-				return error('-C requires an argument')
+				return error('${a} requires an argument')
 			}
 			workspace_alias = args[i + 1]
 			i += 2

--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -143,7 +143,7 @@ pub fn run_swarm(opts SwarmOptions) SwarmReport {
 			swarm_promote(ws, opts)
 		}
 		'list' {
-			swarm_list(ws)
+			swarm_list(ws, opts)
 		}
 		'status' {
 			swarm_status(ws, opts)
@@ -230,7 +230,7 @@ Usage:
     agent-toolkit swarm resume <run-id>
     agent-toolkit swarm stop <run-id>
     agent-toolkit swarm cleanup <run-id> [--force] [--dry-run]
-    agent-toolkit swarm list
+    agent-toolkit swarm list [--json] [--workspace PATH] [-C PATH] [--repo PATH]
     agent-toolkit swarm status [run-id]
     agent-toolkit swarm approve <run-id> <gate>
     agent-toolkit swarm reject <run-id> <gate> --reason TEXT
@@ -992,9 +992,78 @@ fn spawn_herdr_workspace(ws string, run_id string, task string, recipe string, r
 	return SwarmReport{ ok: true, message: 'workspace swarm-' + run_id + ' (' + ws_id + ') — ' + roles.len.str() + ' tabs, shell=' + shell + ', focused', data: { 'backend': 'herdr', 'run_id': run_id, 'workspace_id': ws_id } }
 }
 
-fn swarm_list(ws string) SwarmReport {
-	dir := swarm_runs_dir(ws)
-	if !os.is_dir(dir) {
+fn list_all_swarm_runs(ws string) []string {
+	mut out := []string{}
+	primary := swarm_runs_dir(ws)
+	if os.is_dir(primary) {
+		for n in os.ls(primary) or { []string{} } {
+			full := os.join_path(primary, n)
+			if os.is_dir(full) {
+				out << full
+			}
+		}
+	}
+	projects_dir := os.join_path(ws, 'projects')
+	if os.is_dir(projects_dir) {
+		for link in os.ls(projects_dir) or { []string{} } {
+			p := os.join_path(projects_dir, link)
+			if os.is_link(p) {
+				target := os.real_path(p)
+				if target.len == 0 {
+					continue
+				}
+				alt := os.join_path(target, '.agent-toolkit', 'swarm', 'runs')
+				if os.is_dir(alt) {
+					for n in os.ls(alt) or { []string{} } {
+						full2 := os.join_path(alt, n)
+						if os.is_dir(full2) {
+							out << full2
+						}
+					}
+				}
+			}
+		}
+	}
+	out.sort_with_compare(fn (a &string, b &string) int {
+		ma := os.file_last_mod_unix(*a)
+		mb := os.file_last_mod_unix(*b)
+		if ma > mb {
+			return -1
+		}
+		if ma < mb {
+			return 1
+		}
+		return 0
+	})
+	return out
+}
+
+fn swarm_list(ws string, opts SwarmOptions) SwarmReport {
+	all := list_all_swarm_runs(ws)
+	if opts.json_output {
+		mut arr := []map[string]string{}
+		for rd in all {
+			st := read_swarm_state(rd) or { continue }
+			arr << {
+				'run_id':     st.run_id
+				'recipe':     st.recipe
+				'run_state':  st.run_state
+				'created_at': st.created_at
+				'workspace':  ws
+				'run_dir':    rd
+			}
+		}
+		encoded := json.encode(arr)
+		return SwarmReport{
+			ok:      true
+			message: encoded
+			data:    {
+				'subcommand': 'list'
+				'count':      '${arr.len}'
+			}
+		}
+	}
+	if all.len == 0 {
 		return SwarmReport{
 			ok:      true
 			message: 'No swarm runs found.'
@@ -1004,12 +1073,9 @@ fn swarm_list(ws string) SwarmReport {
 			}
 		}
 	}
-	mut names := os.ls(dir) or { []string{} }
-	names.sort()
 	mut lines := []string{}
 	mut count := 0
-	for n in names {
-		rd := os.join_path(dir, n)
+	for rd in all {
 		st := read_swarm_state(rd) or { continue }
 		lines << '${st.run_id}\t${st.recipe}\t${st.run_state}\t${st.created_at}'
 		count++
@@ -1036,7 +1102,7 @@ fn swarm_list(ws string) SwarmReport {
 
 fn swarm_status(ws string, opts SwarmOptions) SwarmReport {
 	if opts.run_id.len == 0 {
-		return swarm_list(ws)
+		return swarm_list(ws, opts)
 	}
 	if !swarm_valid_run_id(opts.run_id) {
 		return SwarmReport{


### PR DESCRIPTION
TITLE: feat(swarm): `swarm list --json/--workspace/-C` + list_all_runs aggregator (.ai-workspace aware) — Python fbb2280 aggregates across workspace, V only lists single cwd

### Summary

Python `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1073` `swarm list [--json] [--workspace PATH] [--repo PATH] [-C PATH]` aggregates via `store.py:90` `list_all_runs(workspace)` which, when the workspace is an `.ai-workspace` harness (via `find_workspace_root` honoring `AGENT_TOOLKIT_WORKSPACE`/`HARNESS_DIR`), walks `projects/*` symlinks + `ws/.agent-toolkit/swarm/runs/*` and sorts by `mtime` descending, emitting `[{run_id, recipe, state, created_at, workspace, run_dir}]` when `--json` (used by `loop gh_gate` dashboard). V `HEAD` `modules/agent_toolkit_core/swarm.v:500-539` `swarm_list(ws)` does `os.ls(swam_runs_dir(ws))` for a single `ws` from `find_swarm_workspace` (fallback `os.getwd()` if not git), ignores `--json`/`--workspace`/`-C`, and never aggregates. `AGENT_TOOLKIT_WORKSPACE=/tmp/my-project swarm list --json` therefore shows only cwd runs and `swarm list --json | jq length` excludes cross-project runs in an ensemble, diverging from Python `list_all_runs`.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `swarm/store.py:148`, `cli.py:2448`.
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — at `packages/agent-toolkit-cli/src/agent_toolkit/swarm/store.py:90` `list_all_runs` (same).
- `0e6d276` (`2026-08-06 feat(swarm): backend-neutral (#331)`) — origin `store.py` aggregator.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes `store.py`.

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/store.py:90-115` — list_all_runs

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/store.py:90-115
def list_all_runs(workspace: Path | None = None) -> list[Path]:
    # aggregator for .ai-workspace ensemble
    ws = workspace or find_workspace_root(None) or Path.cwd()
    candidates = []
    # primary: ws/.agent-toolkit/swarm/runs/*
    candidates.extend((ws / ".agent-toolkit" / "swarm" / "runs").glob("*"))
    # ensemble: walk projects/* symlinks if harness
    if (ws / "projects").is_dir():
        for link in (ws / "projects").iterdir():
            if link.is_symlink():
                target = link.resolve()
                candidates.extend((target / ".agent-toolkit" / "swarm" / "runs").glob("*"))
    # also respect AGENT_TOOLKIT_WORKSPACE env already via find_workspace_root
    # sort by mtime desc
    return sorted([p for p in candidates if p.is_dir()], key=lambda p: p.stat().st_mtime, reverse=True)

def list_runs(repo: Path) -> list[Path]:  # legacy alias
    return list_all_runs(repo)
```

`30ff687:store.py:90` identical (`list_all_runs` introduced at `0e6d276`).

#### 2. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1073-1105` — cmd_list

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1073-1105
def cmd_list(args: list[str]) -> int:
    parser = argparse.ArgumentParser(prog="agent-toolkit swarm list")
    parser.add_argument("--json", action="store_true")
    parser.add_argument("--workspace", default=None, help="Workspace path or OWNER/REPO")
    parser.add_argument("--repo", default=None, help="Alias for --workspace")
    parser.add_argument("-C", dest="workspace_C", default=None, help="Alias for --workspace")
    ns = parser.parse_args(args)
    workspace_flag = ns.workspace or ns.repo or ns.workspace_C
    ws = find_repo_root(prompt_text=None, workspace=workspace_flag) if workspace_flag else find_workspace_root(None) or Path.cwd()
    runs = list_all_runs(ws)
    if ns.json:
        out = [{"run_id": p.name, "recipe": (read_state(p) or {}).get("recipe"), "run_state": (read_state(p) or {}).get("run_state"),
                "created_at": (read_state(p) or {}).get("created_at"), "workspace": str(ws), "run_dir": str(p)} for p in runs]
        print(json.dumps(out, indent=2))
    else:
        for p in runs:
            st = read_state(p) or {}
            print(f"{p.name}\t{st.get('recipe')}\t{st.get('run_state')}\t{st.get('created_at')}")
    return 0
```

Human mode prints `run_id\trecipe\tstate\tcreated_at` sorted by `mtime`; `--json` array is what `dispatch` `--json` wrapper also needs.

### V evidence (HEAD)

- `modules/agent_toolkit_core/swarm.v:500-539` simple single-root ls:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:500-539
fn swarm_list(ws string) SwarmReport {
    dir := swarm_runs_dir(ws)
    if !os.is_dir(dir) {
        return SwarmReport{ok:true, message:'No swarm runs found.', data:{'subcommand':'list','count':'0'}}
    }
    mut names := os.ls(dir) or { []string{} }
    names.sort()
    mut lines := []string{}
    mut count := 0
    for n in names {
        rd := os.join_path(dir, n)
        st := read_swarm_state(rd) or { continue }
        lines << '${st.run_id}\t${st.recipe}\t${st.run_state}\t${st.created_at}'
        count++
    }
    if lines.len == 0 {
        return SwarmReport{ok:true, message:'No swarm runs found.', data:{'subcommand':'list','count':'0'}}
    }
    return SwarmReport{ok:true, message:lines.join('\n'), data:{'subcommand':'list','count':'${count}'}}
}
```

`ws` from `find_swarm_workspace:140` (`AGENT_TOOLKIT_WORKSPACE`/`HARNESS_DIR` via `find_workspace_root` + `find_git_root` + `os.getwd()` fallback) but never aggregates `projects/*`.

- `modules/agent_toolkit_core/swarm.v:140-152` find_swarm_workspace:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:140-152
fn find_swarm_workspace(override string) string {
    if override.len > 0 && os.is_dir(override) { return override }
    if ws := find_workspace_root(override) { return ws }
    if git := find_git_root('') { return git }
    return os.getwd()
}
```

Single root, no `list_all_runs` walk.

- `modules/agent_toolkit_cli/options.v:743-883` `parse_swarm_options` — `list` case ignores `--json/--workspace`:

```v
// HEAD:modules/agent_toolkit_cli/options.v:743-857 parse_swarm_options excerpt for list
    // sub dispatch: if sub.len==0 {sub=a} etc; run_id positional only; --json consumed by global skip
    if a in ['--json','--quiet'] { i++; continue } // global skip, not per-command json_output
    // ... --recipe/--backend etc
    if a.starts_with('-') { i++; continue } // --workspace for list would be caught here but not stored if not matched before
```

So `swarm list --json --workspace /tmp/my-project` silently drops flags.

- `modules/agent_toolkit_cli/commands.v:855-857` no flags on `list`:

```v
cli.Command{name: 'list', description: 'List runs'}
```

No `flags:` array.

**CLI proof:**
```bash
build/agent-toolkit swarm list --json 2>&1 | head -n 20  # human table, not JSON array
build/agent-toolkit swarm list --workspace /tmp/my-project 2>&1 | head -n 10  # same as without
grep -n "list_all_runs\|AGENT_TOOLKIT_WORKSPACE" modules/agent_toolkit_core/swarm.v 2>&1 | head  # 0
```

### Expected behavior

```bash
# Playground /tmp/my-project (ensemble if projects/ exists)
cd /tmp/my-project
mkdir -p projects/demo 2>&1 | head
# Create two runs
agent-toolkit swarm start --recipe pair --backend headless "list json test 1" 2>&1 | tail -n 2
agent-toolkit swarm start --recipe pair --backend headless "list json test 2" 2>&1 | tail -n 2

agent-toolkit swarm list --json 2>&1 | head -n 60
# Expected: [{"run_id":"s...","recipe":"pair","run_state":"running","created_at":"2026-08-25T...Z","workspace":"/tmp/my-project","run_dir":"/tmp/my-project/.agent-toolkit/swarm/runs/s..."}, ...] sorted mtime desc, JSON array (not human table)

agent-toolkit swarm list --json 2>&1 | jq length | grep -q 2 && echo "json count ok"
# With explicit workspace flag
agent-toolkit swarm list --workspace /tmp/my-project --json 2>&1 | jq length | grep -q 2 && echo "workspace flag ok"
agent-toolkit swarm list -C /tmp/my-project --json 2>&1 | jq length | grep -q 2 && echo "-C alias ok"

# Ensemble: AGENT_TOOLKIT_WORKSPACE override
AGENT_TOOLKIT_WORKSPACE=/tmp/my-project agent-toolkit swarm list --json 2>&1 | jq length | grep -q 2 && echo "env tier ok"
# If projects/demo is symlink to /tmp/other-ws with its own run, list_all_runs should aggregate it (Python parity)
```

### Proposed fix

**1. `modules/agent_toolkit_cli/options.v:743` — extend for `list`**

```v
// before catch-all starts_with('-')
if a == '--json' { json_output = true; i++; continue } // stash per-command too if sub=='list' or global
if a in ['--workspace','--repo'] { if i+1>=args.len {return error}; workspace_path=args[i+1]; i+=2; continue }
if a == '-C' { if i+1>=args.len {return error}; workspace_path=args[i+1]; i+=2; continue }
if a.starts_with('--workspace=') { workspace_path=a.all_after('='); i++; continue }
if a.starts_with('--repo=') { workspace_path=a.all_after('='); i++; continue }
```

Add `json_output bool` to `SwarmOptions` (or reuse global mode via dispatch).

**2. `modules/agent_toolkit_core/swarm.v:500` — `list_all_swarm_runs` + json branching**

```v
fn list_all_swarm_runs(ws string) []string {
    mut out := []string{}
    // primary ws
    primary := swarm_runs_dir(ws)
    if os.is_dir(primary) { for n in os.ls(primary) or {[]} { out << os.join_path(primary,n) } }
    // ensemble: projects/* symlinks (harness)
    projects_dir := os.join_path(ws, 'projects')
    if os.is_dir(projects_dir) {
        for link in os.ls(projects_dir) or {[]} {
            p := os.join_path(projects_dir, link)
            if os.is_link(p) {
                target := os.real_path(p)
                alt := os.join_path(target, '.agent-toolkit','swarm','runs')
                if os.is_dir(alt) { for n in os.ls(alt) or {[]} { out << os.join_path(alt,n) } }
            }
        }
    }
    // sort by mtime desc
    out.sort_with_compare(fn(a &string, b &string) int { ma:=os.file_last_mod_unix(*a); mb:=os.file_last_mod_unix(*b); return if ma>mb{-1} else if ma<mb{1} else{0} })
    return out
}
fn swarm_list(ws string, opts SwarmOptions) SwarmReport {
    all := list_all_swarm_runs(ws)
    if opts.json_output {
        mut arr := []map[string]string{}
        for rd in all { st:=read_swarm_state(rd) or {continue}; arr << {'run_id':st.run_id,'recipe':st.recipe,'run_state':st.run_state,'created_at':st.created_at,'workspace':ws,'run_dir':rd} }
        return SwarmReport{message: json.encode(arr), data:{'subcommand':'list','count':'${arr.len}'}}
    }
    // human mode same but from all sorted
}
```

Update `run_swarm` dispatch to pass `opts` to `swarm_list`.

**3. `modules/agent_toolkit_cli/commands.v:855` — add flags**

```v
cli.Command{name: 'list', description: 'List runs', flags: [cli.Flag{name:'json'}, cli.Flag{name:'workspace'}, cli.Flag{name:'repo'}]} // or parent flags already global via promote
```

Or ensure `promote_family_flags` makes `workspace` global so `swarm list --workspace` passes validation.

Gate: `swarm list --json | jq type` == array + count matches `ls runs | wc -l` + `--workspace/-C` honored.

### Severity / Area

- **Severity:** `medium` (P2)
- **Area:** `area:swarm`
- **Kind:** `kind:parity`
- **Labels:** `area:swarm kind:parity severity:medium`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
agent-toolkit swarm start --recipe pair --backend headless "repro P2-03 list" 2>&1 | tail -n 2
ls .agent-toolkit/swarm/runs 2>&1 | head -n 10
build/agent-toolkit swarm list --json 2>&1 | head -n 20 || echo "--json ignored (bug)"
build/agent-toolkit swarm list --workspace /tmp/my-project 2>&1 | head -n 10
build/agent-toolkit swarm list -C /tmp/my-project 2>&1 | head -n 10
grep -n "list_all_runs\|swarm_list" modules/agent_toolkit_core/swarm.v 2>&1 | head -n 20
# BEFORE: human table only; AFTER: JSON array + workspace/-C + ensemble
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/store.py | sed -n '90,115p'`
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py | sed -n '1073,1105p'`
- `modules/agent_toolkit_core/swarm.v:500` `swarm_list` + `:140` `find_swarm_workspace` (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§2.2 list`, `§3.1 A1.06/A1.10 store`, `§4.4 P2-03`.


