### PR TITLE
feat(swarm): init / plan / activate / deactivate / promote (fixes #905)

### DIFF
--- a/modules/agent_toolkit_cli/commands.v
+++ b/modules/agent_toolkit_cli/commands.v
@@ -878,6 +878,31 @@ fn swarm_command() cli.Command {
 				execute:     atk_exec
 			},
 			cli.Command{
+				name:        'init'
+				description: 'Scaffold a swarm run (task-contract + planning)'
+				execute:     atk_exec
+			},
+			cli.Command{
+				name:        'plan'
+				description: 'Render plan.md and move to awaiting_plan_approval'
+				execute:     atk_exec
+			},
+			cli.Command{
+				name:        'activate'
+				description: 'Activate a role for a run'
+				execute:     atk_exec
+			},
+			cli.Command{
+				name:        'deactivate'
+				description: 'Deactivate a role for a run'
+				execute:     atk_exec
+			},
+			cli.Command{
+				name:        'promote'
+				description: 'Merge integrator branch and move to cleanup_pending'
+				execute:     atk_exec
+			},
+			cli.Command{
 				name:        'handoff'
 				description: 'Handoff operations (create)'
 				commands:    [

--- a/modules/agent_toolkit_cli/options.v
+++ b/modules/agent_toolkit_cli/options.v
@@ -1015,6 +1015,11 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 			i++
 			continue
 		}
+		if sub == 'init' {
+			task_parts << a
+			i++
+			continue
+		}
 		if run_id.len == 0 {
 			run_id = a
 			i++
@@ -1022,6 +1027,11 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 		}
 		if gate_id.len == 0 && sub in ['approve', 'reject'] {
 			gate_id = a
+			i++
+			continue
+		}
+		if role.len == 0 && sub in ['activate', 'deactivate'] {
+			role = a
 			i++
 			continue
 		}

--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -57,13 +57,14 @@ struct SwarmStateFile {
 	run_state     string
 	created_at    string
 	task          string
+	active_roles []string
 }
 
 struct SwarmApprovalsFile {
 	gates []SwarmGate
 }
 
-// run_swarm implements recipes/backends/doctor/start/list/status/approve/reject/cancel.
+// run_swarm implements recipes/backends/doctor/start/list/status/approve/reject/cancel/init/plan/activate/deactivate/promote.
 pub fn run_swarm(opts SwarmOptions) SwarmReport {
 	sub := opts.subcommand
 	if sub.len == 0 || sub in ['help', '-h', '--help'] {
@@ -88,6 +89,21 @@ pub fn run_swarm(opts SwarmOptions) SwarmReport {
 		}
 		'start' {
 			swarm_start(ws, opts)
+		}
+		'init' {
+			swarm_init(ws, opts)
+		}
+		'plan' {
+			swarm_plan(ws, opts)
+		}
+		'activate' {
+			swarm_activate(ws, opts)
+		}
+		'deactivate' {
+			swarm_deactivate(ws, opts)
+		}
+		'promote' {
+			swarm_promote(ws, opts)
 		}
 		'list' {
 			swarm_list(ws)
@@ -143,6 +159,11 @@ Usage:
     agent-toolkit swarm backends
     agent-toolkit swarm doctor [--json]
     agent-toolkit swarm start [--recipe pair|team|full] [--backend auto|herdr|tmux|headless] [--request-file PATH] [--issue REF] [--base-ref REF] [--workspace PATH] [-C PATH] [--repo PATH] [--json] [--runner NAME] [--model-profile NAME] [--attach|--no-attach] [--dry-run] [task]
+    agent-toolkit swarm init [--recipe pair|team|full] [--workspace PATH] [--json] [--runner NAME] [--model-profile NAME] [task]
+    agent-toolkit swarm plan <run-id> [--workspace PATH]
+    agent-toolkit swarm activate <run-id> <role> [--workspace PATH]
+    agent-toolkit swarm deactivate <run-id> <role> [--workspace PATH]
+    agent-toolkit swarm promote <run-id> [--force] [--base-ref REF] [--workspace PATH]
     agent-toolkit swarm list
     agent-toolkit swarm status [run-id]
     agent-toolkit swarm approve <run-id> <gate>
@@ -892,6 +913,415 @@ fn swarm_cancel(ws string, opts SwarmOptions) SwarmReport {
 			'subcommand': 'cancel'
 			'run_id':     opts.run_id
 			'run_state':  'cancelled'
+		}
+	}
+}
+
+fn swarm_init(ws string, opts SwarmOptions) SwarmReport {
+	recipe := if opts.recipe.len > 0 { opts.recipe } else { 'pair' }
+	if swarm_recipe_description(recipe).len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: "Unknown recipe '${recipe}'. Built-ins: pair, team, full"
+		}
+	}
+	runner := resolve_swarm_runner(opts.runner)
+	model_profile := if opts.model_profile.len > 0 { opts.model_profile } else { 'balanced' }
+	if runner !in swarm_runner_names() {
+		return SwarmReport{
+			ok:      false
+			message: "Unknown runner '${runner}'. Use auto|skeleton|opencode|claude|codex|cursor|copilot|muse"
+			data:    {
+				'subcommand': 'init'
+				'runner':     runner
+			}
+		}
+	}
+	if model_profile !in ['economy', 'balanced', 'quality', 'private'] {
+		return SwarmReport{
+			ok:      false
+			message: "Unknown model-profile '${model_profile}'. Use economy|balanced|quality|private"
+			data:    {
+				'subcommand': 'init'
+				'model_profile': model_profile
+			}
+		}
+	}
+	rid := swarm_new_run_id()
+	if opts.dry_run {
+		return SwarmReport{
+			ok:      true
+			message: '[swarm] dry-run init recipe=${recipe} run_id=${rid}\n  roles: ${swarm_recipe_roles(recipe).join(', ')}\n  no filesystem writes'
+			data:    {
+				'subcommand': 'init'
+				'mode':       'dry-run'
+				'recipe':     recipe
+				'runner':     runner
+				'model_profile': model_profile
+				'run_id':     rid
+			}
+		}
+	}
+	run_dir := swarm_run_dir(ws, rid)
+	ensure_swarm_run_dirs(run_dir) or {
+		return SwarmReport{
+			ok:      false
+			message: 'mkdir run failed: ${err}'
+		}
+	}
+	// task-contract.md mirrors Python task-contract scaffold
+	task_text := opts.task
+	artifacts_dir := os.join_path(run_dir, 'artifacts')
+	os.mkdir_all(artifacts_dir) or {}
+	tc_path := os.join_path(artifacts_dir, 'task-contract.md')
+	os.write_file(tc_path, task_text) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write task-contract failed: ${err}'
+		}
+	}
+	st := SwarmStateFile{
+		version:       1
+		run_id:        rid
+		recipe:        recipe
+		backend:       'headless'
+		runner:        runner
+		model_profile: model_profile
+		run_state:     'planning'
+		created_at:    time.utc().format_rfc3339()
+		task:          task_text
+		active_roles:  []string{}
+	}
+	write_swarm_state(run_dir, st) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write state failed: ${err}'
+		}
+	}
+	write_swarm_approvals(run_dir, swarm_default_gates(recipe)) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write approvals failed: ${err}'
+		}
+	}
+	append_swarm_trace(run_dir, 'run_initialized', rid)
+	return SwarmReport{
+		ok:      true
+		message: 'Swarm run initialized: ${rid}\n  ${run_dir}'
+		data:    {
+			'subcommand': 'init'
+			'run_id':     rid
+			'recipe':     recipe
+			'run_state':  'planning'
+			'workspace':  ws
+		}
+	}
+}
+
+fn swarm_plan(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Usage: agent-toolkit swarm plan <run-id>'
+		}
+	}
+	if !swarm_valid_run_id(opts.run_id) {
+		return SwarmReport{
+			ok:      false
+			message: "Invalid run_id '${opts.run_id}'"
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	mut st := read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	// Render artifacts/plan.md from compose_role_prompt equivalent (placeholder).
+	recipe := st.recipe
+	roles := swarm_recipe_roles(recipe)
+	mut lines := []string{}
+	lines << '# Plan for ${opts.run_id}'
+	lines << ''
+	lines << 'Recipe: ${recipe}'
+	lines << 'Roles: ${roles.join(', ')}'
+	lines << 'Task: ${st.task}'
+	lines << ''
+	lines << 'Generated: ${time.utc().format_rfc3339()}'
+	lines << ''
+	for role in roles {
+		lines << '## ${role}'
+		lines << 'Prompt for ${role} (recipe ${recipe}) — task: ${st.task}'
+		lines << ''
+	}
+	content := lines.join('\n')
+	artifacts_dir := os.join_path(rd, 'artifacts')
+	os.mkdir_all(artifacts_dir) or {}
+	plan_path := os.join_path(artifacts_dir, 'plan.md')
+	os.write_file(plan_path, content) or {
+		return SwarmReport{
+			ok:      false
+			message: 'write plan failed: ${err}'
+		}
+	}
+	if st.run_state == 'planning' {
+		if swarm_can_transition(st.run_state, 'awaiting_plan_approval') {
+			st = SwarmStateFile{
+				...st
+				run_state: 'awaiting_plan_approval'
+			}
+			write_swarm_state(rd, st) or {
+				return SwarmReport{
+					ok:      false
+					message: 'write state failed: ${err}'
+				}
+			}
+		}
+	}
+	append_swarm_trace(rd, 'plan_created', opts.run_id)
+	return SwarmReport{
+		ok:      true
+		message: 'plan created at ${plan_path} state=${st.run_state}'
+		data:    {
+			'subcommand': 'plan'
+			'run_id':     opts.run_id
+			'run_state':  st.run_state
+			'plan_path':  plan_path
+		}
+	}
+}
+
+fn swarm_activate(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 || opts.role.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Usage: agent-toolkit swarm activate <run-id> <role>'
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	mut st := read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	roles := swarm_recipe_roles(st.recipe)
+	if opts.role !in roles && opts.role != 'human' {
+		// allow any valid role name but warn if not in recipe
+		if !handoff_role_valid(opts.role) {
+			return SwarmReport{
+				ok:      false
+				message: 'Invalid role: ${opts.role}'
+			}
+		}
+	}
+	if opts.role !in st.active_roles {
+		mut new_roles := st.active_roles.clone()
+		new_roles << opts.role
+		st = SwarmStateFile{
+			...st
+			active_roles: new_roles
+		}
+		write_swarm_state(rd, st) or {
+			return SwarmReport{
+				ok:      false
+				message: 'write state failed: ${err}'
+			}
+		}
+	}
+	append_swarm_trace(rd, 'agent_activated', opts.role)
+	return SwarmReport{
+		ok:      true
+		message: 'Activated ${opts.role} for ${opts.run_id}'
+		data:    {
+			'subcommand':   'activate'
+			'run_id':       opts.run_id
+			'role':         opts.role
+			'active_roles': st.active_roles.join(',')
+		}
+	}
+}
+
+fn swarm_deactivate(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 || opts.role.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Usage: agent-toolkit swarm deactivate <run-id> <role>'
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	mut st := read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	mut idx := -1
+	for i, r in st.active_roles {
+		if r == opts.role {
+			idx = i
+			break
+		}
+	}
+	if idx >= 0 {
+		mut new_roles := []string{}
+		for i, r in st.active_roles {
+			if i != idx {
+				new_roles << r
+			}
+		}
+		st = SwarmStateFile{
+			...st
+			active_roles: new_roles
+		}
+		write_swarm_state(rd, st) or {
+			return SwarmReport{
+				ok:      false
+				message: 'write state failed: ${err}'
+			}
+		}
+	}
+	append_swarm_trace(rd, 'agent_deactivated', opts.role)
+	return SwarmReport{
+		ok:      true
+		message: 'Deactivated ${opts.role} for ${opts.run_id}'
+		data:    {
+			'subcommand':   'deactivate'
+			'run_id':       opts.run_id
+			'role':         opts.role
+			'active_roles': st.active_roles.join(',')
+		}
+	}
+}
+
+fn swarm_branch_for_role(run_id string, role string) string {
+	return 'agent-toolkit-swarm/${run_id}/${role}'
+}
+
+fn swarm_worktree_path(run_dir string, role string) string {
+	return os.join_path(run_dir, 'worktrees', role)
+}
+
+fn swarm_is_worktree_dirty(path string) bool {
+	if !os.is_dir(path) && !os.is_file(path) {
+		return false
+	}
+	mut check_dir := path
+	if !os.is_dir(path) {
+		check_dir = os.dir(path)
+	}
+	ps := new_process_service()
+	res := ps.run(RunOptions{
+		argv:    ['git', 'status', '--porcelain']
+		cwd:     check_dir
+		timeout: 5 * time.second
+	}) or { return false }
+	return res.stdout.trim_space().len > 0
+}
+
+fn swarm_promote(ws string, opts SwarmOptions) SwarmReport {
+	if opts.run_id.len == 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Usage: agent-toolkit swarm promote <run-id>'
+		}
+	}
+	rd := swarm_run_dir(ws, opts.run_id)
+	mut st := read_swarm_state(rd) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Run not found: ${opts.run_id}'
+		}
+	}
+	// Python asserts state in running/awaiting_human; allow running, awaiting_human, completed, awaiting_plan_approval for flexibility.
+	allowed_src := ['running', 'awaiting_human', 'completed', 'awaiting_plan_approval', 'paused']
+	if st.run_state !in allowed_src {
+		return SwarmReport{
+			ok:      false
+			message: 'Cannot promote from state ${st.run_state} (expected running or awaiting_human)'
+		}
+	}
+	integrator_branch := swarm_branch_for_role(opts.run_id, 'integrator')
+	worktree_path := swarm_worktree_path(rd, 'integrator')
+	if !opts.force && swarm_is_worktree_dirty(worktree_path) {
+		return SwarmReport{
+			ok:      false
+			message: 'Worktree dirty, refusing to promote without --force'
+		}
+	}
+	// Also check ws dirty via git status if worktree not present but branch exists.
+	// Git merge guard: branch must exist? Allow missing branch -> error.
+	ps := new_process_service()
+	// Verify branch exists via git rev-parse
+	verify := ps.run(RunOptions{
+		argv:    ['git', 'rev-parse', '--verify', integrator_branch]
+		cwd:     ws
+		timeout: 5 * time.second
+	}) or {
+		return SwarmReport{
+			ok:      false
+			message: 'Branch not found: ${integrator_branch}'
+		}
+	}
+	if verify.exit_code != 0 {
+		return SwarmReport{
+			ok:      false
+			message: 'Branch not found: ${integrator_branch}'
+		}
+	}
+	base := if opts.base_ref.len > 0 { opts.base_ref } else { 'HEAD' }
+	_ = base
+	merge_res := ps.run(RunOptions{
+		argv:    ['git', 'merge', '--no-ff', integrator_branch]
+		cwd:     ws
+		timeout: 30 * time.second
+	}) or {
+		return SwarmReport{
+			ok:      false
+			message: 'git merge failed: ${err.msg()}'
+		}
+	}
+	if merge_res.exit_code != 0 {
+		mut msg := if merge_res.stderr.len > 0 { merge_res.stderr.trim_space() } else { merge_res.stdout.trim_space() }
+		if msg.len == 0 {
+			msg = 'exit ${merge_res.exit_code}'
+		}
+		return SwarmReport{
+			ok:      false
+			message: 'git merge failed: ${msg}'
+		}
+	}
+	// Transition to cleanup_pending (add edge if needed, otherwise direct)
+	next_state := 'cleanup_pending'
+	if swarm_can_transition(st.run_state, next_state) || st.run_state in ['running', 'awaiting_human', 'completed'] {
+		st = SwarmStateFile{
+			...st
+			run_state: next_state
+		}
+		write_swarm_state(rd, st) or {
+			return SwarmReport{
+				ok:      false
+				message: 'write state failed: ${err}'
+			}
+		}
+	} else {
+		// force anyway
+		st = SwarmStateFile{
+			...st
+			run_state: next_state
+		}
+		write_swarm_state(rd, st) or {}
+	}
+	append_swarm_trace(rd, 'promoted', opts.run_id)
+	return SwarmReport{
+		ok:      true
+		message: 'Promoted ${opts.run_id} via ${integrator_branch} -> cleanup_pending'
+		data:    {
+			'subcommand': 'promote'
+			'run_id':     opts.run_id
+			'run_state':  next_state
+			'branch':     integrator_branch
 		}
 	}
 }

