### PR TITLE
refactor(cli): enforce single source of truth for CLI surfaces (closes #969)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -204,6 +204,18 @@ jobs:
           VMODULES: ${{ github.workspace }}/modules
         run: ./build/agent-toolkit build --check
 
+  check-surface:
+    name: Check Surface (OpenAPI + CLI help)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install dependencies
+        run: pip install pyyaml==6.0.2
+
+      - name: Check generated surface artifacts (OpenAPI, CLI help) from cli-contract.yaml
+        run: python3 scripts/generate_surface.py --check
+
   check-catalogs:
     name: Check Generated Catalogs
     runs-on: ubuntu-latest
@@ -902,6 +914,7 @@ jobs:
       - validate-upstream
       - check-build
       - check-v-modules
+      - check-surface
       - check-catalogs
       - check-skill-matrix
       - check-target-matrix
@@ -929,6 +942,7 @@ jobs:
           if [[ "${{ needs.validate-upstream.result }}" != "success" ]]; then echo "validate-upstream failed: ${{ needs.validate-upstream.result }}"; failed="true"; fi
           if [[ "${{ needs.check-build.result }}" != "success" ]]; then echo "check-build failed: ${{ needs.check-build.result }}"; failed="true"; fi
           if [[ "${{ needs.check-v-modules.result }}" != "success" ]]; then echo "check-v-modules failed: ${{ needs.check-v-modules.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-surface.result }}" != "success" ]]; then echo "check-surface failed: ${{ needs.check-surface.result }}"; failed="true"; fi
           if [[ "${{ needs.check-catalogs.result }}" != "success" ]]; then echo "check-catalogs failed: ${{ needs.check-catalogs.result }}"; failed="true"; fi
           if [[ "${{ needs.check-skill-matrix.result }}" != "success" ]]; then echo "check-skill-matrix failed: ${{ needs.check-skill-matrix.result }}"; failed="true"; fi
           if [[ "${{ needs.check-target-matrix.result }}" != "success" ]]; then echo "check-target-matrix failed: ${{ needs.check-target-matrix.result }}"; failed="true"; fi

--- a/scripts/generate_surface.py
+++ b/scripts/generate_surface.py
@@ -262,9 +262,13 @@ def main() -> int:
         contract_names = {c["name"] for c in contract.get("commands", [])}
         missing = contract_names - found
         if missing:
-            stale.append(f"docs/CLI_SURFACES.md (missing contract commands: {', '.join(sorted(missing))})")
+            stale.append(
+                f"docs/CLI_SURFACES.md (missing contract commands: {', '.join(sorted(missing))})"
+            )
             if not check:
-                print(f"warning: docs/CLI_SURFACES.md missing {sorted(missing)} — update manually or regenerate")
+                print(
+                    f"warning: docs/CLI_SURFACES.md missing {sorted(missing)} — update manually or regenerate"
+                )
 
     openapi = gen_openapi(contract)
     add_native_paths(openapi["paths"])
@@ -301,24 +305,33 @@ def main() -> int:
                 target = legacy.readlink() if hasattr(legacy, "readlink") else None
                 if target is not None and canonical.exists():
                     # Resolve symlink target relative to dist/surface
-                    resolved = (legacy.parent / target).resolve() if not target.is_absolute() else target
+                    resolved = (
+                        (legacy.parent / target).resolve() if not target.is_absolute() else target
+                    )
                     if resolved != canonical.resolve():
                         stale.append(str(legacy.relative_to(ROOT)) + " (symlink target mismatch)")
                         if not check and canonical.exists():
                             legacy.unlink(missing_ok=True)
                             legacy.symlink_to(f"../../docs/surface/{canonical.name}")
-                            print(f"fixed symlink {legacy.relative_to(ROOT)} -> ../../docs/surface/{canonical.name}")
+                            print(
+                                f"fixed symlink {legacy.relative_to(ROOT)} -> ../../docs/surface/{canonical.name}"
+                            )
             else:
                 # Regular file: must be identical to canonical, else stale
                 if canonical.exists():
                     legacy_content = legacy.read_text(encoding="utf-8") if legacy.exists() else None
                     canonical_content = canonical.read_text(encoding="utf-8")
                     if legacy_content != canonical_content:
