### PR TITLE
fix(desktop): onboarding workspace truth and per-domain catalog truth

### DIFF
--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -141,6 +141,30 @@ Evidence:
 - Native desktop binary builds.
 - Golden UI fixtures regenerated and committed.
 
+### S4 — Shared action/entity registry
+
+Status: identified, deferred. The palette currently mixes a static production
+palette (`main.v:1617`) with `modules/desktop/palette/palette.v`. Building a
+single typed Engine-backed action/entity registry is an architecture refactor
+that exceeds the immediate recovery scope and deserves its own design pass.
+Tracked in #1119.
+
+### S5/S6 — Onboarding/workspace truth and per-domain catalog truth
+
+Status: in progress. Fixes workspace/catalog conflations that survived S1-S3:
+
+- `modules/desktop_engine/onboarding_service.v`: stop using `toolkit_root` as a
+  fallback workspace root; workspace existence/personas are now scoped to the
+  real harness root or recent workspace.
+- `modules/desktop_engine/engine.v`: doctor matrix/provenance/cli-contract
+  checks now use `data_file_exists` so embedded binaries can resolve bundled
+  `docs/research/platform-capability-matrix.md`, `capabilities/upstream.lock`,
+  and `docs/compatibility/cli-contract.yaml`.
+
+Evidence:
+- `./make.vsh test` green.
+- Native desktop binary builds.
+
 ### Recommended next steps
 
 1. Replace master tracker with product outcomes and explicit evidence gaps; link durable mission/journey/coverage/QA documents. Retain all valid capability work even when presentation issues are superseded.

--- a/modules/desktop_engine/engine.v
+++ b/modules/desktop_engine/engine.v
@@ -614,13 +614,14 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 		}
 	}
 	// ── matrix / compiler ──
-	matrix_path := os.join_path(env.toolkit_root, 'docs', 'research', 'platform-capability-matrix.md')
+	matrix_rel := 'docs/research/platform-capability-matrix.md'
+	matrix_found := data_file_exists(env, matrix_rel)
 	checks << DoctorCheck{
 		id: 'matrix:platform-capability-matrix'
 		category: 'matrix'
 		name: 'platform-capability-matrix'
-		status: if os.is_file(matrix_path) { 'pass' } else { 'warn' }
-		message: if os.is_file(matrix_path) { matrix_path } else { 'not found: ${matrix_path}' }
+		status: if matrix_found { 'pass' } else { 'warn' }
+		message: if matrix_found { matrix_rel } else { 'not found: ${matrix_rel}' }
 		fixable: false
 	}
 	// ── context-cost ──
@@ -643,14 +644,15 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 		fixable: true
 	}
 	// ── provenance ──
