### PR TITLE
fix(distribution): model runtime requirements for github MCP (closes #975)

### DIFF
--- a/distributions/products.yaml
+++ b/distributions/products.yaml
@@ -29,7 +29,12 @@ products:
         plugin_id: agent-toolkit-core
         manifest: plugins/agent-toolkit-core/.cursor-plugin/plugin.json
     requires:
-      executables: []
+      executables:
+        - name: docker
+          description: Docker for GitHub MCP (ghcr.io/github/github-mcp-server)
+          install_url: https://docs.docker.com/get-docker/
+          required: false
+          capability: mcp:github
       env: []
     security:
       approval_required: false

--- a/docs/SKILL_PRODUCT_MATRIX.md
+++ b/docs/SKILL_PRODUCT_MATRIX.md
@@ -8,7 +8,7 @@ _Generated from 5 products × 116 skills × 18 agents._
 
 | Product | Stability | Targets | Skills | Agents |
 |---------|-----------|---------|--------|--------|
-| `agent-toolkit-core` | stable | claude-code, cursor, requires, security | 6 | 1 |
+| `agent-toolkit-core` | stable | claude-code, cursor, executables, requires, security | 6 | 1 |
 | `agent-toolkit-agents` | stable | claude-code, cursor | 0 | 18 |
 | `agent-toolkit-forge` | stable | claude-code, cursor | 8 | 0 |
 | `agent-toolkit-craft` | stable | claude-code, cursor | 3 | 0 |
@@ -27,14 +27,14 @@ _Generated from 5 products × 116 skills × 18 agents._
 | `architecture/c4-model` | `agent-toolkit-complete` | — |
 | `cloud/aws-well-architected-review` | `agent-toolkit-complete` | — |
 | `cloud/cloud-design-patterns` | `agent-toolkit-complete` | — |
-| `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, requires, security |
-| `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, requires, security |
-| `core/onboarding` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, requires, security |
-| `core/output-handshake` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, requires, security |
-| `core/pr-fallback` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, requires, security |
+| `core/assistant` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, executables, requires, security |
+| `core/dev-companion` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, executables, requires, security |
+| `core/onboarding` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, executables, requires, security |
+| `core/output-handshake` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, executables, requires, security |
+| `core/pr-fallback` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, executables, requires, security |
 | `core/project` | `agent-toolkit-complete` | — |
 | `core/workspace` | `agent-toolkit-complete` | — |
-| `core/workspace-knowledge-sync` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, requires, security |
+| `core/workspace-knowledge-sync` | `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, executables, requires, security |
 | `data/dbt-validation` | `agent-toolkit-complete` | — |
 | `data/snowflake-validation` | `agent-toolkit-complete` | — |
 | `delivery/adr` | `agent-toolkit-complete` | — |
@@ -144,7 +144,7 @@ _Generated from 5 products × 116 skills × 18 agents._
 | `assistant` | `agent-toolkit-agents`, `agent-toolkit-complete` | claude-code, cursor |
 | `build-error-resolver` | `agent-toolkit-agents`, `agent-toolkit-complete` | claude-code, cursor |
 | `client-workflow-bootstrap` | `agent-toolkit-agents`, `agent-toolkit-complete` | claude-code, cursor |
-| `code-reviewer` | `agent-toolkit-agents`, `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, requires, security |
+| `code-reviewer` | `agent-toolkit-agents`, `agent-toolkit-complete`, `agent-toolkit-core` | claude-code, cursor, executables, requires, security |
 | `data-engineer` | `agent-toolkit-agents`, `agent-toolkit-complete` | claude-code, cursor |
 | `designer` | `agent-toolkit-agents`, `agent-toolkit-complete` | claude-code, cursor |
 | `e2e-runner` | `agent-toolkit-agents`, `agent-toolkit-complete` | claude-code, cursor |

--- a/modules/agent_toolkit_core/doctor.v
+++ b/modules/agent_toolkit_core/doctor.v
@@ -320,6 +320,15 @@ fn collect_mcp_checks(root string) []DoctorCheck {
 			out << DoctorCheck{'mcp', provider, 'warn', 'template missing'}
 		}
 	}
+	// 975: surface docker runtime for github MCP (ghcr.io image)
+	if 'github' in providers {
+		docker_path := os.find_abs_path_of_executable('docker') or { '' }
+		if docker_path.len == 0 {
+			out << DoctorCheck{'mcp', 'docker', 'warn', 'docker not found (required for mcp:github) — install https://docs.docker.com/get-docker/'}
+		} else {
+			out << DoctorCheck{'mcp', 'docker', 'ok', 'docker at ${docker_path} (for mcp:github)'}
+		}
+	}
 	return out
 }
 

--- a/modules/agent_toolkit_core/mcp.v
+++ b/modules/agent_toolkit_core/mcp.v
@@ -455,6 +455,13 @@ fn mcp_health(root string, provider string) McpReport {
 }
 
 fn mcp_doctor(root string, cfg_path string, provider string) McpReport {
+	// 975: if provider is github, surface docker runtime requirement even when not configured
+	if provider == 'github' || provider.len == 0 {
+		docker_path := os.find_abs_path_of_executable('docker') or { '' }
+		if docker_path.len == 0 {
+			// still continue to normal doctor, but ensure docker hint is included via check below
+		}
+	}
 	cfg := load_mcp_config(cfg_path)
 	mut targets := []string{}
 	if provider.len > 0 {
@@ -464,6 +471,18 @@ fn mcp_doctor(root string, cfg_path string, provider string) McpReport {
 		targets.sort()
 	}
 	if targets.len == 0 {
+		// for 975: if no configured providers but github registry exists, surface docker hint
+		if provider.len == 0 || provider == 'github' {
+			if 'github' in list_known_mcp_providers(root) {
+				docker_path := os.find_abs_path_of_executable('docker') or { '' }
+				if docker_path.len == 0 {
+					return McpReport{
+						ok:      true
+						message: '  ⚠  No MCP providers configured. Run: agent-toolkit mcp list\n  ⚠  docker not found (required for mcp:github) — install https://docs.docker.com/get-docker/'
+					}
+				}
+			}
+		}
 		return McpReport{
 			ok:      true
 			message: '  ⚠  No MCP providers configured. Run: agent-toolkit mcp list'
@@ -541,6 +560,17 @@ fn mcp_doctor(root string, cfg_path string, provider string) McpReport {
 					lines << '  ✗  ${var}: not set'
 					total_err++
 				}
+			}
+		}
+		// 975: docker runtime for github MCP (ghcr.io)
+		if p == 'github' {
+			docker_path := os.find_abs_path_of_executable('docker') or { '' }
+			if docker_path.len == 0 {
+				lines << '  ✗  docker not found (required for mcp:github) — install https://docs.docker.com/get-docker/'
+				total_err++
+			} else {
+				lines << '  ✓  docker: found at ${docker_path} (for mcp:github)'
+				total_ok++
 			}
 		}
 	}


### PR DESCRIPTION
Closes #975

- products.yaml adds docker as optional capability mcp:github
- doctor checks docker when github provider present
- mcp doctor surfaces docker missing with install URL https://docs.docker.com/get-docker/
