### PR TITLE
fix(targets): distinguish portable Agent Plugins capability from client extension (closes #973)

### DIFF
--- a/capabilities/targets/registry.yaml
+++ b/capabilities/targets/registry.yaml
@@ -45,6 +45,7 @@ targets:
   tier: A
   tier_rationale: Full plugin (.claude-plugin/) - native skills/agents/subagents, nested+parallel+auto
     delegation, perms/models, 33 hooks, MCP, v1 marketplace
+  agent_plugins_extension: portable
 - id: cursor
   display_name: Cursor
   adapter: agent_toolkit.compiler.targets.cursor.CursorAdapter
@@ -82,6 +83,7 @@ targets:
   tier: A
   tier_rationale: Full plugin (.cursor-plugin/) v2.5+ - skills/agents/subagents, auto+parallel delegation,
     perms/models, 16+ hooks, MCP, v1 marketplace; nested partial only
+  agent_plugins_extension: portable
 - id: opencode
   display_name: OpenCode
   adapter: agent_toolkit.compiler.targets.opencode.OpenCodeAdapter
@@ -117,6 +119,7 @@ targets:
   tier: B
   tier_rationale: JS/TS module - native agents/subagents/parallel/perms/models, but auto/nested partial
     and MCP/hooks require TypeScript runtime bridge
+  agent_plugins_extension: opencode.json (requires TypeScript runtime)
 - id: gemini-cli
   display_name: Gemini CLI
   adapter: agent_toolkit.compiler.targets.gemini_cli.GeminiCLIAdapter
@@ -154,6 +157,7 @@ targets:
   tier: B
   tier_rationale: Extension (gemini-extension.json) + TOML commands - native agents, MCP/hooks native,
     but primary/subagents/delegation/parallel partial
+  agent_plugins_extension: gemini-extension.json
 - id: copilot-cli
   display_name: GitHub Copilot CLI
   adapter: agent_toolkit.compiler.targets.copilot.CopilotCLIAdapter
@@ -190,6 +194,7 @@ targets:
   tier: B
   tier_rationale: Open Plugin Spec (plugin.json) - native agents/primary/subagents partial, perms/models
     partial, MCP/hooks unknown - limited delegation
+  agent_plugins_extension: portable
 - id: copilot-repository
   display_name: GitHub Copilot Repository
   adapter: agent_toolkit.compiler.targets.copilot.CopilotRepositoryAdapter
@@ -224,6 +229,7 @@ targets:
   tier: C
   tier_rationale: Repository customization (.github/copilot-instructions.md, .github/agents/*.agent.md,
     .github/skills/) - no plugin/marketplace, no subagents/delegation/hooks/MCP
+  agent_plugins_extension: none
 - id: pi
   display_name: Pi Coding Agent
   adapter: agent_toolkit.compiler.targets.pi.PiAdapter
@@ -259,6 +265,7 @@ targets:
   tier: B
   tier_rationale: npm package (pi-package.json) - native agents/subagents/perms/models, but MCP/hooks/parallel
     partial requiring TypeScript ExtensionAPI
+  agent_plugins_extension: pi-package.json (requires TypeScript ExtensionAPI)
 - id: windsurf
   display_name: Windsurf
   adapter: agent_toolkit.compiler.targets.windsurf.WindsurfAdapter
@@ -294,6 +301,7 @@ targets:
   tier: D
   tier_rationale: 'No marketplace extensions per docs.devin.ai - customization bundle only: rules .mdc
     + manual MCP, no agents/subagents/delegation/perms/models/hooks/commands'
+  agent_plugins_extension: none
 - id: codex
   display_name: OpenAI Codex
   adapter: agent_toolkit.compiler.targets.codex.CodexAdapter
@@ -329,6 +337,7 @@ targets:
   tier: B
   tier_rationale: Experimental .codex-plugin (Mar 2026) - native agents/subagents/parallel, MCP partial,
     hooks unknown-blocked, delegation partial
+  agent_plugins_extension: portable
 - id: muse-code
   display_name: Muse Code
   adapter: agent_toolkit.compiler.targets.muse_code.MuseCodeAdapter
@@ -364,6 +373,7 @@ targets:
   tier: C
   tier_rationale: Custom plugin - skills under ~/.config/muse/skills + .agents/skills fallback, agents
     true but no primary/subagents/delegation/hooks, MCP partial, no marketplace
+  agent_plugins_extension: muse-plugin (custom ~/.config/muse/skills)
 - id: agent-plugins
   display_name: Agent Plugins (Portable)
   adapter: agent_toolkit.compiler.targets.agent_plugins.AgentPluginsAdapter
@@ -398,3 +408,4 @@ targets:
   tier: C
   tier_rationale: Synthetic portable plugin.json + skills/ + mcp.json for Cursor/VS Code/Copilot/Kiro/Codex;
     agents via com.anthropic.claude-code extension; no primary/subagents/delegation
+  agent_plugins_extension: portable

--- a/docs/AGENT_PLUGINS.md
+++ b/docs/AGENT_PLUGINS.md
@@ -76,6 +76,30 @@ plugins/agent-toolkit-core/
 
 Other clients ignore `com.anthropic.claude-code`.
 
+## Portable vs client extension (#973)
+
+> **Single matrix:** `capabilities/targets/registry.yaml` → `docs/TARGET_CAPABILITY_MATRIX.md` (generated) is the source of truth for which targets are portable vs extension-based. See also `schemas/target-capability-registry.schema.json` (`agent_plugins_extension`).
+
+**Guaranteed portable (Agent Plugins 1.0, `v1` + `agent_plugins_extension: portable`):**
+
+- `skills/` + `mcp.json` are portable per [agent-plugins.org](https://agent-plugins.org) — discovered via `plugin.json` at root.
+- Targets: `claude-code`, `cursor`, `copilot-cli`, `codex`, `agent-plugins` (synthetic). These emit `plugin.json` + `skills/` + `mcp.json` that any v1 client can consume; `agents/`/`hooks` remain client-specific via `com.anthropic.claude-code` extension where present, but `skills`/`mcp` are portable.
+
+**Client-specific extension (custom, not portable without that extension):**
+
+- `opencode` → `opencode.json` (requires TypeScript runtime, JS/TS module via `opencode.json` + `.opencode/skills`)
+- `gemini-cli` → `gemini-extension.json` + `commands.toml` (Extension)
+- `pi` → `pi-package.json` (requires TypeScript ExtensionAPI, npm package)
+- `muse-code` → `muse-plugin` (custom `~/.config/muse/skills/<name>/SKILL.md` + `.agents/skills` fallback, no marketplace)
+
+For these `custom` targets, `agent_plugins_extension` in the registry records the required extension. A consumer must not expect a custom agent written for the portable `agent-plugins` bundle to run on a `custom` target without that extension — the matrix cell reads `` `custom` (requires <extension>) `` not `` `v1` ``. Validation: `python3 scripts/generate-target-matrix.py --check` fails on ambiguous `custom` without extension annotation — see `capabilities/targets/registry.yaml` (`agent_plugins_extension`) and `schemas/target-capability-registry.schema.json`.
+
+**Not portable / no plugin (`none` + `agent_plugins_extension: none`):**
+
+- `copilot-repository`, `windsurf` — repo-scoped customization or bundle only, no `plugin.json` marketplace.
+
+See `docs/TARGET_CAPABILITY_MATRIX.md` Legend and Per-Target Details for the rendered portable vs extension distinction and `capabilities/targets/registry.yaml` for the canonical data.
+
 ## MCP in Agent Plugins
 
 Portable `mcp.json` (closed schema, no top-level extra):

--- a/docs/TARGET_CAPABILITY_MATRIX.md
+++ b/docs/TARGET_CAPABILITY_MATRIX.md
@@ -27,15 +27,19 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 | ◐ partial | Partial / bridged / requires runtime |
 | ❓ unknown | Could not confirm from official docs |
 | `v1` | Agent Plugins 1.0 portable |
+| `v1` (portable) | Portable via agent-plugins.org (skills + mcp.json) |
 | `custom` | Tool-specific custom format |
+| `custom` (requires extension X) | Custom agents via client extension — not portable without that extension |
 | — | None / not applicable |
+
+> **Portable vs extension (#973):** `agent_plugins: v1` with `agent_plugins_extension: portable` means portable Agent Plugins 1.0 (skills + mcp.json) per https://agent-plugins.org — guaranteed across Cursor, VS Code, Copilot, Codex, Claude Code. `custom` with `agent_plugins_extension: <extension>` (e.g. `opencode.json`, `gemini-extension.json`, `pi-package.json`) means custom-agent support requires that vendor-specific extension inside an otherwise portable `plugin.json` — not portable without it. `none` = no plugin manifest.
 
 ## Capability × Target
 
 | Capability | Claude Code | Cursor | OpenCode | Gemini CLI | GitHub Copilot CLI | GitHub Copilot Repository | Pi Coding Agent | Windsurf | OpenAI Codex | Muse Code | Agent Plugins (Portable) |
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | Agent Skills | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ partial | ✅ | ✅ | ✅ |
-| Agent Plugins | `v1` | `v1` | `custom` | `custom` | `v1` | — | `custom` | — | `v1` | `custom` | `v1` |
+| Agent Plugins | `v1` (portable) | `v1` (portable) | `custom` (requires opencode.json) | `custom` (requires gemini-extension.json) | `v1` (portable) | — | `custom` (requires pi-package.json) | — | `v1` (portable) | `custom` (requires muse-plugin) | `v1` (portable) |
 | Native Custom Agents | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ partial | ✅ | ✅ | ✅ |
 | Primary / Default Agents | ✅ | ✅ | ◐ partial | ◐ partial | ✅ | ❌ | ◐ partial | ❌ | ✅ | ❌ | ❌ |
 | Subagents | ✅ | ✅ | ✅ | ◐ partial | ◐ partial | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ |
@@ -91,6 +95,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=✅ release=✅
 - **Tier:** A
 - **Tier rationale:** Full plugin (.claude-plugin/) - native skills/agents/subagents, nested+parallel+auto delegation, perms/models, 33 hooks, MCP, v1 marketplace
+- **Agent Plugins:** `v1` (portable via https://agent-plugins.org)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -108,6 +113,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=✅ release=✅
 - **Tier:** A
 - **Tier rationale:** Full plugin (.cursor-plugin/) v2.5+ - skills/agents/subagents, auto+parallel delegation, perms/models, 16+ hooks, MCP, v1 marketplace; nested partial only
+- **Agent Plugins:** `v1` (portable via https://agent-plugins.org)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -125,6 +131,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=✅ release=✅
 - **Tier:** B
 - **Tier rationale:** JS/TS module - native agents/subagents/parallel/perms/models, but auto/nested partial and MCP/hooks require TypeScript runtime bridge
+- **Agent Plugins:** `custom` (requires extension `opencode.json (requires TypeScript runtime)` — not portable without it)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -140,6 +147,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=❌ release=✅
 - **Tier:** B
 - **Tier rationale:** Extension (gemini-extension.json) + TOML commands - native agents, MCP/hooks native, but primary/subagents/delegation/parallel partial
+- **Agent Plugins:** `custom` (requires extension `gemini-extension.json` — not portable without it)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -156,6 +164,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=❌ release=✅
 - **Tier:** B
 - **Tier rationale:** Open Plugin Spec (plugin.json) - native agents/primary/subagents partial, perms/models partial, MCP/hooks unknown - limited delegation
+- **Agent Plugins:** `v1` (portable via https://agent-plugins.org)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -171,6 +180,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=❌ release=✅
 - **Tier:** C
 - **Tier rationale:** Repository customization (.github/copilot-instructions.md, .github/agents/*.agent.md, .github/skills/) - no plugin/marketplace, no subagents/delegation/hooks/MCP
+- **Agent Plugins:** `none` / extension `none`
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -185,6 +195,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=❌ release=✅
 - **Tier:** B
 - **Tier rationale:** npm package (pi-package.json) - native agents/subagents/perms/models, but MCP/hooks/parallel partial requiring TypeScript ExtensionAPI
+- **Agent Plugins:** `custom` (requires extension `pi-package.json (requires TypeScript ExtensionAPI)` — not portable without it)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -200,6 +211,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=❌ release=✅
 - **Tier:** D
 - **Tier rationale:** No marketplace extensions per docs.devin.ai - customization bundle only: rules .mdc + manual MCP, no agents/subagents/delegation/perms/models/hooks/commands
+- **Agent Plugins:** `none` / extension `none`
 - **Maturity:** limited
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -215,6 +227,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=❌ release=✅
 - **Tier:** B
 - **Tier rationale:** Experimental .codex-plugin (Mar 2026) - native agents/subagents/parallel, MCP partial, hooks unknown-blocked, delegation partial
+- **Agent Plugins:** `v1` (portable via https://agent-plugins.org)
 - **Maturity:** experimental
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -230,6 +243,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=❌ release=✅
 - **Tier:** C
 - **Tier rationale:** Custom plugin - skills under ~/.config/muse/skills + .agents/skills fallback, agents true but no primary/subagents/delegation/hooks, MCP partial, no marketplace
+- **Agent Plugins:** `custom` (requires extension `muse-plugin (custom ~/.config/muse/skills)` — not portable without it)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**
@@ -244,6 +258,7 @@ Tiers describe the **harness adapter richness** — what the harness natively su
 - **Commands:** build=✅ diff=✅ release=✅
 - **Tier:** C
 - **Tier rationale:** Synthetic portable plugin.json + skills/ + mcp.json for Cursor/VS Code/Copilot/Kiro/Codex; agents via com.anthropic.claude-code extension; no primary/subagents/delegation
+- **Agent Plugins:** `v1` (portable via https://agent-plugins.org)
 - **Maturity:** stable
 - **Researched at:** 2026-08-25
 - **Sources:**

--- a/schemas/target-capability-registry.schema.json
+++ b/schemas/target-capability-registry.schema.json
@@ -133,6 +133,11 @@
         "tier_rationale": {
           "type": "string",
           "description": "One-sentence rationale for tier assignment"
+        },
+        "agent_plugins_extension": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Portable vs extension annotation for agent_plugins (#973): 'portable' for Agent Plugins v1 portable (agent-plugins.org), 'none' for no plugin, otherwise client-specific extension identifier like 'opencode.json', 'gemini-extension.json', 'pi-package.json', 'muse-plugin' or reverse-domain 'com.anthropic.claude-code'. Required when agent_plugins is 'custom' to avoid misleading portability claims; validates that custom agents require extension X."
         }
       }
     }

--- a/scripts/generate-target-matrix.py
+++ b/scripts/generate-target-matrix.py
@@ -130,10 +130,60 @@ def validate_profiles_coverage(targets):
         sys.exit(1)
 
 
+def validate_agent_plugins_extension(targets):
+    """Validate portable vs extension annotation (#973).
+
+    - agent_plugins == v1 must have extension 'portable'
+    - agent_plugins == none must have extension 'none'
+    - agent_plugins == custom must have a client-specific extension (not portable/none)
+    Fails on ambiguous custom without extension annotation.
+    """
+    for t in targets:
+        tid = t.get("id", "<unknown>")
+        caps = t.get("capabilities", {})
+        ap = caps.get("agent_plugins")
+        ext = t.get("agent_plugins_extension")
+        if ext is None or str(ext).strip() == "":
+            print(
+                f"FAIL: {tid}: missing agent_plugins_extension (required #973 to distinguish portable vs extension)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        ext_norm = str(ext).strip()
+        if ap == "custom":
+            if ext_norm.lower() in ("portable", "none"):
+                print(
+                    f"FAIL: {tid}: agent_plugins is 'custom' but extension is {ext!r} — must specify client extension like 'opencode.json' or 'gemini-extension.json' (#973)",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if len(ext_norm) < 3:
+                print(
+                    f"FAIL: {tid}: agent_plugins custom extension too short: {ext!r}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        elif ap == "v1":
+            if ext_norm != "portable":
+                print(
+                    f"FAIL: {tid}: agent_plugins 'v1' must have extension 'portable' (got {ext!r})",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        elif ap == "none":
+            if ext_norm != "none":
+                print(
+                    f"FAIL: {tid}: agent_plugins 'none' must have extension 'none' (got {ext!r})",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+
 def render_md(data) -> str:
     targets = data["targets"]
     # preserve registry order
     validate_profiles_coverage(targets)
+    validate_agent_plugins_extension(targets)
 
     lines = []
     lines.append("# Target Capability Matrix")
@@ -202,8 +252,16 @@ def render_md(data) -> str:
     lines.append("| ◐ partial | Partial / bridged / requires runtime |")
     lines.append("| ❓ unknown | Could not confirm from official docs |")
     lines.append("| `v1` | Agent Plugins 1.0 portable |")
+    lines.append("| `v1` (portable) | Portable via agent-plugins.org (skills + mcp.json) |")
     lines.append("| `custom` | Tool-specific custom format |")
+    lines.append(
+        "| `custom` (requires extension X) | Custom agents via client extension — not portable without that extension |"
+    )
     lines.append("| — | None / not applicable |")
+    lines.append("")
+    lines.append(
+        "> **Portable vs extension (#973):** `agent_plugins: v1` with `agent_plugins_extension: portable` means portable Agent Plugins 1.0 (skills + mcp.json) per https://agent-plugins.org — guaranteed across Cursor, VS Code, Copilot, Codex, Claude Code. `custom` with `agent_plugins_extension: <extension>` (e.g. `opencode.json`, `gemini-extension.json`, `pi-package.json`) means custom-agent support requires that vendor-specific extension inside an otherwise portable `plugin.json` — not portable without it. `none` = no plugin manifest."
+    )
     lines.append("")
 
     # Main Capability x Target table
@@ -225,7 +283,19 @@ def render_md(data) -> str:
         row = [label]
         for t in targets:
             v = t.get("capabilities", {}).get(cap, "—")
-            row.append(fmt(v))
+            # #973: annotate agent_plugins with portable vs extension distinction
+            if cap == "agent_plugins":
+                ext = t.get("agent_plugins_extension", "")
+                if v == "v1" and ext == "portable":
+                    row.append("`v1` (portable)")
+                elif v == "custom" and ext and ext not in ("portable", "none"):
+                    # show custom + requires extension, truncate long extension for cell readability
+                    short = ext.split(" (")[0]
+                    row.append(f"`custom` (requires {short})")
+                else:
+                    row.append(fmt(v))
+            else:
+                row.append(fmt(v))
         lines.append("| " + " | ".join(row) + " |")
     lines.append("")
 
@@ -269,6 +339,18 @@ def render_md(data) -> str:
         lines.append(f"- **Tier:** {t.get('tier', '—')}")
         if t.get("tier_rationale"):
             lines.append(f"- **Tier rationale:** {t.get('tier_rationale')}")
+        # #973 portable vs extension
+        ext = t.get("agent_plugins_extension", "—")
+        caps = t.get("capabilities", {})
+        ap = caps.get("agent_plugins", "—")
+        if ap == "v1" and ext == "portable":
+            lines.append(f"- **Agent Plugins:** `{ap}` (portable via https://agent-plugins.org)")
+        elif ap == "custom" and ext not in ("portable", "none", "—", ""):
+            lines.append(
+                f"- **Agent Plugins:** `{ap}` (requires extension `{ext}` — not portable without it)"
+            )
+        else:
+            lines.append(f"- **Agent Plugins:** `{ap}` / extension `{ext}`")
         lines.append(f"- **Maturity:** {t.get('maturity', '—')}")
         lines.append(f"- **Researched at:** {t.get('researched_at', '—')}")
         srcs = t.get("sources", [])


### PR DESCRIPTION
Closes #973

- Add `agent_plugins_extension` field (portable vs custom extension vs none) to registry and schema
  - claude-code/cursor/copilot-cli/codex/agent-plugins → portable
  - opencode → opencode.json, gemini-cli → gemini-extension.json, pi → pi-package.json, muse-code → muse-plugin (custom)
  - copilot-repository/windsurf → none
- Validate portable vs extension in `scripts/generate-target-matrix.py`; --check fails on ambiguous custom without extension
- Matrix now renders `v1 (portable)` and `custom (requires extension)` with legend and per-target details
- docs/AGENT_PLUGINS.md: add Portable vs client extension section clarifying guaranteed portable vs client-specific

Verification:
- python3 scripts/generate-target-matrix.py --check passes after regen
- ambiguous custom without extension correctly fails
- VJOBS=2 vet + pytest 14 passed