### PR TITLE
feat(swarm): per-recipe Budget 900k/$4.00/7200s + budget_exhausted state (fixes #892)

### DIFF
--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -59,17 +59,19 @@ pub:
 
 struct SwarmStateFile {
 pub mut:
-	version       int
-	run_id        string
-	recipe        string
-	backend       string
-	runner        string
-	model_profile string
-	run_state     string
-	created_at    string
-	task          string
-	active_roles []string
-	worktrees  []SwarmWorktree
+	version         int
+	run_id          string
+	recipe          string
+	backend         string
+	runner          string
+	model_profile   string
+	run_state       string
+	created_at      string
+	task            string
+	budget          Budget
+	budget_consumed BudgetConsumed
+	active_roles    []string
+	worktrees       []SwarmWorktree
 }
 
 struct SwarmApprovalsFile {
@@ -390,13 +392,20 @@ fn swarm_recipes(opts SwarmOptions) SwarmReport {
 		gates_str := if recipe.gates.len > 0 { recipe.gates.join(', ') } else { 'none' }
 		execution_str := 'max_concurrency=${recipe.execution.max_concurrency} lazy_start=${recipe.execution.lazy_start}'
 		budget_str := '${recipe.budget.max_total_tokens} tokens / \$${recipe.budget.max_cost_usd:.2f} / ${recipe.budget.max_wall_seconds}s'
+		b := recipe_budget(name)
+		bj := json.encode(b)
 		return SwarmReport{
 			ok:      true
-			message: '${name}\t${recipe.description}\nroles: ${roles}\nexecution: ${execution_str}\ngates: ${gates_str}\nbudget: ${budget_str}'
+			message: '${name}\t${recipe.description}\nroles: ${roles}\nexecution: ${execution_str}\ngates: ${gates_str}\nbudget: ${budget_str}\nbudget_json: ${bj}'
 			data:    {
-				'subcommand': 'recipes'
-				'recipe':     name
-				'roles':      roles
+				'subcommand':       'recipes'
+				'recipe':           name
+				'roles':            roles
+				'budget':           bj
+				'max_total_tokens': b.max_total_tokens.str()
+				'max_cost_usd':     b.max_cost_usd.str()
+				'max_wall_seconds': b.max_wall_seconds.str()
+				'max_concurrency':  b.max_concurrency.str()
 			}
 		}
 	}
@@ -413,18 +422,23 @@ fn swarm_recipes(opts SwarmOptions) SwarmReport {
 	}
 	mut lines := []string{}
 	for n in names {
+		b := recipe_budget(n)
 		if r := builtin_recipes[n] {
-			lines << '${n}\t${r.description}'
+			lines << '${n}\t${r.description}\tbudget: ${json.encode(b)}'
 		} else {
-			lines << '${n}\t${swarm_recipe_description(n)}'
+			lines << '${n}\t${swarm_recipe_description(n)}\tbudget: ${json.encode(b)}'
 		}
 	}
 	return SwarmReport{
 		ok:      true
 		message: lines.join('\n')
 		data:    {
-			'subcommand': 'recipes'
-			'recipes':    names.join(',')
+			'subcommand':  'recipes'
+			'recipes':     names.join(',')
+			'pair_budget': json.encode(recipe_budget('pair'))
+			'team_budget': json.encode(recipe_budget('team'))
+			'full_budget': json.encode(recipe_budget('full'))
+			'budget':      json.encode(recipe_budget('pair'))
 		}
 	}
 }
@@ -804,17 +818,19 @@ fn swarm_start(ws string, opts SwarmOptions) SwarmReport {
 		append_swarm_trace(run_dir, 'worktree_created', role + ':' + wt.branch + ':' + wt.path)
 	}
 	mut st := SwarmStateFile{
-		version:       swarm_state_version
-		run_id:        rid
-		recipe:        recipe
-		backend:       backend
-		runner:        runner
-		model_profile: model_profile
-		run_state:     initial
-		created_at:    time.utc().format_rfc3339()
-		task:          opts.task
-		active_roles:  []string{}
-		worktrees:     created_wts
+		version:         swarm_state_version
+		run_id:          rid
+		recipe:          recipe
+		backend:         backend
+		runner:          runner
+		model_profile:   model_profile
+		run_state:       initial
+		created_at:      time.utc().format_rfc3339()
+		task:            opts.task
+		budget:          recipe_budget(recipe)
+		budget_consumed: BudgetConsumed{}
+		active_roles:    []string{}
+		worktrees:       created_wts
 	}
 	write_swarm_state(run_dir, st) or {
 		return SwarmReport{
@@ -837,6 +853,16 @@ fn swarm_start(ws string, opts SwarmOptions) SwarmReport {
 		append_swarm_trace(run_dir, 'prompt_composed', role)
 	}
 	append_swarm_trace(run_dir, 'run_created', rid)
+	if _ := check_budget(run_dir) {
+		if swarm_can_transition(initial, 'budget_exhausted') {
+			ns := SwarmStateFile{
+				...st
+				run_state: 'budget_exhausted'
+			}
+			write_swarm_state(run_dir, ns) or {}
+			append_swarm_trace(run_dir, 'budget_exhausted', rid)
+		}
+	}
 	// Herdr UI spawn (ADR-008: UI is adapter, not engine). Only when --attach and not dry-run.
 	mut herdr_note := ''
 	if opts.attach && !opts.no_attach && backend == 'herdr' {
@@ -1240,17 +1266,38 @@ fn swarm_status(ws string, opts SwarmOptions) SwarmReport {
 			}
 		}
 	}
+	mut b := st.budget
+	if b.max_total_tokens == 0 {
+		b = recipe_budget(st.recipe)
+	}
+	created := time.parse_rfc3339(st.created_at) or { time.utc() }
+	wall := int(time.utc().unix() - created.unix())
+	bj := json.encode(b)
+	bc := st.budget_consumed
+	bcj := json.encode(bc)
+	msg += '\nbudget: ${bj} consumed: ${bcj} wall_seconds: ${wall}'
+	if wt_data.len > 0 && !msg.contains('worktrees:') {
+		msg += '\nworktrees: ${wt_data}'
+	}
 	return SwarmReport{
 		ok:      true
 		message: msg
 		data:    {
-			'subcommand': 'status'
-			'run_id':     st.run_id
-			'recipe':     st.recipe
-			'backend':    st.backend
-			'run_state':  st.run_state
-			'gates':      gtxt.join(',')
-			'worktrees':  wt_data
+			'subcommand':       'status'
+			'run_id':           st.run_id
+			'recipe':           st.recipe
+			'backend':          st.backend
+			'run_state':        st.run_state
+			'gates':            gtxt.join(',')
+			'worktrees':        wt_data
+			'budget':           bj
+			'budget_consumed':  bcj
+			'max_total_tokens': b.max_total_tokens.str()
+			'total_tokens':     bc.total_tokens.str()
+			'max_cost_usd':     b.max_cost_usd.str()
+			'total_cost':       bc.total_cost.str()
+			'max_wall_seconds': b.max_wall_seconds.str()
+			'wall_seconds':     wall.str()
 		}
 	}
 }
@@ -2884,6 +2931,29 @@ fn swarm_handoff_create(ws string, opts SwarmOptions) SwarmReport {
 			}
 		}
 	}
