### PR TITLE
feat(ci): golden-image regression job + tofu detector (#1111)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -856,6 +856,63 @@ jobs:
           ./make.vsh vet
           ./make.vsh test
 
+  # ── Job: golden-image regression for the desktop GUI (#1111) ──
+  # Compares both theme fixture sets against a fresh build. Starts as
+  # non-blocking (continue-on-error) until 20 green runs prove stability.
+  golden-ui:
+    name: Golden UI (paper + ink)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install X11/GL + capture deps
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            xorg-dev libgl1-mesa-dev libegl1-mesa-dev \
+            xdotool imagemagick xvfb
+
+      - name: Setup pinned V
+        uses: ./.github/actions/setup-v
+
+      - name: Build desktop binary
+        env:
+          VMODULES: ${{ github.workspace }}/modules
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          # gg_text_buff_size=4096 — 4096² fontstash atlas (see release.yml)
+          "${VBIN:-v}" -d gg_text_buff_size=4096 -o build/agent-toolkit-desktop-native cmd/agent-toolkit-desktop
+
+      - name: Compare paper fixtures
+        run: |
+          set -euo pipefail
+          ./scripts/golden.sh compare
+
+      - name: Compare ink fixtures
+        run: |
+          set -euo pipefail
+          ATK_GOLDEN_THEME=ink ./scripts/golden.sh compare
+
+      - name: Tofu detector
+        run: |
+          set -euo pipefail
+          python3 scripts/check-tofu.py
+
+      - name: Upload mismatch artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: golden-mismatch
+          path: |
+            tests/golden-app.log
+            tests/golden/**/*.new.png
+            tests/golden/**/*.diff.png
+          if-no-files-found: ignore
+
   swarm-e2e:
     name: Swarm e2e (skeleton, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/scripts/check-tofu.py
+++ b/scripts/check-tofu.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""check-tofu.py — tofu detector for desktop golden fixtures (#1111).
+
+Two deterministic guards (no OCR heuristics):
+
+1. Bundled-fonts proof: the app must have booted with the EMBEDDED fonts
+   (``fonts: dir=...assets/fonts`` in tests/golden-app.log). System fallback
+   fonts change glyph metrics and are the actual tofu vector for the CJK and
+   Arabic chrome — a capture without this line proves nothing.
+2. Fixture sanity: all 26 fixtures (paper + ink) must exist and exceed a
+   minimum byte size, catching black/empty/truncated captures.
+
+Usage: python3 scripts/check-tofu.py
+Exit status is non-zero with a diagnostic on the first failure.
+"""
+
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PAPER = [f'tests/golden/panel-{i:02d}.png' for i in range(10)]
+PAPER += ['tests/golden/panel-products.png', 'tests/golden/panel-insights.png',
+          'tests/golden/panel-onboarding.png']
+INK = ['tests/golden/ink/' + os.path.basename(p) for p in PAPER]
+MIN_BYTES = 20 * 1024
+
+
+def fail(msg: str) -> int:
+    print(f'TOFU FAIL: {msg}')
+    return 1
+
+
+def main() -> int:
+    log = os.path.join(ROOT, 'tests', 'golden-app.log')
+    try:
+        with open(log, encoding='utf-8', errors='replace') as fh:
+            app_log = fh.read()
+    except OSError:
+        return fail(f'app log missing: {log} (run scripts/golden.sh first)')
+    font_lines = [line for line in app_log.splitlines() if 'fonts: dir=' in line]
+    if not font_lines:
+        return fail('no "fonts: dir=" line in app log — capture did not prove bundled fonts')
+    if not any(line.split('fonts: dir=', 1)[1].split()[0].rstrip('/').endswith('assets/fonts')
+               for line in font_lines):
+        return fail(f'fonts not bundled: {font_lines[-1][:160]}')
+    print(f'tofu fonts OK — {font_lines[-1][:120]}')
+    missing = []
+    tiny = []
+    for rel in PAPER + INK:
+        path = os.path.join(ROOT, rel)
+        if not os.path.isfile(path):
+            missing.append(rel)
+            continue
+        if os.path.getsize(path) < MIN_BYTES:
+            tiny.append(f'{rel} ({os.path.getsize(path)}B)')
+    if missing:
+        return fail(f'{len(missing)} fixtures missing: {missing[:5]}')
+    if tiny:
+        return fail(f'{len(tiny)} fixtures suspiciously small: {tiny[:5]}')
+    print(f'tofu fixtures OK — {len(PAPER) + len(INK)} present, all >= {MIN_BYTES}B')
+    print('TOFU PASS')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/golden.sh
+++ b/scripts/golden.sh
@@ -11,6 +11,11 @@
 #   ./scripts/golden.sh compare [fuzz%]    # default fuzz 8%
 #   ATK_GOLDEN_THEME=ink ./scripts/golden.sh capture|compare  # Ink fixtures
 # Requires: Xvfb/xdotool (see scripts/ui-smoke.sh), ImageMagick, built binary.
+#
+# Fixture update policy (#1111): intentional visual changes re-capture with
+# capture (both themes) and include the RMSE summary in the PR description.
+# Never hand-edit a fixture; compare passing on the old set is the no-drift
+# proof — capture only after that proof is recorded.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -33,8 +38,10 @@ XVFB="${XVFB:-Xvfb}"
 if ! command -v "$XVFB" >/dev/null 2>&1 && [ -x /tmp/opencode/xtools/usr/bin/Xvfb ]; then
 	XVFB=/tmp/opencode/xtools/usr/bin/Xvfb
 fi
-xdt() { DISPLAY="${GOLDEN_DISPLAY:-:77}" LD_LIBRARY_PATH="$XLIB" "$XD" "$@"; }
-shot() { sleep 1.2; DISPLAY="${GOLDEN_DISPLAY:-:77}" import -window "$WID" "$1"; }
+# timeout guards: a degraded Xvfb hangs xdotool/import forever — fail fast
+# instead (#1111; observed on a long-lived :77 server)
+xdt() { DISPLAY="${GOLDEN_DISPLAY:-:77}" LD_LIBRARY_PATH="$XLIB" timeout 30 "$XD" "$@"; }
+shot() { sleep 1.2; DISPLAY="${GOLDEN_DISPLAY:-:77}" timeout 60 import -window "$WID" "$1"; }
 
 [ -x "$BIN" ] || { echo "error: build the desktop binary first" >&2; exit 2; }
 mkdir -p "$GOLD"
@@ -100,17 +107,19 @@ for k in 1 2 3 4 5 6 7 8 9 0 p i o; do
 			continue
 		fi
 		rmse=$(compare -metric RMSE -fuzz "$FUZZ%" "$GOLD/$name.png" "$tmp" "$tmp.diff.png" 2>&1 || true)
-		rm -f "$tmp.diff.png" "$tmp"
 		# Live Engine data (log timestamps, activity pulses) moves between capture
 		# and compare even under ATK_GUI_FREEZE — that is ~0.2% normalized RMSE.
 		# Fail only on layout-scale drift (tofu, missing panels, moved chrome).
+		# Passing shots are deleted; failures keep $tmp.new.png + .diff for forensics (#1111).
 		norm=$(echo "$rmse" | grep -oE '\(0?\.[0-9]+\)' | tr -d '()' || true)
 		if [ -z "$rmse" ] || [ "${rmse%% *}" = "0" ] || [ "$(echo "$rmse" | cut -d' ' -f1)" = "0" ]; then
+			rm -f "$tmp.diff.png" "$tmp"
 			echo "OK   $name ($rmse)"
 		elif [ -n "$norm" ] && awk -v n="$norm" 'BEGIN { exit (n < 0.01) ? 0 : 1 }'; then
+			rm -f "$tmp.diff.png" "$tmp"
 			echo "OK   $name ($rmse — live-data noise under 2%)"
 		else
-			echo "FAIL $name: RMSE $rmse exceeds tolerance"
+			echo "FAIL $name: RMSE $rmse exceeds tolerance (kept $tmp + $tmp.diff.png)"
 			fail=1
 		fi
 	fi


### PR DESCRIPTION
## Summary

- Adds the `golden-ui` CI job to `validate.yml` (ubuntu-latest): installs X11/GL + xdotool/imagemagick/xvfb, builds the desktop binary with the 4096 atlas flag, runs paper + ink golden compares, then the tofu detector. Starts non-blocking (`continue-on-error: true`) until stability is proven.
- Adds `scripts/check-tofu.py`: asserts captures booted with the bundled fonts (`fonts: dir=...assets/fonts` in the app log) and all 26 fixtures exist above minimum size.
- Hardens `scripts/golden.sh`: `timeout` guards on xdotool/import (a degraded Xvfb hung them forever — observed), failures keep `.new.png` + `.diff.png` forensics (uploaded by CI on failure), fixture-update policy documented.

## Type

- [ ] New skill
- [ ] New loop template
- [ ] New agent persona
- [ ] New profile (per-tool config)
- [ ] New pack
- [ ] Catalog update (skill-catalog, agent-catalog, loop-catalog)
- [ ] Schema update
- [ ] Documentation
- [ ] Bug fix
- [x] Other — CI

## Changes

- `.github/workflows/validate.yml` — new `golden-ui` job (deps, build, paper compare, ink compare, tofu, failure upload with repo-pinned `upload-artifact@v7`).
- `scripts/check-tofu.py` — NEW detector, exit non-zero with diagnostics.
- `scripts/golden.sh` — timeout guards, keep-forensics-on-fail, policy header.

## Testing

- [x] `python3 scripts/check-tofu.py` — TOFU PASS (bundled fonts proven, 26/26 fixtures)
- [x] `./scripts/golden.sh compare` + ink compare — both GOLDEN PASS locally
- [x] Negative proof: black-boxed panel-05 fixture → `FAIL panel-05: RMSE 22112.5 (0.337415)`, exit 1, `.new.png` + `.diff.png` kept; fixture restored byte-identical (`cmp`), suite green again
- [x] Workflow YAML parses; job uses repo-pinned actions only (`checkout@v7.0.1`, local `setup-v`, `upload-artifact@v7`)
- [ ] Green on main (CI run after merge — job is `continue-on-error: true` initially per issue)

## Checklist

- [x] No secrets, tokens, API keys, or credentials committed
- [x] Commit messages are in English and follow conventional commits format

Closes #1111.
