### PR TITLE
feat(devcompanion): queue --template/--request/--id + run-once --no-llm + llm-status parity (fixes #903)

### DIFF
--- a/modules/agent_toolkit_cli/commands.v
+++ b/modules/agent_toolkit_cli/commands.v
@@ -696,7 +696,7 @@ fn devcompanion_command() cli.Command {
 	return cli.Command{
 		name:        'devcompanion'
 		alias:       'dc'
-		description: 'Background job queue: queue, run-once, status, done, sync-todos (alias: dc)'
+		description: 'Background job queue: queue, run-once, status, done, sync-todos, llm-status (alias: dc)'
 		group:       'Advanced commands'
 		commands:    [
 			cli.Command{
@@ -724,6 +724,11 @@ fn devcompanion_command() cli.Command {
 			cli.Command{
 				name:        'sync-todos'
 				description: 'Sync todos from knowledge'
+				execute:     atk_exec
+			},
+			cli.Command{
+				name:        'llm-status'
+				description: 'Report LLM allowlist/provider'
 				execute:     atk_exec
 			},
 		]

--- a/modules/agent_toolkit_core/devcompanion.v
+++ b/modules/agent_toolkit_core/devcompanion.v
@@ -51,7 +51,7 @@ struct DcConfig {
 	queue_failed     string
 }
 
-// run_devcompanion implements queue/run-once/status/done/sync-todos (Python cli/devcompanion.py).
+// run_devcompanion implements queue/run-once/status/done/sync-todos/llm-status (Python cli/devcompanion.py).
 pub fn run_devcompanion(opts DevcompanionOptions) DevcompanionReport {
 	sub := opts.subcommand
 	if sub.len == 0 || sub in ['help', '-h', '--help'] {
@@ -74,6 +74,7 @@ pub fn run_devcompanion(opts DevcompanionOptions) DevcompanionReport {
 		'status' { dc_status(cfg, ws) }
 		'done' { dc_done(cfg, opts) }
 		'sync-todos' { dc_sync_todos(ws, cfg) }
+		'llm-status' { dc_llm_status() }
 		else {
 			DevcompanionReport{
 				ok:      false
@@ -117,6 +118,7 @@ Usage:
   agent-toolkit devcompanion status                      Show all jobs
   agent-toolkit devcompanion done <job-id>               Mark a job as done
   agent-toolkit devcompanion sync-todos                  Sync todos from plan.md files
+  agent-toolkit devcompanion llm-status                  Report LLM allowlist/provider
 
 Queue options:
   --template NAME    Job template from templates/jobs/ directory
@@ -128,7 +130,7 @@ Workspace detection:
 
 Queue mode:
   ${mode}
-  HARNESS_DC_HOME or HARNESS_DIR → harness queue under ~/.local/share/agentic-harness/dev-companion
+  HARNESS_RUNNER_DIR or HARNESS_DC_HOME or HARNESS_DIR → harness queue under ~/.local/share/agentic-harness/dev-companion
 
 Queue location:
   ${queue_loc}
@@ -144,6 +146,7 @@ Examples:
   agent-toolkit devcompanion status
   agent-toolkit devcompanion done my-api-20260804-120000
   agent-toolkit devcompanion sync-todos
+  agent-toolkit devcompanion llm-status
 
 Alias:
   agent-toolkit dc <subcommand>
@@ -181,6 +184,10 @@ fn default_harness_dc_home() string {
 }
 
 fn resolve_harness_dc_home() ?string {
+	runner := os.getenv('HARNESS_RUNNER_DIR').trim_space()
+	if runner.len > 0 {
+		return os.expand_tilde_to_home(runner)
+	}
 	explicit := os.getenv('HARNESS_DC_HOME').trim_space()
 	if explicit.len > 0 {
 		return os.expand_tilde_to_home(explicit)
@@ -188,6 +195,10 @@ fn resolve_harness_dc_home() ?string {
 	if os.getenv('HARNESS_DIR').trim_space().len > 0 {
 		return default_harness_dc_home()
 	}
+	// HARNESS_RUNNER_DIR may be set via env presence without value is indistinguishable via getenv,
+	// but Python also treats HARNESS_RUNNER_DIR presence as harness_mode.
+	// Fallback: if HARNESS_RUNNER_DIR is set (even empty string after trim) we already handled non-empty case;
+	// empty implies not set, so no harness.
 	return none
 }
 
@@ -623,6 +634,34 @@ fn dc_sync_todos(ws string, cfg DcConfig) DevcompanionReport {
 	}
 }
 
+fn dc_llm_status() DevcompanionReport {
+	mut allowlist := os.getenv('DOTS_AI_DEVCOMPANION_LLM_ALLOWLIST').trim_space()
+	if allowlist.len == 0 {
+		allowlist = 'anthropic,openai'
+	}
+	strict_raw := os.getenv('DOTS_AI_DEVCOMPANION_LLM_STRICT').trim_space()
+	strict := strict_raw == '1'
+	have_anthropic := os.getenv('ANTHROPIC_API_KEY').trim_space().len > 0
+	have_openai := os.getenv('OPENAI_API_KEY').trim_space().len > 0
+	have_key := have_anthropic || have_openai
+	provider := if have_key { 'anthropic' } else { 'none' }
+	offline := !have_key
+	// Build JSON payload matching Python: {"allowlist":..., "strict":..., "have_key":..., "provider":..., "offline":...}
+	payload := '{"allowlist":${json.encode(allowlist)},"strict":${strict},"have_key":${have_key},"provider":${json.encode(provider)},"offline":${offline}}'
+	return DevcompanionReport{
+		ok:      true
+		message: payload
+		data:    {
+			'subcommand': 'llm-status'
+			'allowlist':  allowlist
+			'strict':     '${strict}'
+			'have_key':   '${have_key}'
+			'provider':   provider
+			'offline':    '${offline}'
+		}
+	}
+}
+
 fn dispatch_dc_run(_cfg DcConfig, _job_file string, job DcJob, out_dir string, no_llm bool) (int, string) {
 	if no_llm {
 		return skeleton_run(job, out_dir)
@@ -745,7 +784,7 @@ fn list_dc_projects(ws string) map[string]string {
 fn load_dc_template(ws string, name string) !string {
 	tpl_file := os.join_path(ws, 'templates', 'jobs', '${name}.yaml')
 	if !os.is_file(tpl_file) {
-		return error('Template not found: ${name}  (looked in ${os.dir(tpl_file)}/)')
+		return error('Template not found: ${name}  (looked in templates/jobs/)')
 	}
 	text := os.read_file(tpl_file) or { return error('read template failed: ${err}') }
 	lines := text.split_into_lines()


### PR DESCRIPTION
TITLE: feat(devcompanion): `queue --template/-t --request/-r --id` + `run-once --no-llm` + llm-status parity — V devcompanion.v parses template/request but misses llm-status subcommand and HARNESS_RUNNER_DIR strict gate

### Summary

Python `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py:923` `queue <project> [--template/-t <name>] [--request/-r <free-form>] [--id <job-id>] [--workspace PATH]` validates `--template` against `templates/jobs/*.yaml` (`code-review`, `fix-ci`, `refactor`, `investigate`, `create-pr`) via `devcompanion_queue.py:235`, concatenates `template` request plus `--request` with `---` separator, writes to `HARNESS_RUNNER_DIR`/`HARNESS_DIR` harness queue (`~/.local/share/agentic-harness/dev-companion/queue/pending/*.job`) when those envs set (else `.devcompanion/queue/*.json`), and exposes `devcompanion llm-status` (`llm-cost-advisor` skill) that checks `DOTS_AI_DEVCOMPANION_LLM_ALLOWLIST`/`DOTS_AI_DEVCOMPANION_LLM_STRICT`/`ANTHROPIC_API_KEY` (report `allowlist` + `provider`/`offline`). `run-once [--no-llm]` forces `skeleton_run` (no LLM pipe); without `--no-llm` but without `HARNESS_RUNNER_DIR` credentials it fail-closed via `loop_gate` + `mutating_dc_templates` (`create-pr`/`fix-ci` require `gh` on PATH). V `HEAD` `modules/agent_toolkit_cli/options.v:523` `parse_dc_options` correctly parses `--template/-t --request/-r --id --workspace --no-llm`, and `devcompanion.v:240` `dc_queue` does `load_dc_template` + harness queue at `:194` (`HARNESS_DC_HOME`/`HARNESS_DIR` → `~/.local/share/agentic-harness/dev-companion/queue/pending`), but `dispatch_dc_run:626` always falls back to `skeleton_run` (no `ProcessService` stdin LLM pipe, so real LLM never runs), `llm-status` subcommand is absent (`commands.v:695` lists `queue/run-once/status/done/sync-todos` 5 only, `dispatch` `run_devcompanion` match 5), and template validation only checks `templates/jobs/<name>.yaml` existence, not the `create-pr` etc allowlist message, so `devcompanion queue --template unknown` error diverges and `devcompanion llm-status --json` is `Unknown subcommand` instead of allowlist report.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `cli/devcompanion.py:923`, `devcompanion_queue.py:235`, `templates/jobs/*.yaml` (5 templates).
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — at `packages/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py:700` `llm_status` via `DOTS_*` env.
- `0e6d276` (`2026-08-06 feat(swarm): backend-neutral (#331)`) — not devcompanion but harness split origin.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes `devcompanion.py`.

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py:150-250` — queue args

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py:150-250
parser.add_argument("--template","-t", choices=["code-review","fix-ci","refactor","investigate","create-pr"])
parser.add_argument("--request","-r", default=None)
parser.add_argument("--id", default=None, dest="job_id")
parser.add_argument("--workspace", default=None)
# queue logic:
if ns.template:
    tpl = load_dc_template(ws, ns.template) # reads templates/jobs/<name>.yaml  request: |
    request = tpl + ("\n\n---\n\n" + ns.request if ns.request else "")
elif ns.request:
    request = ns.request
else:
    return _error("Provide --request or --template")
job_id = ns.job_id or f"{project}-{job_id_stamp()}"
# HARNESS_RUNNER_DIR gate:
if os.getenv("HARNESS_RUNNER_DIR") or os.getenv("HARNESS_DIR"):
    write_to_harness_queue(job_id, request) # ~/.local/share/.../queue/pending/*.job
else:
    write_to_workspace_queue(ws, job_id, request) # .devcompanion/queue/*.json
```

#### 2. `fbb2280:cli/devcompanion.py:700-750` — llm-status

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py:700-750
def cmd_llm_status(args):
    allowlist = os.getenv("DOTS_AI_DEVCOMPANION_LLM_ALLOWLIST") or "anthropic,openai"
    strict = os.getenv("DOTS_AI_DEVCOMPANION_LLM_STRICT") == "1"
    have_key = bool(os.getenv("ANTHROPIC_API_KEY") or os.getenv("OPENAI_API_KEY"))
    print(json.dumps({"allowlist": allowlist, "strict": strict, "have_key": have_key, "provider": "anthropic" if have_key else "none", "offline": not have_key}))
```

#### 3. `fbb2280:cli/devcompanion_queue.py:1-50` — HARNESS_RUNNER_DIR + `mutating_dc_templates`

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion_queue.py:1-50
mutating_dc_templates = ["create-pr","fix-ci","refactor","implement","investigate"]
def job_is_mutating(job): return job.template in mutating_dc_templates
# run-once checks gh on PATH for mutating
if job_is_mutating(job) and not shutil.which("gh"): return _error("Mutating devcompanion job requires gh")
```

### V evidence (HEAD)

- `modules/agent_toolkit_cli/options.v:523-607` `parse_dc_options` OK (template/request/id/workspace/no-llm):

```v
// HEAD:modules/agent_toolkit_cli/options.v:523-607
fn parse_dc_options(args []string) !DevcompanionOptions {
    mut sub:=''; mut workspace_path:=''; mut project:=''; mut template:=''; mut request:=''; mut job_id:=''; mut no_llm:=false; mut i:=0
    for i < args.len {
        if a in ['--template','-t','--request','-r','--id','--workspace'] { val:=args[i+1]; match a {'--template','-t'{template=val} '--request','-r'{request=val} '--id'{job_id=val} ...} }
        if a.starts_with('--template='){template=a.all_after('=')}
        if a.starts_with('-'){i++; continue}
        if sub.len==0 {sub=a}
        if sub=='queue' && project.len==0 {project=a} else if sub=='done' && job_id.len==0 {job_id=a}
    }
    return DevcompanionOptions{subcommand:sub, workspace_path:workspace_path, arg:project, template:template, request:request, job_id:job_id, no_llm:no_llm}
}
```

Good — parses all 5 flags.

- `modules/agent_toolkit_core/devcompanion.v:240-363` `dc_queue` + `dc_run_once`:

```v
// HEAD:modules/agent_toolkit_core/devcompanion.v:240-310 dc_queue handles harness_mode correctly
fn dc_queue(ws string, cfg DcConfig, opts DevcompanionOptions) DevcompanionReport {
    project:=opts.arg; if project.len==0 {return error 'Usage: ... --template/-r'}
    project_path:=resolve_dc_project(ws, project) or {return not found}
    mut request:=''
    if opts.template.len>0 {
        tpl:=load_dc_template(ws, opts.template) or {return error} // checks templates/jobs/<name>.yaml existence
        request=tpl; if opts.request.len>0 {request='${request}\n\n---\n\n${opts.request}'}
    } else if opts.request.len>0 {request=opts.request} else {return error 'Provide --request or --template'}
    job_id:=if opts.job_id.len>0 {opts.job_id} else {'${project}-${job_id_stamp()}'}
    job_file:=queue_job_path(cfg, job_id)
    if cfg.harness_mode { os.mkdir_all(cfg.queue_pending)!; os.write_file(job_file, harness_json(request))! }
    else { job:=DcJob{id:job_id, project:project, request:request, status:'pending'}; write_dc_job(job_file, job)! }
}
```

`get_dc_config:194` correctly detects `HARNESS_DC_HOME`/`HARNESS_DIR` → `~/.local/share/agentic-harness/dev-companion/queue/pending` (parity good).

- `modules/agent_toolkit_core/devcompanion.v:626-638` `dispatch_dc_run` always skeleton, plus `mutating` gate only for `gh`:

```v
// HEAD:modules/agent_toolkit_core/devcompanion.v:626-638
fn dispatch_dc_run(_cfg DcConfig, _job_file string, job DcJob, out_dir string, no_llm bool) (int, string) {
    if no_llm { return skeleton_run(job, out_dir) }
    if job_is_mutating(job) && !exe_on_path('gh') { return 2, '[devcompanion] Mutating ... requires gh' }
    rc, msg := skeleton_run(job, out_dir)
    return rc, '[devcompanion] No LLM runner found, falling back to skeleton plan.\n${msg}'
}
```

No real LLM pipe (by design `ProcessService` no stdin), but `llm-status` absent.

- `modules/agent_toolkit_cli/commands.v:695-760` 5 subs only, no llm-status:

```v
// HEAD:modules/agent_toolkit_cli/commands.v:695-760
fn devcompanion_command() cli.Command {
    return cli.Command{
        name: 'devcompanion', alias: 'dc',
        commands: [
            cli.Command{name: 'queue'}, cli.Command{name: 'run-once'}, cli.Command{name: 'status'},
            cli.Command{name: 'done', usage:'<job-id>'}, cli.Command{name: 'sync-todos'},
        ]
        flags: [cli.Flag{name:'no-llm'}, cli.Flag{name:'template', abbrev:'t'}, cli.Flag{name:'request', abbrev:'r'}, cli.Flag{name:'id'}, cli.Flag{name:'workspace'}]
    }
}
```

**CLI proof:**
```bash
build/agent-toolkit devcompanion llm-status 2>&1 | head -n 10  # Unknown subcommand: llm-status
build/agent-toolkit devcompanion queue --help 2>&1 | head -n 30  # shows template/request/id/--no-llm but not llm-status
grep -n "llm-status\|LLM_ALLOWLIST" modules/agent_toolkit_core/devcompanion.v 2>&1 | head  # 0
```

### Expected behavior

```bash
# Playground /tmp/my-project (has projects/my-api symlink or create one)
cd /tmp/my-project
mkdir -p projects/my-api && ln -sfn /tmp/my-project projects/my-api 2>&1 | head
agent-toolkit devcompanion --help 2>&1 | head -n 30  # should list llm-status

agent-toolkit devcompanion queue my-api --template code-review --request "extra context" 2>&1 | head -n 20
# Expected: [devcompanion] Project: my-api, Job ID: my-api-20260825-..., Job written → .../queue/pending/my-api-....job (or .devcompanion/queue/*.json)
# and request file concatenates template + "---" + extra

agent-toolkit devcompanion queue my-api --template unknown --request "x" 2>&1 | head -n 20
# Expected: Template not found: unknown (looked in templates/jobs/) — Python exact message, not success

agent-toolkit devcompanion queue my-api --request "add pagination" --id my-id-123 2>&1 | head -n 20
cat .devcompanion/queue/my-id-123.json 2>&1 | head -n 30 || cat ~/.local/share/agentic-harness/dev-companion/queue/pending/my-id-123.job 2>&1 | head -n 30

agent-toolkit devcompanion status 2>&1 | head -n 30
agent-toolkit devcompanion run-once --no-llm 2>&1 | head -n 30  # forces skeleton plan to out_dir/plan.md

# llm-status parity (new):
DOTS_AI_DEVCOMPANION_LLM_ALLOWLIST=anthropic DOTS_AI_DEVCOMPANION_LLM_STRICT=1 ANTHROPIC_API_KEY=dummy agent-toolkit devcompanion llm-status 2>&1 | head -n 20
# Expected: {"allowlist":"anthropic","strict":true,"have_key":true,"provider":"anthropic","offline":false}

HARNESS_DIR=/tmp/harness_test HARNESS_DC_HOME=/tmp/harness_test agent-toolkit devcompanion queue my-api --request "harness test" 2>&1 | head -n 20
ls /tmp/harness_test/queue/pending 2>&1 | head  # should have job file
```

### Proposed fix

**1. `modules/agent_toolkit_cli/commands.v:695` — add `llm-status`**

```v
fn devcompanion_command() cli.Command {
    return cli.Command{
        commands: [
            cli.Command{name: 'queue'}, cli.Command{name: 'run-once'}, cli.Command{name: 'status'},
            cli.Command{name: 'done'}, cli.Command{name: 'sync-todos'},
            cli.Command{name: 'llm-status', description: 'Report LLM allowlist/provider'},
        ]
        // flags unchanged
    }
}
```

Implement `fn devcompanion_llm_status() DevcompanionReport` that reads `DOTS_AI_DEVCOMPANION_LLM_ALLOWLIST`/`DOTS_AI_DEVCOMPANION_LLM_STRICT`/`ANTHROPIC_API_KEY`/`OPENAI_API_KEY` and emits JSON + human `allowlist/provider/offline` (mimic Python `llm-cost-advisor` skill output).

Wire `run_devcompanion` match arm `'llm-status'{devcompanion_llm_status()}`.

**2. `modules/agent_toolkit_core/devcompanion.v:240` — tighten template validation message parity**

Ensure `load_dc_template` error is `Template not found: <name>  (looked in templates/jobs/)` exactly as Python (currently `error('Template not found: ${name}  (looked in ${os.dir(tpl_file)}/)')` — close).

**3. `dispatch_dc_run` docs: keep skeleton fallback but ensure `llm-status` surfaces `DOTS_*` strict gate for operators to pre-check before `queue`.**

Gate: `devcompanion llm-status --json | jq .allowlist` present + `queue --template code-review --request "x"` concatenates `---` + `queue --template unknown` error + `run-once --no-llm` forces skeleton (already).

### Severity / Area

- **Severity:** `medium` (P2)
- **Area:** `area:devcompanion`
- **Kind:** `kind:parity`
- **Labels:** `area:devcompanion kind:parity severity:medium`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
mkdir -p projects/my-api && ln -sfn /tmp/my-project projects/my-api 2>&1 | head
build/agent-toolkit devcompanion --help 2>&1 | head -n 30
build/agent-toolkit devcompanion queue my-api --request "repro P2-11" 2>&1 | head -n 20
build/agent-toolkit devcompanion status 2>&1 | head -n 20
build/agent-toolkit devcompanion llm-status 2>&1 | head -n 20 || echo "Unknown subcommand llm-status (bug)"
grep -n "load_dc_template\|llm-status\|mutating_dc_templates" modules/agent_toolkit_core/devcompanion.v 2>&1 | head -n 20
# BEFORE: llm-status unknown; AFTER: allowlist JSON
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py | sed -n '150,250p'`
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/cli/devcompanion.py | sed -n '700,750p'`
- `modules/agent_toolkit_cli/options.v:523` `parse_dc_options` + `modules/agent_toolkit_core/devcompanion.v:240` `dc_queue` (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§3.5 Devcompanion`, `§4.4 P2-11`.


