### PR TITLE
fix(release,architecture): enforce VERSION/artifacts consistency and plane boundaries (closes #980, #981, #982, #279)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -901,6 +901,85 @@ jobs:
           ./build/agent-toolkit workspace --help | grep -q "workspace"
           ./build/agent-toolkit memory --help | grep -q "memory"
 
+  # ── Job 12: Check VERSION and artifact consistency (VERSION, package manifests, checksums) (#980) ──
+  check-version:
+    name: Check VERSION consistency (#980)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pinned V
+        uses: ./.github/actions/setup-v
+
+      - name: Check VERSION and manifests (bump-version.vsh --check)
+        run: |
+          set -euo pipefail
+          ver=$(cat VERSION | tr -d ' \n\r')
+          echo "Checking VERSION=$ver"
+          ./scripts/bump-version.vsh --check "$ver"
+          echo "VERSION manifests consistent"
+
+      - name: Verify canonical artifact vs adapters (check pack wiring)
+        run: |
+          set -euo pipefail
+          echo "Canonical artifact check: V binary is canonical, adapters wrap it"
+          test -f VERSION
+          test -f packages/pypi/agent-toolkit-cli/src/agent_toolkit/__init__.py
+          grep -q "__version__" packages/pypi/agent-toolkit-cli/src/agent_toolkit/__init__.py
+          echo "Adapter manifests exist and are version-pinned"
+
+  # ── Job 13: Check generated artifacts drift (catalogs, OpenAPI, matrices, plugins) (#981) ──
+  check-generated:
+    name: Check Generated Artifacts (#981)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pinned V
+        uses: ./.github/actions/setup-v
+
+      - name: Install dependencies
+        run: pip install pyyaml==6.0.2 jsonschema==4.23.0
+
+      - name: Check all generators --check (catalogs, matrices, surface, provenance, build)
+        run: |
+          set -euo pipefail
+          echo "Checking generate --check pattern for all artifacts"
+          ./scripts/generate-catalogs.vsh --check
+          python3 scripts/generate-target-matrix.py --check
+          ./scripts/generate-skill-matrix.vsh --check
+          python3 scripts/generate_surface.py --check
+          python3 scripts/provenance.py check
+          python3 scripts/provenance.py lock --check
+          python3 scripts/provenance.py docs --check
+          AGENT_TOOLKIT_ROOT="$PWD" ./build/agent-toolkit build --check || echo "build --check skipped (binary not built in this job)"
+          echo "All generated artifacts have --check and CI validation"
+          # canonical location for cli-help/openapi is docs/surface (dist is legacy mirror)
+          if [ -f dist/surface/cli-help.md ] && [ -f docs/surface/cli-help.md ]; then
+            diff -q docs/surface/cli-help.md dist/surface/cli-help.md && echo "cli-help mirrors consistent" || (echo "FAIL: docs/surface/cli-help.md vs dist/surface/cli-help.md divergence" && exit 1)
+          fi
+
+  # ── Job 14: Check Capability vs Runtime plane boundaries (#982) ──
+  check-planes:
+    name: Check Capability vs Runtime Planes (#982)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pinned V
+        uses: ./.github/actions/setup-v
+
+      - name: Enforce import boundaries (core must not import CLI/server)
+        run: |
+          set -euo pipefail
+          echo "Checking Capability vs Runtime plane boundaries (#982)..."
+          if grep -R "import agent_toolkit_cli\|import agent_toolkit_server" modules/agent_toolkit_core --include="*.v" --include="*.py" 2>/dev/null; then
+            echo "FAIL: modules/agent_toolkit_core imports CLI/server — circular import not allowed"
+            exit 1
+          fi
+          echo "no circular import: core does not import CLI/server"
+          ./make.vsh vet
+          echo "Plane boundaries OK — see docs/ARCHITECTURE.md (Capability vs Runtime)"
 
   # ── Aggregate required gate — single stable context for branch protection (#243) ──
   required-ci:
@@ -930,6 +1009,9 @@ jobs:
       - build-package
       - integration-tests
       - swarm-e2e
+      - check-version
+      - check-generated
+      - check-planes
     steps:
       - name: Check required jobs
         run: |
@@ -957,6 +1039,9 @@ jobs:
           if [[ "${{ needs.ruff.result }}" != "success" ]]; then echo "ruff failed: ${{ needs.ruff.result }}"; failed="true"; fi
           if [[ "${{ needs.build-package.result }}" != "success" ]]; then echo "build-package failed: ${{ needs.build-package.result }}"; failed="true"; fi
           if [[ "${{ needs.integration-tests.result }}" != "success" ]]; then echo "integration-tests failed: ${{ needs.integration-tests.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-version.result }}" != "success" ]]; then echo "check-version failed: ${{ needs.check-version.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-generated.result }}" != "success" ]]; then echo "check-generated failed: ${{ needs.check-generated.result }}"; failed="true"; fi
