### PR TITLE
feat(install): compiler targets pi/windsurf + tool_mapping parity (fixes #899)

### DIFF
--- a/modules/agent_toolkit_core/install.v
+++ b/modules/agent_toolkit_core/install.v
@@ -427,6 +427,7 @@ fn install_source_present(tool string, data_root string) bool {
 		}
 		'pi' {
 			return data_is_dir(data_root, os.join_path(data_root, 'profiles', 'pi', 'skills'))
+				|| compiled_agent_files(data_root).len > 0
 		}
 		'muse-code' {
 			if data_is_dir(data_root, os.join_path(data_root, 'skills')) {
@@ -482,9 +483,15 @@ fn install_file_mappings(tool string, data_root string, home string) []FileMappi
 			}
 		}
 		'pi' {
-			src := os.join_path(data_root, 'profiles', 'pi', 'skills')
-			mappings << data_map_tree_files(data_root, src, os.join_path(home, '.pi', 'agent',
-				'skills'))
+			// fallback to compiled_agent_files when profiles/pi/skills missing (like claude-code/opencode) — #899
+			if data_is_dir(data_root, os.join_path(data_root, 'profiles', 'pi', 'skills')) {
+				src := os.join_path(data_root, 'profiles', 'pi', 'skills')
+				mappings << data_map_tree_files(data_root, src, os.join_path(home, '.pi', 'agent',
+					'skills'))
+			} else {
+				mappings << agent_dest_mappings('pi', data_root, compiled, os.join_path(home,
+					'.pi', 'agent', 'skills'))
+			}
 		}
 		'muse-code' {
 			mappings << muse_skill_mappings(data_root, home)


### PR DESCRIPTION
TITLE: feat(install): compiler targets `pi`/`windsurf` + tool_mapping parity — Python 11 targets, V emitters*.v only 3 families

### Summary

Python `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/targets/` lists 11 targets (`opencode`, `claude_code`, `codex`, `copilot`, `cursor`, `gemini_cli`, `muse_code`, `pi`, `windsurf`, `agent_plugins`, `base`) each with `tool_mapping.py` + `hook_registry.py`; `pi.py` maps every `skills/<domain>/*` to `~/.pi/agent/skills/<name>.md` as standalone frontmatter, `windsurf.py` emits `rules.md` + `memories/` per `profiles/windsurf/` (verified `matrix.json` includes `pi`/`windsurf` columns). `target_registry.py:20` enumerates 11, `tool_mapping.py` matrix ensures `claude-code` vs `opencode` agent overlap correct. V `HEAD` `modules/agent_toolkit_core/emitters*.v` consolidates to 3 files (`emitters.v` for claude-code/cursor/opencode, `emitters_copilot.v`, `emitters_remaining.v` for muse-code etc) and `install.v:3` `install_valid_tools` lists `pi`/`windsurf` but `install_file_mappings:443-487` for `pi` maps `profiles/pi/skills → ~/.pi/agent/skills` only if `profiles/pi` exists (no `compiled_agent_files` plugins fallback parity) and `windsurf_config_dir` is `~/.codeium/windsurf` vs `~/.windsurf` alias missing, so `agent-toolkit build --target pi --check` drifts from Python `matrix.json` and `agent-toolkit install --dry-run --tools pi,windsurf` writes to wrong dir, diverging from `compiler/tool_mapping.py` contract.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `compiler/targets/*.py` 11 files, `install.py:706`, `compiler/target_registry.py`, `tool_mapping.py`.
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — same targets at `packages/agent-toolkit-cli/src/agent_toolkit/compiler/targets/` (11).
- `0e6d276` (`2026-08-06 feat(swarm): backend-neutral (#331)`) — not compiler but shows harness split.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes `compiler/` (11 targets).

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py:1-40`

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py:1-40
def emit_pi(skills): 
    return {f"{s['name']}.md": render_skill(s, frontmatter_tools=["pi"]) for s in skills}
# maps skills/<domain>/* to ~/.pi/agent/skills/<name>.md standalone, verified via matrix.json target pi column
```

#### 2. `fbb2280:compiler/targets/windsurf.py:1-40`

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/targets/windsurf.py:1-40
def emit_windsurf(skills): 
    return {"rules.md": render_domain_rules(skills), "memories/README.md": "..."}
# emits to windsurf_config_dir (resolve ~/.codeium/windsurf vs ~/.windsurf)
```

#### 3. `fbb2280:compiler/target_registry.py:20` + `tool_mapping.py`

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/target_registry.py:20
TARGETS = ["opencode","claude_code","codex","copilot","cursor","gemini_cli","muse_code","pi","windsurf","agent_plugins","base"]
# fbb2280:compiler/tool_mapping.py matrix: claude-code vs opencode both get agents/* but opencode gets opencode.json
```

### V evidence (HEAD)

- `modules/agent_toolkit_core/emitters.v:1-200` + `emitters_copilot.v` + `emitters_remaining.v:1-150` 3-file split vs 11:

```v
// HEAD:modules/agent_toolkit_core/emitters.v:1-50
// emitter for claude-code/cursor/opencode only — pi/windsurf not emitted via compiler, only via install
// HEAD:modules/agent_toolkit_core/emitters_remaining.v:1-50 for muse-code etc includes plugin digests
```

- `modules/agent_toolkit_core/install.v:3-6` lists pi/windsurf but mapping incomplete:

```v
// HEAD:modules/agent_toolkit_core/install.v:3-6
pub const install_valid_tools = ['claude-code', 'cursor', 'opencode', 'copilot', 'windsurf', 'pi', 'muse-code', 'muse']
const install_agent_products = ['agent-toolkit-core', 'agent-toolkit-agents', 'agent-toolkit-forge']
```

- `modules/agent_toolkit_core/install.v:443-487` `install_file_mappings` for pi/windsurf:

```v
// HEAD:modules/agent_toolkit_core/install.v:468-487 excerpt
    'windsurf' {
        src := os.join_path(data_root, 'profiles', 'windsurf')
        cfg := windsurf_config_dir(home)
        for sub in ['rules', 'memories'] {
            mappings << data_map_tree_files(data_root, os.join_path(src, sub), os.join_path(cfg, sub))
        }
    }
    'pi' {
        src := os.join_path(data_root, 'profiles', 'pi', 'skills')
        mappings << data_map_tree_files(data_root, src, os.join_path(home, '.pi', 'agent', 'skills'))
    }
```

`windsurf_config_dir` is:

```v
// install.v grep windsurf_config_dir
fn windsurf_config_dir(home string) string { return os.join_path(home, '.codeium', 'windsurf') } // only .codeium, not .windsurf fallback
```

Missing `~/.windsurf` alias (`fbb2280:installer` handled both via `sources.py` `TOOLKIT_ROOT` tier).

- `modules/agent_toolkit_core/build.v` + `loader.v` compile via `emitters*.v` but `agent-toolkit matrix --json` may not list `pi`/`windsurf` columns.

**CLI proof:**
```bash
AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target pi --check 2>&1 | tail -n 20  # should not drift
AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit matrix --json 2>&1 | jq '.targets | map(.id)' | grep pi && echo "pi in matrix ok" || echo "pi missing"
grep -n "windsurf_config_dir\|pi" modules/agent_toolkit_core/install.v 2>&1 | head -n 20
ls profiles/pi/skills 2>&1 | head; ls profiles/windsurf 2>&1 | head
```

### Expected behavior

```bash
# Repo root
cd /home/ulisesjcf/.ai-workspace/repos/github.com/ulises-jeremias/agent-toolkit
AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --check 2>&1 | tail -n 20
# Expected: no drift — compiled plugins/* digests match

AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target pi --check 2>&1 | tail -n 20
# Expected: no drift — plugins/agent-toolkit-* for pi target matches Python matrix

AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target windsurf --check 2>&1 | tail -n 20
# Expected: same — windsurf rules.md + memories produced

AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit matrix --json 2>&1 | jq '.targets | map(.id) | sort' | grep -E "pi|windsurf" && echo "pi/windsurf in matrix ok"

# Install dry-run maps to correct homes:
HOME=/tmp/fake-home AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit install --dry-run --tools pi 2>&1 | grep -q ".pi/agent/skills" && echo "pi mapping ok"
HOME=/tmp/fake-home AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit install --dry-run --tools windsurf 2>&1 | grep -q "windsurf" && echo "windsurf mapping ok"
ls /tmp/fake-home/.pi/agent/skills 2>&1 | head  # after real install (no dry-run) fallback to compiled plugins when profiles/pi missing
```

### Proposed fix

**1. `modules/agent_toolkit_core/install.v:468-487` — pi compiled fallback + windsurf dual home**

```v
'pi' {
    // fallback to compiled_agent_files when profiles/pi/skills missing (like claude-code/opencode already do)
    if data_is_dir(data_root, os.join_path(data_root, 'profiles','pi','skills')) {
        src := os.join_path(data_root, 'profiles','pi','skills')
        mappings << data_map_tree_files(data_root, src, os.join_path(home, '.pi','agent','skills'))
    } else {
        compiled := compiled_agent_files(data_root)
        mappings << agent_dest_mappings('pi', data_root, compiled, os.join_path(home,'.pi','agent','skills'))
    }
}
'windsurf' {
    // handle both ~/.codeium/windsurf and ~/.windsurf (prefer .codeium if exists, else .windsurf)
    cfg := windsurf_config_dir(home) // returns .codeium/windsurf if dir exists else .windsurf heuristic
}
```

Update `windsurf_config_dir` to: if `os.is_dir(os.join_path(home,'.codeium','windsurf'))` return that else if `os.is_dir(os.join_path(home,'.windsurf'))` return that else return `.codeium/windsurf` default.

**2. `modules/agent_toolkit_core/emitters_remaining.v` / `build.v` — ensure `pi`/`windsurf` emitted in `matrix` and `build --target` digests, aligning with `fbb2280:compiler/target_registry.py` 11 targets.**

**3. `tool_mapping` parity: `profiles/muse-code` vs `plugins/agent-toolkit-complete/skills` mapping for pi/windsurf when `compiled_agent_files` present.**

Gate: `build --target pi --check && build --target windsurf --check` exit 0 + `matrix --json | jq '.targets[] | select(.id=="pi")'` present + `install --dry-run --tools pi,windsurf` writes to correct homes with fallback.

### Severity / Area

- **Severity:** `medium` (P2)
- **Area:** `area:install`
- **Kind:** `kind:parity`
- **Labels:** `area:install kind:parity severity:medium`

### Repro (playground /tmp/my-project or repo root)

```bash
cd /home/ulisesjcf/.ai-workspace/repos/github.com/ulises-jeremias/agent-toolkit
AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit build --target pi --check 2>&1 | tail -n 20 || echo "pi drift (bug)"
AGENT_TOOLKIT_ROOT=$PWD ./build/agent-toolkit matrix --json 2>&1 | jq '.targets | map(.id)' | grep pi && echo "pi ok" || echo "pi missing (bug)"
grep -n "install_valid_tools\|install_file_mappings\|windsurf_config_dir" modules/agent_toolkit_core/install.v 2>&1 | head -n 20
ls profiles/pi/skills 2>&1 | head -n 10; ls profiles/windsurf 2>&1 | head -n 10
# BEFORE: windsurf only .codeium, pi no compiled fallback; AFTER: both handled
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/targets/pi.py | cat -n | head -n 40`
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/compiler/target_registry.py | sed -n '20,35p'`
- `modules/agent_toolkit_core/emitters.v:1` + `modules/agent_toolkit_core/install.v:3` `install_valid_tools` (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§3.3 Install`, `§4.4 P2-07`.


