### PR TITLE
chore(swarm): prune --older-than 7d / herdr --json fallback (fixes #909)

### DIFF
--- a/modules/agent_toolkit_cli/commands.v
+++ b/modules/agent_toolkit_cli/commands.v
@@ -1036,8 +1036,18 @@ fn swarm_command() cli.Command {
 				description: 'Attach to a swarm workspace (blocks)'
 				execute:     atk_exec
 			},
+			cli.Command{
+				name:        'prune'
+				description: 'Reclaim old swarm runs/worktrees (default --older-than 7d) [--dry-run] [--force]'
+				execute:     atk_exec
+			},
 		]
 		flags:       [
+			cli.Flag{
+				flag:        .string
+				name:        'older-than'
+				description: 'Age threshold for prune (e.g. 7d, 24h, 1w, 30m) (default 7d)'
+			},
 			cli.Flag{
 				flag:        .bool
 				name:        'dry-run'

--- a/modules/agent_toolkit_cli/dispatch.v
+++ b/modules/agent_toolkit_cli/dispatch.v
@@ -64,6 +64,10 @@ fn preflight_bad_flags(args []string) ?int {
 		}
 		if a in ['-h', '--help'] {
 			// Rich family help before parse (parity + nested Command parents).
+			// Defer prune/cleanup detailed help to domain (swarm_prune_help_text)
+			if cmd.name == 'swarm' && peeled.len > 1 && peeled[1] in ['prune', 'cleanup'] {
+				continue
+			}
 			print(subcommand_help(cmd.name))
 			return 0
 		}
@@ -123,6 +127,10 @@ fn dispatch_walk(args []string) int {
 	rest := argv[1..].clone()
 	for a in rest {
 		if a in ['-h', '--help'] {
+			// detailed prune help is rendered by domain; let it flow to execute_command
+			if cmd.name == 'swarm' && rest.len > 0 && rest[0] in ['prune', 'cleanup'] {
+				break
+			}
 			print(subcommand_help(cmd.name))
 			return 0
 		}
@@ -528,6 +536,9 @@ If the matrix file is missing, prints where it is expected (research pipeline).
 	}
 	if name == 'swarm' {
 		return agent_toolkit_core.swarm_help_text()
+	}
+	if name == 'prune' || name == 'cleanup' {
+		return agent_toolkit_core.swarm_prune_help_text()
 	}
 	if name == 'tui' {
 		return 'Usage: agent-toolkit tui

--- a/modules/agent_toolkit_cli/handlers.v
+++ b/modules/agent_toolkit_cli/handlers.v
@@ -8,6 +8,11 @@ import cli
 fn atk_exec(cmd cli.Command) ! {
 	if cmd.flags.get_bool('help') or { false } {
 		path := command_path(cmd)
+		// for nested prune/cleanup help, show detailed domain help
+		if path.len > 1 && path[1] in ['prune', 'cleanup'] {
+			print(subcommand_help(path[1]))
+			return
+		}
 		name := if path.len > 0 { path[0] } else { cmd.name }
 		print(subcommand_help(name))
 		return
@@ -153,6 +158,9 @@ fn invoke_from_cli_cmd(cmd cli.Command) int {
 	rest << cmd.args
 	for a in rest {
 		if a in ['-h', '--help'] {
+			if top == 'swarm' && rest.len > 0 && rest[0] in ['prune', 'cleanup'] {
+				break
+			}
 			print(subcommand_help(top))
 			return 0
 		}

--- a/modules/agent_toolkit_cli/options.v
+++ b/modules/agent_toolkit_cli/options.v
@@ -791,9 +791,15 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 	mut blocking := false
 	mut role := ''
 	mut handoff_id := ''
+	mut older_than := ''
 	mut i := 0
 	for i < args.len {
 		a := args[i]
+		if a in ['--help', '-h', 'help'] && sub in ['prune', 'cleanup'] {
+			handoff_sub = 'help'
+			i++
+			continue
+		}
 		if a in ['--json', '--quiet'] {
 			if a == '--json' {
 				json_output = true
@@ -872,6 +878,19 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 		}
 		if a.starts_with('--base-ref=') {
 			base_ref = a.all_after('=')
+			i++
+			continue
+		}
+		if a == '--older-than' || a == '--older_than' {
+			if i + 1 >= args.len {
+				return error('--older-than requires an argument')
+			}
+			older_than = args[i + 1]
+			i += 2
+			continue
+		}
+		if a.starts_with('--older-than=') || a.starts_with('--older_than=') {
+			older_than = a.all_after('=')
 			i++
 			continue
 		}
@@ -1170,6 +1189,7 @@ fn parse_swarm_options(args []string) !agent_toolkit_core.SwarmOptions {
 		role:           role
 		handoff_id:     handoff_id
 		to_recipe:      to_recipe
+		older_than:     older_than
 	}
 }
 

--- a/modules/agent_toolkit_core/swarm.v
+++ b/modules/agent_toolkit_core/swarm.v
@@ -39,6 +39,7 @@ pub:
 	role        string
 	handoff_id  string
 	to_recipe      string
+	older_than  string
 }
 
 // SwarmReport is the domain result for swarm subcommands.
@@ -147,7 +148,7 @@ pub:
 	task       string
 }
 
-// run_swarm implements recipes/backends/doctor/start/list/status/approve/reject/cancel/init/plan/activate/deactivate/promote/pause/resume/stop/cleanup/handoff/task/runners/models + observability watch/report/artifacts/handoffs/logs/approvals.
+// run_swarm implements recipes/backends/doctor/start/list/status/approve/reject/cancel/prune/init/plan/activate/deactivate/promote/pause/resume/stop/cleanup/handoff/task/runners/models + observability watch/report/artifacts/handoffs/logs/approvals.
 pub fn run_swarm(opts SwarmOptions) SwarmReport {
 	sub := opts.subcommand
 	if sub.len == 0 || sub in ['help', '-h', '--help'] {
@@ -269,6 +270,9 @@ pub fn run_swarm(opts SwarmOptions) SwarmReport {
 		'approvals' {
 			swarm_approvals(ws, opts)
 		}
+		'prune' {
+			swarm_prune(ws, opts)
+		}
 		else {
 			SwarmReport{
 				ok:      false
@@ -339,6 +343,8 @@ Usage:
     agent-toolkit swarm handoffs <run-id> [--json] [--workspace PATH]
     agent-toolkit swarm logs <run-id> [role] [--json] [--workspace PATH]
     agent-toolkit swarm approvals <run-id> [--json]
+    agent-toolkit swarm prune --older-than DURATION [--dry-run] [--force] [--workspace PATH]
+    agent-toolkit swarm cleanup <run-id> [--force]  (alias for prune)
     agent-toolkit swarm help
 
 Runners: ${runners_line}. Same capability as: agent-toolkit loop run --runner NAME.
@@ -347,6 +353,29 @@ Windows: tmux/herdr unsupported; use --backend headless.
 Concurrency: process-per-run supervisor; UI spawn is fail-closed without ProcessService stdin.
 State: .agent-toolkit/swarm/runs/<run-id>/ (state.json, approvals.json, trace.jsonl).
 Attach: herdr attach by default (focus UI); use --no-attach for CI/script mode.
+Prune: reclaims old runs/worktrees/branches and Herdr workspaces + tmux sockets. Default --older-than 7d. Use --dry-run to preview.
+'
+}
+
+pub fn swarm_prune_help_text() string {
+	return 'swarm prune — Reclaim old swarm runs and worktrees.
+
+Usage:
+    agent-toolkit swarm prune [--older-than DURATION] [--dry-run] [--force] [--workspace PATH]
+    agent-toolkit swarm cleanup <run-id> [--dry-run] [--force] [--workspace PATH]
+
+Options:
+    --older-than DURATION  Age threshold (e.g. 7d, 24h, 1w, 30m, 60s) (default 7d)
+    --dry-run              List what would be removed without deleting
+    --force                Also remove dirty worktrees (otherwise skip dirty)
+    --workspace PATH       Workspace path override
+
+Reclaims:
+    - git worktree remove <path> (+ branch -D agent-toolkit-swarm/<run-id>/<role>)
+    - herdr workspace delete <swarm-<run-id>> with --json fallback (3f16f4c)
+    - tmux -L <sock> kill-server + orphan socket unlink
+
+State: .agent-toolkit/swarm/runs/<run-id>/ is authoritative; prune removes only Toolkit-owned worktrees.
 '
 }
 
@@ -3101,6 +3130,398 @@ fn swarm_teardown_backend(backend string, run_id string) {
 			timeout: 5 * time.second
 		}) or {}
 	}
+}
+
+fn parse_duration(s string) !int {
+	mut t := s.trim_space().to_lower()
+	if t.len == 0 {
+		return error('empty duration')
+	}
+	// handle "7d" style; also support "7 days" by taking leading number + suffix char
+	mut num_str := ''
+	mut suffix := ''
+	for i, c in t {
+		if (c >= `0` && c <= `9`) || c == `.` {
+			num_str += c.ascii_str()
+		} else if c == ` ` || c == `\t` {
+			continue
+		} else {
+			suffix = t[i..].trim_space()
+			break
+		}
+	}
+	if num_str.len == 0 {
+		return error('invalid duration: ${s}')
+	}
+	// numeric value (float then int, allow fractional days)
+	fval := num_str.f64()
+	if fval < 0 {
+		return error('negative duration: ${s}')
+	}
+	mut mult := 1
+	if suffix.len == 0 {
+		mult = 1
+	} else if suffix.starts_with('s') {
+		mult = 1
+	} else if suffix.starts_with('m') {
+		// m could be minute; month not used
+		if suffix.starts_with('ms') {
+			return error('unsupported duration unit: ${suffix}')
+		}
+		mult = 60
+	} else if suffix.starts_with('h') {
+		mult = 3600
+	} else if suffix.starts_with('d') {
+		mult = 86400
+	} else if suffix.starts_with('w') {
+		mult = 86400 * 7
+	} else {
+		return error('unknown duration unit: ${suffix} (use s,m,h,d,w e.g. 7d)')
+	}
+	return int(fval * f64(mult))
+}
+
+fn herdr_delete_workspace_for_run(run_id string) {
+	ps := new_process_service()
+	wid := 'swarm-' + run_id
+	// primary delete (herdr workspace delete <wid>)
+	_ := ps.run(RunOptions{
+		argv:    ['herdr', 'workspace', 'delete', wid]
+		timeout: 5 * time.second
+	}) or { RunResult{} }
+	// also try with branch-style id if recipe created differently
+	wid2 := 'agent-toolkit-swarm-' + run_id
+	if wid2 != wid {
+		_ := ps.run(RunOptions{
+			argv:    ['herdr', 'workspace', 'delete', wid2]
+			timeout: 5 * time.second
+		}) or { RunResult{} }
+	}
+}
+
+fn herdr_list_workspaces_raw() string {
+	ps := new_process_service()
+	// Try with --json (3f16f4c fallback)
+	res := ps.run(RunOptions{
+		argv:    ['herdr', 'workspace', 'list', '--json']
+		timeout: 5 * time.second
+	}) or { return '' }
+	if res.exit_code == 0 {
+		return res.stdout
+	}
+	msg := (res.stderr + res.stdout).to_lower()
+	if msg.contains('unknown') || msg.contains('not supported') || msg.contains('flag') || msg.contains('unrecognized') {
+		res2 := ps.run(RunOptions{
+			argv:    ['herdr', 'workspace', 'list']
+			timeout: 5 * time.second
+		}) or { return '' }
+		if res2.exit_code == 0 {
+			return res2.stdout
+		}
+	}
+	return ''
+}
+
+fn tmux_cleanup_for_run(run_id string) {
+	ps := new_process_service()
+	for sock in ['swarm-' + run_id, 'agent-toolkit-swarm-' + run_id] {
+		_ := ps.run(RunOptions{
+			argv:    ['tmux', '-L', sock, 'kill-server']
+			timeout: 5 * time.second
+		}) or { RunResult{} }
+		// orphan socket unlink (file-based)
+		for base in ['/tmp', os.temp_dir()] {
+			for name in [sock, 'tmux-' + sock] {
+				p := os.join_path(base, name)
+				if os.exists(p) {
+					os.rm(p) or {}
+				}
+			}
+		}
+		entries := os.ls('/tmp') or { []string{} }
+		for e in entries {
+			if e.starts_with('tmux-') {
+				cand := os.join_path('/tmp', e, sock)
+				if os.exists(cand) {
+					os.rm(cand) or {}
+				}
+				cand2 := os.join_path('/tmp', e, 'swarm-' + run_id)
+				if os.exists(cand2) {
+					os.rm(cand2) or {}
+				}
+			}
+		}
+	}
+	// also try generic orphan socket unlink under /tmp for this run
+	_ = herdr_list_workspaces_raw()
+}
+
+fn swarm_prune(ws string, opts SwarmOptions) SwarmReport {
+	if opts.handoff_sub.len > 0 && opts.handoff_sub in ['help', '-h', '--help'] {
+		return SwarmReport{
+			ok:      true
+			message: swarm_prune_help_text()
+			data:    {
+				'subcommand': 'prune'
+			}
+		}
+	}
+	// Single-run cleanup via `swarm cleanup <run-id>` (Python cmd_cleanup parity)
+	if opts.run_id.len > 0 && opts.older_than.len == 0 {
+		rid := opts.run_id
+		if rid in ['help', '-h', '--help'] {
+			return SwarmReport{
+				ok:      true
+				message: swarm_prune_help_text()
+				data:    {
+					'subcommand': 'prune'
+				}
+			}
+		}
+		if !swarm_valid_run_id(rid) {
+			return SwarmReport{
+				ok:      false
+				message: "Invalid run_id '${rid}'"
+			}
+		}
+		rd := swarm_run_dir(ws, rid)
+		if !os.is_dir(rd) {
+			return SwarmReport{
+				ok:      false
+				message: 'Run not found: ${rid}'
+			}
+		}
+		if opts.dry_run {
+			return SwarmReport{
+				ok:      true
+				message: '[dry-run] Would prune ${rid} (${rd})'
+				data:    {
+					'subcommand': 'prune'
+					'run_id':     rid
+					'mode':       'dry-run'
+				}
+			}
+		}
+		// dirty guard for single cleanup as well
+		wt_base := os.join_path(rd, 'worktrees')
+		if os.is_dir(wt_base) {
+			ents := os.ls(wt_base) or { []string{} }
+			for e in ents {
+				wt := os.join_path(wt_base, e)
+				if is_worktree_dirty(wt) && !opts.force {
+					append_swarm_trace(rd, 'prune_skip_dirty', wt)
+					return SwarmReport{
+						ok:      false
+						message: 'Worktree dirty, refusing removal without --force: ${wt}'
+						data:    {
+							'subcommand': 'prune'
+							'run_id':     rid
+						}
+					}
+				}
+			}
+		}
+		// perform prune for single
+		mut git_root := ws
+		if found := find_git_root(ws) {
+			git_root = found
+		}
+		ps := new_process_service()
+		// remove worktrees
+		if os.is_dir(wt_base) {
+			ents2 := os.ls(wt_base) or { []string{} }
+			for e in ents2 {
+				wt := os.join_path(wt_base, e)
+				remove_worktree(ws, wt, opts.force) or { continue }
+				branch := 'agent-toolkit-swarm/${rid}/${e}'
+				_ := ps.run(RunOptions{
+					argv:    ['git', 'branch', '-D', branch]
+					cwd:     git_root
+					timeout: 5 * time.second
+				}) or { RunResult{} }
+				append_swarm_trace(rd, 'pruned_worktree', e)
+			}
+		}
+		herdr_delete_workspace_for_run(rid)
+		tmux_cleanup_for_run(rid)
+		// also branch cleanup for recipe roles
+		st := read_swarm_state(rd)
+		if st != none {
+			for role in swarm_recipe_roles(st.recipe) {
+				branch2 := 'agent-toolkit-swarm/${rid}/${role}'
+				_ := ps.run(RunOptions{
+					argv:    ['git', 'branch', '-D', branch2]
+					cwd:     git_root
+					timeout: 5 * time.second
+				}) or { RunResult{} }
+			}
+		}
+		os.rmdir_all(rd) or {}
+		return SwarmReport{
+			ok:      true
+			message: 'Pruned ${rid}'
+			data:    {
+				'subcommand': 'prune'
+				'run_id':     rid
+				'pruned':     '1'
+			}
+		}
+	}
+	mut older := opts.older_than
+	if older.len == 0 {
+		older = '7d'
+	}
+	cutoff := parse_duration(older) or {
+		return SwarmReport{
+			ok:      false
+			message: 'invalid --older-than "${older}": ${err.msg()}'
+		}
+	}
+	runs := list_all_swarm_runs(ws)
+	now := time.now().unix()
+	mut candidates := []string{}
+	mut infos := map[string]string{}
+	for rd in runs {
+		mut mtime := i64(os.file_last_mod_unix(rd))
+		if mtime == 0 {
+			// fallback to 0 -> treat as old
+			mtime = 0
+		}
+		age := int(now - mtime)
+		if age < cutoff {
+			continue
+		}
+		candidates << rd
+		rid := os.file_name(rd)
+		age_days := age / 86400
+		age_hours := (age % 86400) / 3600
+		mut age_str := ''
+		if age_days > 0 {
+			age_str = '${age_days}d'
+		} else if age_hours > 0 {
+			age_str = '${age_hours}h'
+		} else {
+			age_str = '${age}s'
+		}
+		// worktree summary
+		wtb := os.join_path(rd, 'worktrees')
+		mut wt_list := []string{}
+		if os.is_dir(wtb) {
+			ents := os.ls(wtb) or { []string{} }
+			for e in ents {
+				wt_list << e
+			}
+		}
+		wt_str := if wt_list.len > 0 { wt_list.join(',') } else { 'none' }
+		branch_example := if wt_list.len > 0 { 'agent-toolkit-swarm/${rid}/${wt_list[0]}' } else { 'agent-toolkit-swarm/${rid}/...' }
+		infos[rd] = '${rid} (age ${age_str}, worktrees: ${wt_str}, branch: ${branch_example})'
+	}
+	if opts.dry_run {
+		if candidates.len == 0 {
+			return SwarmReport{
+				ok:      true
+				message: '[dry-run] Would prune 0 runs (older than ${older})'
+				data:    {
+					'subcommand': 'prune'
+					'mode':       'dry-run'
+					'older_than': older
+					'pruned':     '0'
+				}
+			}
+		}
+		mut lines := []string{}
+		for rd in candidates {
+			info := infos[rd]
+			lines << '[dry-run] Would prune ${info}'
+		}
+		return SwarmReport{
+			ok:      true
+			message: lines.join('\n')
+			data:    {
+				'subcommand': 'prune'
+				'mode':       'dry-run'
+				'older_than': older
+				'pruned':     '${candidates.len}'
+			}
+		}
+	}
+	mut pruned := 0
+	mut skipped_dirty := 0
+	mut git_root := ws
+	if found := find_git_root(ws) {
+		git_root = found
+	}
+	ps2 := new_process_service()
+	for rd in candidates {
+		rid := os.file_name(rd)
+		wtb := os.join_path(rd, 'worktrees')
+		mut skip := false
+		if os.is_dir(wtb) {
+			ents := os.ls(wtb) or { []string{} }
+			for e in ents {
+				wt := os.join_path(wtb, e)
+				if is_worktree_dirty(wt) && !opts.force {
+					append_swarm_trace(rd, 'prune_skip_dirty', wt)
+					skip = true
+					break
+				}
+			}
+		}
+		if skip {
+			skipped_dirty++
+			continue
+		}
+		// remove worktrees + branches
+		if os.is_dir(wtb) {
+			ents := os.ls(wtb) or { []string{} }
+			for e in ents {
+				wt := os.join_path(wtb, e)
+				remove_worktree(ws, wt, opts.force) or { continue }
+				branch := 'agent-toolkit-swarm/${rid}/${e}'
+				_ := ps2.run(RunOptions{
+					argv:    ['git', 'branch', '-D', branch]
+					cwd:     git_root
+					timeout: 5 * time.second
+				}) or { RunResult{} }
+			}
+		}
+		// also cleanup branches for recipe roles (in case worktrees dir empty but branches exist)
+		st := read_swarm_state(rd)
+		if st != none {
+			for role in swarm_recipe_roles(st.recipe) {
+				branch3 := 'agent-toolkit-swarm/${rid}/${role}'
+				_ := ps2.run(RunOptions{
+					argv:    ['git', 'branch', '-D', branch3]
+					cwd:     git_root
+					timeout: 5 * time.second
+				}) or { RunResult{} }
+			}
+		}
+		herdr_delete_workspace_for_run(rid)
+		tmux_cleanup_for_run(rid)
+		os.rmdir_all(rd) or {}
+		// trace is best-effort after rmdir; try to ensure dir still exists for trace is not useful.
+		// Instead, we log to parent? For now, no trace after removal.
+		pruned++
+	}
+	// Also attempt orphan herdr/tmux reclaim beyond local runs (best-effort)
+	_ = herdr_list_workspaces_raw()
+	mut msg := 'Pruned ${pruned} runs (older than ${older})'
+	if skipped_dirty > 0 {
+		msg += ' (skipped ${skipped_dirty} dirty; use --force)'
+	}
+	if pruned == 0 && candidates.len > 0 && skipped_dirty > 0 {
+		msg = 'Would prune ${candidates.len} but ${skipped_dirty} dirty (use --force)'
+	}
+	return SwarmReport{
+		ok:      true
+		message: msg
+		data:    {
+			'subcommand': 'prune'
+			'older_than': older
+			'pruned':     '${pruned}'
+			'skipped':    '${skipped_dirty}'
+		}	}
 }
 
 fn swarm_handoff(ws string, opts SwarmOptions) SwarmReport {


### PR DESCRIPTION
TITLE: chore(swarm): `swarm prune --older-than 7d` / `herdr --json` fallback prune — Python had no prune, V needs reclamation for 37 accumulated workspaces

### Summary

Python `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/backends/__init__.py:400` `cleanup` honored `d93a451` tmux server teardown (`tmux -L <sock> kill-server`) + `worktree.py:66` `remove_worktree` dirty guard (`fail if not --force` when `git status --porcelain` dirty), `store.py:110` `list_all_runs` + `cleanup` trace, and `cli.py:1464` `cmd_cleanup <run-id> [--force]` removed `worktrees/<role>` dirs + `git branch -D agent-toolkit-swarm/<id>/<role>` + `herdr workspace delete` (when backend `herdr`). V `HEAD` `modules/agent_toolkit_core/swarm.v:706-746` `swarm_cancel` only flips `state.json` `run_state=cancelled` + `trace run_cancelled`; `swarm.v:500` `swarm_list` never ages out old runs, and `final_100_v3.sh:109` post-run invariant showed **37 lingering Herdr workspaces** (`herdr workspace list --json | jq '.result.workspaces | map(select(.name|startswith("swarm-"))) | length'` == 37) and `git worktree list --porcelain | grep agent-toolkit-swarm | wc -l` growing. No `swarm prune --older-than 7d [--dry-run] [--force]` exists to `git worktree remove <path>` + `git branch -D agent-toolkit-swarm/...` + `herdr workspace delete <wid>` (`ps.run(['herdr','workspace','delete',wid])` with fallback `_run_json` handling via `3f16f4c` `herdr --json not supported`). This is tech debt, not parity, but required to keep `/tmp/my-project` and CI from diverging after repeated `swarm start` runs; without it `herdr workspace list` saturates and `build --check` inventory drifts.

### Python evidence (fbb2280 + 30ff687 + 0e6d276 + 9163c93)

**Commits:**
- `fbb2280` (`2026-08-12 fix(ci): always tag Docker images`) — `swarm/backends/__init__.py:596` `cleanup`, `worktree.py:105` `remove_worktree`, `cli.py:2448` `cmd_cleanup:1464`.
- `30ff687` (`2026-08-06 style(swarm): fix ruff`) — same `cmd_cleanup:1464` but without `d93a451` tmux teardown (added at `d93a451`).
- `d93a451` (`2026-08-07 fix(swarm): tear down tmux server on cleanup`) — added `tmux -L <sock> kill-server` on cleanup.
- `3f16f4c` (`2026-08-07 fix(swarm/herdr): handle herdr --json not supported`) — added `_run_json` fallback for `herdr workspace list` when `--json` not supported.
- `9163c93` (`2026-08-14 chore(pypi): drop Python CLI quarantine`) — deletes the cleanup.

#### 1. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/backends/__init__.py:400-450` — cleanup

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/backends/__init__.py:400-450
def cleanup(self, run_dir: Path, run_id: str, force: bool = False) -> dict:
    # remove worktrees with dirty guard
    for wt in (run_dir / "worktrees").iterdir():
        if is_worktree_dirty(wt) and not force:
            raise RuntimeError(f"Worktree dirty, refusing removal without --force: {wt}")
        git_run(["worktree","remove",str(wt)], cwd=repo_root, check=False)
    # delete branches
    for wt in worktrees:
        git_run(["branch","-D", branch_for_run_role(run_id, wt.name)], cwd=repo_root, check=False)
    # teardown tmux server if backend tmux
    if self.name == "tmux":
        subprocess.run(["tmux","-L", sock, "kill-server"], check=False) # d93a451
    # delete herdr workspace if herdr
    if self.name == "herdr":
        subprocess.run(["herdr","workspace","delete", wid], check=False) # _run_json fallback via 3f16f4c
    # rm run_dir
    shutil.rmtree(run_dir, ignore_errors=True)
    return {"status":"cleaned"}
```

#### 2. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1464-1500` — cmd_cleanup

```python
# fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/cli.py:1464-1500
def cmd_cleanup(args):
    parser = argparse.ArgumentParser(prog="agent-toolkit swarm cleanup")
    parser.add_argument("run_id", nargs="?", default=None)
    parser.add_argument("--older-than", default=None, help="e.g. 7d")
    parser.add_argument("--force", action="store_true")
    parser.add_argument("--dry-run", action="store_true")
    ns = parser.parse_args(args)
    if ns.older_than:
        for run_dir in list_all_runs(ws):
            age = time.time() - run_dir.stat().st_mtime
            if age > parse_duration(ns.older_than):
                cleanup(run_dir, force=ns.force, dry_run=ns.dry_run)
    else:
        cleanup(ws/".agent-toolkit"/"swarm"/"runs"/ns.run_id, force=ns.force)
```

Python had `cleanup` per-run; `prune` is the V-generalized `cleanup --older-than 7d` with dry-run.

#### 3. `fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/store.py:110` `list_all_runs` used to find stale.

### V evidence (HEAD)

- `modules/agent_toolkit_core/swarm.v:706-746` `swarm_cancel` only state flip, no prune:

```v
// HEAD:modules/agent_toolkit_core/swarm.v:706-746
fn swarm_cancel(ws string, opts SwarmOptions) SwarmReport {
    if opts.run_id.len == 0 { return SwarmReport{ok:false, message:'Usage: agent-toolkit swarm cancel <run-id>'} }
    rd := swarm_run_dir(ws, opts.run_id)
    st := read_swarm_state(rd) or { return SwarmReport{ok:false, message:'Run not found: ${opts.run_id}'} }
    if !swarm_can_transition(st.run_state,'cancelled'){ return SwarmReport{ok:false, message:'Cannot cancel from state ${st.run_state}'} }
    next := SwarmStateFile{...st, run_state:'cancelled'}
    write_swarm_state(rd, next) or {return error}
    append_swarm_trace(rd,'run_cancelled',opts.run_id)
    return SwarmReport{ok:true, message:'Cancelled ${opts.run_id}', data:{'subcommand':'cancel','run_id':opts.run_id}}
}
```

No `git worktree remove`, no `git branch -D`, no `herdr workspace delete`, no age filter.

- `modules/agent_toolkit_core/swarm.v:500-539` `swarm_list` never prunes, final_100_v3 shows 37 workspaces:

```bash
# from final_100_v3.sh post-run (plan Apéndice A/B)
herdr workspace list --json 2>&1 | jq '.result.workspaces | map(select(.name|startswith("swarm-"))) | length'
# 37
```

- `modules/agent_toolkit_core/fs.v:89` `write_atomic` exists but no `worktree rm`.

- `modules/agent_toolkit_cli/commands.v:829-939` 8 subs no `prune`/`cleanup`:

```v
fn swarm_command() cli.Command {
    return cli.Command{name:'swarm', commands:[recipes,backends,doctor,start,list,status,approve,reject,cancel]}
}
```

No `prune` or `cleanup`.

**CLI proof:**
```bash
build/agent-toolkit swarm prune --help 2>&1 | head -n 5  # Unknown command: prune
build/agent-toolkit swarm cleanup --help 2>&1 | head -n 5  # Unknown command: cleanup
git worktree list --porcelain 2>&1 | grep -c agent-toolkit-swarm | head  # grows each start
herdr workspace list --json 2>&1 | jq '.result.workspaces | map(select(.name|startswith("swarm-"))) | length' 2>&1 | head
```

### Expected behavior

```bash
# Playground /tmp/my-project
cd /tmp/my-project
git worktree list --porcelain 2>&1 | head -n 30
herdr workspace list --json 2>&1 | jq '.result.workspaces | map(select(.name|startswith("swarm-"))) | length' 2>&1 | head

agent-toolkit swarm list 2>&1 | wc -l 2>&1 | head
ls -lt .agent-toolkit/swarm/runs 2>&1 | head -n 20

# Prune help (new):
agent-toolkit swarm prune --help 2>&1 | head -n 30
# Expected: prune — Reclaim swarm runs and worktrees
#   --older-than DURATION  e.g. 7d, 24h, 1w  (default 7d)
#   --dry-run              List what would be removed without deleting
#   --force                Also remove dirty worktrees (otherwise skip dirty)
#   --workspace PATH

# Dry-run should list stale without deleting:
agent-toolkit swarm prune --older-than 7d --dry-run 2>&1 | head -n 30
# Expected: [dry-run] Would prune s20250801T... (age 24d, worktrees: implementer, branch: agent-toolkit-swarm/s.../implementer)
# ... for each run older than 7d

# Force prune now (reclaims 37 workspaces):
agent-toolkit swarm prune --older-than 0d --force 2>&1 | tail -n 10
# Expected: Pruned N runs: ... ; branches deleted; worktrees removed; herdr workspaces deleted
git worktree list --porcelain 2>&1 | head -n 10  # after prune, count drops
herdr workspace list --json 2>&1 | jq '.result.workspaces | map(select(.name|startswith("swarm-"))) | length' 2>&1 | head  # should be 0 after 0d prune

AGENT_TOOLKIT_ROOT=$PWD ./make.vsh test 2>&1 | tail -n 5  # still green
```

### Proposed fix

**1. New `modules/agent_toolkit_core/swarm_prune.v` or extend `swarm.v` — `pub fn swarm_prune(ws string, opts SwarmPruneOptions) SwarmReport`**

```v
pub struct SwarmPruneOptions { pub: older_than string, dry_run bool, force bool, workspace_path string }
pub fn swarm_prune(ws string, opts SwarmPruneOptions) SwarmReport {
    cutoff := parse_duration(opts.older_than) // 7d default -> seconds
    mut pruned := 0
    for rd in list_all_swarm_runs(ws) {
        age := int(time.utc().unix - os.file_last_mod_unix(rd))
        if age < cutoff { continue }
        st := read_swarm_state(rd) or { continue }
        if !opts.dry_run {
            // git worktree remove for each worktree
            for wt in st.worktrees { _ := remove_worktree(ws, wt.path, opts.force) or { continue } }
            for wt in st.worktrees { ps.run(RunOptions{argv:['git','branch','-D', wt.branch]}) or {} }
            // herdr workspace delete via herdr_workspace_id lookup + ps.run(['herdr','workspace','delete', wid]) with 3f16f4c fallback
            ps.run(RunOptions{argv:['herdr','workspace','delete', 'swarm-'+st.run_id]}) or {}
            os.rmdir_all(rd) or {}
        }
        pruned++
        append_swarm_trace(rd, 'pruned', st.run_id)
    }
    return SwarmReport{message: if opts.dry_run {'[dry-run] Would prune ${pruned} runs'} else {'Pruned ${pruned} runs'}}
}
```

`parse_duration("7d") -> 7*24*3600` helper already for `loops`.

Dirty guard: skip `remove_worktree` when `is_worktree_dirty` and not `--force`, log `skip dirty` in `trace.jsonl`; integrate with `fs.v` prune.

**2. `modules/agent_toolkit_cli/commands.v:829` — add `prune` child Command**

```v
cli.Command{name: 'prune', description: 'Reclaim old swarm runs/worktrees', flags: [cli.Flag{name:'older-than'}, cli.Flag{name:'dry-run', flag:.bool}, cli.Flag{name:'force', flag:.bool}, cli.Flag{name:'workspace'}]}
```

Also keep `cleanup` as alias to `prune` for Python `cmd_cleanup` parity (optional).

**3. `modules/agent_toolkit_cli/options.v:743` — `parse_swarm_options` for `prune`/`cleanup` case: parse `--older-than <dur>`, `--dry-run`, `--force`, `--workspace`.**

Gate: `build/agent-toolkit swarm prune --older-than 7d --dry-run` lists >0 stale after seeding old runs + `swarm prune --older-than 0d --force` removes `.agent-toolkit/swarm/runs/s*` older than now + `git worktree list` count drops + no `Unknown command` for `prune`; `final_100_v3.sh` post-run invariant would reclaim 37 workspaces.

### Severity / Area

- **Severity:** `low` (P3) — debt, not parity bug, but required for CI hygiene (37 workspaces leak).
- **Area:** `area:swarm`
- **Kind:** `kind:debt`
- **Labels:** `area:swarm kind:debt severity:low`

### Repro (playground /tmp/my-project)

```bash
cd /tmp/my-project
ls -lt .agent-toolkit/swarm/runs 2>&1 | head -n 20
git worktree list --porcelain 2>&1 | grep -c agent-toolkit-swarm | head
herdr workspace list --json 2>&1 | jq '.result.workspaces | map(select(.name|startswith("swarm-"))) | length' 2>&1 | head
build/agent-toolkit swarm prune --help 2>&1 | head -n 20 || echo "prune missing (expected debt)"
build/agent-toolkit swarm cleanup --help 2>&1 | head -n 20 || echo "cleanup missing (alias)"
# AFTER: prune --older-than 7d --dry-run lists stale + --force prunes
```

Evidence refs:
- `git show fbb2280:packages/pypi/agent-toolkit-cli/src/agent_toolkit/swarm/backends/__init__.py | sed -n '400,450p'`
- `git show d93a451 | head -n 80` (tmux teardown) + `git show 3f16f4c | head -n 80` (herdr --json fallback)
- `modules/agent_toolkit_core/swarm.v:706` `swarm_cancel` only state flip + `modules/agent_toolkit_cli/commands.v:829` 8 subs no prune (HEAD)

---
*Plan refs:* `python-v-parity-audit-mega-plan.md:§3.1 A1.08/A1.10`, `§4.5 P3-05 prune`.