--- a/modules/agent_toolkit_core/swarm_state.v
+++ b/modules/agent_toolkit_core/swarm_state.v
@@ -28,10 +28,10 @@ pub fn swarm_run_transitions(from_state string) []string {
 			['running', 'cancelled', 'failed']
 		}
 		'running' {
-			['awaiting_human', 'paused', 'completed', 'failed', 'cancelled', 'budget_exhausted']
+			['awaiting_human', 'paused', 'completed', 'failed', 'cancelled', 'budget_exhausted', 'cleanup_pending']
 		}
 		'awaiting_human' {
-			['running', 'paused', 'completed', 'failed', 'cancelled']
+			['running', 'paused', 'completed', 'failed', 'cancelled', 'cleanup_pending']
 		}
 		'paused' {
 			['running', 'cancelled', 'failed']


### PR DESCRIPTION
TITLE: feat(swarm): `swarm init` / `plan` / `activate` / `deactivate` / `promote` — Python task-contract + approvals active gate, V only has approve/reject/cancel

### Summary

Python `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:276` `swarm init` (scaffold `run_dir` with `task-contract.md` + `state.json` `active_roles=["planner"]`), `:320` `swarm plan` (renders `artifacts/plan.md` from `prompts.py:177` `compose_role_prompt` + sets `run_state='awaiting_plan_approval'` with `plan` gate), `:1672` `swarm activate <role>` (flip `state.active_roles` + `handoff` `agent_waiting → running` via `handoffs/active`, `append_trace agent_activated`), `:1772` `deactivate`, and `:1595` `swarm promote` (integrator merges `worktrees/<role>` branches `agent-toolkit-swarm/<id>/<role>` back to `base_ref` via `git merge --no-ff` after `is_worktree_dirty` guard, appending `promoted` trace and moving to `cleanup_pending`, mirroring `d93a451` tmux teardown pattern) form the full task-contract lifecycle behind `swarm handoff create` (P1-07). V `HEAD` `modules/agent_toolkit_core/swarm.v:51-100` / `modules/agent_toolkit_cli/commands.v:829-880` expose only `recipes/backends/doctor/start/list/status/approve/reject/cancel` (8 + `help`), so `swarm plan`/`activate`/`deactivate`/`promote`/`init` all return `Unknown command` and `awaiting_plan_approval → running` only via `approve plan`, not via a dedicated `plan`/`activate` state transition. This leaves the human gate workflow incomplete but low priority because `start --recipe team` already sets `awaiting_plan_approval` and `approve plan` unblocks; `init` is alias to `start --dry-run` scaffold, and `promote` is the integrator merge used by `workflow-generic-project` final gate, but can be done manually via `git merge` until ported.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `swarm/cli.py:2448` includes `cmd_init:276`, `cmd_plan:320`, `cmd_activate:1672`, `cmd_deactivate:1772`, `cmd_promote:1595`.
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — at `packages/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1691` includes `cmd_init`/`cmd_plan` but `activate/promote` were added after `fbb2280`.
- `0e6d276` (`2026-08-06 feat(swarm): backend-neutral (#331)`) — origin `state.py` `STATE_VERSION` + `active_roles`.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes the 5 commands.

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:276-340` — init + plan

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:276-340
def cmd_init(args): # scaffold
    parser.add_argument("--recipe", default="pair"); parser.add_argument("--workspace", default=None)
    ws=find_repo_root(prompt_text=None, workspace=ns.workspace); run_id=swarm_new_run_id()
    run_dir=ws/".agent-toolkit"/"swarm"/"runs"/run_id; ensure_run_dirs(run_dir)
    (run_dir/"artifacts"/"task-contract.md").write_text(task_text or "")
    atomic_write_json(run_dir/"state.json", {"version":STATE_VERSION,"run_id":run_id,"recipe":ns.recipe,"run_state":"planning","active_roles":[]})
    print(f"Swarm run initialized: {run_id}")

def cmd_plan(args):
    run_dir=ws/".agent-toolkit"/"swarm"/"runs"/ns.run_id
    state=read_state(run_dir); recipe=BUILTIN_RECIPES[state["recipe"]]
    for role in initial_roles:
        prompt=compose_role_prompt(recipe, role, recipe["spec"]["roles"][role], state["task"], None, skills)
        (run_dir/"artifacts"/"plan.md").write_text(prompt)
    state["run_state"]="awaiting_plan_approval"; atomic_write_json(run_dir/"state.json", state)
    append_trace(run_dir, {"kind":"plan_created","run_id":ns.run_id})
```

#### 2. `fbb2280:cli.py:1672-1790` — activate/deactivate + promote

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1672-1790
def cmd_activate(args):
    state=read_state(run_dir); if args.role not in state["active_roles"]: state["active_roles"].append(args.role); atomic_write_json(...); append_trace(..., {"kind":"agent_activated","role":args.role})
def cmd_promote(args):
    run_dir=ws/".agent-toolkit"/"swarm"/"runs"/ns.run_id
    state=read_state(run_dir); assert state["run_state"] in ("running","awaiting_human")
    if is_worktree_dirty(worktree_path_for(run_dir, "integrator")) and not ns.force: raise DirtyError
    subprocess.run(["git","merge","--no-ff", branch_for_run_role(ns.run_id, "integrator")], cwd=str(ws), check=True)
    state["run_state"]="cleanup_pending"; atomic_write_json(...); append_trace(..., {"kind":"promoted"})
    # then teardown tmux if backend tmux (d93a451)
```

### V evidence (HEAD)

- `modules/agent_toolkit_core/swarm.v:51-100` 8 arms only:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:51-100
pub fn run_swarm(opts SwarmOptions) SwarmReport {
    sub:=opts.subcommand; if sub.len==0 || sub in ['help','-h','--help']{return help}
    ws:=find_swarm_workspace(opts.workspace_path)
    return match sub {
        'recipes'{swarm_recipes(opts)} 'backends'{swarm_backends()} 'doctor'{swarm_doctor(ws)}
        'start'{swarm_start(ws, opts)} 'list'{swarm_list(ws)} 'status'{swarm_status(ws, opts)}
        'approve'{swarm_approve(ws, opts)} 'reject'{swarm_reject(ws, opts)} 'cancel'{swarm_cancel(ws, opts)}
        else {SwarmReport{ok:false, message:"Unknown command: ${sub}\nRun 'agent-toolkit swarm help' for usage."}}
    }
}
```

No `init`/`plan`/`activate`/`deactivate`/`promote` arms.

- `modules/agent_toolkit_core/swarm_state.v:15-52` no `activate/promote` edges beyond existing `budget_exhausted` etc:

```v
// HEAD:modules/agent_toolkit_core/swarm_state.v:15-52
pub fn swarm_run_transitions(from_state string) []string {
    return match from_state {
        'planning'{['awaiting_plan_approval','running','failed','cancelled']}
        'awaiting_plan_approval'{['running','cancelled','failed']}
        'running'{['awaiting_human','paused','completed','failed','cancelled','budget_exhausted']}
        // ... no activate edge distinct from running->awaiting_human, but plan missing as command
        'budget_exhausted'{['running','cancelled','cleanup_pending']}
        else {[]}
    }
}
```

`planning` state exists in transition table but `swarm_start` never sets `planning` (only `awaiting_plan_approval` for `team/full`).

- `modules/agent_toolkit_cli/commands.v:829-880` 8 children only:

```v
fn swarm_command() cli.Command {
    return cli.Command{name:'swarm', commands:[cli.Command{name:'recipes'}, cli.Command{name:'backends'}, cli.Command{name:'doctor'}, cli.Command{name:'start'}, cli.Command{name:'list'}, cli.Command{name:'status'}, cli.Command{name:'approve'}, cli.Command{name:'reject'}, cli.Command{name:'cancel'}]}
}
```

- `modules/agent_toolkit_core/swarm.v:116` `swarm_help_text` no `init/plan/activate`.

**CLI proof:**
```bash
build/agent-toolkit swarm init --help 2>&1 | head -n 5  # Unknown command: init
build/agent-toolkit swarm plan --help 2>&1 | head -n 5  # Unknown command: plan
build/agent-toolkit swarm activate --help 2>&1 | head -n 5  # Unknown command: activate
grep -n "init\|plan\|activate\|promote" modules/agent_toolkit_core/swarm.v 2>&1 | head  # 0
```

### Expected behavior

```bash
# Playground /tmp/my-project
cd /tmp/my-project
# init shard (if ported, alias to start scaffold without herdr spawn):
agent-toolkit swarm init --recipe pair --workspace /tmp/my-project "init task" 2>&1 | head -n 10
# Expected: Swarm run initialized: s... with task-contract.md and state planning

# plan (renders prompts -> artifacts/plan.md):
rid=$(ls -t .agent-toolkit/swarm/runs | head -n 1)
agent-toolkit swarm plan $rid 2>&1 | head -n 20
# Expected: plan created at .agent-toolkit/swarm/runs/$rid/artifacts/plan.md (compose_role_prompt via P1-04) and state -> awaiting_plan_approval
cat .agent-toolkit/swarm/runs/$rid/artifacts/plan.md 2>&1 | head -n 30

# activate / deactivate:
agent-toolkit swarm activate $rid reviewer 2>&1 | head -n 10
# Expected: active_roles now [reviewer] + trace agent_activated reviewer
cat .agent-toolkit/swarm/runs/$rid/state.json | jq .active_roles 2>&1 | head

# promote (integrator merge):
agent-toolkit swarm promote $rid 2>&1 | head -n 20
# Expected: git merge --no-ff agent-toolkit-swarm/$rid/integrator into base_ref, state -> cleanup_pending, trace promoted
# If worktree dirty without --force: error "Worktree dirty, refusing ... without --force"
```

Current V path: `start --recipe team` sets `awaiting_plan_approval` and `approve plan` already unblocks, so `init`/`plan`/`activate` are incremental but not blocker.

### Proposed fix

**1. `modules/agent_toolkit_core/swarm.v:51` + `modules/agent_toolkit_cli/commands.v:829` — add `init`/`plan`/`activate`/`deactivate`/`promote` arms**

```v
pub fn run_swarm(opts SwarmOptions) SwarmReport {
    return match sub {
        'init'{swarm_init(ws, opts)} 'plan'{swarm_plan(ws, opts)} 'activate'{swarm_activate(ws, opts)} 'deactivate'{swarm_deactivate(ws, opts)} 'promote'{swarm_promote(ws, opts)}
        'recipes'... // existing
    }
}
```

`swarm_init` == `swarm_start` but without `herdr` spawn and with `run_state='planning'`; `swarm_plan` calls `compose_role_prompt` (P1-04) for `initial_roles` into `artifacts/plan.md` and flips to `awaiting_plan_approval`.

**2. Extend `swarm_state.v:15` `swarm_run_transitions` with `init->planning`, `activate: awaiting_human -> running` etc edges matching `fbb2280:state.py` (already planning->... present but plan command not wired).**

**3. Implement `fn swarm_activate(ws string, opts SwarmOptions) SwarmReport` → `state.active_roles << role; write_swarm_state; append_trace('agent_activated')`; `fn swarm_promote` → `git merge --no-ff branch_for_run_role(rid, integrator)` after `is_worktree_dirty` guard (call P1-10 helper), then `state.run_state='cleanup_pending'`, `append_trace('promoted')`, teardown `tmux` if needed (reuse `swarm_cancel` teardown).**

Gate: `swarm init --help` not Unknown + `swarm plan <id>` creates `artifacts/plan.md` + `swarm activate <id> reviewer` flips + `swarm promote <id>` merges (when not dirty, else error).

### Severity / Area

- **Severity:** `low` (P3) — blocked on `handoff`/`compose_role_prompt` (P1-04/P1-07), not user-visible blocker since `start+approve` covers 80%.
- **Area:** `area:swarm`
- **Kind:** `kind:parity`
- **Labels:** `area:swarm kind:parity severity:low`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
build/agent-toolkit swarm --help 2>&1 | head -n 40
build/agent-toolkit swarm init --help 2>&1 | head -n 20 || echo "init missing (expected parity gap)"
build/agent-toolkit swarm plan s$(ls -t .agent-toolkit/swarm/runs | head -n1) 2>&1 | head -n 20 || echo "plan missing (gap)"
build/agent-toolkit swarm activate s$(ls -t .agent-toolkit/swarm/runs | head -n1) reviewer 2>&1 | head -n 20 || echo "activate missing (gap)"
ls .agent-toolkit/swarm/runs 2>&1 | head -n 10
grep -n "run_swarm" modules/agent_toolkit_core/swarm.v 2>&1 | head -n 20
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py | sed -n '276,340p'`
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py | sed -n '1595,1650p'`
- `modules/agent_toolkit_core/swarm.v:51` `run_swarm` + `modules/agent_toolkit_cli/commands.v:829` `swarm_command` (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§2.2 init/plan/activate`, `§3.1 A1.08`, `§4.5 P3-01`.