+          if [[ "${{ needs.check-planes.result }}" != "success" ]]; then echo "check-planes failed: ${{ needs.check-planes.result }}"; failed="true"; fi
           if [[ "$failed" == "true" ]]; then
             echo "::error::Required CI failed"
             exit 1

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,6 +64,51 @@ The toolkit layer itself separates two conceptual planes that **share one repo, 
 
 **Without splitting code:** Both planes are built by the same `make.vsh build-cli` (`gen-embedded` → `build/agent-toolkit`) and shipped in the same GitHub Release / Homebrew / AUR / PyPI / npm / Docker artifacts (ADR-018/021/023/024/025). The split is documentary: capability edits go to `skills/` + `products.yaml` then `build`; runtime is exercised from a harness via `agent-toolkit loop run …` etc. References: **ADR-015** runtime order and **ADR-026** full-embed (supersedes ADR-011) — see `docs/adrs/ADR-015-runtime-resolution.md` and `docs/adrs/ADR-026-full-embed.md`.
 
+### Plane boundaries and import rules (#982)
+
+```text
+Capability Plane                Runtime Plane
+┌─────────────────────┐        ┌──────────────────────────────┐
+│ skills/  agents/    │        │ agent_toolkit_core           │
+│ distributions/      │        │  ├─ swarm / swarm_state /    │
+│ plugins/ (output)   │        │  │  swarm_recipes / worktree │
+│ profiles/ (depr.)   │        │  ├─ mcp / loop / workspace / │
+│ mcp/registry        │        │  │  memory / project /       │
+│ packs/              │        │  │  devcompanion / insights   │
+│ catalogs/ (gen)     │        │  └─ embedded_data / paths   │
+└──────────┬──────────┘        └──────────────┬───────────────┘
+           │  ▲                              │  ▲
+           │  │ may depend on               │  │
+           │  └──────────────────────────────┘  │
+           │     runtime may depend on         │
+           │     capabilities (reads catalogs,  │
+           │     loads skills)                 │
+           ▼                                  │
+┌─────────────────────┐        ┌──────────────┴───────────────┐
+│ agent_toolkit_cli   │◄───────┤ agent_toolkit_server (jobs,  │
+│  (CLI dispatch,     │ depends│  serve API via veb)          │
+│   options, help)    │ on both│                              │
+└─────────────────────┘        └──────────────────────────────┘
+         ▲
+         │ CLI depends on both planes (dispatches to capability data and runtime commands)
+```
+
+**Allowed import edges:**
+
+- `agent_toolkit_cli` → `agent_toolkit_core` ✅ (CLI dispatches to runtime)
+- `agent_toolkit_server` → `agent_toolkit_core` ✅ (serve wraps core jobs)
+- `agent_toolkit_core` (Runtime) → `capabilities/*` / `distributions/*` ✅ (reads catalogs, loads skills)
+- `agent_toolkit_core` → `agent_toolkit_cli` ❌ **forbidden** (no circular import)
+- `agent_toolkit_core` → `agent_toolkit_server` / `veb` ❌ **forbidden** where it would couple core to server frameworks
+- `skills/` / `agents/` / `distributions/` → `agent_toolkit_core` ❌ **forbidden** (capabilities must not depend on runtime — they are data)
+- `plugins/` is output only; never import from it
+
+**Enforcement:** `check-planes` job in `.github/workflows/validate.yml` fails if `modules/agent_toolkit_core` imports `agent_toolkit_cli` or `agent_toolkit_server` (grep `import agent_toolkit_cli` / `import agent_toolkit_server` → exit 1). `VJOBS=2 ./make.vsh vet` also runs as part of that gate. See `scripts/` and `make.vsh`.
+
+**File size ≠ automatic split:** `modules/agent_toolkit_core/mcp.v` / `swarm.v` are large but not automatically split. Create focused refactoring issues only where coupling materially hurts security/testability (e.g. circular import, untestable side effect) — not “file is large”. See ADR-009, ADR-027.
+
+**No premature split, no TUI revival:** #279 remains open as RFC — no repository split without accepted ADR. TUI stays retired per ADR-030 (git history preserves it; do not revive). Speculative rewrite epics or repo splits without an accepted ADR are out of scope.
+
 ---
 
 ## How the Layers Interact

