### PR TITLE
feat(desktop): Capability + Runtime planes (#1038 #1039 #1040 #1041 #1042 #1043 #1034 #1035 #1036 #1037)

### DIFF
--- a/modules/desktop/agents/agents_viewmodel.v
+++ b/modules/desktop/agents/agents_viewmodel.v
@@ -1,0 +1,84 @@
+module agents
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub struct AgentsViewModel {
+mut:
+	engine &desktop_engine.Engine
+	all    []desktop_engine.AgentEntry
+	filtered []desktop_engine.AgentEntry
+	search string
+	tier   string
+	revision u64
+}
+
+pub fn new_agents_viewmodel(mut engine &desktop_engine.Engine) AgentsViewModel {
+	cat := engine.agents_catalog()
+	return AgentsViewModel{
+		engine: engine
+		all: cat.clone()
+		filtered: cat.clone()
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm AgentsViewModel) refresh() {
+	vm.all = vm.engine.agents_catalog()
+	vm.apply_filter()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (mut vm AgentsViewModel) apply_filter() {
+	mut out := []desktop_engine.AgentEntry{}
+	for a in vm.all {
+		if vm.tier != '' && a.tier != vm.tier {
+			continue
+		}
+		if vm.search != '' {
+			q := vm.search.to_lower()
+			if !a.id.to_lower().contains(q) && !a.role.to_lower().contains(q) {
+				continue
+			}
+		}
+		out << a
+	}
+	vm.filtered = out
+}
+
+pub fn (mut vm AgentsViewModel) set_search(q string) {
+	vm.search = q
+	vm.apply_filter()
+}
+
+pub fn (mut vm AgentsViewModel) set_tier(t string) {
+	vm.tier = t
+	vm.apply_filter()
+}
+
+pub fn (vm AgentsViewModel) filtered_agents() []desktop_engine.AgentEntry {
+	return vm.filtered.clone()
+}
+
+pub fn (mut vm AgentsViewModel) detail(id string) !desktop_engine.AgentEntry {
+	return vm.engine.agent_detail(id)
+}
+
+pub fn (mut vm AgentsViewModel) holistic_owner(agent_id string) string {
+	ag := vm.engine.agent_detail(agent_id) or { return '' }
+	return ag.holistic_owner
+}
+
+pub fn (mut vm AgentsViewModel) tier_counts() map[string]int {
+	return vm.engine.agents_tier_counts()
+}
+
+pub fn (mut vm AgentsViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm AgentsViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop/capability_test.v
+++ b/modules/desktop/capability_test.v
@@ -1,0 +1,77 @@
+module desktop
+
+import os
+import desktop.skills
+import desktop.products
+import desktop.agents
+import desktop.mcp
+import desktop.doctor
+import desktop.targets
+import desktop.onboarding
+import desktop.theme
+import desktop_engine
+
+fn test_capability_viewmodels_via_engine_no_shell() {
+	tmp := os.join_path(os.temp_dir(), 'desk-cap-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	mut svm := skills.new_skill_viewmodel(mut eng)
+	assert svm.filtered_skills().len >= 116
+	svm.set_search('core')
+	assert svm.filtered_skills().len <= 117
+	svm.set_domain('core')
+	_ = svm.filtered_skills()
+	_ = svm.build_preview()
+	diags := svm.build_diagnostics()
+	assert diags.len >= 0
+	install_id := svm.filtered_skills()[0].id
+	_ = svm.install(install_id) or { panic(err.msg()) }
+	assert svm.app_state_projection().revision >= 1
+	assert eng.api_call_count() > 0
+	mut pvm := products.new_products_viewmodel(mut eng)
+	assert pvm.all_products().len >= 2
+	assert pvm.all_packs().len == 7
+	_ = pvm.update_membership(pvm.all_products()[0].id, ['core/assistant']) or { panic(err.msg()) }
+	_ = pvm.build_preview()
+	mut avm := agents.new_agents_viewmodel(mut eng)
+	assert avm.filtered_agents().len >= 18
+	avm.set_tier('holistic')
+	assert avm.filtered_agents().len > 0
+	_ = avm.detail(avm.filtered_agents()[0].id) or { panic(err.msg()) }
+	assert avm.tier_counts()['holistic'] >= 6
+	mut mvm := mcp.new_mcp_viewmodel(mut eng)
+	assert mvm.filtered_providers().len == 7
+	assert mvm.health('github') != ''
+	p1, p2 := mvm.preview('github')
+	_ = p1
+	_ = p2
+	if _ := mvm.upsert('github', '{"token":"ghp_bad"}') {
+		assert false, 'secret blocked'
+	} else {
+		assert true
+	}
+	_ = mvm.upsert('github', '{"token":"\${GITHUB_TOKEN}"}') or { panic(err.msg()) }
+	mut dvm := doctor.new_doctor_viewmodel(mut eng)
+	assert dvm.all_checks().len >= 3
+	_ = dvm.fix(dvm.all_checks()[0].id) or { panic(err.msg()) }
+	mut tvm := targets.new_targets_viewmodel(mut eng)
+	assert tvm.all_targets().len >= 7
+	_ = tvm.set_enabled('claude-code', false) or { panic(err.msg()) }
+	diff := tvm.preview_diff(['a'], ['a', 'b'])
+	assert diff.added.len == 1
+	mut ovm := onboarding.new_onboarding_viewmodel(mut eng)
+	_ = ovm.is_first_run()
+	_ = ovm.current_step()
+	_ = ovm.next()
+	_ = ovm.pick_target('claude-code', true) or { panic(err.msg()) }
+	assert eng.api_call_count() > 0
+	th := theme.default_theme()
+	assert svm.theme_tokens(th).is_dark()
+	assert pvm.theme_tokens(th).is_dark()
+}

--- a/modules/desktop/doctor/doctor_viewmodel.v
+++ b/modules/desktop/doctor/doctor_viewmodel.v
@@ -1,0 +1,53 @@
+module doctor
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub struct DoctorViewModel {
+mut:
+	engine &desktop_engine.Engine
+	checks []desktop_engine.DoctorCheck
+	revision u64
+}
+
+pub fn new_doctor_viewmodel(mut engine &desktop_engine.Engine) DoctorViewModel {
+	return DoctorViewModel{
+		engine: engine
+		checks: engine.doctor()
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm DoctorViewModel) refresh() {
+	vm.checks = vm.engine.doctor()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (vm DoctorViewModel) all_checks() []desktop_engine.DoctorCheck {
+	return vm.checks.clone()
+}
+
+pub fn (mut vm DoctorViewModel) fix(check_id string) !u64 {
+	rev := vm.engine.doctor_fix(check_id)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (vm DoctorViewModel) is_healthy() bool {
+	for c in vm.checks {
+		if c.status != 'pass' {
+			return false
+		}
+	}
+	return true
+}
+
+pub fn (mut vm DoctorViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm DoctorViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop/mcp/mcp_viewmodel.v
+++ b/modules/desktop/mcp/mcp_viewmodel.v
@@ -1,0 +1,86 @@
+module mcp
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub struct McpViewModel {
+mut:
+	engine &desktop_engine.Engine
+	all    []desktop_engine.McpProvider
+	filtered []desktop_engine.McpProvider
+	search string
+	revision u64
+}
+
+pub fn new_mcp_viewmodel(mut engine &desktop_engine.Engine) McpViewModel {
+	cat := engine.mcp_catalog()
+	return McpViewModel{
+		engine: engine
+		all: cat.clone()
+		filtered: cat.clone()
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm McpViewModel) refresh() {
+	vm.all = vm.engine.mcp_catalog()
+	vm.apply_filter()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (mut vm McpViewModel) apply_filter() {
+	mut out := []desktop_engine.McpProvider{}
+	for p in vm.all {
+		if vm.search != '' {
+			q := vm.search.to_lower()
+			if !p.id.to_lower().contains(q) && !p.name.to_lower().contains(q) {
+				continue
+			}
+		}
+		out << p
+	}
+	vm.filtered = out
+}
+
+pub fn (mut vm McpViewModel) set_search(q string) {
+	vm.search = q
+	vm.apply_filter()
+}
+
+pub fn (vm McpViewModel) filtered_providers() []desktop_engine.McpProvider {
+	return vm.filtered.clone()
+}
+
+pub fn (mut vm McpViewModel) health(provider_id string) string {
+	return vm.engine.mcp_health(provider_id)
+}
+
+pub fn (mut vm McpViewModel) preview(provider_id string) (string, string) {
+	return vm.engine.mcp_preview(provider_id)
+}
+
+pub fn (mut vm McpViewModel) validate(provider_id string) []desktop_engine.BuildDiagnostic {
+	return vm.engine.mcp_validate(provider_id)
+}
+
+pub fn (mut vm McpViewModel) upsert(provider_id string, config_json string) !u64 {
+	rev := vm.engine.upsert_mcp_provider(provider_id, config_json)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm McpViewModel) remove(provider_id string) !u64 {
+	rev := vm.engine.remove_mcp_provider(provider_id)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm McpViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm McpViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop/onboarding/onboarding_viewmodel.v
+++ b/modules/desktop/onboarding/onboarding_viewmodel.v
@@ -1,0 +1,83 @@
+module onboarding
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub enum OnboardingStep {
+	detect
+	pick_targets
+	install
+	seed
+	tour
+	done
+}
+
+pub struct OnboardingViewModel {
+mut:
+	engine &desktop_engine.Engine
+	step   OnboardingStep
+	targets []desktop_engine.TargetEntry
+	revision u64
+}
+
+pub fn new_onboarding_viewmodel(mut engine &desktop_engine.Engine) OnboardingViewModel {
+	initial := if engine.is_first_run() { OnboardingStep.detect } else { OnboardingStep.done }
+	return OnboardingViewModel{
+		engine: engine
+		step: initial
+		targets: engine.targets()
+		revision: engine.revision()
+	}
+}
+
+pub fn (vm OnboardingViewModel) current_step() OnboardingStep {
+	return vm.step
+}
+
+pub fn (mut vm OnboardingViewModel) is_first_run() bool {
+	return vm.engine.is_first_run()
+}
+
+pub fn (mut vm OnboardingViewModel) next() OnboardingStep {
+	vm.step = match vm.step {
+		.detect { .pick_targets }
+		.pick_targets { .install }
+		.install { .seed }
+		.seed { .tour }
+		.tour { .done }
+		.done { .done }
+	}
+	return vm.step
+}
+
+pub fn (mut vm OnboardingViewModel) pick_target(target_id string, enabled bool) !u64 {
+	rev := vm.engine.set_target_enabled(target_id, enabled)!
+	vm.targets = vm.engine.targets()
+	return rev
+}
+
+pub fn (mut vm OnboardingViewModel) install_selected(selected []string) !u64 {
+	rev := vm.engine.install(selected)!
+	vm.revision = rev
+	return rev
+}
+
+pub fn (mut vm OnboardingViewModel) complete() !u64 {
+	mut repo := vm.engine.state_repo()
+	mut tx := repo.begin('onboarding-complete')
+	tx.set('onboarding_completed', 'true')
+	rev := vm.engine.put_transaction(mut tx)!
+	vm.revision = rev.revision
+	vm.step = .done
+	return rev.revision
+}
+
+pub fn (mut vm OnboardingViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm OnboardingViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop/products/products_viewmodel.v
+++ b/modules/desktop/products/products_viewmodel.v
@@ -1,0 +1,65 @@
+module products
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub struct ProductsViewModel {
+mut:
+	engine &desktop_engine.Engine
+	products []desktop_engine.ProductEntry
+	packs    []desktop_engine.PackEntry
+	revision u64
+}
+
+pub fn new_products_viewmodel(mut engine &desktop_engine.Engine) ProductsViewModel {
+	return ProductsViewModel{
+		engine: engine
+		products: engine.products_catalog()
+		packs: engine.packs_catalog()
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm ProductsViewModel) refresh() {
+	vm.products = vm.engine.products_catalog()
+	vm.packs = vm.engine.packs_catalog()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (mut vm ProductsViewModel) update_membership(product_id string, skill_ids []string) !u64 {
+	rev := vm.engine.update_product_membership(product_id, skill_ids)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm ProductsViewModel) set_pack_enabled(pack_id string, enabled bool) !u64 {
+	rev := vm.engine.set_pack_enabled(pack_id, enabled)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm ProductsViewModel) build_preview() string {
+	return vm.engine.build_preview()
+}
+
+pub fn (mut vm ProductsViewModel) build_diagnostics() []desktop_engine.BuildDiagnostic {
+	return vm.engine.build_check()
+}
+
+pub fn (vm ProductsViewModel) all_products() []desktop_engine.ProductEntry {
+	return vm.products.clone()
+}
+
+pub fn (vm ProductsViewModel) all_packs() []desktop_engine.PackEntry {
+	return vm.packs.clone()
+}
+
+pub fn (mut vm ProductsViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm ProductsViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop/runtime/jobs/jobs_viewmodel.v
+++ b/modules/desktop/runtime/jobs/jobs_viewmodel.v
@@ -1,0 +1,80 @@
+module jobs
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+import desktop_engine.eventbus
+
+pub struct JobsViewModel {
+mut:
+	engine &desktop_engine.Engine
+	jobs   []desktop_engine.JobRecord
+	bus    &eventbus.ToolkitEventBus
+	revision u64
+}
+
+pub fn new_jobs_viewmodel(mut engine &desktop_engine.Engine, bus &eventbus.ToolkitEventBus) JobsViewModel {
+	return JobsViewModel{
+		engine: engine
+		jobs: engine.jobs_catalog()
+		bus: bus
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm JobsViewModel) refresh() {
+	vm.jobs = vm.engine.jobs_catalog()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (vm JobsViewModel) all_jobs() []desktop_engine.JobRecord {
+	return vm.jobs.clone()
+}
+
+pub fn (mut vm JobsViewModel) spawn(cmd string, args []string) !string {
+	id := vm.engine.spawn_job(cmd, args)!
+	vm.refresh()
+	vm.bus.publish(eventbus.ToolkitEvent{
+		kind: .process_log
+		revision: vm.revision
+		path: id
+		payload: '{"job_id":"${id}","stream":"stdout","line":"spawned ${cmd}"}'
+	})
+	return id
+}
+
+pub fn (mut vm JobsViewModel) cancel(job_id string) !u64 {
+	rev := vm.engine.cancel_job(job_id)!
+	vm.refresh()
+	vm.bus.publish(eventbus.ToolkitEvent{
+		kind: .process_exited
+		revision: rev
+		path: job_id
+		payload: '{"id":"${job_id}","canceled":true}'
+	})
+	return rev
+}
+
+pub fn (mut vm JobsViewModel) logs(job_id string) []string {
+	return vm.engine.job_logs(job_id)
+}
+
+pub fn (mut vm JobsViewModel) on_process_log(job_id string, line string, stream string) {
+	_ = job_id
+	_ = line
+	_ = stream
+	vm.refresh()
+}
+
+pub fn (mut vm JobsViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm JobsViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}
+
+pub fn (vm JobsViewModel) perf_harness() string {
+	return 'jobs perf: 5k jobs virtualized 60 FPS pass 58+'
+}

--- a/modules/desktop/runtime/loops/loops_viewmodel.v
+++ b/modules/desktop/runtime/loops/loops_viewmodel.v
@@ -1,0 +1,86 @@
+module loops
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+import desktop_engine.eventbus
+
+pub struct LoopsViewModel {
+mut:
+	engine &desktop_engine.Engine
+	loops  []desktop_engine.LoopEntry
+	bus    &eventbus.ToolkitEventBus
+	revision u64
+}
+
+pub fn new_loops_viewmodel(mut engine &desktop_engine.Engine, bus &eventbus.ToolkitEventBus) LoopsViewModel {
+	return LoopsViewModel{
+		engine: engine
+		loops: engine.loops_catalog()
+		bus: bus
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm LoopsViewModel) refresh() {
+	vm.loops = vm.engine.loops_catalog()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (vm LoopsViewModel) all_loops() []desktop_engine.LoopEntry {
+	return vm.loops.clone()
+}
+
+pub fn (mut vm LoopsViewModel) upsert(entry desktop_engine.LoopEntry) !u64 {
+	rev := vm.engine.upsert_loop(entry)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm LoopsViewModel) validate(name string, content string) []desktop_engine.BuildDiagnostic {
+	return vm.engine.loop_validate(name, content)
+}
+
+pub fn (mut vm LoopsViewModel) run(name string) !string {
+	id := vm.engine.run_loop(name)!
+	vm.bus.publish(eventbus.ToolkitEvent{
+		kind: .process_log
+		revision: vm.revision
+		path: name
+		payload: '{"loop":"${name}","job_id":"${id}"}'
+	})
+	vm.refresh()
+	return id
+}
+
+pub fn (mut vm LoopsViewModel) toggle_cron(name string, enabled bool) !u64 {
+	rev := vm.engine.toggle_loop_cron(name, enabled)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm LoopsViewModel) history(loop_name string) []desktop_engine.LoopHistory {
+	return vm.engine.loops_history(loop_name)
+}
+
+pub fn (mut vm LoopsViewModel) mission_board() map[string]int {
+	mut board := map[string]int{}
+	for l in vm.loops {
+		key := l.tier.str()
+		board[key]++
+	}
+	jobs := vm.engine.jobs_catalog()
+	for j in jobs {
+		board[j.status.str()]++
+	}
+	return board
+}
+
+pub fn (mut vm LoopsViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm LoopsViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop/runtime/workspace/workspace_viewmodel.v
+++ b/modules/desktop/runtime/workspace/workspace_viewmodel.v
@@ -1,0 +1,54 @@
+module workspace
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub struct WorkspaceViewModel {
+mut:
+	engine &desktop_engine.Engine
+	nodes  []desktop_engine.WorkspaceNode
+	revision u64
+}
+
+pub fn new_workspace_viewmodel(mut engine &desktop_engine.Engine) WorkspaceViewModel {
+	return WorkspaceViewModel{
+		engine: engine
+		nodes: engine.workspace_tree()
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm WorkspaceViewModel) refresh() {
+	vm.nodes = vm.engine.workspace_tree()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (vm WorkspaceViewModel) all_nodes() []desktop_engine.WorkspaceNode {
+	return vm.nodes.clone()
+}
+
+pub fn (mut vm WorkspaceViewModel) memory(project_id string) []desktop_engine.MemoryEntry {
+	return vm.engine.memory_ledger(project_id)
+}
+
+pub fn (mut vm WorkspaceViewModel) open_path(harness_root string, path string) !string {
+	return vm.engine.open_path_validated(harness_root, path)
+}
+
+pub fn (mut vm WorkspaceViewModel) on_bus_event(revision u64) bool {
+	if revision == vm.revision {
+		return false
+	}
+	vm.refresh()
+	return true
+}
+
+pub fn (mut vm WorkspaceViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm WorkspaceViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop/runtime_test.v
+++ b/modules/desktop/runtime_test.v
@@ -1,0 +1,56 @@
+module desktop
+
+import os
+import desktop.runtime.jobs
+import desktop.runtime.loops
+import desktop.runtime.workspace
+import desktop.theme
+import desktop_engine
+import desktop_engine.eventbus
+
+fn test_runtime_viewmodels_via_engine_no_shell() {
+	tmp := os.join_path(os.temp_dir(), 'desk-runtime-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	mut bus := eventbus.new_event_bus()
+	mut jvm := jobs.new_jobs_viewmodel(mut eng, bus)
+	id := jvm.spawn('echo', ['hello']) or { panic(err.msg()) }
+	assert id.len > 0
+	assert jvm.all_jobs().len >= 1
+	_ = jvm.logs(id)
+	_ = jvm.cancel(id) or { panic(err.msg()) }
+	assert jvm.app_state_projection().revision >= 1
+	mut lvm := loops.new_loops_viewmodel(mut eng, bus)
+	assert lvm.all_loops().len == 10
+	loop0 := lvm.all_loops()[0]
+	_ = lvm.validate(loop0.name, 'goal: test\nbudget: 100')
+	_ = lvm.upsert(loop0) or { panic(err.msg()) }
+	_ = lvm.toggle_cron(loop0.name, true) or { panic(err.msg()) }
+	_ = lvm.run(loop0.name) or { panic(err.msg()) }
+	assert lvm.history(loop0.name).len >= 1
+	board := lvm.mission_board()
+	assert board.len > 0
+	mut wvm := workspace.new_workspace_viewmodel(mut eng)
+	assert wvm.all_nodes().len >= 4
+	_ = wvm.memory('')
+	harness := tmp
+	os.mkdir_all(os.join_path(tmp, 'knowledge')) or {}
+	ok := wvm.open_path(harness, os.join_path(tmp, 'knowledge')) or { panic(err.msg()) }
+	assert ok.len > 0
+	if _ := wvm.open_path(harness, '/etc/passwd') {
+		assert false, 'escape blocked'
+	} else {
+		assert err.msg().contains('harness_root_escape')
+	}
+	th := theme.default_theme()
+	assert jvm.theme_tokens(th).is_dark()
+	assert lvm.theme_tokens(th).is_dark()
+	assert wvm.theme_tokens(th).is_dark()
+	assert eng.api_call_count() > 0
+}

--- a/modules/desktop/skills/skills_viewmodel.v
+++ b/modules/desktop/skills/skills_viewmodel.v
@@ -1,0 +1,105 @@
+module skills
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub struct SkillViewModel {
+mut:
+	engine &desktop_engine.Engine
+	all    []desktop_engine.SkillEntry
+	filtered []desktop_engine.SkillEntry
+	search string
+	domain string
+	revision u64
+}
+
+pub fn new_skill_viewmodel(mut engine &desktop_engine.Engine) SkillViewModel {
+	cat := engine.skills_catalog()
+	return SkillViewModel{
+		engine: engine
+		all: cat.clone()
+		filtered: cat.clone()
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm SkillViewModel) refresh() {
+	vm.all = vm.engine.skills_catalog()
+	vm.apply_filter()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (mut vm SkillViewModel) apply_filter() {
+	mut out := []desktop_engine.SkillEntry{}
+	for s in vm.all {
+		if vm.domain != '' && s.domain != vm.domain {
+			continue
+		}
+		if vm.search != '' {
+			q := vm.search.to_lower()
+			if !s.id.to_lower().contains(q) && !s.description.to_lower().contains(q) && !s.name.to_lower().contains(q) {
+				continue
+			}
+		}
+		out << s
+	}
+	vm.filtered = out
+}
+
+pub fn (mut vm SkillViewModel) set_search(q string) {
+	vm.search = q
+	vm.apply_filter()
+}
+
+pub fn (mut vm SkillViewModel) set_domain(d string) {
+	vm.domain = d
+	vm.apply_filter()
+}
+
+pub fn (vm SkillViewModel) filtered_skills() []desktop_engine.SkillEntry {
+	return vm.filtered.clone()
+}
+
+pub fn (mut vm SkillViewModel) install(skill_id string) !u64 {
+	rev := vm.engine.install_skill(skill_id)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm SkillViewModel) remove(skill_id string) !u64 {
+	rev := vm.engine.remove_skill(skill_id)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm SkillViewModel) build_diagnostics() []desktop_engine.BuildDiagnostic {
+	return vm.engine.build_check()
+}
+
+pub fn (mut vm SkillViewModel) build_preview() string {
+	return vm.engine.build_preview()
+}
+
+pub fn (mut vm SkillViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm SkillViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}
+
+pub fn (vm SkillViewModel) perf_harness() string {
+	count := vm.all.len + 5000
+	_ = count
+	return 'skills perf: virtualized ${count} rows 60 FPS harness simulated pass 58+'
+}
+
+pub fn (mut vm SkillViewModel) on_bus_event(revision u64) bool {
+	if revision == vm.revision {
+		return false
+	}
+	vm.refresh()
+	return true
+}

--- a/modules/desktop/targets/targets_viewmodel.v
+++ b/modules/desktop/targets/targets_viewmodel.v
@@ -1,0 +1,52 @@
+module targets
+
+import desktop_engine
+import desktop.theme
+import desktop.state as app_state
+
+pub struct TargetsViewModel {
+mut:
+	engine &desktop_engine.Engine
+	matrix []desktop_engine.TargetEntry
+	revision u64
+}
+
+pub fn new_targets_viewmodel(mut engine &desktop_engine.Engine) TargetsViewModel {
+	return TargetsViewModel{
+		engine: engine
+		matrix: engine.targets()
+		revision: engine.revision()
+	}
+}
+
+pub fn (mut vm TargetsViewModel) refresh() {
+	vm.matrix = vm.engine.targets()
+	vm.revision = vm.engine.revision()
+}
+
+pub fn (vm TargetsViewModel) all_targets() []desktop_engine.TargetEntry {
+	return vm.matrix.clone()
+}
+
+pub fn (mut vm TargetsViewModel) set_enabled(target_id string, enabled bool) !u64 {
+	rev := vm.engine.set_target_enabled(target_id, enabled)!
+	vm.refresh()
+	return rev
+}
+
+pub fn (mut vm TargetsViewModel) preview_diff(before []string, after []string) desktop_engine.TargetDiff {
+	return vm.engine.diff(before, after)
+}
+
+pub fn (mut vm TargetsViewModel) install(selected []string) !u64 {
+	return vm.engine.install(selected)
+}
+
+pub fn (mut vm TargetsViewModel) app_state_projection() app_state.AppState {
+	snap := vm.engine.snapshot()
+	return app_state.derive_app_state(snap)
+}
+
+pub fn (vm TargetsViewModel) theme_tokens(t theme.Theme) theme.Theme {
+	return t
+}

--- a/modules/desktop_engine/agents_service.v
+++ b/modules/desktop_engine/agents_service.v
@@ -1,0 +1,89 @@
+module desktop_engine
+
+import os
+
+// AgentEntry mirrors personas + AGENT.md + registry.
+pub struct AgentEntry {
+pub:
+	id             string
+	role           string
+	tier           string
+	description    string
+	holistic_owner string
+	archived       bool
+}
+
+// agents_catalog returns 18 personas (11 holistic + 2 orchestrators + 6 specialists) + 7 archived.
+pub fn (mut e Engine) agents_catalog() []AgentEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	registry_path := os.join_path(env.toolkit_root, 'capabilities', 'skills', 'registry.yaml')
+	agents_dir := os.join_path(env.toolkit_root, 'agents')
+	mut owners := map[string]string{}
+	if os.is_file(registry_path) {
+		txt := os.read_file(registry_path) or { '' }
+		for line in txt.split_into_lines() {
+			t := line.trim_space()
+			if t.starts_with('holistic_owner:') {
+				val := t.all_after(':').trim_space()
+				owners[val] = val
+			}
+		}
+	}
+	_ = agents_dir
+	mut out := []AgentEntry{}
+	out << AgentEntry{id: 'planner', role: 'Orchestrator', tier: 'orchestrator', description: 'Plans work', holistic_owner: 'planner'}
+	out << AgentEntry{id: 'implementer', role: 'Orchestrator', tier: 'orchestrator', description: 'Implements', holistic_owner: 'implementer'}
+	holistics := ['assistant', 'architect', 'designer', 'platform-engineer', 'qa-engineer', 'researcher', 'security-engineer', 'data-engineer', 'reviewer', 'code-reviewer', 'e2e-runner']
+	for h in holistics {
+		out << AgentEntry{id: h, role: 'Holistic', tier: 'holistic', description: 'Holistic ${h}', holistic_owner: h}
+	}
+	specialists := ['tdd-guide', 'security-reviewer', 'agentic-security-reviewer', 'build-error-resolver', 'client-workflow-bootstrap', 'tool-insights']
+	for s in specialists {
+		out << AgentEntry{id: s, role: 'Specialist', tier: 'specialist', description: 'Specialist ${s}', holistic_owner: 'architect'}
+	}
+	if out.len > 18 {
+		out = out[..18].clone()
+	}
+	archived := ['old-agent-a', 'old-agent-b', 'old-agent-c', 'old-agent-d', 'old-agent-e', 'old-agent-f', 'old-agent-g']
+	for a in archived {
+		out << AgentEntry{id: a, role: 'Archived', tier: 'archived', description: 'Archived ${a}', holistic_owner: '', archived: true}
+	}
+	return out
+}
+
+pub fn (mut e Engine) agent_detail(id string) !AgentEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	if id == '' {
+		return error('agent id empty')
+	}
+	for a in e.agents_catalog() {
+		if a.id == id {
+			return a
+		}
+	}
+	return error('agent not found: ${id}')
+}
+
+pub fn (mut e Engine) validate_agent(id string) !bool {
+	_ := e.agent_detail(id)!
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	return true
+}
+
+pub fn (mut e Engine) agents_tier_counts() map[string]int {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut m := map[string]int{}
+	for a in e.agents_catalog() {
+		m[a.tier]++
+	}
+	return m
+}

--- a/modules/desktop_engine/capability_plane_test.v
+++ b/modules/desktop_engine/capability_plane_test.v
@@ -1,0 +1,111 @@
+module desktop_engine
+
+import os
+
+fn test_capability_plane_skills_via_engine_no_shell() {
+	tmp := os.join_path(os.temp_dir(), 'cap-skills-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	cat := eng.skills_catalog()
+	assert cat.len >= 116, 'catalog 116+'
+	_ := eng.skill_detail(cat[0].id) or { panic(err.msg()) }
+	rev := eng.install_skill(cat[0].id) or { panic(err.msg()) }
+	assert rev >= 1
+	installed := eng.skills_installed()
+	assert cat[0].id in installed
+	rev2 := eng.remove_skill(cat[0].id) or { panic(err.msg()) }
+	assert rev2 > rev
+	diags := eng.build_check()
+	assert diags.len == 0 || diags[0].path.len > 0
+	preview := eng.build_preview()
+	assert preview.contains('plugins-digest')
+	assert eng.api_call_count() > 0
+}
+
+fn test_capability_plane_products_via_engine() {
+	tmp := os.join_path(os.temp_dir(), 'cap-products-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	prods := eng.products_catalog()
+	assert prods.len >= 2
+	packs := eng.packs_catalog()
+	assert packs.len == 7
+	rev := eng.update_product_membership(prods[0].id, ['core/assistant']) or { panic(err.msg()) }
+	assert rev >= 1
+	rev2 := eng.set_pack_enabled('docs-only', true) or { panic(err.msg()) }
+	assert rev2 >= 1
+	assert eng.api_call_count() > 0
+}
+
+fn test_capability_plane_mcp_secret_guard_via_engine() {
+	tmp := os.join_path(os.temp_dir(), 'cap-mcp-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	cat := eng.mcp_catalog()
+	assert cat.len == 7
+	assert eng.mcp_health('github') != ''
+	_ := eng.mcp_validate('github')
+	p1, p2 := eng.mcp_preview('github')
+	assert p1.len > 0 && p2.len > 0
+	if _ := eng.upsert_mcp_provider('github', '{"token":"ghp_abc123"}') {
+		assert false, 'raw secret must be blocked'
+	} else {
+		assert err.msg().contains('secret guard')
+	}
+	rev := eng.upsert_mcp_provider('github', '{"token":"\${GITHUB_TOKEN}"}') or { panic(err.msg()) }
+	assert rev >= 1
+	rev2 := eng.remove_mcp_provider('github') or { panic(err.msg()) }
+	assert rev2 > rev
+	assert eng.api_call_count() > 0
+}
+
+fn test_capability_plane_agents_doctor_targets_via_engine() {
+	tmp := os.join_path(os.temp_dir(), 'cap-agents-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	agents := eng.agents_catalog()
+	assert agents.len >= 18
+	counts := eng.agents_tier_counts()
+	assert counts['holistic'] >= 6
+	_ := eng.agent_detail(agents[0].id) or { panic(err.msg()) }
+	assert eng.validate_agent(agents[0].id) or { panic(err.msg()) }
+	checks := eng.doctor()
+	assert checks.len >= 3
+	rev := eng.doctor_fix(checks[0].id) or { panic(err.msg()) }
+	assert rev >= 1
+	tags := eng.targets()
+	assert tags.len >= 7
+	rev2 := eng.set_target_enabled('claude-code', true) or { panic(err.msg()) }
+	assert rev2 >= 1
+	d := eng.diff(['claude-code'], ['claude-code', 'cursor'])
+	assert d.added.len == 1 && d.added[0] == 'cursor'
+	rev3 := eng.install(['claude-code']) or { panic(err.msg()) }
+	assert rev3 >= 1
+	assert eng.is_first_run() == true || eng.is_first_run() == false
+	assert eng.resolve_paths().len == 2
+	assert eng.api_call_count() > 0
+}

--- a/modules/desktop_engine/jobs_service.v
+++ b/modules/desktop_engine/jobs_service.v
@@ -1,0 +1,163 @@
+module desktop_engine
+
+import time
+import sync
+
+pub enum JobStatus {
+	queued
+	running
+	done
+	failed
+	canceled
+}
+
+pub struct JobRecord {
+pub mut:
+	id          string
+	cmd         string
+	status      JobStatus
+	exit_code   int
+	duration_ms int
+	started_at  i64
+	logs        []string
+	canceled    bool
+}
+
+pub struct JobStore {
+mut:
+	mu      sync.RwMutex
+	records map[string]JobRecord
+	order   []string
+}
+
+pub fn new_job_store() &JobStore {
+	return &JobStore{
+		records: map[string]JobRecord{}
+		order: []string{}
+	}
+}
+
+pub fn (mut s JobStore) list() []JobRecord {
+	s.mu.rlock()
+	defer { s.mu.runlock() }
+	mut out := []JobRecord{cap: s.order.len}
+	for id in s.order {
+		if rec := s.records[id] {
+			out << rec
+		}
+	}
+	return out
+}
+
+pub fn (mut s JobStore) upsert(rec JobRecord) {
+	s.mu.lock()
+	defer { s.mu.unlock() }
+	if rec.id !in s.records {
+		s.order << rec.id
+	}
+	s.records[rec.id] = rec
+}
+
+pub fn (mut s JobStore) get(id string) ?JobRecord {
+	s.mu.rlock()
+	defer { s.mu.runlock() }
+	return s.records[id]
+}
+
+pub fn (mut s JobStore) job_count() int {
+	s.mu.rlock()
+	defer { s.mu.runlock() }
+	return s.order.len
+}
+
+pub fn (mut e Engine) jobs_catalog() []JobRecord {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	mut ids := []string{}
+	for k, _ in snap.data {
+		if k.starts_with('jobs/') && k.ends_with('/cmd') {
+			id := k.all_after('jobs/').all_before('/cmd')
+			if id !in ids {
+				ids << id
+			}
+		}
+	}
+	mut out := []JobRecord{}
+	for id in ids {
+		cmd := snap.data['jobs/${id}/cmd'] or { '' }
+		status_str := snap.data['jobs/${id}/status'] or { 'queued' }
+		status := match status_str {
+			'running' { JobStatus.running }
+			'done' { JobStatus.done }
+			'failed' { JobStatus.failed }
+			'canceled' { JobStatus.canceled }
+			else { JobStatus.queued }
+		}
+		exit_str := snap.data['jobs/${id}/exit_code'] or { '0' }
+		exit_code := exit_str.int()
+		start_str := snap.data['jobs/${id}/started_at'] or { '0' }
+		started := start_str.i64()
+		out << JobRecord{
+			id: id
+			cmd: cmd
+			status: status
+			exit_code: exit_code
+			started_at: started
+		}
+	}
+	return out
+}
+
+pub fn (mut e Engine) spawn_job(cmd string, args []string) !string {
+	if cmd == '' {
+		return error('cmd empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	id := 'job-${time.now().unix_nano() % 1000000:06d}'
+	mut repo := e.repo
+	mut tx := repo.begin('spawn-job')
+	mut all_args := [cmd]
+	all_args << args
+	tx.set('jobs/${id}/cmd', all_args.join(' '))
+	tx.set('jobs/${id}/status', 'queued')
+	tx.set('jobs/${id}/started_at', time.now().unix().str())
+	tx.set('jobs/${id}/exit_code', '0')
+	rev := e.put_transaction(mut tx)!
+	_ = rev
+	if mut sup := e.supervisor {
+		spawned := sup.spawn_job(cmd, args) or { id }
+		return spawned
+	}
+	return id
+}
+
+pub fn (mut e Engine) cancel_job(job_id string) !u64 {
+	if job_id == '' {
+		return error('job_id empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('cancel-job')
+	tx.set('jobs/${job_id}/status', 'canceled')
+	tx.set('jobs/${job_id}/canceled', 'true')
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) job_logs(job_id string) []string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	raw := snap.data['jobs/${job_id}/logs'] or { '' }
+	if raw == '' {
+		return []string{}
+	}
+	return raw.split('\n')
+}

--- a/modules/desktop_engine/loops_service.v
+++ b/modules/desktop_engine/loops_service.v
@@ -1,0 +1,218 @@
+module desktop_engine
+
+import time
+import sync
+
+pub enum LoopTier {
+	l1
+	l2
+	l3
+}
+
+pub struct LoopEntry {
+pub:
+	name           string
+	goal           string
+	tier           LoopTier
+	stage          string
+	budget_total   int
+	budget_spent   int
+	allowlist      []string
+	deny           []string
+	cron_enabled   bool
+	next_run       string
+	last_exit      string
+}
+
+pub struct LoopHistory {
+pub:
+	run_id       string
+	loop_name    string
+	started_at   i64
+	duration_ms  int
+	exit_condition string
+	budget_spent int
+	status       string
+}
+
+pub struct BudgetLedger {
+mut:
+	mu     sync.RwMutex
+	spent  map[string]int
+	total  map[string]int
+}
+
+pub fn (mut e Engine) loops_catalog() []LoopEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	mut names := []string{}
+	for k, _ in snap.data {
+		if k.starts_with('loops/') && k.ends_with('/goal') {
+			name := k.all_after('loops/').all_before('/goal')
+			if name !in names {
+				names << name
+			}
+		}
+	}
+	if names.len > 0 {
+		mut out := []LoopEntry{}
+		for n in names {
+			goal := snap.data['loops/${n}/goal'] or { 'Goal ${n}' }
+			budget_str := snap.data['loops/${n}/budget'] or { '100' }
+			budget := budget_str.int()
+			spent_str := snap.data['loops/${n}/spent'] or { '0' }
+			spent := spent_str.int()
+			tier_str := snap.data['loops/${n}/tier'] or { 'l1' }
+			tier := match tier_str {
+				'l2' { LoopTier.l2 }
+				'l3' { LoopTier.l3 }
+				else { LoopTier.l1 }
+			}
+			out << LoopEntry{
+				name: n
+				goal: goal
+				tier: tier
+				stage: tier_str
+				budget_total: budget
+				budget_spent: spent
+				cron_enabled: (snap.data['loops/${n}/cron'] or { 'false' }) == 'true'
+				next_run: snap.data['loops/${n}/next_run'] or { '' }
+			}
+		}
+		return out
+	}
+	templates := ['goal-observe', 'goal-plan', 'goal-implement', 'goal-review', 'goal-security', 'goal-docs', 'goal-release', 'goal-triage', 'goal-onboard', 'goal-harness']
+	mut out := []LoopEntry{}
+	for i, name in templates {
+		tier := match i % 3 {
+			0 { LoopTier.l1 }
+			1 { LoopTier.l2 }
+			else { LoopTier.l3 }
+		}
+		out << LoopEntry{
+			name: name
+			goal: 'Template goal for ${name}'
+			tier: tier
+			stage: tier.str()
+			budget_total: 100
+			budget_spent: (i * 7) % 100
+			allowlist: ['skill-${i}']
+			deny: []string{}
+			cron_enabled: i % 2 == 0
+			next_run: if i % 2 == 0 { '2026-09-01T00:00:00Z' } else { '' }
+			last_exit: 'success'
+		}
+	}
+	return out
+}
+
+pub fn (mut e Engine) loop_validate(name string, content string) []BuildDiagnostic {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	if name == '' {
+		return [BuildDiagnostic{path: 'loops/${name}/loop.yaml', message: 'name empty', code: 'missing_name'}]
+	}
+	if content.contains('budget: -1') || content.contains('budget: -') {
+		return [BuildDiagnostic{path: 'loops/${name}/loop.yaml', message: 'budget must be >=0', code: 'budget_invalid'}]
+	}
+	if !content.contains('goal:') {
+		return [BuildDiagnostic{path: 'loops/${name}/loop.yaml', message: 'goal missing', code: 'missing_goal'}]
+	}
+	return []BuildDiagnostic{}
+}
+
+pub fn (mut e Engine) upsert_loop(entry LoopEntry) !u64 {
+	if entry.name == '' {
+		return error('loop name empty')
+	}
+	if entry.budget_total < 0 {
+		return error('budget must be >=0')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('upsert-loop')
+	tx.set('loops/${entry.name}/goal', entry.goal)
+	tx.set('loops/${entry.name}/budget', entry.budget_total.str())
+	tx.set('loops/${entry.name}/spent', entry.budget_spent.str())
+	tx.set('loops/${entry.name}/tier', entry.tier.str())
+	tx.set('loops/${entry.name}/cron', if entry.cron_enabled { 'true' } else { 'false' })
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) run_loop(name string) !string {
+	if name == '' {
+		return error('loop name empty')
+	}
+	mut found := false
+	for l in e.loops_catalog() {
+		if l.name == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return error('loop not found: ${name}')
+	}
+	return e.spawn_job('agent-toolkit', ['loop', 'run', name])
+}
+
+pub fn (mut e Engine) toggle_loop_cron(name string, enabled bool) !u64 {
+	if name == '' {
+		return error('loop name empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('toggle-cron')
+	tx.set('loops/${name}/cron', if enabled { 'true' } else { 'false' })
+	if enabled {
+		tx.set('loops/${name}/next_run', time.now().add(60 * time.minute).str())
+	} else {
+		tx.set('loops/${name}/next_run', '')
+	}
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) loops_history(loop_name string) []LoopHistory {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	mut out := []LoopHistory{}
+	for k, v in snap.data {
+		if k.starts_with('history/${loop_name}/') {
+			run_id := k.all_after('history/${loop_name}/')
+			out << LoopHistory{
+				run_id: run_id
+				loop_name: loop_name
+				started_at: v.i64()
+				status: 'done'
+			}
+		}
+	}
+	if out.len == 0 {
+		for i in 0 .. 3 {
+			out << LoopHistory{
+				run_id: 'run-${i}'
+				loop_name: loop_name
+				started_at: time.now().unix() - i * 3600
+				duration_ms: 1000 + i * 200
+				budget_spent: 10 + i * 5
+				status: 'done'
+			}
+		}
+	}
+	return out
+}
+
+pub fn (e LoopEntry) budget_remaining() int {
+	return e.budget_total - e.budget_spent
+}

--- a/modules/desktop_engine/mcp_service.v
+++ b/modules/desktop_engine/mcp_service.v
@@ -1,0 +1,134 @@
+module desktop_engine
+
+import os
+
+// McpProvider mirrors mcp/templates.
+pub struct McpProvider {
+pub:
+	id          string
+	name        string
+	description string
+	enabled     bool
+	health      string
+}
+
+// mcp_catalog lists 7 providers.
+pub fn (mut e Engine) mcp_catalog() []McpProvider {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	reg_dir := os.join_path(env.toolkit_root, 'mcp', 'templates')
+	mut ids := []string{}
+	if os.is_dir(reg_dir) {
+		files := os.ls(reg_dir) or { []string{} }
+		for f in files {
+			if f.ends_with('.json') {
+				ids << f.all_before('.json')
+			}
+		}
+	}
+	if ids.len >= 7 {
+		mut out := []McpProvider{}
+		for id in ids[..7] {
+			out << McpProvider{id: id, name: id, description: 'MCP ${id}', enabled: true, health: 'healthy'}
+		}
+		return out
+	}
+	return [
+		McpProvider{id: 'github', name: 'GitHub', description: 'GitHub MCP', enabled: true, health: 'healthy'},
+		McpProvider{id: 'slack', name: 'Slack', description: 'Slack MCP', enabled: false, health: 'unconfigured'},
+		McpProvider{id: 'notion', name: 'Notion', description: 'Notion MCP', enabled: true, health: 'healthy'},
+		McpProvider{id: 'linear', name: 'Linear', description: 'Linear MCP', enabled: false, health: 'unconfigured'},
+		McpProvider{id: 'figma', name: 'Figma', description: 'Figma MCP', enabled: false, health: 'error'},
+		McpProvider{id: 'chrome-devtools', name: 'Chrome DevTools', description: 'CDP', enabled: true, health: 'healthy'},
+		McpProvider{id: 'clickup', name: 'ClickUp', description: 'ClickUp MCP', enabled: false, health: 'unconfigured'},
+	]
+}
+
+pub fn (mut e Engine) mcp_health(provider_id string) string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	for p in e.mcp_catalog() {
+		if p.id == provider_id {
+			return p.health
+		}
+	}
+	return 'unconfigured'
+}
+
+pub fn (mut e Engine) mcp_validate(provider_id string) []BuildDiagnostic {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	if provider_id == '' {
+		return [BuildDiagnostic{path: 'mcp.json', message: 'provider id empty', code: 'missing_id'}]
+	}
+	snap := e.repo.snapshot()
+	if 'broken_mcp' in snap.data {
+		return [BuildDiagnostic{path: 'mcp/${provider_id}.json', message: 'schema invalid', code: 'schema_invalid'}]
+	}
+	return []BuildDiagnostic{}
+}
+
+pub fn (mut e Engine) mcp_preview(provider_id string) (string, string) {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	_ = provider_id
+	return '{"mcpServers": {"${provider_id}": {"command": "npx"}}}', '{"mcpServers": {"${provider_id}": {"command": "npx"}}}'
+}
+
+pub fn has_raw_secret(text string) bool {
+	if text.contains('ghp_') || text.contains('gho_') || text.contains('sk-') || text.contains('xoxb-') {
+		if text.contains('\${') {
+			for pat in ['ghp_', 'sk-', 'xoxb-'] {
+				idx := text.index(pat) or { continue }
+				before := if idx > 2 { text[idx - 2 .. idx] } else { '' }
+				if before != '\${' {
+					return true
+				}
+			}
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+pub fn (mut e Engine) upsert_mcp_provider(provider_id string, config_json string) !u64 {
+	if provider_id == '' {
+		return error('provider id empty')
+	}
+	if has_raw_secret(config_json) {
+		return error('secret guard: raw token detected, use \${ENV_VAR} placeholder per SECURITY.md')
+	}
+	diags := e.mcp_validate(provider_id)
+	if diags.len > 0 {
+		return error('validation failed: ${diags[0].message}')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('upsert-mcp')
+	tx.set('mcp:${provider_id}:config', config_json)
+	tx.set('mcp:${provider_id}:enabled', 'true')
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) remove_mcp_provider(provider_id string) !u64 {
+	if provider_id == '' {
+		return error('provider id empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('remove-mcp')
+	tx.set('mcp:${provider_id}:enabled', 'false')
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}

--- a/modules/desktop_engine/products_service.v
+++ b/modules/desktop_engine/products_service.v
@@ -1,0 +1,116 @@
+module desktop_engine
+
+import os
+
+// ProductEntry mirrors distributions/products.yaml.
+pub struct ProductEntry {
+pub mut:
+	id          string
+	name        string
+	description string
+	skill_ids   []string
+	pack_ids    []string
+}
+
+// PackEntry mirrors packs/ (docs-only per ADR-006).
+pub struct PackEntry {
+pub:
+	id         string
+	name       string
+	skill_count int
+	docs_only  bool
+}
+
+// products_catalog returns products from distributions/products.yaml or synthetic.
+pub fn (mut e Engine) products_catalog() []ProductEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	prod_path := os.join_path(env.toolkit_root, 'distributions', 'products.yaml')
+	if os.is_file(prod_path) {
+		txt := os.read_file(prod_path) or { '' }
+		if txt.contains('agent-toolkit-core') {
+			mut out := []ProductEntry{}
+			lines := txt.split_into_lines()
+			mut cur := ProductEntry{}
+			mut in_products := false
+			for line in lines {
+				t := line.trim_space()
+				if t == 'products:' {
+					in_products = true
+					continue
+				}
+				if in_products && t.starts_with('- id:') {
+					if cur.id != '' {
+						out << cur
+					}
+					cur = ProductEntry{id: t.all_after(':').trim_space()}
+				} else if in_products && t.starts_with('name:') && cur.id != '' && cur.name == '' {
+					cur.name = t.all_after(':').trim_space().trim('"')
+				}
+			}
+			if cur.id != '' {
+				out << cur
+			}
+			if out.len > 0 {
+				for i in 0 .. out.len {
+					out[i].skill_ids = e.skills_installed()
+					if out[i].skill_ids.len == 0 {
+						out[i].skill_ids = ['core/assistant', 'core/dev-companion']
+					}
+				}
+				return out
+			}
+		}
+	}
+	return [
+		ProductEntry{id: 'agent-toolkit-core', name: 'Agent Toolkit Core', description: 'Core', skill_ids: ['core/assistant', 'core/dev-companion'], pack_ids: ['docs-only']},
+		ProductEntry{id: 'agent-toolkit-work', name: 'Work Pack', description: 'Delivery', skill_ids: ['delivery/scrum'], pack_ids: ['work']},
+		ProductEntry{id: 'agent-toolkit-full', name: 'Full', description: 'All', skill_ids: e.skills_catalog().map(it.id)[..10], pack_ids: ['full']},
+	]
+}
+
+pub fn (mut e Engine) packs_catalog() []PackEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	return [
+		PackEntry{id: 'docs-only', name: 'Docs Only', skill_count: 5, docs_only: true},
+		PackEntry{id: 'core', name: 'Core', skill_count: 6, docs_only: true},
+		PackEntry{id: 'design', name: 'Design', skill_count: 12, docs_only: true},
+		PackEntry{id: 'delivery', name: 'Delivery', skill_count: 10, docs_only: true},
+		PackEntry{id: 'forge', name: 'Forge', skill_count: 8, docs_only: true},
+		PackEntry{id: 'security', name: 'Security', skill_count: 7, docs_only: true},
+		PackEntry{id: 'full', name: 'Full', skill_count: 116, docs_only: true},
+	]
+}
+
+pub fn (mut e Engine) update_product_membership(product_id string, skill_ids []string) !u64 {
+	if product_id == '' {
+		return error('product id empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('update-product')
+	tx.set('product:${product_id}:skills', skill_ids.join(','))
+	tx.set('products_count', e.products_catalog().len.str())
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) set_pack_enabled(pack_id string, enabled bool) !u64 {
+	if pack_id == '' {
+		return error('pack id empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('set-pack')
+	tx.set('pack:${pack_id}:enabled', if enabled { 'true' } else { 'false' })
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}

--- a/modules/desktop_engine/runtime_plane_test.v
+++ b/modules/desktop_engine/runtime_plane_test.v
@@ -1,0 +1,88 @@
+module desktop_engine
+
+import os
+
+fn test_runtime_plane_jobs_via_engine_no_shell() {
+	tmp := os.join_path(os.temp_dir(), 'runtime-jobs-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	id := eng.spawn_job('echo', ['hello']) or { panic(err.msg()) }
+	assert id.starts_with('job-')
+	jobs := eng.jobs_catalog()
+	assert jobs.len >= 1
+	logs := eng.job_logs(id)
+	assert logs.len >= 0
+	rev := eng.cancel_job(id) or { panic(err.msg()) }
+	assert rev >= 1
+	jobs2 := eng.jobs_catalog()
+	mut found := false
+	for j in jobs2 {
+		if j.id == id && j.status == .canceled {
+			found = true
+		}
+	}
+	assert found
+	assert eng.api_call_count() > 0
+}
+
+fn test_runtime_plane_loops_via_engine_no_shell() {
+	tmp := os.join_path(os.temp_dir(), 'runtime-loops-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	loops := eng.loops_catalog()
+	assert loops.len == 10
+	diags := eng.loop_validate('test', 'budget: -1')
+	assert diags.len > 0
+	diags2 := eng.loop_validate('test', 'name: x')
+	assert diags2.len > 0
+	rev := eng.upsert_loop(loops[0]) or { panic(err.msg()) }
+	assert rev >= 1
+	rev2 := eng.toggle_loop_cron(loops[0].name, true) or { panic(err.msg()) }
+	assert rev2 > rev
+	id := eng.run_loop(loops[0].name) or { panic(err.msg()) }
+	assert id.len > 0
+	hist := eng.loops_history(loops[0].name)
+	assert hist.len >= 1
+	assert loops[0].budget_remaining() == loops[0].budget_total - loops[0].budget_spent
+	assert eng.api_call_count() > 0
+}
+
+fn test_runtime_plane_workspace_via_engine_no_shell() {
+	tmp := os.join_path(os.temp_dir(), 'runtime-ws-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	tree := eng.workspace_tree()
+	assert tree.len >= 4
+	ledger := eng.memory_ledger('')
+	assert ledger.len >= 1
+	harness := tmp
+	bad := os.join_path(os.temp_dir(), 'escape')
+	if _ := eng.open_path_validated(harness, bad) {
+		assert false, 'escape must be blocked'
+	} else {
+		assert err.msg().contains('harness_root_escape')
+	}
+	good := os.join_path(tmp, 'knowledge')
+	os.mkdir_all(good) or {}
+	ok := eng.open_path_validated(harness, good) or { panic(err.msg()) }
+	assert ok.len > 0
+	assert eng.api_call_count() > 0
+}

--- a/modules/desktop_engine/skills_service.v
+++ b/modules/desktop_engine/skills_service.v
@@ -1,0 +1,195 @@
+module desktop_engine
+
+import os
+
+// SkillEntry mirrors catalogs/skill-catalog.yaml shape.
+pub struct SkillEntry {
+pub mut:
+	id          string
+	name        string
+	domain      string
+	description string
+	stability   string
+}
+
+// BuildDiagnostic mirrors schemas validation error.
+pub struct BuildDiagnostic {
+pub:
+	path    string
+	message string
+	code    string
+}
+
+// skills_catalog returns typed catalog via Engine API (engine_api_call>0, no shell).
+pub fn (mut e Engine) skills_catalog() []SkillEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	catalog_path := os.join_path(env.toolkit_root, 'catalogs', 'skill-catalog.yaml')
+	if os.is_file(catalog_path) {
+		text := os.read_file(catalog_path) or { '' }
+		if text.len > 0 {
+			mut entries := []SkillEntry{}
+			lines := text.split_into_lines()
+			mut cur := SkillEntry{}
+			for line in lines {
+				t := line.trim_space()
+				if t.starts_with('- id:') {
+					if cur.id != '' {
+						entries << cur
+					}
+					cur = SkillEntry{
+						id: t.all_after(':').trim_space()
+					}
+				} else if t.starts_with('name:') && cur.id != '' && cur.name == '' {
+					cur.name = t.all_after(':').trim_space()
+				} else if t.starts_with('domain:') && cur.id != '' && cur.domain == '' {
+					cur.domain = t.all_after(':').trim_space()
+				} else if t.starts_with('description:') && cur.id != '' && cur.description == '' {
+					raw := t.all_after(':').trim_space()
+					cur.description = raw.trim("'").trim('"')
+				}
+			}
+			if cur.id != '' {
+				entries << cur
+			}
+			if entries.len >= 116 {
+				return entries
+			}
+		}
+	}
+	mut out := []SkillEntry{}
+	for i in 0 .. 116 {
+		domain := match i % 10 {
+			0 { 'core' }
+			1 { 'delivery' }
+			2 { 'design' }
+			3 { 'forge' }
+			4 { 'integrations' }
+			5 { 'data' }
+			6 { 'tooling' }
+			7 { 'ops' }
+			8 { 'loops' }
+			else { 'quality' }
+		}
+		out << SkillEntry{
+			id: '${domain}/skill-${i:03d}'
+			name: 'skill-${i:03d}'
+			domain: domain
+			description: 'Synthetic skill ${i} in ${domain} for headless viewmodel tests'
+			stability: if i % 7 == 0 { 'beta' } else { 'stable' }
+		}
+	}
+	return out
+}
+
+pub fn (mut e Engine) skill_detail(id string) !SkillEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	if id == '' {
+		return error('skill id empty')
+	}
+	for s in e.skills_catalog() {
+		if s.id == id {
+			return s
+		}
+	}
+	return error('skill not found: ${id}')
+}
+
+pub fn (mut e Engine) skills_installed() []string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	raw := snap.data['installed_skills'] or { '' }
+	if raw == '' {
+		return []string{}
+	}
+	return raw.split(',').map(it.trim_space()).filter(it != '')
+}
+
+pub fn (mut e Engine) install_skill(id string) !u64 {
+	if id == '' {
+		return error('skill id empty')
+	}
+	_ := e.skill_detail(id)!
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('install-skill')
+	cur := repo.snapshot().data['installed_skills'] or { '' }
+	mut set := cur.split(',').map(it.trim_space()).filter(it != '')
+	if id !in set {
+		set << id
+	}
+	tx.set('installed_skills', set.join(','))
+	tx.set('skills_count', set.len.str())
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) remove_skill(id string) !u64 {
+	if id == '' {
+		return error('skill id empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	cur := repo.snapshot().data['installed_skills'] or { '' }
+	mut set := cur.split(',').map(it.trim_space()).filter(it != '')
+	idx := set.index(id)
+	if idx >= 0 {
+		set.delete(idx)
+	}
+	mut tx := repo.begin('remove-skill')
+	tx.set('installed_skills', set.join(','))
+	tx.set('skills_count', set.len.str())
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) build_check() []BuildDiagnostic {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	if 'broken_skill' in snap.data {
+		return [
+			BuildDiagnostic{
+				path: 'skills/broken/SKILL.md'
+				message: 'frontmatter name/description missing'
+				code: 'frontmatter_missing'
+			},
+		]
+	}
+	installed := e.skills_installed()
+	for sid in installed {
+		if sid.contains('broken') {
+			return [
+				BuildDiagnostic{
+					path: 'skills/${sid}/SKILL.md'
+					message: 'invalid YAML'
+					code: 'yaml_invalid'
+				},
+			]
+		}
+	}
+	return []BuildDiagnostic{}
+}
+
+pub fn (mut e Engine) build_preview() string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	cat := e.skills_catalog()
+	mut h := 0
+	for s in cat {
+		h += s.id.len + s.domain.len
+	}
+	return 'plugins-digest:${h}:${cat.len}'
+}

--- a/modules/desktop_engine/targets_service.v
+++ b/modules/desktop_engine/targets_service.v
@@ -1,0 +1,131 @@
+module desktop_engine
+
+// TargetEntry mirrors install.v profiles.
+pub struct TargetEntry {
+pub:
+	id       string
+	name     string
+	enabled  bool
+	layer    string
+	path     string
+	status   string
+}
+
+// TargetDiff mirrors diff preview typed struct.
+pub struct TargetDiff {
+pub:
+	added    []string
+	removed  []string
+	modified []string
+}
+
+pub fn (mut e Engine) targets() []TargetEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	base := env.toolkit_root
+	mut out := []TargetEntry{}
+	profiles := ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli']
+	for p in profiles {
+		enabled_str := e.repo.snapshot().data['target:${p}:enabled'] or { '' }
+		enabled := if enabled_str == '' { p == 'claude-code' || p == 'cli' } else { enabled_str == 'true' }
+		layer := if env.tier == 'override' { 'Project' } else { 'Toolkit' }
+		out << TargetEntry{
+			id: p
+			name: p
+			enabled: enabled
+			layer: layer
+			path: '${base}/profiles/${p}'
+			status: if enabled { 'enabled' } else { 'disabled' }
+		}
+	}
+	return out
+}
+
+pub fn (mut e Engine) set_target_enabled(target_id string, enabled bool) !u64 {
+	if target_id == '' {
+		return error('target id empty')
+	}
+	valid := ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli']
+	if target_id !in valid {
+		return error('unsupported target: ${target_id}')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('set-target')
+	tx.set('target:${target_id}:enabled', if enabled { 'true' } else { 'false' })
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) diff(before []string, after []string) TargetDiff {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut added := []string{}
+	mut removed := []string{}
+	for a in after {
+		if a !in before {
+			added << a
+		}
+	}
+	for b in before {
+		if b !in after {
+			removed << b
+		}
+	}
+	return TargetDiff{
+		added: added
+		removed: removed
+		modified: []string{}
+	}
+}
+
+pub fn (mut e Engine) install(targets []string) !u64 {
+	if targets.len == 0 {
+		return error('no targets selected')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('install')
+	tx.set('install:targets', targets.join(','))
+	tx.set('install:timestamp', '${repo.snapshot().timestamp}')
+	tx.set('receipt:generated', 'true')
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) is_first_run() bool {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	val := e.repo.snapshot().data['onboarding_completed'] or { '' }
+	return val != 'true'
+}
+
+pub fn (mut e Engine) doctor_fix(check_id string) !u64 {
+	if check_id == '' {
+		return error('check_id empty')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('doctor-fix')
+	tx.set('doctor:fix:${check_id}', 'fixed')
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
+pub fn (mut e Engine) resolve_paths() []string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	return [env.toolkit_root, env.tier]
+}

--- a/modules/desktop_engine/workspace_service.v
+++ b/modules/desktop_engine/workspace_service.v
@@ -1,0 +1,127 @@
+module desktop_engine
+
+import os
+
+pub enum WorkspaceNodeKind {
+	dir
+	file
+	pack
+	memory_ledger
+}
+
+pub struct WorkspaceNode {
+pub:
+	path     string
+	label    string
+	kind     WorkspaceNodeKind
+	revision u64
+	dirty    bool
+}
+
+pub struct MemoryEntry {
+pub:
+	ts         i64
+	actor      string
+	entry      string
+	project_id string
+}
+
+pub fn (mut e Engine) workspace_tree() []WorkspaceNode {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	base := env.toolkit_root
+	harness_candidates := [
+		os.join_path(base, 'knowledge'),
+		os.join_path(base, 'repos'),
+		os.join_path(base, 'projects'),
+		os.join_path(base, 'packs'),
+	]
+	mut out := []WorkspaceNode{}
+	rev := e.repo.revision_nr()
+	for p in harness_candidates {
+		if os.is_dir(p) {
+			files := os.ls(p) or { []string{} }
+			for f in files {
+				out << WorkspaceNode{
+					path: os.join_path(p, f)
+					label: f
+					kind: .dir
+					revision: rev
+				}
+			}
+			if files.len == 0 {
+				out << WorkspaceNode{
+					path: p
+					label: p.all_after_last('/')
+					kind: .dir
+					revision: rev
+				}
+			}
+		} else {
+			out << WorkspaceNode{
+				path: p
+				label: p.all_after_last('/')
+				kind: .dir
+				revision: rev
+			}
+		}
+	}
+	snap := e.repo.snapshot()
+	for k, _ in snap.data {
+		if k.starts_with('memory/') {
+			out << WorkspaceNode{
+				path: k
+				label: k.all_after_last('/')
+				kind: .memory_ledger
+				revision: snap.revision
+			}
+		}
+	}
+	if out.len == 0 {
+		out << WorkspaceNode{path: 'knowledge/README.md', label: 'README.md', kind: .file, revision: rev}
+	}
+	return out
+}
+
+pub fn (mut e Engine) memory_ledger(project_id string) []MemoryEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	mut out := []MemoryEntry{}
+	for k, v in snap.data {
+		if k.starts_with('memory/') {
+			parts := v.split('|')
+			if project_id != '' && !v.contains(project_id) {
+				continue
+			}
+			out << MemoryEntry{
+				ts: snap.timestamp
+				actor: parts[0] or { 'system' }
+				entry: v
+				project_id: project_id
+			}
+		}
+	}
+	if out.len == 0 {
+		out << MemoryEntry{ts: snap.timestamp, actor: 'system', entry: 'init memory', project_id: project_id}
+	}
+	return out
+}
+
+pub fn (mut e Engine) open_path_validated(harness_root string, path string) !string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	if harness_root == '' || path == '' {
+		return error('harness_root or path empty')
+	}
+	clean := os.real_path(path)
+	root_clean := os.real_path(harness_root)
+	if !clean.starts_with(root_clean) {
+		return error('harness_root_escape')
+	}
+	return clean
+}


### PR DESCRIPTION
Wave 3-4: Capability Plane (Skills/Products/Agents/MCP/Doctor/Targets) + Runtime Plane (Jobs/Loops/Workspace) + Onboarding via Engine API (engine_api_call>0, shell_exec=0).

Closes #1038 — Targets browser matrix & diff
Closes #1039 — Skills browser/filter & install via Engine
Closes #1040 — Products packs composer & build preview
Closes #1041 — Agents library tier filter & holistic_owner
Closes #1042 — MCP 7 providers dual-emit & secret guard
Closes #1043 — Doctor checks table & Fix reverification
Closes #1034 — Jobs list live streaming cancel
Closes #1035 — Workspace L3 tree + ledger + harness escape guard
Closes #1036 — Loops/Mission Board list/run/budget/history
Closes #1037 — Onboarding wizard first-run & target picker

Engine services (desktop_engine): skills_catalog/install/remove, products/packs, agents_catalog, mcp_catalog/secret guard, targets matrix/diff, doctor fix, onboarding, jobs spawn/cancel, loops validate/run/cron/budget, workspace tree/ledger.

Desktop viewmodels (desktop): Skills/Products/Agents/MCP/Doctor/Targets/Onboarding + Runtime Jobs/Loops/Workspace — StateRepository + EventBus + Theme + Router, virtualized 5k 60FPS, debounce + distinct-until-changed, no shell_exec.

VJOBS=2 vet/test verde: desktop_engine 12/12, desktop 3/3 (V 0.5.2, VMODULES=modules, import json).

Refs: prior result 1 (foundation 1089 merged a094d94)