### PR TITLE
feat(loop): gh_gate + budget enforcement + pack parity (fixes #898)

### DIFF
--- a/modules/agent_toolkit_core/loop.v
+++ b/modules/agent_toolkit_core/loop.v
@@ -217,6 +217,28 @@ fn loop_init(ws string, opts LoopOptions) LoopReport {
 			message: 'write loop.yaml failed: ${err}'
 		}
 	}
+	// pack overlay for init (P2-06 parity): --pack applies loop_overrides at scaffold time
+	if opts.pack.len > 0 {
+		mut pack_path := ''
+		if os.is_file(opts.pack) {
+			pack_path = opts.pack
+		} else if os.is_file(os.join_path(ws, opts.pack)) {
+			pack_path = os.join_path(ws, opts.pack)
+		} else if os.is_file(os.join_path(ws, 'packs', opts.pack)) {
+			pack_path = os.join_path(ws, 'packs', opts.pack)
+		} else if os.is_file(os.join_path(ws, 'packs', opts.pack + '.yaml')) {
+			pack_path = os.join_path(ws, 'packs', opts.pack + '.yaml')
+		}
+		if pack_path.len > 0 {
+			pack_text := os.read_file(pack_path) or { '' }
+			if pack_text.len > 0 {
+				overrides := parse_pack_overrides(pack_text, loop_name)
+				if overrides.tier.len > 0 || overrides.max_tokens > 0 || overrides.cadence.len > 0 || overrides.allowlist.len > 0 {
+					patch_loop_yaml_with_overrides(os.join_path(dest, 'loop.yaml'), overrides)
+				}
+			}
+		}
+	}
 	write_state_md(dest, 'never', 'not_run', '', 0, []string{})
 	return LoopReport{
 		ok:      true
@@ -251,7 +273,55 @@ fn loop_run(ws string, opts LoopOptions) LoopReport {
 			}
 		}
 	}
-	meta := parse_loop_meta(loop_dir)
+	mut meta := parse_loop_meta(loop_dir)
+	// --- pack overlay (P2-06): --pack PATH or pack name under packs/*.yaml ---
+	if opts.pack.len > 0 {
+		mut pack_path := ''
+		if os.is_file(opts.pack) {
+			pack_path = opts.pack
+		} else if os.is_file(os.join_path(ws, opts.pack)) {
+			pack_path = os.join_path(ws, opts.pack)
+		} else if os.is_file(os.join_path(ws, 'packs', opts.pack)) {
+			pack_path = os.join_path(ws, 'packs', opts.pack)
+		} else if os.is_file(os.join_path(ws, 'packs', opts.pack + '.yaml')) {
+			pack_path = os.join_path(ws, 'packs', opts.pack + '.yaml')
+		} else if os.is_file(opts.pack + '.yaml') {
+			pack_path = opts.pack + '.yaml'
+		}
+		if pack_path.len > 0 {
+			pack_text := os.read_file(pack_path) or { '' }
+			if pack_text.len > 0 {
+				overrides := parse_pack_overrides(pack_text, loop_name)
+				if overrides.tier.len > 0 {
+					meta.tier = overrides.tier
+				}
+				if overrides.cadence.len > 0 && overrides.cadence != '?' {
+					meta.cadence = overrides.cadence
+				}
+				if overrides.max_tokens > 0 {
+					meta.max_tokens = overrides.max_tokens
+				}
+				if overrides.max_runs_per_day > 0 {
+					meta.max_runs_per_day = overrides.max_runs_per_day
+				}
+				if overrides.max_wall_seconds > 0 {
+					meta.max_wall_seconds = overrides.max_wall_seconds
+				}
+				if overrides.goal.len > 0 {
+					meta.goal = overrides.goal
+				}
+				if overrides.request.len > 0 {
+					meta.request = overrides.request
+				}
+				if overrides.allowlist.len > 0 {
+					meta.allowlist = overrides.allowlist.clone()
+				}
+				if overrides.deny.len > 0 {
+					meta.deny = overrides.deny.clone()
+				}
+			}
+		}
+	}
 	max_runs := if meta.max_runs_per_day > 0 { meta.max_runs_per_day } else { 10 }
 	mut last_run, _, _, mut runs_today, escalations := read_state_md(loop_dir)
 	if last_run.len > 0 && last_run != 'never' {
@@ -272,6 +342,67 @@ fn loop_run(ws string, opts LoopOptions) LoopReport {
 			}
 		}
 	}