+	if _ := check_budget(rd) {
+		if swarm_can_transition(st.run_state, 'budget_exhausted') {
+			ns := SwarmStateFile{
+				...st
+				run_state: 'budget_exhausted'
+			}
+			write_swarm_state(rd, ns) or {}
+			append_swarm_trace(rd, 'budget_exhausted', run_id)
+		}
+		mut b := st.budget
+		if b.max_total_tokens == 0 {
+			b = recipe_budget(st.recipe)
+		}
+		return SwarmReport{
+			ok:      false
+			message: 'budget_exhausted: run ${run_id} has exceeded budget (max_total_tokens=${b.max_total_tokens} max_cost_usd=${b.max_cost_usd} max_wall_seconds=${b.max_wall_seconds})'
+			data:    {
+				'subcommand': 'handoff'
+				'run_id':     run_id
+				'run_state':  'budget_exhausted'
+			}
+		}
+	}
 	mut roles := swarm_recipe_roles(st.recipe)
 	if roles.len == 0 {
 		roles = ['implementer', 'reviewer', 'integrator']
@@ -3261,6 +3331,20 @@ fn read_swarm_state(run_dir string) ?SwarmStateFile {
 		migrate_swarm_state(mut st)
 	}
 	return st
+}
+
+fn check_budget(run_dir string) ?string {
+	st := read_swarm_state(run_dir) or { return none }
+	mut b := st.budget
+	if b.max_total_tokens == 0 {
+		b = recipe_budget(st.recipe)
+	}
+	created := time.parse_rfc3339(st.created_at) or { time.utc() }
+	wall := int(time.utc().unix() - created.unix())
+	if st.budget_consumed.total_tokens >= b.max_total_tokens || st.budget_consumed.total_cost >= b.max_cost_usd || wall >= b.max_wall_seconds {
+		return 'budget_exhausted'
+	}
+	return none
 }
 
 fn write_swarm_approvals(run_dir string, gates []SwarmGate) ! {

--- a/modules/agent_toolkit_core/swarm_state.v
+++ b/modules/agent_toolkit_core/swarm_state.v
@@ -390,3 +390,35 @@ pub const builtin_recipes = {
 		ui_backend: 'herdr'
 	}
 }