-                        stale.append(str(legacy.relative_to(ROOT)) + f" (diverged from docs/surface/{canonical.name})")
+                        stale.append(
+                            str(legacy.relative_to(ROOT))
+                            + f" (diverged from docs/surface/{canonical.name})"
+                        )
                         if not check:
                             # Remove stale duplicate; canonical is docs/surface
                             legacy.unlink(missing_ok=True)
-                            print(f"removed stale {legacy.relative_to(ROOT)} (canonical is docs/surface/{canonical.name})")
+                            print(
+                                f"removed stale {legacy.relative_to(ROOT)} (canonical is docs/surface/{canonical.name})"
+                            )
     if stale:
         print(f"{'stale' if check else 'updated'}: {', '.join(stale)}")
         if check:

--- a/scripts/generate_surface.py
+++ b/scripts/generate_surface.py
@@ -250,6 +250,8 @@ def main() -> int:
     contract = load()
     OUT.mkdir(parents=True, exist_ok=True)
 
+    stale = []
+
     # Validate CLI_SURFACES.md contains every contract command (SSOT check for #969)
     cli_surfaces = ROOT / "docs" / "CLI_SURFACES.md"
     if cli_surfaces.exists():
@@ -270,8 +272,6 @@ def main() -> int:
         OUT / "openapi.json": json.dumps(openapi, indent=2) + "\n",
         OUT / "cli-help.md": gen_help_md(contract),
     }
-
-    stale = []
     for path, content in artifacts.items():
         path.parent.mkdir(parents=True, exist_ok=True)
         current = path.read_text(encoding="utf-8") if path.exists() else None

--- a/scripts/generate_surface.py
+++ b/scripts/generate_surface.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""generate-surface.py — emit OpenAPI, CLI help, TUI registry and Web nav
-from docs/compatibility/cli-contract.yaml (SSOT for all surfaces).
+"""generate-surface.py — emit OpenAPI, CLI help from cli-contract.yaml SSOT.
 
-Part of feature-complete serve epic (#831, Phase 0).
+Part of feature-complete serve epic (#831, Phase 0), ADR-030 canonical.
 Usage:
   python3 scripts/generate_surface.py            # write artifacts
   python3 scripts/generate_surface.py --check    # fail if stale
-Outputs (idempotent):
-  dist/surface/openapi.json
-  dist/surface/cli-help.md
+Outputs (idempotent, canonical per ADR-030):
+  docs/surface/openapi.json  (embedded by server, parity-gated)
+  docs/surface/cli-help.md   (docs/reference)
+Legacy dist/surface/cli-help.md is deprecated — canonical is docs/surface;
+dist is kept as symlink or removed (checked in --check).
 """
 
 from __future__ import annotations
@@ -249,6 +250,20 @@ def main() -> int:
     contract = load()
     OUT.mkdir(parents=True, exist_ok=True)
 
