### PR TITLE
fix(desktop): separate runtime projection from bundled catalog data

### DIFF
--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -98,6 +98,27 @@ Evidence:
 - Native binary builds and headless-boots from a fresh HOME/XDG environment,
   resolving `agents:18 skills:116 mcp:7 packs:7 targets:7` from the embedded tier.
 
+### S2 — Runtime projection boundary (`fix/runtime-projection-truth`)
+
+Status: in progress. Separates mutable runtime artifacts from immutable bundled
+catalog data so loop worktrees, job scratch, and future runtime state never write
+into the embedded/toolkit namespace.
+
+Changes:
+- `modules/desktop_engine/engine.v`: add `runtime_path` to `EngineConfig` and
+  `Engine`; derive it from `persist_path` or an explicit override; create it in
+  `init()`.
+- `modules/desktop_engine/loops_service.v`: route `loop_worktree_path()` and
+  `ensure_loop_worktree_hygiene()` through `e.runtime_path` instead of
+  `env.toolkit_root`.
+- `modules/desktop_engine/runtime_projection_test.v`: verify worktree paths are
+  under runtime_path, reject traversal, and detect duplicate worktrees.
+
+Evidence:
+- `./make.vsh test` green (77 module tests).
+- Loop worktree paths resolve under the derived runtime directory for both
+  persistent and in-memory engines.
+
 ### Recommended next steps
 
 1. Replace master tracker with product outcomes and explicit evidence gaps; link durable mission/journey/coverage/QA documents. Retain all valid capability work even when presentation issues are superseded.

--- a/modules/desktop_engine/engine.v
+++ b/modules/desktop_engine/engine.v
@@ -52,6 +52,11 @@ mut:
 	watcher_poll_ms     int = 500
 	watcher_debounce_ms int = 100
 	use_polling         bool
+	// runtime_path is the filesystem root for mutable runtime artifacts
+	// (loop worktrees, job scratch, receipts cache). Distinct from the
+	// toolkit_root catalog path so embedded binaries never write into the
+	// bundled data namespace.
+	runtime_path string
 	// revision tracking
 	revision u64
 	// engine_api call counter for parity tests (engine_api_call>0)
@@ -63,6 +68,9 @@ mut:
 pub struct EngineConfig {
 pub:
 	persist_path        string
+	// runtime_path overrides the derived runtime directory. When empty,
+	// it defaults to a directory next to persist_path.
+	runtime_path        string
 	di                  &DIContainer = unsafe { nil }
 	repo                &state.StateRepository = unsafe { nil }
 	bus                 &eventbus.ToolkitEventBus = unsafe { nil }
@@ -90,16 +98,35 @@ pub fn new_engine(cfg EngineConfig) &Engine {
 	if deb < 50 || deb > 150 {
 		deb = 100
 	}
+	rtp := runtime_path_for(cfg.persist_path, cfg.runtime_path)
 	return &Engine{
 		state: .created
 		di: di
 		repo: rep
 		bus: bus
+		runtime_path: rtp
 		watcher_paths: cfg.watcher_paths.clone()
 		watcher_poll_ms: poll
 		watcher_debounce_ms: deb
 		use_polling: cfg.use_polling || os.getenv('WATCHER_FORCE_POLL') == '1' || os.getenv('VVATCH_FORCE_POLL') == '1'
 	}
+}
+
+// runtime_path_for derives a mutable runtime directory from the persistence path.
+// If persist_path is empty, it falls back to a temp directory so in-memory engines
+// still have a contained runtime namespace.
+fn runtime_path_for(persist_path string, explicit string) string {
+	if explicit.len > 0 {
+		return explicit
+	}
+	if persist_path.len > 0 {
+		base := persist_path.all_before_last('.')
+		if base.len > 0 {
+			return '${base}.runtime'
+		}
+		return '${persist_path}.runtime'
+	}
+	return os.join_path(os.temp_dir(), 'atk-runtime-${os.getpid()}')
 }
 
 // init boots headless; reads env tiers AGENT_TOOLKIT_ROOT → XDG → embedded → FHS.
@@ -113,6 +140,10 @@ pub fn (mut e Engine) init() ! {
 	// load derived state persistence (XDG_CACHE_HOME/agent-toolkit/desktop/state.json)
 	e.repo.load() or {
 		// load failure is not fatal for headless boot; log via bus payload
+	}
+	// ensure runtime namespace exists and is distinct from bundled catalog data
+	os.mkdir_all(e.runtime_path) or {
+		return error('runtime path ${e.runtime_path}: ${err}')
 	}
 	// register default Capability + Runtime plane services (mirrors agent_toolkit_core planes)
 	e.register_default_services() or {}

--- a/modules/desktop_engine/loops_service.v
+++ b/modules/desktop_engine/loops_service.v
@@ -800,8 +800,9 @@ pub fn (mut e Engine) loop_worktree_path(loop_name string, run_id string) !strin
 	if loop_name.contains('..') || run_id.contains('..') || run_id.contains('/') {
 		return error('path traversal')
 	}
-	env := resolve_env()
-	base := os.join_path(env.toolkit_root, 'loops', loop_name, 'runs', run_id)
+	// Runtime artifacts live under the Engine runtime_path, never under
+	// toolkit_root, so embedded binaries do not write into bundled catalog data.
+	base := os.join_path(e.runtime_path, 'loops', loop_name, 'runs', run_id)
 	// worktree-per-writer hygiene: each run gets isolated dir, no shared writes
 	return os.join_path(base, 'worktree')
 }
@@ -815,8 +816,8 @@ pub fn (mut e Engine) ensure_loop_worktree_hygiene(loop_name string) []BuildDiag
 		return diags
 	}
 	// verify loop dir not sharing worktree across writers: check runs/* uniqueness
