### PR TITLE
fix(ci): always run Validate so the 'Required CI' gate always reports on PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,22 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - "modules/**"
-      - "cmd/**"
-      - "skills/**"
-      - "agents/**"
-      - "loops/**"
-      - "profiles/**"
-      - "mcp/**"
-      - "catalogs/**"
-      - "schemas/**"
-      - "scripts/**"
-      - "make.vsh"
-      - ".v-version"
-      - ".github/workflows/validate.yml"
-      - "packages/pypi/**"
-      - "packages/npm/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Closes the phantom-gate footgun found during the branch-protection audit: branch protection requires the `Required CI` aggregator context, but the workflow-level `pull_request.paths` filter meant PRs touching only non-listed paths (root `README.md`, most `docs/*.md`) skipped the whole workflow — the required check never reported and the PR was **permanently blocked**.

## Change

Removes the `paths:` filter so Validate (and its `Required CI` aggregator) runs on every PR. The aggregator's own pass/skip logic is unchanged.

## Trade-off

Heavy matrix jobs now run on docs-only PRs. If cost matters later, the recommended evolution is a `dorny/paths-filter` `changes` job + per-job `if` conditions, with `Required CI` treating skipped as OK for docs-only runs (it already does for `test-package`).
