### PR TITLE
fix(ci): give macOS V Modules job headroom for full suite

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -827,11 +827,18 @@ jobs:
   check-v-modules:
     name: Check V Modules (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # macOS runners compile the full V module suite materially slower than
+    # ubuntu (V toolchain build + every module test binary); 20 min timed out
+    # deterministically on main (#1123, main Validate) and PRs.
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            timeout: 20
+          - os: macos-latest
+            timeout: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## Problem

Check V Modules (macos-latest) deterministically hits the 20-minute job timeout during vet and test: main Validate run, PR #1123, and PR #1124 (twice, including one rerun). Logs show vet completes and module test binaries are still compiling when the runner cancels the job and orphans vtest. Ubuntu passes in budget. This is CI capacity, not product code, and it blocks every PR's Required CI gate.

## User impact

None on the product. Unblocks merging PRs with a green Required CI.

## Architecture

Minimal workflow change: matrix include with per-OS timeout (ubuntu 20 unchanged, macos 45). No step logic touched.

## Before / After

Before: timeout-minutes 20 for both OSes; macos always cancelled. After: macos gets 45.

## Validation

- YAML parses (python yaml.safe_load)
- Full CI on this PR is the validation (macos job is the test)

## Known limitations

If the suite keeps growing, per-module sharding will beat further timeout bumps; not needed yet.

## Issues closed/updated

Unblocks #1118 R-series merges and PR #1124.