+
+pub struct Budget {
+pub mut:
+	max_total_tokens int
+	max_cost_usd     f64
+	max_wall_seconds int
+	max_concurrency  int
+}
+
+pub struct BudgetConsumed {
+pub mut:
+	total_tokens int
+	total_cost   f64
+}
+
+pub fn recipe_budget(recipe string) Budget {
+	base := Budget{
+		max_total_tokens: 900000
+		max_cost_usd:     4.0
+		max_wall_seconds: 7200
+		max_concurrency:  1
+	}
+	if recipe == 'full' {
+		return Budget{
+			max_total_tokens: base.max_total_tokens
+			max_cost_usd:     base.max_cost_usd
+			max_wall_seconds: base.max_wall_seconds
+			max_concurrency:  2
+		}
+	}
+	return base
+}


### PR DESCRIPTION
TITLE: feat(swarm): per-recipe Budget 900k tokens / $4.00 / 7200s + budget_exhausted state — Python fbb2280 enforces via recipes.py BUILTIN_RECIPES, V swarm_state.v has transition but no field or enforcement

### Summary

Python `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:45-110` attaches identical `budget: {max_total_tokens: 900_000, max_cost_usd: 4.00, max_wall_seconds: 7200, max_concurrency: 1}` to each `BUILTIN_RECIPES` entry (`pair`/`team`/`full` differ only by `roles` + `gates` + `max_concurrency`), `budget.py:22-80` `check_budget(run_dir) -> 'budget_exhausted' | None` sums `prompt_tokens+completion_tokens`/`cost`/`wall` from `trace.jsonl` + `state.json.budget_consumed`, and `cli.py:620` gates `handoff create` and `start_agent` with `if budget_exhausted: state.run_state='budget_exhausted'; append_trace('budget_exhausted'); return`. `swarm status --json` surfaces `budget{max_total_tokens, max_cost_usd, max_wall_seconds, total_tokens, total_cost, wall_seconds}` and `swarm recipes --json` dumps the full budget. V `HEAD` `modules/agent_toolkit_core/swarm_state.v:20-50` defines the `budget_exhausted` edge (`running->budget_exhausted`, `budget_exhausted->[running,cancelled,cleanup_pending]`) as dead code: `SwarmStateFile` at `swarm.v:34` has no `budget` field, `swarm_start:267` never populates it, `swarm_status:542` never prints it, and `recipes:165` never exposes it. Long runs (e.g., `full` with 6 roles) therefore never throttle and `swarm_can_transition('running','budget_exhausted')` is never exercised.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:304`, `budget.py`, `state.py:93`, `cli.py:2448`.
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — same at `packages/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:304` (identical budget block).
- `0e6d276` (`2026-08-06 feat(swarm): backend-neutral (#331)`) — introduced `Budget` struct and `budget_exhausted` state.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes the 4 files.

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:45-110` — BUILTIN_RECIPES budgets

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py:45-110
BUILTIN_RECIPES = {
    "pair": {
        "spec": {"roles": {"implementer": {"persona": "implementer", "worktree": "implementer"}, "reviewer": {"persona": "reviewer"}, "integrator": {"persona": "integrator"}}},
        "execution": {"max_concurrency": 1, "lazy_start": True},
        "gates": ["final"],
        "budget": {"max_total_tokens": 900_000, "max_cost_usd": 4.00, "max_wall_seconds": 7200, "max_concurrency": 1},
    },
    "team": {
        "spec": {"roles": {"planner": ..., "implementer": ..., "reviewer": ..., "architect": ...}},
        "execution": {"max_concurrency": 1, "lazy_start": True},
        "gates": ["plan", "final"],
        "budget": {"max_total_tokens": 900_000, "max_cost_usd": 4.00, "max_wall_seconds": 7200},
    },
    "full": {
        "spec": {"roles": {"planner": ..., "implementer": ..., "refactorer": ..., "architect": ..., "hardener": ..., "qa": ...}},
        "execution": {"max_concurrency": 2, "lazy_start": True},
        "gates": ["plan", "final"],
        "budget": {"max_total_tokens": 900_000, "max_cost_usd": 4.00, "max_wall_seconds": 7200},
    },
}
```

`30ff687:recipes.py:45` identical (`grep -n budget 30ff687:recipes.py` → 3 hits same values).

#### 2. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/budget.py:22-80` — enforcement

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/budget.py:22-80
def check_budget(run_dir: Path, recipe: dict | None = None) -> str | None:
    budget = (recipe or {}).get("budget", {}) or {"max_total_tokens": 900_000, "max_cost_usd": 4.0, "max_wall_seconds": 7200}
    max_tok = budget.get("max_total_tokens", 900_000)
    max_cost = budget.get("max_cost_usd", 4.0)
    max_wall = budget.get("max_wall_seconds", 7200)
    state = read_state(run_dir) or {}
    consumed = state.get("budget_consumed", {}) or {}
    tok = consumed.get("total_tokens", 0)
    cost = consumed.get("total_cost", 0.0)
    wall = time.time() - state.get("created_at_ts", time.time())
    if tok >= max_tok or cost >= max_cost or wall >= max_wall:
        return "budget_exhausted"
    return None

def record_consumption(run_dir: Path, tokens: int, cost: float) -> None:
    state = read_state(run_dir) or {}
    c = state.setdefault("budget_consumed", {})
    c["total_tokens"] = c.get("total_tokens", 0) + tokens
    c["total_cost"] = c.get("total_cost", 0.0) + cost
    atomic_write_json(run_dir / "state.json", state)
```

Called at `fbb2280:cli.py:620` before `start_agent` and at `cli.py:1857` `handoff create` (blocks creating new handoff when exhausted).

#### 3. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/state.py:40-60` — budget in state + trace

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/state.py:40-60
def make_initial_state(run_id, recipe, backend, task):
    return {"version": STATE_VERSION, "run_id": run_id, "recipe": recipe, "backend": backend,
            "run_state": "running" if recipe not in ("team","full") else "awaiting_plan_approval",
            "task": task, "budget": BUILTIN_RECIPES[recipe]["budget"].copy(),
            "budget_consumed": {"total_tokens": 0, "total_cost": 0.0}}
```

`cli.py:620` then:

```python
if check_budget(run_dir, BUILTIN_RECIPES[recipe]):
    state["run_state"] = "budget_exhausted"
    atomic_write_json(run_dir / "state.json", state)
    append_trace(run_dir, {"kind": "budget_exhausted", "recipe": recipe, "budget": state["budget"]})
    return state
```

#### 4. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1115` `cmd_status` — budget in JSON

```python
# fbb2280:cli.py:1115 status budget excerpt
budget = state.get("budget", {})
consumed = state.get("budget_consumed", {})
out["budget"] = {"max_total_tokens": budget.get("max_total_tokens"), "total_tokens": consumed.get("total_tokens"), "max_cost_usd": budget.get("max_cost_usd"), "total_cost": consumed.get("total_cost"), "max_wall_seconds": budget.get("max_wall_seconds"), "wall_seconds": int(time.time()-created_ts)}
```

### V evidence (HEAD)

- `modules/agent_toolkit_core/swarm_state.v:20-50` — `budget_exhausted` transition exists but never entered:

```v
// HEAD:modules/agent_toolkit_core/swarm_state.v:20-50
pub fn swarm_run_transitions(from_state string) []string {
    return match from_state {
        'planning' { ['awaiting_plan_approval', 'running', 'failed', 'cancelled'] }
        'awaiting_plan_approval' { ['running', 'cancelled', 'failed'] }
        'running' { ['awaiting_human', 'paused', 'completed', 'failed', 'cancelled', 'budget_exhausted'] }
        'awaiting_human' { ['running', 'paused', 'completed', 'failed', 'cancelled'] }
        'paused' { ['running', 'cancelled', 'failed'] }
        'completed' { ['cleanup_pending'] }
        'failed' { ['cleanup_pending', 'running'] }
        'cancelled' { ['cleanup_pending'] }
        'budget_exhausted' { ['running', 'cancelled', 'cleanup_pending'] }
        else { []string{} }
    }
}
```

- `modules/agent_toolkit_core/swarm.v:34-43` — `SwarmStateFile` has no budget:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:34-43
struct SwarmStateFile {
    version       int
    run_id        string
    recipe        string
    backend       string
    runner        string
    model_profile string
    run_state     string
    created_at    string
    task          string
    // missing: budget Budget, budget_consumed BudgetConsumed
}
```

- `modules/agent_toolkit_core/swarm.v:165-198` `swarm_recipes` and `267-400` `swarm_start` never set budget:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:267-345 swarm_start excerpt
fn swarm_start(ws string, opts SwarmOptions) SwarmReport {
    recipe := if opts.recipe.len > 0 { opts.recipe } else { 'pair' }
    // ... validate recipe/backends/runner/model_profile
    rid := swarm_new_run_id()
    if opts.dry_run { return SwarmReport{message: '[swarm] dry-run ... roles: ${swarm_recipe_roles(recipe).join(', ')}'} }
    run_dir := swarm_run_dir(ws, rid)
    ensure_swarm_run_dirs(run_dir) or { return err }
    initial := if swarm_require_plan_approval(recipe) { 'awaiting_plan_approval' } else { 'running' }
    st := SwarmStateFile{version: 1, run_id: rid, recipe: recipe, backend: backend, runner: runner, run_state: initial, created_at: time.utc().format_rfc3339(), task: opts.task} // no budget
    write_swarm_state(run_dir, st) or { return err }
    write_swarm_approvals(run_dir, swarm_default_gates(recipe)) or { return err }
    append_swarm_trace(run_dir, 'run_created', rid) // no budget trace
    // ... herdr spawn
    return SwarmReport{message: '[swarm] started ${rid} recipe=${recipe} ... state=${initial}'}
}
```

- `modules/agent_toolkit_core/swarm.v:542-582` `swarm_status` no budget:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:542-582 minimal status
fn swarm_status(ws string, opts SwarmOptions) SwarmReport {
    st := read_swarm_state(rd) or { return not found }
    gates := read_swarm_approvals(rd)
    mut gtxt := []string{}; for g in gates { gtxt << '${g.id}:${if g.approved {'approved'} else {'pending'}}' }
    return SwarmReport{message: 'run ${st.run_id} recipe=${st.recipe} backend=${st.backend} state=${st.run_state}\ngates: ${gtxt.join(', ')}'} // no budget/handoffs/worktrees
}
```

**CLI proof:**
```bash
grep -n "budget\|900_000\|max_total_tokens" modules/agent_toolkit_core/swarm*.v 2>&1 | head -n 20
# only swarm_state.v:29 budget_exhausted string, no numeric budget
cat .agent-toolkit/swarm/runs/s*/state.json 2>&1 | jq .budget 2>&1 | head -n 5  # null (bug)
build/agent-toolkit swarm recipes --json 2>&1 | head -n 20  # only names+desc, no budget
```

### Expected behavior

```bash
# Playground /tmp/my-project
cd /tmp/my-project
rm -rf .agent-toolkit/swarm/runs/s* 2>&1 | head

# 1. Budget populated in state + recipes --json
agent-toolkit swarm start --recipe pair --backend headless "budget repro" 2>&1 | tail -n 5
rid=$(ls -t .agent-toolkit/swarm/runs | head -n 1)
cat .agent-toolkit/swarm/runs/$rid/state.json | jq .budget 2>&1 | head -n 10
# Expected: {"max_total_tokens":900000,"max_cost_usd":4.0,"max_wall_seconds":7200,"max_concurrency":1}
cat .agent-toolkit/swarm/runs/$rid/state.json | jq .budget_consumed 2>&1 | head -n 5
# Expected: {"total_tokens":0,"total_cost":0}

agent-toolkit swarm recipes --json 2>&1 | head -n 40
# Expected: {"pair":{"budget":{"max_total_tokens":900000,"max_cost_usd":4.0,"max_wall_seconds":7200}}, "team":{...}, "full":{...}}
agent-toolkit swarm recipes pair --json 2>&1 | jq .budget.max_total_tokens | grep -q 900000 && echo "recipes budget ok"

# 2. Status --json includes budget
agent-toolkit swarm status $rid --json 2>&1 | head -n 40
# Expected JSON includes: "budget": {"max_total_tokens":900000,"total_tokens":0,"max_cost_usd":4.0,"total_cost":0,"max_wall_seconds":7200,"wall_seconds":~0}

# 3. Budget exhaustion path (simulate by editing consumed or long wall)
# After fix, writing consumed beyond limit should gate next handoff/create:
echo '{"version":2,"run_id":"sBUDGET","recipe":"pair","run_state":"running","budget":{"max_total_tokens":900000,"max_cost_usd":4.0,"max_wall_seconds":7200},"budget_consumed":{"total_tokens":900001,"total_cost":0}}' > /tmp/fake-state.json
# swarm handoff create --to reviewer should then return budget_exhausted via check_budget

# 4. Recipes differ only by concurrency but share budget (verify)
agent-toolkit swarm recipes --json 2>&1 | jq '.pair.execution.max_concurrency, .full.execution.max_concurrency' | head -n 5
# Expected: 1 and 2 (full has 2), but budgets identical 900k/4.00/7200
```

### Proposed fix

**1. `modules/agent_toolkit_core/swarm_state.v` — `Budget` struct + `recipe_budget()`**

```v
pub struct Budget {
pub mut:
    max_total_tokens int
    max_cost_usd     f64
    max_wall_seconds int
    max_concurrency  int
}
pub fn recipe_budget(recipe string) Budget {
    base := Budget{max_total_tokens: 900_000, max_cost_usd: 4.0, max_wall_seconds: 7200, max_concurrency: 1}
    if recipe == 'full' { return Budget{...base, max_concurrency: 2} }
    return base
}
pub struct BudgetConsumed {
pub mut:
    total_tokens int
    total_cost   f64
}
```

Share across `pair`/`team`/`full`; `max_concurrency` differs (`full` = 2 per `recipes.py:full` spec).

**2. `modules/agent_toolkit_core/swarm.v:34` `SwarmStateFile` — add fields**

```v
struct SwarmStateFile {
    version         int
    run_id          string
    recipe          string
    backend         string
    runner          string
    model_profile   string
    run_state       string
    created_at      string
    task            string
    budget          Budget
    budget_consumed BudgetConsumed
    worktrees       []SwarmWorktree // via P1-03, but budget needs it
}
```

Initialize at `swarm_start:340` as `st := SwarmStateFile{..., budget: recipe_budget(recipe), budget_consumed: BudgetConsumed{}, ...}`.

**3. `modules/agent_toolkit_core/swarm.v` — `fn check_budget(run_dir string) ?string`**

```v
fn check_budget(run_dir string) ?string {
    st := read_swarm_state(run_dir) or { return none }
    wall := int(time.utc().unix - time.parse_iso8601(st.created_at) or { time.utc() }.unix)
    if st.budget_consumed.total_tokens >= st.budget.max_total_tokens || st.budget_consumed.total_cost >= st.budget.max_cost_usd || wall >= st.budget.max_wall_seconds {
        return 'budget_exhausted'
    }
    return none
}
```

Call in `swarm_start` after `write_swarm_state` (guard) and at `handoff create` (P1-07) to flip `run_state` via `swarm_can_transition`.

**4. `swarm_recipes` + `swarm_status` expose budget**

- `swarm_recipes --json` → `json.encode(map[recipe]Budget)` including `budget` + `execution`.
- `swarm_status --json` → `budget: st.budget` + `budget_consumed` + `wall_seconds`.

Gate: `agent-toolkit swarm recipes --json | jq .pair.budget.max_total_tokens` 900000 + `swarm status <id> --json | jq .budget_consumed` present + `budget_exhausted` transition test in `swarm_state_test.v`.

### Severity / Area

- **Severity:** `medium` (P1) — correctness for long/LLM runs but not blocker for skeleton/headless short tasks.
- **Area:** `area:swarm`
- **Kind:** `kind:parity` (regression from `fbb2280` green Budget to V dead `budget_exhausted` edge)
- **Labels:** `area:swarm kind:parity severity:medium`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
rm -rf .agent-toolkit/swarm/runs/s* 2>&1 | head
build/agent-toolkit swarm start --recipe pair --backend headless "repro P1-11 budget" 2>&1 | tail -n 5
cat .agent-toolkit/swarm/runs/$(ls -t .agent-toolkit/swarm/runs | head -n1)/state.json | jq .budget 2>&1 | head -n 10
build/agent-toolkit swarm recipes --json 2>&1 | head -n 40 || echo "no --json (bug)"
grep -n "budget_exhausted\|recipe_budget\|max_total_tokens" modules/agent_toolkit_core/swarm*.v 2>&1 | head -n 20
# BEFORE: no max_total_tokens; AFTER: 900000 + 4.0 + 7200
build/agent-toolkit swarm status $(ls -t .agent-toolkit/swarm/runs | head -n1) --json 2>&1 | head -n 40 || echo "no budget in status (bug)"
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/recipes.py | sed -n '45,110p'`
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/budget.py | cat -n`
- `modules/agent_toolkit_core/swarm_state.v:20` `budget_exhausted` transition + `modules/agent_toolkit_core/swarm.v:34` `SwarmStateFile` (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§3.1 A1.11`, `§4.3 P1-11`.


