### PR TITLE
fix(desktop): tier-aware catalog discovery and S1 truth recovery

### DIFF
--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -373,14 +373,7 @@ fn vt_label(app &GuiApp, id int) string {
 }
 
 // spawn_session — spawn an agent CLI on a real PTY and focus it fullscreen.
-fn bc2(msg string) {
-	mut f := os.open_file('/tmp/opencode/bc2.log', 'ab', 0o644) or { return }
-	f.writeln(msg) or {}
-	f.close()
-}
-
 fn spawn_session(mut app &GuiApp, ab pty_mod.AgentBin) {
-	bc2('spawn:enter ${ab.agent}')
 	s := pty_mod.spawn(ab.agent, ab.binary, [], 120, 32) or {
 		app.inspector_msg = 'Session ${ab.agent} error: ${err}'
 		return
@@ -392,7 +385,6 @@ fn spawn_session(mut app &GuiApp, ab pty_mod.AgentBin) {
 	}
 	app.term_view = 15 + app.sessions.len - 1
 	app.sessions_dialog = false
-	bc2('spawn:done total=${app.sessions.len}')
 	app.inspector_msg = 'Session ${ab.agent} spawned (pid ${s.pid}) — Fleet chip returns'
 }
 
@@ -1937,13 +1929,6 @@ fn clamp_scroll(scroll int, total int, visible int) int {
 	return scroll
 }
 
-fn pad2(n int) string {
-	if n < 10 {
-		return '0' + n.str()
-	}
-	return n.str()
-}
-
 fn pad4(n int) string {
 	mut s := n.str()
 	for s.len < 4 {
@@ -3000,91 +2985,6 @@ fn draw_world(mut app GuiApp, w int, h int) {
 	// Handoff visuals are derived from observed Engine events. Until that event
 	// stream is connected, render no envelopes or trails; ambient motion must not
 	// imply that agents are working.
-	if false {
-	for e in 0 .. 5 {
-		a_idx := e % desks.len
-		mut b_idx := (e * 7 + 3) % desks.len
-		if a_idx == b_idx {
-			b_idx = (b_idx + 5) % desks.len
-		}
-		ax := rects_x[a_idx] + 70
-		ay := rects_y[a_idx] + 43
-		bx := rects_x[b_idx] + 70
-		by := rects_y[b_idx] + 43
-		phase := (app.frame * 2 + e * 67) % 240
-		progress := f32(phase) / 240.0
-		if progress > 0.94 {
-			continue
-		}
-		arc_h := f32(26)
-		// GOD mailbox arc: 4*t*(1-t) * arc_h — workshop handoff law, native V only
-		arc := arc_h * 4.0 * progress * (1.0 - progress)
-		fx_ := f32(ax)
-		fy_ := f32(ay)
-		tx_ := f32(bx)
-		ty_ := f32(by)
-		xf := fx_ + (tx_ - fx_) * progress
-		ground_y := fy_ + (ty_ - fy_) * progress
-		yf := ground_y - arc
-		x := int(xf)
-		y := int(yf)
-		// segmented arc line from source to envelope (brass, translucent)
-		segments := 10
-		for s in 0 .. segments {
-			t0 := f32(s) / f32(segments) * progress
-			t1 := f32(s + 1) / f32(segments) * progress
-			x0 := int(fx_ + (tx_ - fx_) * t0)
-			y0 := int(fy_ + (ty_ - fy_) * t0 - arc_h * 4.0 * t0 * (1.0 - t0))
-			x1 := int(fx_ + (tx_ - fx_) * t1)
-			y1 := int(fy_ + (ty_ - fy_) * t1 - arc_h * 4.0 * t1 * (1.0 - t1))
-			alpha := u8(55 - s * 3)
-			if alpha < 12 {
-				continue
-			}
-			app.gg.draw_line(x0, y0, x1, y1, tint(app.pnl_select, alpha))
-		}
-		// trail ghosts behind envelope — 4 fading paper rectangles with brass shadow
-		for t in 1 .. 5 {
-			tp := progress - f32(t) * 0.045
-			if tp < 0 {
-				continue
-			}
-			tp_arc := arc_h * 4.0 * tp * (1.0 - tp)
-			txf := fx_ + (tx_ - fx_) * tp
-			tyf := fy_ + (ty_ - fy_) * tp - tp_arc
-			alpha := u8(90 - t * 18)
-			if alpha < 12 {
-				continue
-			}
-			app.gg.draw_rect_filled(int(txf) + 2, int(tyf) + 2, 12, 6, tint(app.pnl_select, alpha / 2))
-			app.gg.draw_rect_filled(int(txf), int(tyf), 12, 6, tint(app.pnl_bg, alpha))
-		}
-		// signature floor shadow ellipse under envelope — shrinks as arc rises (parabolic soft shadow)
-		shadow_w := int(14 - arc / 3.2)
-		sw := if shadow_w < 6 { 6 } else { shadow_w }
-		shadow_alpha := u8(28 - int(arc * 0.7))
-		sa := if shadow_alpha < 8 { u8(8) } else { shadow_alpha }
-		ground_x := int(xf)
-		shadow_y := int(ground_y) + 6
-		if shadow_y > fy + 36 && shadow_y < fy + fh - 4 && ground_x > fx && ground_x < fx + fw {
-			app.gg.draw_rect_filled(ground_x - sw / 2 + 4, shadow_y, sw, 3, tint(app.pnl_text, sa))
-			app.gg.draw_rect_filled(ground_x - sw / 2 + 6, shadow_y + 1, sw - 4, 1, tint(app.pnl_text, sa / 2))
-		}
-		// main envelope — paper with brass shadow + mail glyph + envelope shadows (native gg)
-		app.gg.draw_rect_filled(x + 1, y + 1, 18, 10, tint(app.pnl_text, 40))
-		app.gg.draw_rect_filled(x + 2, y + 2, 16, 6, tint(app.pnl_text, 22))
-		app.gg.draw_rect_filled(x - 1, y - 1, 18, 10, tint(app.pnl_select, 110))
-		app.gg.draw_rect_filled(x, y, 16, 8, app.pnl_bg)
-		// flap line — workshop envelope fold
-		app.gg.draw_line(x, y, x + 8, y + 4, app.pnl_border_hi)
-		app.gg.draw_line(x + 8, y + 4, x + 16, y, app.pnl_border_hi)
-		// inner envelope shadow 1px bottom edge for depth
-		app.gg.draw_line(x + 1, y + 7, x + 15, y + 7, tint(app.pnl_text, 12))
-		if desks[a_idx].status == 'blocked' || desks[b_idx].status == 'blocked' {
-			app.gg.draw_rect_filled(x + 12, y + 1, 3, 3, app.pnl_danger)
-		}
-	}
-	}
 
 	if app.desktop != unsafe { nil } && app.desktop.engine_jobs_catalog().len == 0 {
 		app.gg.draw_text(fx + 56, fy + 54, 'No agents are currently running.', gg.TextCfg{ color: app.pnl_text_mut, size: 12 })
@@ -3525,18 +3425,6 @@ struct SkillEntryProxy {
 	domain      string
 	description string
 	stability   string
-}
-
-fn skills_filtered_for_app(mut app GuiApp) []string {
-	// Delegates to Engine (227) via Desktop proxy — no direct os/catalog read.
-	// Use engine_skills_search for ranked fuzzy. An unavailable catalog is an
-	// honest empty state; it must never be replaced with invented entries.
-	cat := app.desktop.engine_skills_search(app.skills_query, app.skills_domain)
-	mut out := []string{}
-	for s in cat {
-		out << s.id
-	}
-	return out
 }
 
 fn skills_filtered_entries(mut app GuiApp) []SkillEntryProxy {

--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -67,7 +67,38 @@ Classifications are recommendations requiring relevant runtime proof before clos
 | [#1055](https://github.com/ulises-jeremias/agent-toolkit/issues/1055) feat(desktop): native platform — menus/tray/file dialogs/clipboard/drag-drop/notifications (7.1) | NEEDS_REWRITE | P1 | Replace vlang/gui VGuiBackend framing with native gg backend seam. Clipboard present main.v:2038; modules/desktop/backend/backend.v exists. File/folder pickers high value to standalone lifecycle. |
 | [#1030](https://github.com/ulises-jeremias/agent-toolkit/issues/1030) feat(desktop): activity — status, progress, background tasks surface | PARTIALLY_DONE | P1 | Per-panel status/toasts exist, global actual activity needs shared typed projection. main.v:4408/:4746/:5067 supply per-domain rendering; do not invent percentage/activity. |
 
-## Recommended next steps
+## Salvage ledger
+
+### S1 — Catalog truth and embedded resolution (`fix/catalog-embedded-truth`)
+
+Status: in progress. Replaces raw filesystem catalog discovery in `desktop_engine`
+with the tier-aware `data_*` abstraction so embedded binaries, checkouts, XDG
+installs, and FHS installs all resolve the same bundled product truth.
+
+Changes:
+- `modules/desktop_engine/di.v`: add `data_dir_exists` and `data_list_dir` helpers.
+- `modules/desktop_engine/mcp_service.v`: discover providers from
+  `mcp/templates/<id>/config.template.json` via `data_*`; remove fabricated
+  7-provider fallback; make `mcp_preview`, `mcp_install_preview`,
+  `mcp_template_json`, and `mcp_probe` truthful across tiers.
+- `modules/desktop_engine/products_service.v`: discover `packs/*/config.yaml`
+  via `data_*`; remove hardcoded pack roster; add `enabled` field to `PackEntry`.
+- `modules/desktop_engine/loops_service.v`: discover bundled `loops/*/loop.yaml`
+  via `data_*`; read yaml budgets through `data_file_read`.
+- `cmd/agent-toolkit-desktop/main.v`: remove `bc2` debug logger
+  (`/tmp/opencode/bc2.log`), dead `if false` ambient animation branch, and
+  unused `skills_filtered_for_app` / `pad2` helpers.
+- Tests: pin `AGENT_TOOLKIT_ROOT` to repo root for hermetic execution;
+  update `mcp_drawer_test.v`, `capability_plane_test.v`, and
+  `runtime_plane_test.v` to match truthful semantics; add
+  `embedded_catalog_test.v` proving clean-machine resolution.
+
+Evidence:
+- `./make.vsh test` green (75 module tests).
+- Native binary builds and headless-boots from a fresh HOME/XDG environment,
+  resolving `agents:18 skills:116 mcp:7 packs:7 targets:7` from the embedded tier.
+
+### Recommended next steps
 
 1. Replace master tracker with product outcomes and explicit evidence gaps; link durable mission/journey/coverage/QA documents. Retain all valid capability work even when presentation issues are superseded.
 2. Resolve production truth before increasing panel depth; independently inspect synthetic activity and handoff-derived statuses.

--- a/modules/desktop_engine/capability_plane_test.v
+++ b/modules/desktop_engine/capability_plane_test.v
@@ -33,6 +33,10 @@ fn test_capability_plane_skills_via_engine_no_shell() {
 }
 
 fn test_capability_plane_products_via_engine() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'cap-products-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }
@@ -45,15 +49,26 @@ fn test_capability_plane_products_via_engine() {
 	prods := eng.products_catalog()
 	assert prods.len >= 2
 	packs := eng.packs_catalog()
-	assert packs.len == 7
+	// A temporary Engine may resolve to an isolated root without packaged packs.
+	// The catalog must remain truthful and may therefore be empty.
+	for pack in packs {
+		assert pack.provenance.starts_with('packs/')
+		assert pack.skill_count >= 0
+	}
 	rev := eng.update_product_membership(prods[0].id, ['core/assistant']) or { panic(err.msg()) }
 	assert rev >= 1
-	rev2 := eng.set_pack_enabled('docs-only', true) or { panic(err.msg()) }
-	assert rev2 >= 1
+	if packs.len > 0 {
+		rev2 := eng.set_pack_enabled(packs[0].id, true) or { panic(err.msg()) }
+		assert rev2 >= 1
+	}
 	assert eng.api_call_count() > 0
 }
 
 fn test_capability_plane_mcp_secret_guard_via_engine() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'cap-mcp-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }
@@ -82,6 +97,10 @@ fn test_capability_plane_mcp_secret_guard_via_engine() {
 }
 
 fn test_capability_plane_agents_doctor_targets_via_engine() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'cap-agents-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }

--- a/modules/desktop_engine/di.v
+++ b/modules/desktop_engine/di.v
@@ -183,3 +183,14 @@ pub fn data_file_exists(env EnvResolver, rel string) bool {
 pub fn data_file_read(env EnvResolver, rel string) !string {
 	return agent_toolkit_core.data_read_file(env.toolkit_root, data_path(env, rel))
 }
+
+// data_dir_exists reports directory existence through the same tier-aware
+// abstraction used for files, so catalog discovery works for embedded binaries.
+pub fn data_dir_exists(env EnvResolver, rel string) bool {
+	return agent_toolkit_core.data_is_dir(env.toolkit_root, data_path(env, rel))
+}
+
+// data_list_dir returns immediate children of a tier-aware directory path.
+pub fn data_list_dir(env EnvResolver, rel string) []string {
+	return agent_toolkit_core.data_ls(env.toolkit_root, data_path(env, rel))
+}

--- a/modules/desktop_engine/embedded_catalog_test.v
+++ b/modules/desktop_engine/embedded_catalog_test.v
@@ -1,0 +1,49 @@
+module desktop_engine
+
+import os
+
+// embedded_catalog_resolution ensures a clean machine (no AGENT_TOOLKIT_ROOT,
+// no XDG data) still resolves bundled product catalogs from the embedded tier.
+// This is the S1 catalog-truth acceptance test: catalog must not depend on a
+// checkout or pre-installed data directory.
+fn test_embedded_catalog_resolution_on_clean_machine() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	prev_data := os.getenv('XDG_DATA_HOME')
+	prev_cache := os.getenv('XDG_CACHE_HOME')
+	prev_home := os.getenv('HOME')
+	clean_home := os.join_path(os.temp_dir(), 'atk-clean-home-${os.getpid()}')
+	os.mkdir_all(os.join_path(clean_home, '.local', 'share')) or { panic(err.msg()) }
+	os.setenv('AGENT_TOOLKIT_ROOT', '', true)
+	os.setenv('XDG_DATA_HOME', os.join_path(clean_home, '.local', 'share'), true)
+	os.setenv('XDG_CACHE_HOME', os.join_path(clean_home, '.cache'), true)
+	os.setenv('HOME', clean_home, true)
+	defer {
+		os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true)
+		os.setenv('XDG_DATA_HOME', prev_data, true)
+		os.setenv('XDG_CACHE_HOME', prev_cache, true)
+		os.setenv('HOME', prev_home, true)
+		os.rmdir_all(clean_home) or {}
+	}
+
+	tmp := os.join_path(os.temp_dir(), 'atk-embedded-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	env := resolve_env()
+	assert env.tier == 'embedded', 'clean machine must resolve to embedded tier, got ${env.tier}'
+	assert eng.agents_catalog().len >= 18, 'agents catalog from embedded'
+	assert eng.skills_catalog().len >= 116, 'skills catalog from embedded'
+	assert eng.mcp_catalog().len == 7, 'MCP catalog from embedded'
+	assert eng.packs_catalog().len == 7, 'packs catalog from embedded'
+	assert eng.products_catalog().len >= 2, 'products catalog from embedded'
+	assert eng.targets().len >= 7, 'targets catalog from embedded'
+	assert eng.api_call_count() > 0
+}

--- a/modules/desktop_engine/loops_service.v
+++ b/modules/desktop_engine/loops_service.v
@@ -108,15 +108,15 @@ pub fn (mut e Engine) loops_catalog() []LoopEntry {
 			}
 		}
 	}
-	// also discover from filesystem loops/* loop.yaml for easy management when State empty
+	// also discover from bundled loops/* loop.yaml for easy management when State empty
 	if names.len == 0 {
 		env := resolve_env()
-		loops_dir := os.join_path(env.toolkit_root, 'loops')
-		if os.is_dir(loops_dir) {
-			entries := os.ls(loops_dir) or { []string{} }
+		loops_dir_rel := 'loops'
+		if data_dir_exists(env, loops_dir_rel) {
+			entries := data_list_dir(env, loops_dir_rel)
 			for en in entries {
-				loop_yaml := os.join_path(loops_dir, en, 'loop.yaml')
-				if os.is_file(loop_yaml) {
+				loop_yaml_rel := '${loops_dir_rel}/${en}/loop.yaml'
+				if data_file_exists(env, loop_yaml_rel) {
 					if en !in names {
 						names << en
 					}
@@ -127,21 +127,21 @@ pub fn (mut e Engine) loops_catalog() []LoopEntry {
 	if names.len > 0 {
 		mut out := []LoopEntry{}
 		for n in names {
-			goal := snap.data['loops/${n}/goal'] or { 'Goal ${n}' }
-			// budgets — read new keys first, fallback to old single budget (audit-aligned 80k/1/900)
-			max_tokens := (snap.data['loops/${n}/budget/max_tokens'] or { snap.data['loops/${n}/budget'] or { '80000' } }).int()
-			max_runs := (snap.data['loops/${n}/budget/max_runs_per_day'] or { '1' }).int()
-			max_wall := (snap.data['loops/${n}/budget/max_wall_seconds'] or { '900' }).int()
-			// also try filesystem yaml if State missing
+			goal := snap.data['loops/${n}/goal'] or { '' }
+			// Budgets and cadence are unknown unless explicitly configured or authored.
+			max_tokens := (snap.data['loops/${n}/budget/max_tokens'] or { '0' }).int()
+			max_runs := (snap.data['loops/${n}/budget/max_runs_per_day'] or { '0' }).int()
+			max_wall := (snap.data['loops/${n}/budget/max_wall_seconds'] or { '0' }).int()
+			// also try bundled yaml if State missing
 			mut fs_budget := LoopBudget{ max_tokens: max_tokens, max_runs_per_day: max_runs, max_wall_seconds: max_wall }
-			mut fs_cadence := snap.data['loops/${n}/cadence'] or { '1d' }
+			mut fs_cadence := snap.data['loops/${n}/cadence'] or { '' }
 			mut fs_verifier := snap.data['loops/${n}/verifier'] or { '' }
 			mut fs_description := snap.data['loops/${n}/description'] or { '' }
 			mut fs_tier_str := snap.data['loops/${n}/tier'] or { '' }
 			env2 := resolve_env()
-			yaml_path := os.join_path(env2.toolkit_root, 'loops', n, 'loop.yaml')
-			if os.is_file(yaml_path) {
-				content := os.read_file(yaml_path) or { '' }
+			yaml_rel := 'loops/${n}/loop.yaml'
+			if data_file_exists(env2, yaml_rel) {
+				content := data_file_read(env2, yaml_rel) or { '' }
 				if content.len > 0 {
 					// lightweight parse for cadence/budget/tier if State empty — distinct L1/L2/L3
 					lines := content.split_into_lines()

--- a/modules/desktop_engine/mcp_drawer_test.v
+++ b/modules/desktop_engine/mcp_drawer_test.v
@@ -18,6 +18,10 @@ fn test_mask_mcp_secrets_masks_all_prefixes() {
 
 // Drawer data: template fallback + typed probe (#1106).
 fn test_mcp_drawer_template_and_probe() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'mcp-drawer-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }
@@ -30,14 +34,14 @@ fn test_mcp_drawer_template_and_probe() {
 
 	cat := eng.mcp_catalog()
 	assert cat.len >= 7
-	// unknown provider → default stanza, not an error (drawer always renders)
+	// unknown provider → unavailable, never a fabricated stanza
 	content, from_file := eng.mcp_template_json('no-such-provider')
 	assert from_file == false
-	assert content.contains('no-such-provider')
-	// probe is typed and honest: figma reports error
+	assert content == ''
+	// probe is typed and honest: an unconfigured provider is not healthy
 	fig := eng.mcp_probe('figma') or { panic(err.msg()) }
 	assert fig.healthy == false
-	assert fig.detail.contains('error')
+	assert fig.detail.contains('unconfigured')
 	// github probes against live health without writing state
 	gh := eng.mcp_probe('github') or { panic(err.msg()) }
 	assert gh.detail != ''

--- a/modules/desktop_engine/mcp_service.v
+++ b/modules/desktop_engine/mcp_service.v
@@ -39,71 +39,48 @@ pub:
 	provenance_path string
 }
 
-// mcp_catalog lists 7 providers — super-potent: reads mcp/templates + registry, provenance.
+// mcp_catalog discovers providers from packaged mcp/templates/<id>/ files.
+// A missing catalog is empty rather than a reason to invent a provider roster.
+// Catalog discovery uses the tier-aware data_* helpers so embedded binaries
+// resolve bundled templates the same way a checkout does.
 pub fn (mut e Engine) mcp_catalog() []McpProvider {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	env := resolve_env()
-	reg_dir := os.join_path(env.toolkit_root, 'mcp', 'templates')
+	reg_dir_rel := 'mcp/templates'
 	mut ids := []string{}
-	if os.is_dir(reg_dir) {
-		files := os.ls(reg_dir) or { []string{} }
-		for f in files {
-			if f.ends_with('.json') {
-				ids << f.all_before('.json')
+	if data_dir_exists(env, reg_dir_rel) {
+		entries := data_list_dir(env, reg_dir_rel)
+		for id in entries {
+			template_rel := '${reg_dir_rel}/${id}/config.template.json'
+			local_template_rel := '${reg_dir_rel}/${id}/config.local.template.json'
+			if data_file_exists(env, template_rel) || data_file_exists(env, local_template_rel) {
+				ids << id
 			}
 		}
 	}
-	// prefer real files if >=7
-	if ids.len >= 7 {
-		mut out := []McpProvider{}
-		for id in ids[..7] {
-			snap := e.repo.snapshot()
-			enabled_str := snap.data['mcp:${id}:enabled'] or { 'true' }
-			enabled := enabled_str == 'true'
-			health := e.mcp_health_detailed(id)
-			out << McpProvider{
-				id: id
-				name: id
-				description: 'MCP ${id} — template ${id}.json'
-				enabled: enabled
-				health: health
-				requires_docker: id == 'github'
-				template_path: os.join_path(reg_dir, '${id}.json')
-				registry_path: os.join_path(env.toolkit_root, 'mcp', 'registry', '${id}.yaml')
-				version: '1.0.0'
-				provenance: 'mcp/templates/${id}.json'
-			}
-		}
-		return out
-	}
-	snap := e.repo.snapshot()
+	ids.sort()
 	mut out := []McpProvider{}
-	defs := [
-		['github', 'GitHub', 'GitHub MCP (requires docker)', 'true', 'healthy', 'true'],
-		['slack', 'Slack', 'Slack MCP — chat + workflow', 'false', 'unconfigured', 'false'],
-		['notion', 'Notion', 'Notion MCP — pages + db', 'true', 'healthy', 'false'],
-		['linear', 'Linear', 'Linear MCP — issues', 'false', 'unconfigured', 'false'],
-		['figma', 'Figma', 'Figma MCP — design tokens', 'false', 'error', 'false'],
-		['chrome-devtools', 'Chrome DevTools', 'CDP — browser automation', 'true', 'healthy',
-			'false'],
-		['clickup', 'ClickUp', 'ClickUp MCP — tasks', 'false', 'unconfigured', 'false'],
-	]
-	for d in defs {
-		id := d[0]
-		enabled_str := snap.data['mcp:${id}:enabled'] or { d[3] }
+	snap := e.repo.snapshot()
+	for id in ids {
+		template_name := if data_file_exists(env, '${reg_dir_rel}/${id}/config.template.json') {
+			'config.template.json'
+		} else {
+			'config.local.template.json'
+		}
+		enabled_str := snap.data['mcp:${id}:enabled'] or { 'false' }
 		out << McpProvider{
 			id: id
-			name: d[1]
-			description: d[2]
+			name: id
+			description: 'MCP ${id} — packaged template'
 			enabled: enabled_str == 'true'
-			health: d[4]
-			requires_docker: d[5] == 'true'
-			template_path: os.join_path(env.toolkit_root, 'mcp', 'templates', '${id}.json')
-			registry_path: os.join_path(env.toolkit_root, 'mcp', 'registry', '${id}.yaml')
-			version: '1.0.0'
-			provenance: 'mcp/templates/${id}.json'
+			health: e.mcp_health_detailed(id)
+			requires_docker: id == 'github'
+			template_path: '${reg_dir_rel}/${id}/${template_name}'
+			registry_path: 'mcp/registry/${id}.yaml'
+			version: ''
+			provenance: '${reg_dir_rel}/${id}/${template_name}'
 		}
 	}
 	return out
@@ -137,7 +114,8 @@ pub fn (mut e Engine) mcp_health(provider_id string) string {
 	return 'unconfigured'
 }
 
-// mcp_health_detailed checks docker for github, file existence etc.
+// mcp_health_detailed checks docker for github when enabled; disabled
+// providers are honestly unconfigured rather than hardcoded to error.
 pub fn (mut e Engine) mcp_health_detailed(provider_id string) string {
 	e.mu.lock()
 	e.api_calls++
@@ -146,6 +124,10 @@ pub fn (mut e Engine) mcp_health_detailed(provider_id string) string {
 	if 'mcp:${provider_id}:health' in snap.data {
 		return snap.data['mcp:${provider_id}:health'] or { 'unconfigured' }
 	}
+	enabled := (snap.data['mcp:${provider_id}:enabled'] or { 'false' }) == 'true'
+	if !enabled {
+		return 'unconfigured'
+	}
 	if provider_id == 'github' {
 		docker := os.find_abs_path_of_executable('docker') or { '' }
 		if docker == '' {
@@ -153,12 +135,8 @@ pub fn (mut e Engine) mcp_health_detailed(provider_id string) string {
 		}
 		return 'healthy'
 	}
-	if provider_id == 'figma' {
-		return 'error'
-	}
-	// enabled providers healthy, disabled unconfigured
-	enabled := (snap.data['mcp:${provider_id}:enabled'] or { 'false' }) == 'true'
-	return if enabled { 'healthy' } else { 'unconfigured' }
+	// enabled providers without a special probe are healthy
+	return 'healthy'
 }
 
 // mcp_stats returns super-potent aggregation.
@@ -202,8 +180,14 @@ pub fn (mut e Engine) mcp_preview(provider_id string) (string, string) {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	_ = provider_id
-	return '{"mcpServers": {"${provider_id}": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-${provider_id}"]}}}', '{"mcpServers": {"${provider_id}": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-${provider_id}"]}}}'
+	env := resolve_env()
+	for p in e.mcp_catalog() {
+		if p.id == provider_id {
+			content := data_file_read(env, p.template_path) or { '' }
+			return content, content
+		}
+	}
+	return '', ''
 }
 
 // mcp_install_preview returns dry-run diff (easy management).
@@ -211,15 +195,28 @@ pub fn (mut e Engine) mcp_install_preview(provider_id string) McpInstallPreview 
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	env := resolve_env()
+	mut template_path := ''
+	for p in e.mcp_catalog() {
+		if p.id == provider_id {
+			template_path = p.template_path
+			break
+		}
+	}
+	if template_path == '' {
+		return McpInstallPreview{
+			provider_id: provider_id
+			will_write: []
+			will_update: []
+			receipt_path: ''
+			provenance_path: ''
+		}
+	}
 	return McpInstallPreview{
 		provider_id: provider_id
-		will_write: [
-			os.join_path(env.toolkit_root, 'mcp', 'templates', '${provider_id}.json'),
-		]
+		will_write: [template_path]
 		will_update: [os.join_path(os.home_dir(), '.config', 'mcp.json')]
 		receipt_path: os.join_path(os.home_dir(), '.config', 'agent-toolkit', 'receipts', '${provider_id}-mcp.json')
-		provenance_path: os.join_path(env.toolkit_root, 'mcp', 'templates', '${provider_id}.json')
+		provenance_path: template_path
 	}
 }
 
@@ -231,24 +228,23 @@ pub:
 	detail  string
 }
 
-// mcp_template_json returns the real template content when the file exists,
-// else the default npx stanza. The bool reports which (#1106). Never errors
-// so the drawer always has something masked to show.
+// mcp_template_json returns only real packaged template content. The bool
+// reports whether the provider was discovered from a file (#1106).
 pub fn (mut e Engine) mcp_template_json(provider_id string) (string, bool) {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
+	env := resolve_env()
 	for p in e.mcp_catalog() {
 		if p.id == provider_id {
-			content := os.read_file(p.template_path) or { '' }
+			content := data_file_read(env, p.template_path) or { '' }
 			if content != '' {
 				return content, true
 			}
 			break
 		}
 	}
-	return '{"mcpServers": {"${provider_id}": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-${provider_id}"]}}}',
-		false
+	return '', false
 }
 
 // mcp_probe runs the typed health probe: schema validation + secret-guard
@@ -279,7 +275,7 @@ pub fn (mut e Engine) mcp_probe(provider_id string) !McpProbeResult {
 		problems << 'raw secret in template — replace with \${ENV_VAR}'
 	}
 	health_now := e.mcp_health_detailed(provider_id)
-	if health_now == 'error' || health_now == 'fail' {
+	if health_now != 'healthy' {
 		problems << 'provider reports ${health_now}'
 	}
 	if problems.len == 0 {

--- a/modules/desktop_engine/products_service.v
+++ b/modules/desktop_engine/products_service.v
@@ -23,6 +23,7 @@ pub:
 	name         string
 	skill_count  int
 	docs_only    bool
+	enabled      bool
 	provenance   string
 	receipt_path string
 }
@@ -93,19 +94,55 @@ pub fn (mut e Engine) products_search(query string) []ProductEntry {
 	return out
 }
 
+// packs_catalog discovers packs/*/config.yaml and derives enabled skill counts
+// from each config. It uses the tier-aware data_* helpers so embedded binaries
+// resolve bundled packs the same way a checkout does.
 pub fn (mut e Engine) packs_catalog() []PackEntry {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	return [
-		PackEntry{ id: 'docs-only', name: 'Docs Only', skill_count: 5, docs_only: true, provenance: 'packs/docs-only/config.yaml', receipt_path: 'receipts/pack-docs-only.json' },
-		PackEntry{ id: 'core', name: 'Core', skill_count: 6, docs_only: true, provenance: 'packs/core/config.yaml', receipt_path: 'receipts/pack-core.json' },
-		PackEntry{ id: 'design', name: 'Design', skill_count: 12, docs_only: true, provenance: 'packs/design/config.yaml', receipt_path: 'receipts/pack-design.json' },
-		PackEntry{ id: 'delivery', name: 'Delivery', skill_count: 10, docs_only: true, provenance: 'packs/delivery/config.yaml', receipt_path: 'receipts/pack-delivery.json' },
-		PackEntry{ id: 'forge', name: 'Forge', skill_count: 8, docs_only: true, provenance: 'packs/forge/config.yaml', receipt_path: 'receipts/pack-forge.json' },
-		PackEntry{ id: 'security', name: 'Security', skill_count: 7, docs_only: true, provenance: 'packs/security/config.yaml', receipt_path: 'receipts/pack-security.json' },
-		PackEntry{ id: 'full', name: 'Full', skill_count: 116, docs_only: true, provenance: 'packs/full/config.yaml', receipt_path: 'receipts/pack-full.json' },
-	]
+	env := resolve_env()
+	root_rel := 'packs'
+	mut ids := []string{}
+	if data_dir_exists(env, root_rel) {
+		ids = data_list_dir(env, root_rel)
+	}
+	ids.sort()
+	mut out := []PackEntry{}
+	snap := e.repo.snapshot()
+	for id in ids {
+		config_rel := '${root_rel}/${id}/config.yaml'
+		if !data_file_exists(env, config_rel) {
+			continue
+		}
+		text := data_file_read(env, config_rel) or { '' }
+		mut skill_count := 0
+		mut in_skills := false
+		for line in text.split_into_lines() {
+			t := line.trim_space()
+			if t == 'skills:' {
+				in_skills = true
+				continue
+			}
+			if in_skills && (t == 'agents:' || t == 'loops:' || t == 'mcp:') {
+				in_skills = false
+			}
+			if in_skills && t.starts_with('enabled:') && t.all_after(':').trim_space() == 'true' {
+				skill_count++
+			}
+		}
+		enabled := (snap.data['pack:${id}:enabled'] or { 'false' }) == 'true'
+		out << PackEntry{
+			id: id
+			name: id.replace('-', ' ').title()
+			skill_count: skill_count
+			docs_only: true
+			enabled: enabled
+			provenance: config_rel
+			receipt_path: 'receipts/pack-${id}.json'
+		}
+	}
+	return out
 }
 
 // packs_search fuzzy.

--- a/modules/desktop_engine/runtime_plane_test.v
+++ b/modules/desktop_engine/runtime_plane_test.v
@@ -3,6 +3,10 @@ module desktop_engine
 import os
 
 fn test_runtime_plane_jobs_via_engine_no_shell() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'runtime-jobs-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }
@@ -32,6 +36,10 @@ fn test_runtime_plane_jobs_via_engine_no_shell() {
 }
 
 fn test_runtime_plane_loops_via_engine_no_shell() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'runtime-loops-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }
@@ -42,24 +50,40 @@ fn test_runtime_plane_loops_via_engine_no_shell() {
 	eng.start()!
 	defer { eng.stop() or {} }
 	loops := eng.loops_catalog()
-	assert loops.len == 10
+	for loop in loops {
+		assert !loop.name.starts_with('goal-'), 'runtime must not invent template loops'
+	}
 	diags := eng.loop_validate('test', 'budget: -1')
 	assert diags.len > 0
 	diags2 := eng.loop_validate('test', 'name: x')
 	assert diags2.len > 0
-	rev := eng.upsert_loop(loops[0]) or { panic(err.msg()) }
+	entry := LoopEntry{
+		name: 'test-loop'
+		goal: 'Exercise the runtime loop lifecycle'
+		tier: .l1
+		stage: 'l1'
+		cadence: '1d'
+		schedule: cadence_to_cron('1d')
+		budget: loop_budget_defaults(.l1)
+		budget_total: loop_budget_defaults(.l1).max_tokens
+	}
+	rev := eng.upsert_loop(entry) or { panic(err.msg()) }
 	assert rev >= 1
-	rev2 := eng.toggle_loop_cron(loops[0].name, true) or { panic(err.msg()) }
+	rev2 := eng.toggle_loop_cron(entry.name, true) or { panic(err.msg()) }
 	assert rev2 > rev
-	id := eng.run_loop(loops[0].name) or { panic(err.msg()) }
+	id := eng.run_loop(entry.name) or { panic(err.msg()) }
 	assert id.len > 0
-	hist := eng.loops_history(loops[0].name)
+	hist := eng.loops_history(entry.name)
 	assert hist.len >= 1
-	assert loops[0].budget_remaining() == loops[0].budget_total - loops[0].budget_spent
+	assert entry.budget_remaining() == entry.budget_total - entry.budget_spent
 	assert eng.api_call_count() > 0
 }
 
 fn test_runtime_plane_workspace_via_engine_no_shell() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'runtime-ws-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }


### PR DESCRIPTION
## What

S1 catalog-truth recovery: make `desktop_engine` catalog discovery tier-aware so
embedded binaries resolve bundled agents, skills, MCP providers, packs, loops,
products and targets the same way a checkout or XDG install does.

## Why

PR #1139 exposed that `mcp_catalog()`, `packs_catalog()` and loop discovery used
raw `os.is_dir`/`os.ls` against `resolve_env().toolkit_root`. When the Engine
resolves to the embedded tier, those paths are abstract (`embedded/...`) and
filesystem calls return empty results, causing `Check V Modules` to fail with
`cat.len == 0` on clean machines.

This change replaces the raw filesystem calls with the existing `data_*`
abstraction (`data_is_dir`, `data_ls`, `data_is_file`, `data_read_file`) and
removes fabricated fallbacks so the catalog is always truthful.

## Changes

- `modules/desktop_engine/di.v`: add `data_dir_exists` and `data_list_dir` helpers.
- `modules/desktop_engine/mcp_service.v`:
  - Discover providers from `mcp/templates/<id>/config.template.json` via `data_*`.
  - Remove the hardcoded 7-provider fallback.
  - Make `mcp_preview`, `mcp_install_preview`, `mcp_template_json`, and
    `mcp_probe` truthful across checkout/embedded/XDG/FHS tiers.
- `modules/desktop_engine/products_service.v`:
  - Discover `packs/*/config.yaml` via `data_*`.
  - Remove hardcoded pack roster.
  - Add `enabled` field to `PackEntry`.
- `modules/desktop_engine/loops_service.v`:
  - Discover bundled `loops/*/loop.yaml` via `data_*`.
  - Read loop yaml budgets through `data_file_read`.
- `cmd/agent-toolkit-desktop/main.v`:
  - Remove `bc2` debug logger writing `/tmp/opencode/bc2.log`.
  - Remove dead `if false` ambient handoff-animation branch.
  - Remove unused `skills_filtered_for_app` and `pad2` helpers.
- Tests:
  - Pin `AGENT_TOOLKIT_ROOT` to repo root for hermetic execution.
  - Update `mcp_drawer_test.v`, `capability_plane_test.v`, and
    `runtime_plane_test.v` to match truthful semantics.
  - Add `embedded_catalog_test.v` proving clean-machine resolution.
- `docs/desktop/BACKLOG_AUDIT.md`: add S1 salvage ledger entry.

## Verification

- `make.vsh test` green locally: 75 module tests pass.
- Native binary builds and headless-boots from a fresh HOME/XDG environment,
  resolving:
  - agents: 18
  - skills: 116
  - mcp: 7
  - packs: 7
  - targets: 7

## Related

- Salvage source: PR #1139 (`r2-office-shell`) — not merged as a unit.
- Reconciles the `Check V Modules` failure that blocked PR #1139.
- Closes no visual redesign items (S3 remains blocked pending screenshot review).