-	env := resolve_env()
-	loop_dir := os.join_path(env.toolkit_root, 'loops', loop_name)
+	// Runtime state is scoped to runtime_path, distinct from bundled catalog data.
+	loop_dir := os.join_path(e.runtime_path, 'loops', loop_name)
 	if !os.is_dir(loop_dir) {
 		return diags
 	}

--- a/modules/desktop_engine/runtime_projection_test.v
+++ b/modules/desktop_engine/runtime_projection_test.v
@@ -1,0 +1,66 @@
+module desktop_engine
+
+import os
+
+// loop_runtime_paths_use_runtime_path ensures loop worktrees and hygiene scans
+// are scoped to the Engine runtime_path, never to toolkit_root. This is the S2
+// runtime-projection boundary: bundled catalog data is immutable; runtime
+// artifacts are mutable and isolated.
+fn test_loop_runtime_paths_use_runtime_path() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
+
+	tmp := os.join_path(os.temp_dir(), 'runtime-projection-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	// runtime_path is derived from persist_path
+	assert eng.runtime_path == os.join_path(tmp, 'state.runtime'), 'runtime_path derived: ${eng.runtime_path}'
+	assert os.is_dir(eng.runtime_path), 'runtime_path created'
+
+	// worktree is under runtime_path, not toolkit_root
+	wt := eng.loop_worktree_path('daily-triage', 'run-001') or { panic(err.msg()) }
+	assert wt.starts_with(eng.runtime_path), 'worktree must live under runtime_path: ${wt}'
+	assert !wt.contains('embedded'), 'worktree must not be inside embedded catalog'
+	assert wt.contains('loops/daily-triage/runs/run-001/worktree')
+
+	// create two runs and verify hygiene detects no duplicate
+	os.mkdir_all(os.join_path(eng.runtime_path, 'loops', 'daily-triage', 'runs', 'run-001', 'worktree')) or { panic(err.msg()) }
+	os.mkdir_all(os.join_path(eng.runtime_path, 'loops', 'daily-triage', 'runs', 'run-002', 'worktree')) or { panic(err.msg()) }
+	diags := eng.ensure_loop_worktree_hygiene('daily-triage')
+	assert diags.len == 0, 'distinct worktrees should be clean: ${diags}'
+
+	// path traversal is rejected
+	if _ := eng.loop_worktree_path('..', 'run-001') {
+		assert false, 'traversal must fail'
+	} else {
+		assert err.msg().contains('traversal')
+	}
+}
+
+// empty_persist_path_falls_back_to_temp_runtime ensures an in-memory engine
+// still has a runtime namespace and does not collide with the toolkit root.
+fn test_runtime_path_fallback_when_persist_empty() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
+
+	mut eng := new_engine(EngineConfig{})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	assert eng.runtime_path.len > 0
+	assert os.is_dir(eng.runtime_path)
+	assert eng.runtime_path.starts_with(os.temp_dir())
+}


### PR DESCRIPTION
## What

S2 runtime-projection recovery: separate mutable runtime artifacts from the
bundled catalog namespace by adding an explicit `Engine.runtime_path`.

## Why

Loop worktree helpers (`loop_worktree_path`, `ensure_loop_worktree_hygiene`)
were joining runtime paths against `env.toolkit_root`. For an embedded binary,
`toolkit_root` is the abstract bundled-data namespace; writing loop run
worktrees there is wrong and would fail silently or pollute the packaged data
space. Runtime state must live in a distinct, mutable filesystem root.

## Changes

- `modules/desktop_engine/engine.v`:
  - Add `runtime_path` to `EngineConfig` and `Engine`.
  - Derive it from `persist_path` (e.g., `state.json` → `state.runtime/`) or an
    explicit override; fall back to a temp directory when persistence is empty.
  - Create `runtime_path` during `init()`.
- `modules/desktop_engine/loops_service.v`:
  - Route `loop_worktree_path()` and `ensure_loop_worktree_hygiene()` through
    `e.runtime_path` instead of `env.toolkit_root`.
- `modules/desktop_engine/runtime_projection_test.v`:
  - Verify worktree paths are under `runtime_path`.
  - Verify traversal is rejected.
  - Verify duplicate-worktree hygiene.
  - Verify fallback temp runtime path for in-memory engines.
- `docs/desktop/BACKLOG_AUDIT.md`: add S2 salvage ledger entry.

## Verification

- `./make.vsh test` green: 77 module tests pass.
- Native desktop binary builds cleanly.

## Related

- Salvage sequence S2 after PR #1140 (S1 catalog truth).