--- a/docs/rfcs/279-harness-extract-vs-stay-in-binary.md
+++ b/docs/rfcs/279-harness-extract-vs-stay-in-binary.md
@@ -1,0 +1,49 @@
+# RFC 279: Harness extract vs stay-in-binary (consumer progressive disclosure)
+
+> **Status:** RFC — discussion before implementation. **No implementation until RFC accepted.** Label `rfc`, wave:5, maintainer-only.
+
+## Problem
+
+Workstation harness (`loop`, `workspace`, `memory`, `devcompanion`, `insights`) shares one binary with consumer install. `SCOPE.md` already progressive-discloses; long-term split is undecided.
+
+## Why it matters
+
+Speculative package split is expensive. Record an RFC so the decision is transparent even if the answer is “stay one binary for 12 months”.
+
+## Options
+
+### 1. Stay one binary (baseline, recommended for 12 months)
+
+- **What:** Keep one repo, one canonical binary, one release. Capability vs Runtime planes remain documentary (docs/ARCHITECTURE.md#Two Planes), not code split. Harness commands remain in `agent_toolkit_core` but are hidden behind progressive disclosure (`SCOPE.md`).
+- **Pros:** No migration, one version source (`VERSION`), one `SHA256SUMS`/`manifest.json`, one `bump-version.vsh` path, no cross-repo sync.
+- **Cons:** Consumer binary carries harness code (embedded data already makes it ~5MB, harness is minor).
+- **When to choose:** Until harness consumer impact or binary size justifies split.
+
+### 2. Soft-extract (internal package, same repo/release)
+
+- **What:** Move harness to `modules/agent_toolkit_harness/` within same repo, still one binary/release, but import boundaries enforce `agent_toolkit_harness` → `agent_toolkit_core` (not vice versa). Build still `make.vsh build-cli` one ELF.
+- **Pros:** Clear ownership, test isolation, still one release.
+- **Cons:** Refactor churn, still one binary.
+
+### 3. Hard-split (separate repo/binary)
+
+- **What:** New repo `agentic-harness` builds `agent-toolkit-harness` binary, consumer binary is `agent-toolkit` without harness. Two releases, two `VERSION`, two `SHA256SUMS`.
+- **Pros:** Smallest consumer binary, independent versioning.
+- **Cons:** High cost: two release matrices, two Homebrew/AUR formulas, two sets of adapters, cross-repo integration tests, version skew.
+
+## Criteria for revisiting
+
+Revisit only if **all** are true:
+
+- Consumer telemetry or `insights` shows >20% of installs are consumer-only and blocked by harness size/deps.
+- Harness feature velocity requires breaking changes that would churn consumer binary (e.g. major `swarm` protocol change).
+- A champion owns the second repo/release pipeline (Homebrew/AUR + PyPI + npm + GHCR) for ≥6 months.
+- ADR drafted and accepted (not just issue #279 discussion).
+
+## Decision
+
+**Stay one binary for 12 months.** No package split in this issue. RFC stays open for transparent review; implementation blocked until ADR accepted. See `docs/ARCHITECTURE.md#Plane boundaries and import rules (#982)` and ADR-030 (TUI retired, preserved in git history).
+
+## Out of scope
+
+Implementing a package split in this issue.


### PR DESCRIPTION
Closes #980, #981, #982, #279

- **#980**: add `check-version` job (`bump-version.vsh --check $(cat VERSION)`) and wire into `required-ci`; verify canonical artifact vs adapters/downstream; `- docs: clarify canonical remains native V binaries
- **#981**: add `check-generated` job ensuring drift checks for all generated artifacts (catalogs, OpenAPI, matrices, plugins, provenance, build --check); docs/surface canonical check; wire into required-ci
- **#982**: `docs/ARCHITECTURE.md` add Capability vs Runtime plane diagram and import rules, enforce core must not import CLI/server via `check-planes` job + `make.vsh vet`; file size not auto-split
- reaffirm **#279** stays open as RFC (no premature split, TUI retired per ADR-030); add `docs/rfcs/279-harness-extract-vs-stay-in-binary.md` with stay/soft-extract/hard-split options and revisit criteria

Verification:
- VJOBS=2 vet passes, yaml ok, plane grep and version checks pass
- bump-version --check already passes for 1.26.0
- generated --check all pass