-	lock_path := os.join_path(env.toolkit_root, 'capabilities', 'upstream.lock')
-	if os.is_file(lock_path) {
+	lock_rel := 'capabilities/upstream.lock'
+	lock_found := data_file_exists(env, lock_rel)
+	if lock_found {
 		checks << DoctorCheck{
 			id: 'provenance:upstream.lock'
 			category: 'provenance'
 			name: 'upstream.lock'
 			status: 'pass'
-			message: lock_path
+			message: lock_rel
 			fixable: false
 		}
 		// sha
@@ -662,19 +664,22 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 			message: 'sha verified via upstream.lock'
 			fixable: false
 		}
-		// expiry via mtime
-		mtime := os.file_last_mod_unix(lock_path)
-		if mtime > 0 {
-			age_days := (time.now().unix() - mtime) / 86400
-			checks << DoctorCheck{
-				id: 'provenance:expiry'
-				category: 'provenance'
-				name: 'expiry'
-				status: if age_days > 90 { 'warn' } else { 'pass' }
-				message: if age_days > 90 {
-					'stale: ${age_days}d since last update (>90d)'} else {
-					'${age_days}d since update'}
-				fixable: false
+		// expiry via mtime only for filesystem tiers; embedded has no stable mtime
+		if env.tier != 'embedded' {
+			lock_path := data_path(env, lock_rel)
+			mtime := os.file_last_mod_unix(lock_path)
+			if mtime > 0 {
+				age_days := (time.now().unix() - mtime) / 86400
+				checks << DoctorCheck{
+					id: 'provenance:expiry'
+					category: 'provenance'
+					name: 'expiry'
+					status: if age_days > 90 { 'warn' } else { 'pass' }
+					message: if age_days > 90 {
+						'stale: ${age_days}d since last update (>90d)'} else {
+						'${age_days}d since update'}
+					fixable: false
+				}
 			}
 		}
 	} else {
@@ -683,20 +688,19 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 			category: 'provenance'
 			name: 'upstream.lock'
 			status: 'warn'
-			message: 'not found under toolkit root (checkout only)'
+			message: 'not found in resolved toolkit data'
 			fixable: false
 		}
 	}
 	// cli-contract
-	contract_path := os.join_path(env.toolkit_root, 'docs', 'compatibility', 'cli-contract.yaml')
+	contract_rel := 'docs/compatibility/cli-contract.yaml'
+	contract_found := data_file_exists(env, contract_rel)
 	checks << DoctorCheck{
 		id: 'provenance:cli-contract'
 		category: 'provenance'
 		name: 'cli-contract'
-		status: if os.is_file(contract_path) { 'pass' } else { 'warn' }
-		message: if os.is_file(contract_path) {
-			contract_path} else {
-			'not found: ${contract_path}'}
+		status: if contract_found { 'pass' } else { 'warn' }
+		message: if contract_found { contract_rel } else { 'not found: ${contract_rel}' }
 		fixable: false
 	}
 	// ── receipts verification ──

--- a/modules/desktop_engine/onboarding_service.v
+++ b/modules/desktop_engine/onboarding_service.v
@@ -38,19 +38,19 @@ pub fn (mut e Engine) onboarding_status(harness_root string) OnboardingStatus {
 	rev := snap.revision
 	is_first := snap.data['onboarding_completed'] or { '' } != 'true'
 	completed := !is_first
-	// resolve harness root for existence checks
-	env := resolve_env()
+	// resolve harness root for existence checks. Runtime workspace state is
+	// distinct from bundled toolkit data; never fall back to toolkit_root for
+	// workspace existence because embedded toolkits have no filesystem root.
 	mut root := harness_root.trim_space()
 	if root == '' {
-		// prefer recent_workspace from state, else toolkit_root
-		root = snap.data['recent_workspace'] or { env.toolkit_root }
+		root = snap.data['recent_workspace'] or { '' }
 	}
 	// workspace_exists: knowledge/ repos/ projects/ packs/
-	workspace_exists := os.is_dir(os.join_path(root, 'knowledge')) || os.is_dir(os.join_path(root, 'repos'))
-	personas_dir := os.join_path(root, 'personas')
+	workspace_exists := root.len > 0 && (os.is_dir(os.join_path(root, 'knowledge')) || os.is_dir(os.join_path(root, 'repos')))
+	personas_dir := if root.len > 0 { os.join_path(root, 'personas') } else { '' }
 	mut persona_count := 0
 	mut personas_bootstrapped := false
-	if os.is_dir(personas_dir) {
+	if personas_dir.len > 0 && os.is_dir(personas_dir) {
 		ents := os.ls(personas_dir) or { []string{} }
 		for en in ents {
 			if en.ends_with('.md') {


### PR DESCRIPTION
## What

S5/S6 follow-ups: fix remaining workspace/catalog conflations in
`onboarding_service.v` and `engine.v` doctor checks.

## Why

After S1-S3, a few places still confused bundled toolkit data with runtime
workspace state or used raw filesystem paths against `toolkit_root`:

- `onboarding_service.v` fell back to `env.toolkit_root` when no workspace was
  configured. For an embedded binary, `toolkit_root` is the abstract bundled
  namespace, not a user workspace, so persona/workspace checks were wrong.
- `engine.v` doctor checks for `docs/research/platform-capability-matrix.md`,
  `capabilities/upstream.lock`, and `docs/compatibility/cli-contract.yaml` used
  `os.is_file` with `toolkit_root`, failing in embedded.

## Changes

- `modules/desktop_engine/onboarding_service.v`:
  - Remove `env.toolkit_root` fallback for workspace root.
  - Scope `workspace_exists` and `personas_bootstrapped` to the real harness
    root or `recent_workspace` only.
- `modules/desktop_engine/engine.v`:
  - Use `data_file_exists` for matrix, upstream.lock, and cli-contract checks.
  - Skip upstream.lock mtime/expiry check for the embedded tier (no stable
    filesystem mtime).
- `docs/desktop/BACKLOG_AUDIT.md`: add S5/S6 ledger entry; note S4 registry
  refactor is deferred to #1119.

## Verification

- `./make.vsh test` green.
- Native desktop binary builds.

## Related

- Salvage S5/S6 after PR #1142 (S3 Office visual recovery).
- S4 (typed action/entity registry) deferred to #1119.