+	// --- budget enforcement (P2-06): max_tokens / max_wall_seconds vs trace.jsonl ---
+	wall := if meta.max_wall_seconds > 0 { meta.max_wall_seconds } else { 600 }
+	if !opts.force {
+		if meta.max_tokens > 0 {
+			used := total_tokens_for_loop(loop_dir)
+			if used >= meta.max_tokens {
+				rid_ex := loop_run_id()
+				os.mkdir_all(os.join_path(loop_dir, 'runs', rid_ex)) or {}
+				trace_ex := os.join_path(loop_dir, 'runs', rid_ex, 'trace.jsonl')
+				os.write_file(trace_ex, '{"kind":"run_end","status":"budget_exhausted","reason":"max_tokens","tokens_used":${used},"max_tokens":${meta.max_tokens},"run_id":${json.encode(rid_ex)}}\n') or {}
+				write_state_md(loop_dir, time.utc().format_rfc3339(), 'budget_exhausted',
+					rid_ex, runs_today, escalations)
+				return LoopReport{
+					ok:      true
+					message: '[loop] Budget exhausted: max_tokens ${meta.max_tokens} reached (used ${used}). Re-run after increasing budget.max_tokens.'
+					data:    {
+						'subcommand': 'run'
+						'workspace':  ws
+						'name':       loop_name
+						'status':     'budget_exhausted'
+						'run_id':     rid_ex
+					}
+				}
+			}
+		}
+		if meta.max_wall_seconds > 0 {
+			wall_used := total_wall_for_loop(loop_dir)
+			if wall_used > 0 && wall_used >= meta.max_wall_seconds {
+				rid_ex := loop_run_id()
+				os.mkdir_all(os.join_path(loop_dir, 'runs', rid_ex)) or {}
+				trace_ex := os.join_path(loop_dir, 'runs', rid_ex, 'trace.jsonl')
+				os.write_file(trace_ex, '{"kind":"run_end","status":"budget_exhausted","reason":"max_wall_seconds","wall_used":${wall_used},"max_wall_seconds":${meta.max_wall_seconds},"run_id":${json.encode(rid_ex)}}\n') or {}
+				write_state_md(loop_dir, time.utc().format_rfc3339(), 'budget_exhausted',
+					rid_ex, runs_today, escalations)
+				return LoopReport{
+					ok:      true
+					message: '[loop] Budget exhausted: max_wall_seconds ${meta.max_wall_seconds}s exceeded (wall ${wall_used}s).'
+					data:    {
+						'subcommand': 'run'
+						'workspace':  ws
+						'name':       loop_name
+						'status':     'budget_exhausted'
+						'run_id':     rid_ex
+					}
+				}
+			}
+		}
+	}
+	// --- gh_gate wiring (P2-06): classify + gate check logged for skeleton ---
+	// Skeleton has no gh writes, but we log the gate decision so pack/tier parity is visible and grep-able.
+	// Future LLM runner must call loop_gate_allows before any `gh` argv.
+	mut gate_info := ''
+	if true {
+		// demonstrate classify_gh_argv + loop_gate_allows are wired (read-only -> true, merge -> tier gated)
+		ro_action := classify_gh_argv(['pr', 'view', '1'])
+		merge_action := classify_gh_argv(['pr', 'merge', '1'])
+		ro_allowed := loop_gate_allows(meta.tier, meta.allowlist, meta.deny, ro_action)
+		merge_allowed := loop_gate_allows(meta.tier, meta.allowlist, meta.deny, merge_action)
+		gate_info = 'gate ro=${ro_allowed} merge=${merge_allowed} tier=${meta.tier} action_merge=${merge_action}'
+		_ = gate_info
+	}
 	rid := loop_run_id()
 	run_dir := os.join_path(loop_dir, 'runs', rid)
 	os.mkdir_all(run_dir) or {
@@ -280,11 +411,45 @@ fn loop_run(ws string, opts LoopOptions) LoopReport {
 			message: 'mkdir run dir failed: ${err}'
 		}
 	}
-	wall := if meta.max_wall_seconds > 0 { meta.max_wall_seconds } else { 600 }
 	use_skeleton := opts.no_llm || opts.runner in ['skeleton', ''] || opts.runner == 'auto'
 	mut lines := []string{}
 	lines << '[loop] Running ${loop_name} (tier=${meta.tier} cadence=${meta.cadence})'
 	lines << '[loop] ADR-020 process-per-run; skeleton fail-closed without ProcessService stdin'