+    # Validate CLI_SURFACES.md contains every contract command (SSOT check for #969)
+    cli_surfaces = ROOT / "docs" / "CLI_SURFACES.md"
+    if cli_surfaces.exists():
+        import re as _re
+
+        text = cli_surfaces.read_text(encoding="utf-8")
+        found = set(_re.findall(r"\| `([^`]+)` \|", text))
+        contract_names = {c["name"] for c in contract.get("commands", [])}
+        missing = contract_names - found
+        if missing:
+            stale.append(f"docs/CLI_SURFACES.md (missing contract commands: {', '.join(sorted(missing))})")
+            if not check:
+                print(f"warning: docs/CLI_SURFACES.md missing {sorted(missing)} — update manually or regenerate")
+
     openapi = gen_openapi(contract)
     add_native_paths(openapi["paths"])
     artifacts = {
@@ -265,6 +280,45 @@ def main() -> int:
             if not check:
                 path.write_text(content, encoding="utf-8")
                 print(f"wrote {path.relative_to(ROOT)}")
+    # Legacy dist/surface handling: canonical is docs/surface per ADR-030.
+    # dist/surface/* is deprecated; canonical is docs/surface. Any file under
+    # dist/surface that is not a symlink to canonical must be removed.
+    legacy_files = [
+        (ROOT / "dist" / "surface" / "cli-help.md", OUT / "cli-help.md"),
+        (ROOT / "dist" / "surface" / "openapi.json", OUT / "openapi.json"),
+    ]
+    # web_nav.json is retired per ADR-030 and must not exist
+    retired = ROOT / "dist" / "surface" / "web_nav.json"
+    if retired.exists() or retired.is_symlink():
+        stale.append(str(retired.relative_to(ROOT)) + " (retired per ADR-030)")
+        if not check:
+            retired.unlink(missing_ok=True)
+            print(f"removed retired {retired.relative_to(ROOT)}")
+    for legacy, canonical in legacy_files:
+        if legacy.exists() or legacy.is_symlink():
+            if legacy.is_symlink():
+                # Symlink should point to canonical
+                target = legacy.readlink() if hasattr(legacy, "readlink") else None
+                if target is not None and canonical.exists():
+                    # Resolve symlink target relative to dist/surface
+                    resolved = (legacy.parent / target).resolve() if not target.is_absolute() else target
+                    if resolved != canonical.resolve():
+                        stale.append(str(legacy.relative_to(ROOT)) + " (symlink target mismatch)")
+                        if not check and canonical.exists():
+                            legacy.unlink(missing_ok=True)
+                            legacy.symlink_to(f"../../docs/surface/{canonical.name}")
+                            print(f"fixed symlink {legacy.relative_to(ROOT)} -> ../../docs/surface/{canonical.name}")
+            else:
+                # Regular file: must be identical to canonical, else stale
+                if canonical.exists():
+                    legacy_content = legacy.read_text(encoding="utf-8") if legacy.exists() else None
+                    canonical_content = canonical.read_text(encoding="utf-8")
+                    if legacy_content != canonical_content:
+                        stale.append(str(legacy.relative_to(ROOT)) + f" (diverged from docs/surface/{canonical.name})")
+                        if not check:
+                            # Remove stale duplicate; canonical is docs/surface
+                            legacy.unlink(missing_ok=True)
+                            print(f"removed stale {legacy.relative_to(ROOT)} (canonical is docs/surface/{canonical.name})")
     if stale:
         print(f"{'stale' if check else 'updated'}: {', '.join(stale)}")
         if check:

--- a/tests/test_cli_contract_ssot.py
+++ b/tests/test_cli_contract_ssot.py
@@ -1,8 +1,13 @@
 """969 SSOT: cli-contract.yaml is canonical for CLI surfaces."""
-import yaml, pathlib, re
+
+import pathlib
+import re
+
+import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "docs/compatibility/cli-contract.yaml"
+
 
 def test_contract_is_ssot_and_check_exists():
     assert CONTRACT.exists()
@@ -19,6 +24,7 @@ def test_contract_is_ssot_and_check_exists():
         if not cmd.get("api", True):
             assert cmd["name"] in ("completion", "serve"), f"{cmd['name']} api false unexpected"
 
+
 def test_cli_surfaces_contains_all_contract_commands():
     data = yaml.safe_load(CONTRACT.read_text())
     names = {c["name"] for c in data["commands"]}
@@ -27,11 +33,13 @@ def test_cli_surfaces_contains_all_contract_commands():
     missing = names - found
     assert not missing, f"CLI_SURFACES.md missing contract commands: {sorted(missing)}"
 
+
 def test_generate_surface_check_wired():
     wf = (ROOT / ".github/workflows/validate.yml").read_text()
     assert "check-surface" in wf
     assert "generate_surface.py --check" in wf
     assert "check-surface" in wf.split("required-ci:")[1].split("needs:")[1].split("steps:")[0]
+
 
 def test_dist_surface_deprecated():
     # dist/surface/cli-help.md should not exist as stale regular file; canonical is docs/surface
@@ -39,11 +47,17 @@ def test_dist_surface_deprecated():
     if legacy.exists() and not legacy.is_symlink():
         # if exists as regular file, must match canonical
         canonical = ROOT / "docs/surface/cli-help.md"
-        assert legacy.read_text() == canonical.read_text(), "dist/surface/cli-help.md diverged from docs/surface/cli-help.md"
+        assert legacy.read_text() == canonical.read_text(), (
+            "dist/surface/cli-help.md diverged from docs/surface/cli-help.md"
+        )
     # openapi should not be duplicated in dist
-    assert not (ROOT / "dist/surface/openapi.json").exists() or (ROOT / "dist/surface/openapi.json").is_symlink(), "dist/surface/openapi.json stale"
+    assert (
+        not (ROOT / "dist/surface/openapi.json").exists()
+        or (ROOT / "dist/surface/openapi.json").is_symlink()
+    ), "dist/surface/openapi.json stale"
     # web_nav retired
     assert not (ROOT / "dist/surface/web_nav.json").exists(), "web_nav.json retired per ADR-030"
+
 
 def test_contract_api_flag():
     data = yaml.safe_load(CONTRACT.read_text())
@@ -56,4 +70,3 @@ def test_contract_api_flag():
         # insights should be api true (was re-ported)
         if name == "insights":
             assert api is True
-

--- a/tests/test_cli_contract_ssot.py
+++ b/tests/test_cli_contract_ssot.py
@@ -1,0 +1,59 @@
+"""969 SSOT: cli-contract.yaml is canonical for CLI surfaces."""
+import yaml, pathlib, re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs/compatibility/cli-contract.yaml"
+
+def test_contract_is_ssot_and_check_exists():
+    assert CONTRACT.exists()
+    data = yaml.safe_load(CONTRACT.read_text())
+    assert "commands" in data
+    # ensure every command has required ssot fields
+    for cmd in data["commands"]:
+        assert "name" in cmd
+        assert "surface" in cmd
+        assert "migration" in cmd
+        assert "disposition" in cmd["migration"]
+        # api boolean must be present or default true
+        # if api false, ensure it's completion or serve
+        if not cmd.get("api", True):
+            assert cmd["name"] in ("completion", "serve"), f"{cmd['name']} api false unexpected"
+
+def test_cli_surfaces_contains_all_contract_commands():
+    data = yaml.safe_load(CONTRACT.read_text())
+    names = {c["name"] for c in data["commands"]}
+    text = (ROOT / "docs/CLI_SURFACES.md").read_text()
+    found = set(re.findall(r"\| `([^`]+)` \|", text))
+    missing = names - found
+    assert not missing, f"CLI_SURFACES.md missing contract commands: {sorted(missing)}"
+
+def test_generate_surface_check_wired():
+    wf = (ROOT / ".github/workflows/validate.yml").read_text()
+    assert "check-surface" in wf
+    assert "generate_surface.py --check" in wf
+    assert "check-surface" in wf.split("required-ci:")[1].split("needs:")[1].split("steps:")[0]
+
+def test_dist_surface_deprecated():
+    # dist/surface/cli-help.md should not exist as stale regular file; canonical is docs/surface
+    legacy = ROOT / "dist/surface/cli-help.md"
+    if legacy.exists() and not legacy.is_symlink():
+        # if exists as regular file, must match canonical
+        canonical = ROOT / "docs/surface/cli-help.md"
+        assert legacy.read_text() == canonical.read_text(), "dist/surface/cli-help.md diverged from docs/surface/cli-help.md"
+    # openapi should not be duplicated in dist
+    assert not (ROOT / "dist/surface/openapi.json").exists() or (ROOT / "dist/surface/openapi.json").is_symlink(), "dist/surface/openapi.json stale"
+    # web_nav retired
+    assert not (ROOT / "dist/surface/web_nav.json").exists(), "web_nav.json retired per ADR-030"
+
+def test_contract_api_flag():
+    data = yaml.safe_load(CONTRACT.read_text())
+    for cmd in data["commands"]:
+        name = cmd["name"]
+        api = cmd.get("api", True)
+        # completion and serve are api false per ADR-030
+        if name in ("completion", "serve"):
+            assert api is False, f"{name} should be api:false"
+        # insights should be api true (was re-ported)
+        if name == "insights":
+            assert api is True
+


### PR DESCRIPTION
Closes #969

- Make cli-contract.yaml canonical for command surfaces, flags, env, effects, disposition and api flag.
- Clean stale dist/surface/cli-help.md vs docs/surface/cli-help.md divergence: canonical is docs/surface per ADR-030, dist deprecated (removed stale openapi.json/web_nav.json, handled via symlink check).
- Add CI check that docs/CLI_SURFACES.md matches contract and generate_surface.py --check fails on drift; wire check-surface into validate.yml required-ci.
- Remove duplicated manual lists where generated: validate CLI_SURFACES inventory vs contract.

VJOBS=2 vet/test sequential.
Refs #969.