### PR TITLE
security(mcp): pin github MCP image to digest (closes #974)

### DIFF
--- a/mcp/registry/github.yaml
+++ b/mcp/registry/github.yaml
@@ -6,7 +6,7 @@ display_name: GitHub
 purpose: Access GitHub repositories, issues, PRs, code, and CI via the official GitHub MCP server
 implementation:
   provenance: official
-  package: ghcr.io/github/github-mcp-server
+  package: ghcr.io/github/github-mcp-server@sha256:fbec75de11c255213fa08d80fb166abe73d851fff631c51c0079872967720699 # pinned digest for latest, see https://github.com/github/github-mcp-server
   repository: https://github.com/github/github-mcp-server
   license: MIT
   version_policy: pin image digest or minor tag

--- a/mcp/templates/github/config.template.json
+++ b/mcp/templates/github/config.template.json
@@ -7,7 +7,7 @@
     "--rm",
     "-e",
     "GITHUB_PERSONAL_ACCESS_TOKEN",
-    "ghcr.io/github/github-mcp-server"
+    "ghcr.io/github/github-mcp-server@sha256:fbec75de11c255213fa08d80fb166abe73d851fff631c51c0079872967720699"
   ],
   "env": {
     "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"

--- a/plugins/agent-toolkit-complete/mcp.json
+++ b/plugins/agent-toolkit-complete/mcp.json
@@ -10,7 +10,7 @@
         "--rm",
         "-e",
         "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
+        "ghcr.io/github/github-mcp-server@sha256:fbec75de11c255213fa08d80fb166abe73d851fff631c51c0079872967720699"
       ],
       "cwd": "${PLUGIN_ROOT}"
     },

--- a/plugins/agent-toolkit-core/mcp.json
+++ b/plugins/agent-toolkit-core/mcp.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
   "mcpServers": {
-    "github": { "type": "stdio", "command": "docker", "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "ghcr.io/github/github-mcp-server"], "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"}, "cwd": "${PLUGIN_ROOT}" }
+    "github": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server@sha256:fbec75de11c255213fa08d80fb166abe73d851fff631c51c0079872967720699"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      },
+      "cwd": "${PLUGIN_ROOT}"
+    }
   }
 }


### PR DESCRIPTION
Closes #974

Pin ghcr.io/github/github-mcp-server to sha256:fbec75de11c255213fa08d80fb166abe73d851fff631c51c0079872967720699 via GHCR OCI index digest (verified via ghcr.io/token + docker-content-digest header).

Updates mcp/registry/github.yaml, mcp/templates/github/config.template.json, plugins/*/mcp.json.