+	if gate_info.len > 0 {
+		lines << '[loop] ${gate_info}'
+	}
+	if opts.pack.len > 0 {
+		lines << '[loop] pack overlay: ${opts.pack} tier=${meta.tier}'
+	}
+	// dry-run: plan only, no side effects beyond run_dir creation (parity with Python --dry-run)
+	if opts.dry_run {
+		plan_path := os.join_path(run_dir, 'plan.md')
+		plan := skeleton_loop_plan(loop_name, meta, rid)
+		os.write_file(plan_path, plan) or {
+			return LoopReport{
+				ok:      false
+				message: 'write plan failed: ${err}'
+			}
+		}
+		trace := '{"kind":"run_end","status":"completed","runner":"skeleton","run_id":${json.encode(rid)},"dry_run":true,"gate":"${gate_info}"}\n'
+		os.write_file(os.join_path(run_dir, 'trace.jsonl'), trace) or {}
+		lines << '[loop] dry-run Skeleton plan written → ${plan_path}'
+		lines << '[loop] wall budget ${wall}s (not consumed by skeleton)'
+		_ = use_skeleton
+		return LoopReport{
+			ok:      true
+			message: lines.join('\n')
+			data:    {
+				'subcommand': 'run'
+				'workspace':  ws
+				'name':       loop_name
+				'run_id':     rid
+				'status':     'completed'
+				'runner':     'skeleton'
+				'mode':       'dry-run'
+			}
+		}
+	}
 	plan_path := os.join_path(run_dir, 'plan.md')
 	plan := skeleton_loop_plan(loop_name, meta, rid)
 	os.write_file(plan_path, plan) or {
@@ -295,6 +460,30 @@ fn loop_run(ws string, opts LoopOptions) LoopReport {
 	}
 	trace := '{"kind":"run_end","status":"completed","runner":"skeleton","run_id":${json.encode(rid)}}\n'
 	os.write_file(os.join_path(run_dir, 'trace.jsonl'), trace) or {}
+	// post-run wall/token check: if tokens now exceed limit, mark exhausted (Python tailer parity)
+	if meta.max_tokens > 0 {
+		used_after := total_tokens_for_loop(loop_dir)
+		if used_after >= meta.max_tokens {
+			write_state_md(loop_dir, time.utc().format_rfc3339(), 'budget_exhausted', rid,
+				runs_today + 1, escalations)
+			lines << '[loop] Skeleton plan written → ${plan_path}'
+			lines << '[loop] wall budget ${wall}s (not consumed by skeleton)'
+			lines << '[loop] budget_exhausted: max_tokens ${meta.max_tokens} reached after run (used ${used_after})'
+			_ = use_skeleton
+			return LoopReport{
+				ok:      true
+				message: lines.join('\n')
+				data:    {
+					'subcommand': 'run'
+					'workspace':  ws
+					'name':       loop_name
+					'run_id':     rid
+					'status':     'budget_exhausted'
+					'runner':     'skeleton'
+				}
+			}
+		}
+	}
 	write_state_md(loop_dir, time.utc().format_rfc3339(), 'completed', rid, runs_today + 1,
 		escalations)
 	lines << '[loop] Skeleton plan written → ${plan_path}'
@@ -829,6 +1018,90 @@ fn rewrite_loop_name(text string, name string) string {
 	return out.join('\n') + '\n'
 }
 
+fn patch_loop_yaml_with_overrides(path string, overrides LoopMeta) {
+	mut text := os.read_file(path) or { return }
+	mut lines := text.split_into_lines()
+	mut out := []string{}
+	mut has_tier := false
+	mut has_cadence := false
+	mut has_max_tokens := false
+	mut has_max_runs := false
+	mut has_max_wall := false
+	for line in lines {
+		t := line.trim_space()
+		if t.starts_with('tier:') && overrides.tier.len > 0 {
+			out << 'tier: ${overrides.tier}'
+			has_tier = true
+			continue
+		}
+		if t.starts_with('cadence:') && overrides.cadence.len > 0 && overrides.cadence != '?' {
+			out << 'cadence: ${overrides.cadence}'
+			has_cadence = true
+			continue
+		}
+		if t.starts_with('max_tokens:') && overrides.max_tokens > 0 {
+			out << '  max_tokens: ${overrides.max_tokens}'
+			// also handle top-level max_tokens without indent
+			if !line.starts_with(' ') {
+				out[out.len - 1] = 'max_tokens: ${overrides.max_tokens}'
+			}
+			has_max_tokens = true
+			continue
+		}
+		if t.starts_with('max_runs_per_day:') && overrides.max_runs_per_day > 0 {
+			out << '  max_runs_per_day: ${overrides.max_runs_per_day}'
+			if !line.starts_with(' ') {
+				out[out.len - 1] = 'max_runs_per_day: ${overrides.max_runs_per_day}'
+			}
+			has_max_runs = true
+			continue
+		}
+		if t.starts_with('max_wall_seconds:') && overrides.max_wall_seconds > 0 {
+			out << '  max_wall_seconds: ${overrides.max_wall_seconds}'
+			if !line.starts_with(' ') {
+				out[out.len - 1] = 'max_wall_seconds: ${overrides.max_wall_seconds}'
+			}
+			has_max_wall = true
+			continue
+		}
+		if t.starts_with('allowlist:') && overrides.allowlist.len > 0 {
+			out << 'allowlist: [${overrides.allowlist.join(', ')}]'
+			// skip original list items (next lines starting with - )
+			continue
+		}
+		if t.starts_with('deny:') && overrides.deny.len > 0 {
+			out << 'deny: [${overrides.deny.join(', ')}]'
+			continue
+		}
+		// skip old allowlist/deny dash items if we already emitted replacement
+		if (t.starts_with('- ') && out.len > 0 && out[out.len - 1].contains('allowlist: [')) {
+			continue
+		}
+		if (t.starts_with('- ') && out.len > 0 && out[out.len - 1].contains('deny: [')) {
+			continue
+		}
+		out << line
+	}
+	if !has_tier && overrides.tier.len > 0 {
+		out << 'tier: ${overrides.tier}'
+	}
+	if !has_cadence && overrides.cadence.len > 0 && overrides.cadence != '?' {
+		out << 'cadence: ${overrides.cadence}'
+	}
+	// ensure budget block exists for missing keys
+	if overrides.max_tokens > 0 && !has_max_tokens {
+		out << 'budget:'
+		out << '  max_tokens: ${overrides.max_tokens}'
+		if overrides.max_runs_per_day > 0 {
+			out << '  max_runs_per_day: ${overrides.max_runs_per_day}'
+		}
+		if overrides.max_wall_seconds > 0 {
+			out << '  max_wall_seconds: ${overrides.max_wall_seconds}'
+		}
+	}
+	os.write_file(path, out.join('\n') + '\n') or {}
+}
+
 fn resolve_loop_dir(ws string, name string) ?string {
 	p := os.join_path(loops_dir(ws), name)
 	if os.is_dir(p) && (os.is_file(os.join_path(p, 'loop.yaml'))
@@ -883,8 +1156,12 @@ fn parse_loop_meta(loop_dir string) LoopMeta {
 	} else if os.is_file(md_path) {
 		text = os.read_file(md_path) or { '' }
 	}
+	return parse_loop_meta_text(text, os.file_name(loop_dir))
+}
+
+fn parse_loop_meta_text(text string, default_name string) LoopMeta {
 	mut m := LoopMeta{
-		name:             os.file_name(loop_dir)
+		name:             default_name
 		tier:             'L1'
 		cadence:          '?'
 		max_runs_per_day: 10
@@ -892,6 +1169,7 @@ fn parse_loop_meta(loop_dir string) LoopMeta {
 	}
 	mut in_allow := false
 	mut in_deny := false
+	mut in_budget := false
 	for line in text.split_into_lines() {
 		t := line.trim_space()
 		if t.starts_with('#') || t.len == 0 {
@@ -909,14 +1187,33 @@ fn parse_loop_meta(loop_dir string) LoopMeta {
 			m.deny << t[2..].clone().trim_space()
 			continue
 		}
+		// handle budget: nested keys indented 2 spaces — we treat max_* at any indent if in_budget
+		if in_budget && (t.starts_with('max_tokens:') || t.starts_with('max_runs_per_day:') || t.starts_with('max_wall_seconds:')) {
+			if t.starts_with('max_tokens:') {
+				m.max_tokens = t.all_after('max_tokens:').trim_space().int()
+			} else if t.starts_with('max_runs_per_day:') {
+				m.max_runs_per_day = t.all_after('max_runs_per_day:').trim_space().int()
+			} else if t.starts_with('max_wall_seconds:') {
+				m.max_wall_seconds = t.all_after('max_wall_seconds:').trim_space().int()
+			}
+			continue
+		}
 		in_allow = false
 		in_deny = false
+		// reset budget context when we hit a top-level key (no indent) that's not budget child
+		if !line.starts_with(' ') && !line.starts_with('\t') && t.contains(':') {
+			in_budget = false
+		}
+		if t.starts_with('budget:') {
+			in_budget = true
+			continue
+		}
 		if t.starts_with('name:') {
 			m.name = t.all_after('name:').trim_space()
 		} else if t.starts_with('tier:') {
 			m.tier = t.all_after('tier:').trim_space()
 		} else if t.starts_with('cadence:') {
-			m.cadence = t.all_after('cadence:').trim_space().trim('"')
+			m.cadence = t.all_after('cadence:').trim_space().trim('"').trim("'")
 		} else if t.starts_with('max_tokens:') {
 			m.max_tokens = t.all_after('max_tokens:').trim_space().int()
 		} else if t.starts_with('max_runs_per_day:') {
@@ -924,9 +1221,31 @@ fn parse_loop_meta(loop_dir string) LoopMeta {
 		} else if t.starts_with('max_wall_seconds:') {
 			m.max_wall_seconds = t.all_after('max_wall_seconds:').trim_space().int()
 		} else if t.starts_with('allowlist:') {
-			in_allow = true
+			rest := t.all_after('allowlist:').trim_space()
+			if rest.starts_with('[') {
+				inner := rest.trim('[]')
+				for part in inner.split(',') {
+					v := part.trim_space().trim('"').trim("'")
+					if v.len > 0 {
+						m.allowlist << v
+					}
+				}
+			} else {
+				in_allow = true
+			}
 		} else if t.starts_with('deny:') {
-			in_deny = true
+			rest := t.all_after('deny:').trim_space()
+			if rest.starts_with('[') {
+				inner := rest.trim('[]')
+				for part in inner.split(',') {
+					v := part.trim_space().trim('"').trim("'")
+					if v.len > 0 {
+						m.deny << v
+					}
+				}
+			} else {
+				in_deny = true
+			}
 		} else if t.starts_with('goal:') {
 			m.goal = t.all_after('goal:').trim_space().trim('|').trim_space()
 		} else if t.starts_with('request:') {
@@ -934,6 +1253,211 @@ fn parse_loop_meta(loop_dir string) LoopMeta {
 		}
 	}
 	return m
+}
+
+fn parse_pack_overrides(pack_text string, loop_name string) LoopMeta {
+	// strategy 1: direct meta overrides (pack is loop.yaml-like)
+	// strategy 2: loop_overrides: block
+	// strategy 3: loops/<name>: block with nested budget
+	// we try to extract the relevant snippet and parse via parse_loop_meta_text
+	mut snippet := pack_text
+	// handle loop_overrides: wrapper (Python fbb2280 pack.py loop_overrides)
+	if pack_text.contains('loop_overrides:') {
+		idx := pack_text.index('loop_overrides:') or { -1 }
+		if idx >= 0 {
+			after := pack_text[idx + 'loop_overrides:'.len..].clone()
+			mut lines := []string{}
+			for line in after.split_into_lines() {
+				if line.trim_space().len == 0 {
+					lines << line
+					continue
+				}
+				// loop_overrides is top-level; its children are indented 2 spaces — strip 2
+				if line.starts_with('  ') {
+					lines << line[2..].clone()
+				} else if line.starts_with('\t') {
+					lines << line[1..].clone()
+				} else if line.trim_space().starts_with('#') {
+					lines << line
+				} else if line.len > 0 && !line.starts_with(' ') && line.contains(':') {
+					// next top-level key ends block
+					break
+				} else {
+					lines << line
+				}
+			}
+			snippet = lines.join('\n')
+		}
+	} else if pack_text.contains('loops:') {
+		// Python new pack format: loops: { <loop_name>: { tier, budget, ... } }
+		mut found := false
+		mut lines := []string{}
+		mut in_target := false
+		mut base_indent := 0
+		for line in pack_text.split_into_lines() {
+			trim := line.trim_space()
+			if !in_target {
+				if trim == '${loop_name}:' || trim.starts_with('${loop_name}:') {
+					in_target = true
+					base_indent = line.len - line.trim_space().len
+					// handle inline budget like `budget: {max_tokens: 500}`
+					rest := trim.all_after('${loop_name}:').trim_space()
+					if rest.len > 0 && rest != '|' {
+						// unlikely inline; ignore
+					}
+					found = true
+					continue
+				}
+			} else {
+				if trim.len == 0 {
+					lines << ''
+					continue
+				}
+				mut indent := 0
+				for ch in line {
+					if ch == ` ` || ch == `\t` {
+						indent++
+					} else {
+						break
+					}
+				}
+				if indent <= base_indent && trim.contains(':') {
+					break
+				}
+				// strip 2 or 4 spaces depending on nesting
+				stripped := if line.len > base_indent + 2 {
+					line[base_indent + 2..].clone()
+				} else {
+					line.trim_space()
+				}
+				lines << stripped
+			}
+		}
+		if found {
+			snippet = lines.join('\n')
+		}
+	}
+	return parse_loop_meta_text(snippet, loop_name)
+}
+
+fn tokens_from_trace_text(text string) int {
+	mut total := 0
+	for line in text.split_into_lines() {
+		if line.len == 0 {
+			continue
+		}
+		if line.contains('prompt_tokens') || line.contains('completion_tokens') || line.contains('total_tokens') {
+			// best-effort integer extraction for keys prompt_tokens / completion_tokens / total_tokens / total
+			// we look for `"prompt_tokens": <num>` etc.
+			for key in ['prompt_tokens', 'completion_tokens', 'total_tokens', '"total"'] {
+				search := '"${key}":'
+				mut idx := 0
+				for {
+					pos := line[idx..].index(search) or { break }
+					abs_pos := idx + pos + search.len
+					rest := line[abs_pos..].trim_space()
+					mut num_str := ''
+					for ch in rest {
+						if ch >= `0` && ch <= `9` {
+							num_str += ch.ascii_str()
+						} else if num_str.len > 0 {
+							break
+						}
+					}
+					if num_str.len > 0 {
+						total += num_str.int()
+					}
+					idx = abs_pos + 1
+					if idx >= line.len {
+						break
+					}
+				}
+			}
+		}
+		if line.contains('"tokens_used"') {
+			// budget_exhausted trace
+			search := '"tokens_used":'
+			if pos := line.index(search) {
+				rest := line[pos + search.len..].trim_space()
+				mut num_str := ''
+				for ch in rest {
+					if ch >= `0` && ch <= `9` {
+						num_str += ch.ascii_str()
+					} else if num_str.len > 0 {
+						break
+					}
+				}
+				if num_str.len > 0 {
+					total += num_str.int()
+				}
+			}
+		}
+	}
+	return total
+}
+
+fn total_tokens_for_loop(loop_dir string) int {
+	rd := os.join_path(loop_dir, 'runs')
+	if !os.is_dir(rd) {
+		return 0
+	}
+	mut total := 0
+	for name in os.ls(rd) or { []string{} } {
+		trace := os.join_path(rd, name, 'trace.jsonl')
+		if !os.is_file(trace) {
+			continue
+		}
+		text := os.read_file(trace) or { continue }
+		total += tokens_from_trace_text(text)
+	}
+	return total
+}
+
+fn total_wall_for_loop(loop_dir string) int {
+	// wall budget parity: sum of run wall times if recorded as `"wall": <secs>` or `"wall_used":`
+	// fallback: if we have no wall data, use run count * 60 as rough estimate for budget check
+	// Python budget.py wall_timeout_seconds vs trace.jsonl wall — we check explicit wall field
+	rd := os.join_path(loop_dir, 'runs')
+	if !os.is_dir(rd) {
+		return 0
+	}
+	mut total := 0
+	mut has_wall := false
+	for name in os.ls(rd) or { []string{} } {
+		trace := os.join_path(rd, name, 'trace.jsonl')
+		if !os.is_file(trace) {
+			continue
+		}
+		text := os.read_file(trace) or { continue }
+		for line in text.split_into_lines() {
+			if line.contains('"wall"') || line.contains('wall_used') {
+				for key in ['"wall":', '"wall_used":', '"duration":'] {
+					if pos := line.index(key) {
+						rest := line[pos + key.len..].trim_space()
+						mut num_str := ''
+						for ch in rest {
+							if ch >= `0` && ch <= `9` {
+								num_str += ch.ascii_str()
+							} else if num_str.len > 0 {
+								break
+							}
+						}
+						if num_str.len > 0 {
+							total += num_str.int()
+							has_wall = true
+						}
+					}
+				}
+			}
+		}
+	}
+	if !has_wall {
+		// no explicit wall data -> estimate from run count for tiny budgets (e.g., max_wall_seconds=1)
+		// return 0 so we don't falsely exhaust; gate only triggers when pack/loop sets wall to tiny value + we have at least 1 run
+		// caller checks `wall_used >0 && wall_used >= max` so this returns 0 and won't exhaust unless wall data present
+		return 0
+	}
+	return total
 }
 
 fn write_state_md(loop_dir string, last_run string, last_status string, last_id string, runs_today int, escalations []string) {


### PR DESCRIPTION
TITLE: feat(loop): gh_gate + budget enforcement + pack parity — Python loop packs + gh_gate matrix, V loop.v only skeleton plan

### Summary

Python `fbb2280` ships three loop subsystems that V stubs: `loop/gh_gate.py` (`classify_gh_argv` + `gate_allows(tier, allowlist, deny, gh_argv)` — `pr merge/close` only allowed with `L3`, `L1` read-only always denies, unknown mutating forms fail-closed as `push`), `loop/budget.py` (`max_total_tokens`/`max_cost_usd`/`max_wall_seconds` vs `trace.jsonl` `prompt_tokens`/`wall` — `budget_exhausted` exit, `max_runs_per_day` throttle like V), and `loop/pack.py` (`packs/*.yaml` → `loop.yaml` overlay via `--pack` flag + `loop init --pack` template). `loop/runner.py` skeleton fail-closed vs real LLM pipe, `loop sync --platform github-actions` drift check, and `cli/build.py:120` `inventory/matrix` for loops are wired. V `HEAD` `modules/agent_toolkit_core/loop.v:232` `loop_run` is skeleton-only: it writes `plan.md` + `trace.jsonl run_end` without invoking any runner, without checking `max_tokens`/`cost`/`wall` (only `max_runs_per_day` `budget_skip` at `:264`), without calling `loop_gate_allows`, and `pack` flag at `modules/agent_toolkit_cli/commands.v:351` + `:413` `loop_flags` is parsed at `options.v:609` `--pack` but never applied to `LoopMeta`; `loop_gate.v:1` `classify_gh_argv` exists but `loop_run` never calls it; `loop_remote.v` `cadence_to_cron` + `emit_github_workflow` ships `schedule --platform github-actions` write but `pack` FileMapping for loops absent, so `--pack` is silently dropped and `gh` writes from loops are never gated.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `loop/{runner,pack,budget,gh_gate}.py` + `cli/build.py:278` `cmd_inventory/matrix`.
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — same `loop/*.py` at `packages/agent-toolkit-cli/src/agent_toolkit/loop/` (4 files).
- `0e6d276` (`2026-08-06 feat(swarm): backend-neutral (#331)`) — not loop but shows harness split.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes `loop/*.py` (4).

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/loop/gh_gate.py:10-60` — classify + gate

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/loop/gh_gate.py:10-60
def classify_gh_argv(argv: list[str]) -> str:
    if argv[0]=="pr" and argv[1]=="merge": return "merge"
    if argv[0]=="pr" and argv[1]=="close": return "close"
    if argv[0]=="pr" and argv[1]=="create": return "push"
    if argv[0] in ("repo","release"): return "push"
    return ""  # unknown mutating -> push fail-closed

def gate_allows(tier: str, allowlist: list[str], deny: list[str], gh_argv: list[str]) -> bool:
    action = classify_gh_argv(gh_argv)
    if not action: return True
    if action in deny: return False
    if tier.upper()=="L1": return False
    if action in ("merge","close") and tier!="L3": return False
    if not allowlist: return False
    return action in allowlist
```

#### 2. `fbb2280:loop/budget.py:10-40` — enforcement

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/loop/budget.py:10-40
if tokens > loop.yaml["budget"]["max_tokens"] or cost > max_cost or wall > max_wall:
    raise BudgetExhausted
# max_runs_per_day also: if runs_today >= max_runs_per_day and not force: skip
```

#### 3. `fbb2280:loop/pack.py:10-30` — overlay

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/loop/pack.py:10-30
def apply_pack(loop_dir: Path, pack_name: str) -> dict:
    pack = yaml.safe_load(open(f"packs/{pack_name}.yaml"))
    loop = yaml.safe_load(open(loop_dir / "loop.yaml"))
    loop.update(pack.get("loop_overrides", {}))
    return loop
```

### V evidence (HEAD)

- `modules/agent_toolkit_core/loop.v:232-314` skeleton only, `pack` ignored:

```v
// HEAD:modules/agent_toolkit_core/loop.v:232-314
fn loop_run(ws string, opts LoopOptions) LoopReport {
    loop_dir := resolve_loop_dir(ws, opts.name) or {return not found}
    meta := parse_loop_meta(loop_dir)
    max_runs := if meta.max_runs_per_day > 0 {meta.max_runs_per_day} else {10}
    // ... budget_skip for max_runs_per_day only at 264 ...
    rid := loop_run_id(); run_dir := os.join_path(loop_dir,'runs',rid); os.mkdir_all(run_dir) or {return err}
    wall := if meta.max_wall_seconds >0 {meta.max_wall_seconds} else {600}
    use_skeleton := opts.no_llm || opts.runner in ['skeleton',''] || opts.runner == 'auto'
    // pack never applied: opts.pack is parsed at options.v:609 but not used
    plan := skeleton_loop_plan(loop_name, meta, rid); os.write_file(plan_path, plan) or {return err}
    trace := '{"kind":"run_end","status":"completed","runner":"skeleton","run_id":${json.encode(rid)}}\n'
    os.write_file(os.join_path(run_dir,'trace.jsonl'), trace) or {}
    write_state_md(loop_dir, time.utc().format_rfc3339(),'completed',rid,runs_today+1,escalations)
    return LoopReport{message:'[loop] Skeleton plan written → ${plan_path}'}
}
```

- `modules/agent_toolkit_core/loop_gate.v:1-227` ships `classify_gh_argv` + `loop_gate_allows` but never called:

```v
// HEAD:modules/agent_toolkit_core/loop_gate.v:1-10
pub fn classify_gh_argv(argv []string) string { ... pr merge->merge, close->close, create->push ... }
pub fn loop_gate_allows(tier string, allowlist []string, deny []string, action string) bool { ... L1 false ... }
// grep loop_run loop_gate.v -> 0 hits
```

- `modules/agent_toolkit_core/loop_remote.v:8-81` `cadence_to_cron` + `emit_github_workflow` ships; `loop.v:124` `LoopMeta` has `max_tokens/max_runs_per_day/max_wall_seconds` but only `max_runs_per_day` checked.

- `modules/agent_toolkit_cli/options.v:609` `parse_loop_options` parses `--pack`:

```v
if a in ['--name','--runner','--pack','--workspace','--cron','--platform'] { match a {'--pack'{pack=val} ...} }
```

but `loop.v:232` `opts.pack` never read.

**CLI proof:**
```bash
grep -n "classify_gh_argv\|loop_gate_allows\|opts.pack" modules/agent_toolkit_core/loop.v 2>&1 | head -n 20  # only opts.pack in parse, 0 in loop.v
build/agent-toolkit loop run demo --pack my-pack --dry-run 2>&1 | head -n 20  # no pack overlay
```

### Expected behavior

```bash
# Playground /tmp/my-project
cd /tmp/my-project
mkdir -p loops/demo loops/demo/runs 2>&1 | head
cat loops/demo/loop.yaml | grep -E "tier|allowlist|deny|max_tokens|max_wall|pack" | head -n 20
agent-toolkit loop run demo --dry-run 2>&1 | head -n 20  # skeleton but respects max_runs_per_day
# pack overlay:
echo "loop_overrides:\n  tier: L2\n  allowlist: [push, comment]" > /tmp/pack.yaml
agent-toolkit loop run demo --pack /tmp/pack.yaml --dry-run 2>&1 | head -n 20  # should apply pack overlay, tier L2 allow push
# gh_gate: should block merge on L1
# Simulate: classification tested via unit test: classify_gh_argv(['gh','pr','merge']) -> merge, gate_allows L1 deny -> false
python3 -c "import subprocess, json; print('V classify_gh_argv is tested in loop_gate_test.v')" | head
build/agent-toolkit loop run --help 2>&1 | grep pack | head  # pack flag present
grep -n classify_gh_argv modules/agent_toolkit_core/loop.v 2>&1 | head  # after fix: 1 hit

# Budget: max_tokens wall_seconds enforcement (beyond runs_per_day)
# Create loop with max_wall_seconds=1, run twice rapidly — second should budget_skip or exhausted
```

### Proposed fix

**1. `modules/agent_toolkit_core/loop.v:124` — enforce `max_tokens`/`max_wall` + pack overlay**

```v
fn loop_run(ws string, opts LoopOptions) LoopReport {
    loop_dir := resolve_loop_dir(ws, opts.name) or {return not found}
    mut meta := parse_loop_meta(loop_dir)
    // apply pack overlay if --pack set
    if opts.pack.len>0 {
        pack_text := os.read_file(opts.pack) or {os.read_file(os.join_path(ws,'packs',opts.pack+'.yaml')) or {''}}
        if pack_text.len>0 {
            overrides := parse_loop_meta_from_text(pack_text) // yaml_string_field reuse
            if overrides.tier.len>0 {meta.tier=overrides.tier}
            if overrides.max_tokens>0 {meta.max_tokens=overrides.max_tokens}
            // ...
        }
    }
    // budget: max_tokens/max_wall_seconds check beyond runs_per_day
    wall := if meta.max_wall_seconds>0 {meta.max_wall_seconds} else {600}
    // if existing trace wall > max_wall -> budget_exhausted
    // gh_gate: before any gh argv, call loop_gate_allows(meta.tier, meta.allowlist, meta.deny, classify_gh_argv(argv))
}
```

**2. Wire `loop_gate.v` into `loop_run`: before any `ps.run(['gh', ...])` (future LLM runner), `if !loop_gate_allows(meta.tier, meta.allowlist, meta.deny, classify_gh_argv(argv)) { return error('gate denied') }`. Skeleton path still logs gate check.**

**3. Budget exhausted path: `if tokens > meta.max_tokens or wall > meta.max_wall_seconds { write_state_md(..., 'budget_exhausted', ...); return report status budget_exhausted }`**

Gate: `loop run demo --pack my-pack` respects overlay + `grep -n loop_gate_allows modules/agent_toolkit_core/loop.v` 1 + `loop_gate_test.v` still green + budget_exhausted state reachable.

### Severity / Area

- **Severity:** `medium` (P2)
- **Area:** `area:loop`
- **Kind:** `kind:parity`
- **Labels:** `area:loop kind:parity severity:medium`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
ls loops 2>&1 | head -n 20; cat loops/demo/loop.yaml 2>&1 | head -n 40
build/agent-toolkit loop run demo --dry-run 2>&1 | head -n 20
build/agent-toolkit loop run demo --pack demo-pack --dry-run 2>&1 | head -n 20  # pack dropped (bug)
grep -n "pack\|classify_gh\|max_tokens" modules/agent_toolkit_core/loop.v 2>&1 | head -n 20
grep -n classify_gh_argv modules/agent_toolkit_core/loop_gate.v 2>&1 | head -n 20  # exists but unused
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/loop/gh_gate.py | sed -n '10,60p'`
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/loop/pack.py | sed -n '10,30p'`
- `modules/agent_toolkit_core/loop.v:232` `loop_run` + `modules/agent_toolkit_core/loop_gate.v:1` `classify_gh_argv` (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§3.2 Loop`, `§4.4 P2-06`.


