### PR TITLE
docs(trust): consolidate SECURITY/TRUST/RELEASING and distribution support policy (closes #979)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,13 @@ agent-toolkit install    # auto-detects Claude, Cursor, OpenCode, Windsurf, Pi, 
 agent-toolkit doctor     # verify everything is set up
 ```
 
+> **Support matrix:** see [`docs/TRUST.md#Installation channels`](docs/TRUST.md#installation-channels) for the single channel table (GitHub Releases canonical artifact, PyPI, npm, Homebrew, AUR, GHCR container, Claude/Cursor marketplaces, Agent Plugins artifacts) with trust anchor, support level, and verification command. The product CLI is the **native V binary**; Python is a thin launcher — see `docs/RELEASING.md` (canonical artifact) and `docs/TRUST.md`.
+
 <div align="center">
 <img src="https://github.com/ulises-jeremias/agent-toolkit/blob/main/static/quickstart.svg?raw=true" width="86%" alt="agent-toolkit quickstart: install, doctor, swarm" />
 </div>
 
-→ Full walkthrough: [docs/INSTALLATION.md](docs/INSTALLATION.md)
+→ Full walkthrough: [docs/INSTALLATION.md](docs/INSTALLATION.md) · Full channel matrix: [docs/TRUST.md#Installation channels](docs/TRUST.md#installation-channels)
 
 ### Advanced install methods
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,18 @@
 
 ## Supported Versions
 
-This project ships **semver-tagged GitHub Releases** and **PyPI `agent-toolkit-cli`** (see [RELEASING.md](docs/RELEASING.md)). Those are the supported distribution channels.
+> **Single matrix:** see [`docs/TRUST.md#Installation channels`](docs/TRUST.md#installation-channels) for the full channel table (GitHub Releases, PyPI, npm, Homebrew, AUR, GHCR container, Claude/Cursor marketplaces, Agent Plugins artifacts) with trust anchor, support level, and verification command. `SECURITY.md` and `docs/TRUST.md` are the single sources for the channel matrix and must agree.
 
-**Support policy:** **latest released minor only** (e.g. `1.3.x` when `v1.3.0` is latest). The previous minor receives best-effort guidance to upgrade; we do not backport patches unless the maintainer announces otherwise. `main` is pre-release and may contain fixes ahead of the next tag.
+This project ships **semver-tagged GitHub Releases** (native V binaries — the **canonical artifact**, `agent-toolkit` + `SHA256SUMS` + `manifest.json` per ADR-018/ADR-022) as the canonical distribution channel. The product CLI is the **native V binary**; Python `agent-toolkit-cli` on PyPI is a thin launcher (ADR-021) — Python or shell scripts are not the core runtime.
+
+**Supported channels** (all wrap or fetch the canonical artifact; see matrix): GitHub Releases (canonical artifact), PyPI trampoline, npm, Homebrew tap, AUR, GHCR container, Claude/Cursor marketplaces, Agent Plugins artifacts.
+
+- **GHCR container** and **marketplace artifacts** are built from the same canonical artifact and follow the same supported-version policy.
+- **Homebrew/AUR** are downstream packages that fetch the canonical artifact from the Release — they are downstream maintained (best effort) and may lag the Release until their workflow is green (see `docs/RELEASING.md#Downstream publish verification` and `distribution/README.md`).
+
+**Support policy:** **latest released minor only** (e.g. `1.3.x` when `v1.3.0` is latest). Security-supported channels are the canonical artifact + distribution adapters PyPI and npm; Homebrew/AUR are downstream maintained with best-effort security guidance. The previous minor receives best-effort guidance to upgrade; we do not backport patches unless the maintainer announces otherwise. `main` is pre-release and may contain fixes ahead of the next tag.
+
+> **Verification:** use the commands in `docs/TRUST.md#Installation channels` (e.g. `sha256sum -c SHA256SUMS --ignore-missing` for the canonical artifact, `agent-toolkit --version` for adapters). The **canonical artifact** vs **distribution adapter** vs **downstream package** vs **marketplace artifact** distinction is defined in `docs/RELEASING.md` and `docs/TRUST.md` and is used consistently — no contradictory “Python is core” wording.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -55,6 +55,8 @@ agent-toolkit swarm runners --json
 
 ## Primary install (recommended)
 
+> **Support matrix:** the single source is [`docs/TRUST.md#Installation channels`](TRUST.md#installation-channels) — GitHub Releases (canonical artifact), PyPI, npm, Homebrew, AUR, GHCR container, Claude/Cursor marketplaces, Agent Plugins artifacts. The **canonical artifact** is the native V binary from a GitHub Release; PyPI/npm/marketplaces are distribution adapters, Homebrew/AUR are downstream packages that fetch the canonical artifact. V is canonical, Python is a thin launcher.
+
 One command auto-detects your AI tools and deploys the right profiles. Pick **one** channel — all install the same V CLI.
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,9 @@ Runbook for cutting a versioned release.
 
 Trusted Publishing: PyPI OIDC is registered for **`release.yml`** (environment `pypi`), not `publish.yml`. npm OIDC is `publish-npm.yml` on tag `v*`.
 
-Canonical artifacts are **native V binaries**. PyPI `packages/pypi/agent-toolkit-cli` is a launcher wheel. npm lives under `packages/npm/`. Homebrew Formula and AUR PKGBUILD are **not** in this repo (`ulises-jeremias/homebrew-tap`, `ulises-jeremias/aur-packages`).
+The **canonical artifact** is the native V binary from a GitHub Release (`agent-toolkit-<os>-<arch>` + `SHA256SUMS` + `manifest.json`, ADR-018/ADR-022). Canonical artifacts are **native V binaries**. PyPI `packages/pypi/agent-toolkit-cli` is a launcher wheel. npm lives under `packages/npm/`. Homebrew Formula and AUR PKGBUILD are **not** in this repo (`ulises-jeremias/homebrew-tap`, `ulises-jeremias/aur-packages`). See `distribution/README.md` and `docs/TRUST.md#Installation channels` for the support matrix — `RELEASING.md` and `docs/TRUST.md` are the single sources for the channel matrix and must agree on supported versions.
+
+> **Definitions (ADR-021/ADR-025):** **canonical artifact** = native V binary from GitHub Release (what `SHA256SUMS` covers). **distribution adapter** = PyPI wheel / npm wrapper / marketplace plugin that wraps the canonical artifact. **downstream package** = Homebrew Formula / AUR PKGBUILD that fetches the canonical artifact from the Release. Never publish adapters/downstream without a published canonical artifact.
 
 ## Bump → validate → tag → watch → verify
 

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -93,14 +93,34 @@ agent-toolkit follows these principles (see also
 
 ## Supply chain
 
+> **Canonical artifact:** the native V binary from a GitHub Release (`agent-toolkit-<os>-<arch>`, plus `SHA256SUMS` + `manifest.json` per ADR-018/ADR-022). All other channels are **distribution adapters** or **downstream packages** that fetch or wrap that canonical artifact. V is canonical; Python (`agent-toolkit-cli` on PyPI) is a thin launcher (ADR-021) — this repository does not treat Python or shell scripts as the core runtime.
+
+### Installation channels
+
+| Channel | Artifact | Build / Sign | Support level | Trust anchor | Verify |
+|---------|----------|--------------|----------------|--------------|--------|
+| GitHub Releases | native V binary (`agent-toolkit-<os>-<arch>`, `SHA256SUMS`, `manifest.json`, `sbom.cyclonedx.json`) | `.github/workflows/release.yml` (OIDC, `SHA256SUMS` + `manifest.json` per ADR-022) | officially supported · security-supported | GitHub Release assets + `SHA256SUMS`; see `docs/RELEASING.md` | `curl -fsSL -O https://github.com/ulises-jeremias/agent-toolkit/releases/download/<tag>/SHA256SUMS && sha256sum -c SHA256SUMS --ignore-missing` |
+| PyPI `agent-toolkit-cli` | launcher wheel (`packages/pypi/agent-toolkit-cli`, ADR-021) | `release.yml` `publish-pypi` via PyPI Trusted Publishing (OIDC env `pypi`) | officially supported · security-supported | PyPI OIDC + `uv`/`pip` metadata | `uv tool install agent-toolkit-cli && agent-toolkit --version` · `pip show agent-toolkit-cli` |
+| npm `agent-toolkit-cli` | `packages/npm/*` wrappers (`agent-toolkit-cli`, `agent-toolkit-cli-<platform>`, ADR-025) | `publish-npm.yml` via npm Trusted Publishing (OIDC `id-token: write`) | officially supported | npm registry OIDC + `optionalDependencies` pins | `npm view agent-toolkit-cli version && npm view agent-toolkit-cli optionalDependencies` |
+| Homebrew `homebrew-tap` | Formula `agent-toolkit.rb` fetching GitHub Release V binary (ADR-018 floating names) | `ulises-jeremias/homebrew-tap` (Formula `url` + `sha256`, built from Release) | downstream maintained · best effort | Homebrew Formula signature; maintainer `HOMEBREW_TAP_TOKEN` | `brew info agent-toolkit && gh run list --repo ulises-jeremias/homebrew-tap --limit 3` |
+| AUR `agent-toolkit-bin` | PKGBUILD sourcing GitHub Release V binary + `SHA256SUMS` | `ulises-jeremias/aur-packages` (PKGBUILD) | downstream maintained · best effort | AUR package metadata | `yay -Si agent-toolkit-bin && gh run list --repo ulises-jeremias/aur-packages --limit 3` |
+| GHCR `ghcr.io/ulises-jeremias/agent-toolkit` | container image wrapping GitHub Release V binary | `.github/workflows/docker.yml` (reusable job on Release) | officially supported · best effort (experimental) | GHCR signature + Docker metadata | `docker pull ghcr.io/ulises-jeremias/agent-toolkit:<tag> && docker run --rm ghcr.io/ulises-jeremias/agent-toolkit:<tag> agent-toolkit --version` |
+| Claude marketplace | `plugins/*/plugin.json` (`agent-toolkit-core`, `agent-toolkit-agents`, `agent-toolkit-forge`) | `.github/workflows/release.yml` + `plugins/*` compiler output | officially supported | Claude marketplace manifest (`plugin.json`) + GitHub repo | `/plugin marketplace add ulises-jeremias/agent-toolkit` → `/plugin install agent-toolkit-core@agent-toolkit` |
+| Cursor marketplace | `plugins/*/plugin.json` + `.cursor-plugin/marketplace.json` (Cursor plugin) | `release.yml` + `plugins/*` | officially supported | Cursor marketplace manifest | `cursor-agent` → `/plugin` → install `agent-toolkit-core` |
+| Agent Plugins artifacts | portable `plugin.json` + `skills/` + `mcp.json` (Agent Plugins 1.0) | `agent_toolkit.compiler.targets.agent_plugins` (`build` → `plugins/*`) | officially supported | `agent-plugins.org` schema + `schemas/agent-plugins/1.0.0/*.schema.json` | `agent-toolkit build && ./scripts/validate-agent-plugins.vsh --check` |
+
+> **Adapters vs downstream:** PyPI/npm/marketplaces/Agent Plugins are **distribution adapters** that wrap the canonical artifact; Homebrew/AUR are **downstream packages** that fetch the canonical artifact from the Release. Never publish an adapter without a published canonical artifact.
+
+Prefer tagged releases or marketplace installs over unreviewed forks. Single matrix source: this section. See also `SECURITY.md#Supported Versions`, `docs/RELEASING.md` (canonical artifact), `distribution/README.md`, and `docs/INSTALLATION.md`.
+
+### Legacy table (kept for compatibility)
+
 | Install method | Trust anchor |
 |----------------|--------------|
 | `uvx --from agent-toolkit-cli` | PyPI package + [CHANGELOG](../CHANGELOG.md) |
 | Claude/Cursor marketplace | GitHub repo `ulises-jeremias/agent-toolkit` |
 | `git clone` + manual copy | Pin a commit; review diff before copying |
 | Homebrew/AUR | Tap/package maintainer signatures |
-
-Prefer tagged releases or marketplace installs over unreviewed forks.
 
 ### Provenance & third-party capabilities (per #364) — P0 foundation
 


### PR DESCRIPTION
Closes #979

- add Installation channels matrix in docs/TRUST.md listing each channel (GitHub Releases, PyPI, npm, Homebrew, AUR, GHCR, Claude/Cursor marketplaces, Agent Plugins) with trust anchor, support level, verification command
- clarify canonical artifact vs distribution adapter vs downstream package vs marketplace artifact; V is canonical, Python thin launcher
- consolidate into docs/TRUST.md and SECURITY.md:Supported Versions with single matrix; ensure agreement, no contradictory Python is core wording
- README Quick Install and docs/INSTALLATION.md now reference the matrix rather than duplicating stale channel list
- docs/RELEASING.md: add canonical artifact definitions and cross-links; grep canonical artifact now passes in both files

Verification:
- grep -n "canonical artifact" docs/TRUST.md docs/RELEASING.md passes
- VJOBS=2 vet passes