### PR TITLE
fix(server): harden job lifecycle — unique IDs, validation, path hardening (closes #966)

### DIFF
--- a/modules/agent_toolkit_server/jobs.v
+++ b/modules/agent_toolkit_server/jobs.v
@@ -84,7 +84,7 @@ pub fn (mut r JobRunner) create(cmd string, args []string, workdir string) !Job 
 		return error('max concurrent jobs (${r.max_running}) reached')
 	}
 	// Use timestamp + pid + random to avoid collisions under parallel creates
-	id := 'job_' + time.utc().format_rfc3339().replace('-', '').replace(':', '').replace('.', '') + '_' + os.getpid().str() + '_' + rand.int_in_range(1000, 9999).str()
+	id := 'job_' + time.utc().format_rfc3339().replace('-', '').replace(':', '').replace('.', '') + '_' + os.getpid().str() + '_' + (rand.int_in_range(1000, 9999) or { 1000 }).str()
 	job := Job{
 		id: id
 		cmd: cmd

--- a/modules/agent_toolkit_server/jobs.v
+++ b/modules/agent_toolkit_server/jobs.v
@@ -4,6 +4,7 @@ module agent_toolkit_server
 // Mirrors ADR-020: spawn CLI subprocess, capture output lines, persist registry.
 import json
 import os
+import rand
 import sync
 import time
 
@@ -82,7 +83,8 @@ pub fn (mut r JobRunner) create(cmd string, args []string, workdir string) !Job 
 	if r.running >= r.max_running {
 		return error('max concurrent jobs (${r.max_running}) reached')
 	}
-	id := 'job_' + time.utc().format_rfc3339().replace('-', '').replace(':', '').replace('.', '')
+	// Use timestamp + pid + random to avoid collisions under parallel creates
+	id := 'job_' + time.utc().format_rfc3339().replace('-', '').replace(':', '').replace('.', '') + '_' + os.getpid().str() + '_' + rand.int_in_range(1000, 9999).str()
 	job := Job{
 		id: id
 		cmd: cmd
@@ -173,11 +175,34 @@ pub fn (r &JobRunner) get(id string) ?Job {
 	return none
 }
 
+// is_valid_job_id reports whether id matches the strict job ID format.
+// Valid IDs are `job_` + alphanumeric, underscore, hyphen; no path separators.
+pub fn is_valid_job_id(id string) bool {
+	if id.len < 5 || !id.starts_with('job_') {
+		return false
+	}
+	if id.contains('/') || id.contains('\\') || id.contains('..') || id.contains('\0') {
+		return false
+	}
+	for ch in id[4..] {
+		if !((ch >= `0` && ch <= `9`) || (ch >= `a` && ch <= `z`) || (ch >= `A` && ch <= `Z`) || ch == `_` || ch == `-`) {
+			return false
+		}
+	}
+	return true
+}
+
 // is_terminal reports whether a job status is final (no further events).
 pub fn is_terminal(status string) bool {
-	return status in ['completed', 'failed']
+	return status in ['completed', 'failed', 'canceled', 'rejected']
 }
 
 pub fn (r &JobRunner) log_path(id string) string {
+	if !is_valid_job_id(id) {
+		// Return a safe path that will not escape; caller should have validated and returned 400.
+		// We still return a path under dir but with sanitized id to avoid traversal.
+		safe := id.replace('/', '_').replace('\\', '_').replace('..', '_')
+		return os.join_path(r.dir, '${safe}.log')
+	}
 	return os.join_path(r.dir, '${id}.log')
 }

--- a/modules/agent_toolkit_server/server.veb.v
+++ b/modules/agent_toolkit_server/server.veb.v
@@ -741,14 +741,17 @@ pub fn (mut app App) jobs_create(mut ctx Ctx) veb.Result {
 		return respond_deny(mut ctx, deny)
 	}
 	req := json.decode(JobCreateReq, ctx.req.data) or {
+		ctx.res.set_status(.bad_request)
 		return ctx.json(DenyErr{ ok: false, error: 'invalid JSON body' })
 	}
 	if req.cmd.len == 0 {
+		ctx.res.set_status(.unprocessable_entity)
 		return ctx.json(DenyErr{ ok: false, error: 'cmd is required' })
 	}
 	mut workspace := ''
 	if req.workspace.len > 0 {
 		if !os.is_dir(req.workspace) {
+			ctx.res.set_status(.not_found)
 			return ctx.json(DenyErr{ ok: false, error: 'workspace not found: ${req.workspace}' })
 		}
 		workspace = req.workspace
@@ -772,7 +775,13 @@ pub fn (mut app App) jobs_create(mut ctx Ctx) veb.Result {
 		}
 	}
 	job := app.runner.create(req.cmd, args, workspace) or {
-		return ctx.json(DenyErr{ ok: false, error: err.msg() })
+		msg := err.msg()
+		if msg.contains('max concurrent') {
+			ctx.res.set_status(.too_many_requests)
+		} else {
+			ctx.res.set_status(.internal_server_error)
+		}
+		return ctx.json(DenyErr{ ok: false, error: msg })
 	}
 	lp := app.runner.log_path(job.id)
 	if !is_file(lp) {
@@ -799,8 +808,13 @@ pub fn (app &App) jobs_log(mut ctx Ctx, id string) veb.Result {
 	if deny != none {
 		return respond_deny(mut ctx, deny)
 	}
+	if !is_valid_job_id(id) {
+		ctx.res.set_status(.bad_request)
+		return ctx.json(DenyErr{ ok: false, error: 'invalid job id' })
+	}
 	lp := app.runner.log_path(id)
 	if !is_file(lp) {
+		ctx.res.set_status(.not_found)
 		return ctx.json(DenyErr{ ok: false, error: 'log not found: ${id}' })
 	}
 	body := os.read_file(lp) or { '' }
@@ -816,7 +830,12 @@ pub fn (app &App) jobs_events(mut ctx Ctx, id string) veb.Result {
 	if deny != none {
 		return respond_deny(mut ctx, deny)
 	}
+	if !is_valid_job_id(id) {
+		ctx.res.set_status(.bad_request)
+		return ctx.json(DenyErr{ ok: false, error: 'invalid job id' })
+	}
 	job := app.runner.get(id) or {
+		ctx.res.set_status(.not_found)
 		return ctx.json(DenyErr{ ok: false, error: 'job not found: ${id}' })
 	}
 	ctx.takeover_conn()


### PR DESCRIPTION
Closes #966

- jobs.v: use timestamp + pid + rand for unique IDs, add is_valid_job_id and is_terminal (canceled/rejected), log_path sanitizes and rejects invalid IDs
- server.veb.v: validate job id in jobs_log/events, return 400 for invalid, 404 for not found

VJOBS=2 vet 0.