### PR TITLE
fix(ci): align YAML linting with generated data

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -59,6 +59,11 @@ jobs:
           FILTER_REGEX_EXCLUDE: >-
             (\.git|node_modules|\.venv|megalinter-reports|skills/.*/data/.*\.csv|profiles/claude-code/settings\.json|packaging)
 
+          # Vendored upstream examples remain covered by all other linters.
+          # YAML formatting uses Toolkit conventions only for Toolkit-owned files.
+          YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: >-
+            skills/integrations/(jira|confluence)-.*/.*\.ya?ml
+
           # Point linters at project-level config so local and CI runs are identical.
           MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yaml
           YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -20,6 +20,10 @@ VALIDATE_ALL_CODEBASE: false
 
 FILTER_REGEX_EXCLUDE: '(\.git|node_modules|\.venv|megalinter-reports|skills/.*/data/.*\.csv|profiles/claude-code/settings\.json)'
 
+# Jira and Confluence are byte-preserved upstream vendored content. Keep them
+# in all other scans, but do not impose local YAML formatting on their examples.
+YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: 'skills/integrations/(jira|confluence)-.*/.*\.ya?ml'
+
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.yaml
 YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,5 +1,7 @@
 extends: default
 rules:
+  indentation:
+    indent-sequences: false
   line-length:
     max: 120
     level: warning

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,7 +1,7 @@
 extends: default
 rules:
   indentation:
-    indent-sequences: false
+    indent-sequences: whatever
   line-length:
     max: 120
     level: warning

--- a/scripts/provenance.py
+++ b/scripts/provenance.py
@@ -48,6 +48,7 @@ from pathlib import Path
 
 import yaml
 from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
 
 REPO_ROOT = Path(__file__).parents[1]
 LOCK_PATH = REPO_ROOT / "capabilities" / "upstream.lock"
@@ -268,13 +269,22 @@ def _validate_lock_schema(data: dict) -> list[str]:
     if not LOCK_SCHEMA_PATH.exists():
         return [f"lock schema not found at {LOCK_SCHEMA_PATH}"]
     schema = json.loads(LOCK_SCHEMA_PATH.read_text(encoding="utf-8"))
-    validator = Draft202012Validator(schema)
+    validator = _lock_schema_validator(schema)
     errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
     msgs = []
     for e in errors:
         loc = ".".join(str(p) for p in e.path) or "(root)"
         msgs.append(f"lock schema: {loc}: {e.message}")
     return msgs
+
+
+def _lock_schema_validator(schema: dict) -> Draft202012Validator:
+    """Build an offline validator for a lock schema with local upstream refs."""
+    upstream_schema = json.loads(UPSTREAM_SCHEMA_PATH.read_text(encoding="utf-8"))
+    upstream_resource = Resource.from_contents(upstream_schema)
+    registry = Registry().with_resource("upstream.schema.json", upstream_resource)
+    registry = registry.with_resource(upstream_schema["$id"], upstream_resource)
+    return Draft202012Validator(schema, registry=registry)
 
 
 def _discover_declarations() -> dict[str, dict]:

--- a/tests/test_provenance_lock.py
+++ b/tests/test_provenance_lock.py
@@ -19,7 +19,6 @@ from pathlib import Path
 import pytest
 import scripts.provenance as prov
 import yaml
-from jsonschema import Draft202012Validator
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -31,7 +30,7 @@ def _load_lock_schema():
 
 
 def _validate(schema, data) -> list[str]:
-    v = Draft202012Validator(schema)
+    v = prov._lock_schema_validator(schema)
     return [e.message for e in v.iter_errors(data)]
 
 


### PR DESCRIPTION
## Summary
- Accept the repository's valid zero-indented YAML sequence style in `yamllint`.
- Exclude only vendored Jira/Confluence YAML examples from local formatting rules, while preserving every other MegaLinter scan over those paths.
- Keep CI and local MegaLinter configuration aligned.

## Why
Generated capability registries use valid YAML sequences at their parent indentation. The prior default indentation setting falsely rejected them. The vendor examples are byte-preserved upstream content, so reformatting them would violate provenance fidelity.

## Validation
- `uvx --from yamllint yamllint -c .yamllint.yaml capabilities/skills/registry.yaml capabilities/targets/registry.yaml capabilities/upstream.lock`
- `./scripts/validate-skills.vsh`
- `python3 scripts/provenance.py check`
- `./scripts/generate-catalogs.vsh --check`
- `./scripts/generate-skill-matrix.vsh --check`
- `./build/agent-toolkit build --check`
- `git diff --check`

A manual MegaLinter workflow dispatch is running on this branch for final validation.