### PR TITLE
fix(desktop): evidence and receipt truth (S7A)

### DIFF
--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -151,7 +151,7 @@ Tracked in #1119.
 
 ### S5/S6 — Onboarding/workspace truth and per-domain catalog truth
 
-Status: in progress. Fixes workspace/catalog conflations that survived S1-S3:
+Status: merged (PR #1143). Fixes workspace/catalog conflations that survived S1-S3:
 
 - `modules/desktop_engine/onboarding_service.v`: stop using `toolkit_root` as a
   fallback workspace root; workspace existence/personas are now scoped to the
@@ -164,6 +164,50 @@ Status: in progress. Fixes workspace/catalog conflations that survived S1-S3:
 Evidence:
 - `./make.vsh test` green.
 - Native desktop binary builds.
+
+### S7A — Evidence & receipt truth (`fix/s7a-evidence-truth`)
+
+Status: in progress. Full audit inventory and authority classification live in
+[TRUTH_LEDGER.md](TRUTH_LEDGER.md). S7A replaces every fabricated digest,
+receipt and provenance claim with real evidence:
+
+- `receipts_service.v`: receipts now come only from real core installer
+  receipts (`agent_toolkit_core.list_install_receipts`) under the user config
+  authority, verified by recomputing each artifact digest from the artifact
+  bytes. Provenance now comes only from real `plugins/<product>/.provenance.json`
+  manifests read through the tier-aware `data_*` helpers, verified by
+  recomputing SHA-256 of artifact bytes against the recorded digests. The
+  `sha256:abc`-style placeholders, unconditional `verified: true`, wrong
+  receipt directory, raw-os scans and fabricated embedded fallback are gone.
+- `skills_service.v`: selection is configuration truth — `install_skill` /
+  `install_skills` write no receipt or provenance keys. `skill_receipt` /
+  `skill_provenance` return real receipt/manifest evidence or none.
+  `build_check` performs a real catalog-drift check instead of magic
+  `broken_skill` fixture keys. `build_preview` computes a real SHA-256 over
+  canonical catalog material instead of a string-length sum.
+- `agents_service.v`: `install_agent` is selection only; `agent_receipt`
+  returns real receipt artifact evidence or none; `agent_provenance_detail`
+  reports `verified` from actual manifest evidence.
+- `products_service.v`: membership updates write no fake digests; product
+  provenance/receipt report real evidence or honest absence.
+- `jobs_service.v`: job completion records runtime truth only; the fabricated
+  job-receipt machinery (`JobReceipt`, length-derived digests) is removed.
+- `mcp_service.v`: enabling uses the packaged template content (never an
+  invented npx stanza), health is `configured` until a probe succeeds, upsert
+  validates real JSON, `mcp_validate` checks the packaged catalog and recorded
+  config, provenance reports the real template path.
+- Tests: new `evidence_truth_test.v` gates (fresh engine has no receipts;
+  selection writes no receipt keys; real receipts verify and tampering fails
+  honestly; provenance is real manifest evidence; digest is a real SHA-256;
+  MCP toggle uses packaged templates). `product_truth_test.v` isolates
+  `XDG_CONFIG_HOME` so genuine user installs do not leak into assertions.
+
+Evidence:
+- `./make.vsh test` green (78 module tests).
+- Native desktop binary builds; clean-machine headless boot resolves all
+  catalogs.
+- Real-user verification: 6 genuine profile-install receipts surface, all
+  digest-verified; 223 real provenance entries with honest drift reporting.
 
 ### Recommended next steps
 

--- a/docs/desktop/TRUTH_LEDGER.md
+++ b/docs/desktop/TRUTH_LEDGER.md
@@ -1,0 +1,91 @@
+# Desktop Engine truth ledger
+
+Status: S7 audit baseline, 2026-09-06, `origin/main cf4a4eb8`. This ledger classifies
+every Desktop Engine value by authority and records the replacement source for
+each contaminated API. It is the contract for S7 slices: **if Agent Toolkit
+cannot prove a fact, it must not manufacture it.** Unknown, unavailable, empty
+and unverified are valid states.
+
+## Authority classes
+
+| Class | Meaning | Canonical sources |
+|---|---|---|
+| PRODUCT / CATALOG TRUTH | What Agent Toolkit bundles/supports | `skills/`, `agents/`, `mcp/templates/`, `loops/`, `packs/`, `distributions/products.yaml`, `capabilities/targets/registry.yaml`, `catalogs/` — read only through tier-aware `data_*` helpers |
+| CONFIGURATION / INSTALLATION TRUTH | What this user/workspace configured | `StateRepository` snapshot keys; core install receipts at `XDG_CONFIG_HOME/agent-toolkit/receipts`; absence means absent, never a convenient default |
+| RUNTIME TRUTH | What is happening now | Process supervisor, PTYs, job/loop/swarm state transitions, event bus; `Engine.runtime_path` for mutable artifacts |
+| EVIDENCE / RECEIPT / PROVENANCE TRUTH | Claims about artifacts | `agent_toolkit_core.receipt.v` (typed InstallReceipt, real digests), `plugins/*/.provenance.json` manifests (ADR-022); verification = recomputed SHA-256 of real bytes matches the recorded digest |
+
+## Path authorities
+
+| Authority | Root | Access |
+|---|---|---|
+| Bundled catalog data | `resolve_env().toolkit_root` (may be abstract `embedded`) | `data_file_exists` / `data_file_read` / `data_dir_exists` / `data_list_dir` only |
+| User application config | `XDG_CONFIG_HOME/agent-toolkit` (receipts under `receipts/`) | core `FsService`; direct `os` is acceptable (real user paths) |
+| Desktop derived state | `EngineConfig.persist_path` (XDG cache) | `StateRepository` |
+| Runtime artifacts | `Engine.runtime_path` (derived from persist_path) | `os` (mutable scratch) |
+| Active workspace | harness root / `recent_workspace` — never `toolkit_root` | `os` with validated paths |
+
+## Contamination inventory and replacements
+
+Severity: B = blocker, H = high, M = medium. Status: pending slices S7A–S7F.
+
+| File | Finding | Sev | Replacement source | Slice |
+|---|---|---|---|---|
+| `git_service.v` | Entire API fabricated: fake authors, synthetic hashes/timestamps/messages, hardcoded diffs; real `.git` probe is dead code | B | Typed Git read backend over the active workspace; explicit empty/unavailable until it exists | S7C |
+| `git_service.v` | Raw `os.join_path(toolkit_root, '.git')` | M | Workspace-rooted probe via workspace authority | S7C |
+| `targets_service.v` | State-only `install()` writes fake receipts (`1.27.0`, `sha256:${len*13}`), no profile files written | B | `capabilities/targets/registry.yaml` roster + `agent_toolkit_core.run_install` real install + real `load_install_receipt` | S7B |
+| `targets_service.v` | Default-enabled `claude-code`/`cli` with no configuration | M | Enabled only from explicit config state | S7B |
+| `targets_service.v` | Duplicated 7-target roster; hardcoded version/digest in `install_receipt_json` | H | Registry.yaml; real receipt fields or none | S7B |
+| `targets_service.v` | `doctor_fix_stamp` fabricates receipt evidence instead of repairing | H | Fix only what is actually repaired; missing receipt stays missing | S7B |
+| `update_service.v` | Entire feed hardcoded (`1.27.1`, `abc123sha256`); `verify()` ignores content; `apply()` state-only | B | Verified release feed or explicit unavailable; no apply until a real updater exists | S7E |
+| `skills_service.v` | `install_skill` writes `sha256:${id.len + set.len}` digests as receipts | B | Selection is config truth only; no receipt keys without real receipts | S7A |
+| `skills_service.v` | `skill_provenance` fabricates `sha256:${id.len * 11}` with `verified: true`; `sha256:abc` fallback | H | Real provenance from `plugins/*/.provenance.json` artifact records; none otherwise | S7A |
+| `skills_service.v` | `build_check` only fires on magic `broken_skill` state key / `broken` substrings | H | Real check: installed skills must resolve in catalog; beta stability from catalog | S7A |
+| `skills_service.v` | `build_preview` "plugins-digest" is a sum of string lengths | H | Real SHA-256 of canonical catalog material | S7A |
+| `agents_service.v` | `install_agent` state-only receipt (`1.0.0`, constructed path) | B | Selection config truth; real receipt evidence from plugin install artifacts | S7A |
+| `agents_service.v` | Hardcoded tier lists, invented triggers, default `architect` owner | H/M | AGENT.md frontmatter / agent catalog | S7D |
+| `agents_service.v` | `agent_provenance_detail` emits `verified: 'true'` unconditionally | H | Real provenance scan; false/none otherwise | S7A |
+| `loops_service.v` | Fabricated 10-loop fallback catalog with fake spend and future `next_run` | B | Bundled loops via data_* (already S1); empty when absent | S7D |
+| `loops_service.v` | Synthetic history rows, "treat synthetic history as completed", invented cost tiers | H | Real state history only; measured or unknown | S7D |
+| `receipts_service.v` | `sha256:abc`/`sha256:def`/`sha256:123` placeholders, unconditional `verified: true` | H | `agent_toolkit_core.list_install_receipts` + recomputed artifact digests | S7A |
+| `receipts_service.v` | Receipt dir read at `toolkit_root/.config` (wrong authority; raw os on embedded) | H | Core `default_receipt_dir()` (user config authority) | S7A |
+| `receipts_service.v` | `.provenance.json` scan uses raw os + file-length "digests"; fabricated embedded fallback | H | Tier-aware `data_*` reads + real SHA-256 of artifact bytes | S7A |
+| `memory_service.v` | Raw os on `toolkit_root` (embedded → cwd); 8 demo palace entries | H | Workspace-rooted knowledge via data_*; empty when empty | S7E |
+| `workspace_service.v` | `active_workspace_root` falls back to `toolkit_root` | H | Empty/unavailable without a configured workspace | S7E |
+| `workspace_service.v` | `git_status_for` filename-pattern "modified" badges | H | No git status without a git backend | S7C |
+| `workspace_service.v` | Placeholder tree node, fabricated "init memory" entry, `saved_at '0'` | M | Empty state | S7E |
+| `jobs_service.v` | `job_complete` writes three length-derived digests | H | Runtime state only; no receipt/provenance keys | S7A |
+| `jobs_service.v` | Missing exit code defaults to 0; supervisor spawn failure swallowed as success | M/H | Unknown stays unknown; failures recorded as failed | S7E |
+| `swarm_service.v` | State-only `running`, invented budget, fabricated log lines | H | Real backend launch or `requested`; logs only from records | S7E |
+| `mcp_service.v` | Enabled providers are `healthy` without probing; `broken_mcp` fixture-keyed validation; toggle installs invented npx config; fabricated registry path | H | Packaged template content via data_*; honest `configured` state; real template schema parse validation | S7A |
+| `products_service.v` | `1.27.0` on every product; invented membership fallback; fake membership digest; fabricated `installed_at` | H | products.yaml; membership from config only; real provenance sidecar evidence | S7A |
+| `engine.v` | Doctor "sha verified" pass without verification; unconditional passes; hardcoded target roster; magic `116` | H | Real checks or honest warns; registry-derived roster | S7E |
+| `di.v` | Undocumented `cwd` tier fallback | M | Document the ladder; embedded tier must not silently become cwd | S7E |
+| `onboarding_service.v` | State-only target enabling; hardcoded persona templates | H/M | Config truth + canonical agent/persona sources | S7B/D |
+
+## Evidence semantics (adopted in S7A)
+
+An Engine action that only records configuration state is **configuration**, not
+installation. States are distinguished as:
+
+- `selected/configured` — state key recorded (e.g. `installed_skills`);
+- `receipt recorded` — a real receipt file exists under the user config receipts
+  dir (written only by an operation that actually deployed artifacts);
+- `provenance recorded` — a real `.provenance.json` manifest exists with source
+  digests;
+- `provenance verified` — recomputed SHA-256 of the referenced bytes matches the
+  recorded digest;
+- `unavailable/none` — no evidence exists; never substituted.
+
+A receipt or provenance entry that cannot be verified reports `verified: false`
+with the reason; it is never dropped or silently marked true.
+
+## Regression gates
+
+- A fresh Engine yields zero receipts and zero provenance entries.
+- No production digest is derived from string lengths or placeholders
+  (`sha256:abc`-style values are forbidden in production output).
+- `verified` is true only after a real verification operation.
+- Receipt lookups never synthesize timestamps/versions.
+- Typed tests in `modules/desktop_engine/evidence_truth_test.v` enforce these;
+  grep-style gates are avoided.

--- a/modules/desktop_engine/agents_service.v
+++ b/modules/desktop_engine/agents_service.v
@@ -1,7 +1,8 @@
 module desktop_engine
 
-import time
+import os
 import x.json2
+import agent_toolkit_core
 
 // AgentEntry mirrors personas + AGENT.md + registry — super-potent: delegates, collaborates, triggers, provenance.
 pub struct AgentEntry {
@@ -352,23 +353,29 @@ pub fn (mut e Engine) agents_by_tier() map[string][]AgentEntry {
 	return m
 }
 
-// agent_receipt returns install receipt for agent (mirrors skill receipt).
+// agent_receipt returns real receipt evidence for an agent: the artifact
+// records of core install receipts whose deployed artifacts include the
+// agent's AGENT.md. Selection state alone is never receipt evidence.
 pub fn (mut e Engine) agent_receipt(id string) ?AgentReceiptInfo {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
-	key := 'receipt:agent:${id}:installed_at'
-	if key !in snap.data {
-		return none
+	needle := 'agents/${id}/AGENT.md'
+	for r in agent_toolkit_core.list_install_receipts('') {
+		for a in r.artifacts {
+			if a.path.contains(needle) {
+				return AgentReceiptInfo{
+					agent_id: id
+					installed: true
+					installed_at: r.installed_at
+					version: r.version
+					receipt_path: os.join_path(agent_toolkit_core.default_receipt_dir(),
+						agent_toolkit_core.receipt_filename(r.target, r.product))
+				}
+			}
+		}
 	}
-	return AgentReceiptInfo{
-		agent_id: id
-		installed: true
-		installed_at: snap.data[key] or { '' }
-		version: snap.data['receipt:agent:${id}:version'] or { '1.0.0' }
-		receipt_path: 'receipts/agent-${id}.json'
-	}
+	return none
 }
 
 // agents_provenance returns provenance manifests for all agents.
@@ -385,7 +392,9 @@ pub fn (mut e Engine) agents_provenance() []AgentReceiptInfo {
 	return out
 }
 
-// install_agent writes receipt via Engine transaction (easy one-click).
+// install_agent records the agent as selected in configuration state.
+// Selection is configuration truth only — no receipt is written; receipt
+// evidence exists only when the core installer deploys real artifacts.
 pub fn (mut e Engine) install_agent(id string) !u64 {
 	_ := e.agent_detail(id)!
 	e.mu.lock()
@@ -393,14 +402,12 @@ pub fn (mut e Engine) install_agent(id string) !u64 {
 	e.mu.unlock()
 	mut repo := e.repo
 	mut tx := repo.begin('install-agent')
-	tx.set('receipt:agent:${id}:installed_at', time.now().str())
-	tx.set('receipt:agent:${id}:version', '1.0.0')
 	tx.set('agents:installed:${id}', 'true')
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
 
-// remove_agent removes receipt.
+// remove_agent clears the selection.
 pub fn (mut e Engine) remove_agent(id string) !u64 {
 	if id == '' {
 		return error('agent id empty')
@@ -411,7 +418,6 @@ pub fn (mut e Engine) remove_agent(id string) !u64 {
 	mut repo := e.repo
 	mut tx := repo.begin('remove-agent')
 	tx.set('agents:installed:${id}', 'false')
-	tx.set('receipt:agent:${id}:removed_at', time.now().str())
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
@@ -430,7 +436,9 @@ pub fn (mut e Engine) agents_delegation_graph() map[string][]string {
 	return m
 }
 
-// agent_provenance_detail returns structured provenance for one agent.
+// agent_provenance_detail returns structured provenance for one agent. The
+// source fields are real catalog facts; verified reflects actual provenance
+// evidence from the bundled manifests, never an unconditional claim.
 pub fn (mut e Engine) agent_provenance_detail(id string) string {
 	_ := e.agent_detail(id) or {
 		return json2.encode({
@@ -439,11 +447,25 @@ pub fn (mut e Engine) agent_provenance_detail(id string) string {
 			escape_unicode: true
 		)
 	}
+	mut verified := false
+	mut source_digest := ''
+	mut generated_digest := ''
+	needle := 'agents/${id}/AGENT.md'
+	for p in e.provenance_catalog() {
+		if p.artifact_path.contains(needle) {
+			verified = p.verified
+			source_digest = p.source_digest
+			generated_digest = p.generated_digest
+			break
+		}
+	}
 	return json2.encode({
-		'id':         id
-		'source':     'agents/${id}/AGENT.md'
-		'provenance': 'catalogs/agent-catalog.yaml'
-		'verified':   'true'
+		'id':              id
+		'source':          'agents/${id}/AGENT.md'
+		'provenance':      'catalogs/agent-catalog.yaml'
+		'sourceDigest':    source_digest
+		'generatedDigest': generated_digest
+		'verified':        if verified { 'true' } else { 'false' }
 	},
 		escape_unicode: true
 	)

--- a/modules/desktop_engine/evidence_truth_test.v
+++ b/modules/desktop_engine/evidence_truth_test.v
@@ -1,0 +1,232 @@
+module desktop_engine
+
+import os
+import agent_toolkit_core
+
+// S7 evidence-truth regression gates. These tests enforce the contract from
+// docs/desktop/TRUTH_LEDGER.md: receipts and provenance exist only as real
+// evidence, digests are real SHA-256 values, verified is earned by an actual
+// verification operation, and unknown stays unknown.
+
+struct EvidenceHarness {
+	tmp      string
+	prev_root string
+	prev_cfg  string
+}
+
+fn evidence_harness_setup() EvidenceHarness {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	prev_cfg := os.getenv('XDG_CONFIG_HOME')
+	tmp := os.join_path(os.temp_dir(), 'evidence-truth-${os.getpid()}')
+	os.mkdir_all(os.join_path(tmp, 'xdg-config')) or { panic(err.msg()) }
+	os.setenv('XDG_CONFIG_HOME', os.join_path(tmp, 'xdg-config'), true)
+	return EvidenceHarness{
+		tmp: tmp
+		prev_root: prev_root
+		prev_cfg: prev_cfg
+	}
+}
+
+fn evidence_harness_teardown(h EvidenceHarness) {
+	os.setenv('AGENT_TOOLKIT_ROOT', h.prev_root, true)
+	os.setenv('XDG_CONFIG_HOME', h.prev_cfg, true)
+	os.rmdir_all(h.tmp) or {}
+}
+
+// A fresh Engine with no install history must surface zero receipts and never
+// invent receipt evidence for selections.
+fn test_fresh_engine_has_no_receipts() {
+	h := evidence_harness_setup()
+	defer { evidence_harness_teardown(h) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(h.tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	rec := eng.receipts_catalog()
+	assert rec.len == 0, 'fresh engine must not invent receipts: got ${rec.len}'
+	stats := eng.receipts_stats()
+	assert stats.total == 0 && stats.verified == 0
+	assert eng.verify_receipts().len == 0
+	// no receipt evidence exists for a selected skill without a real install
+	if _ := eng.skill_receipt('core/assistant') {
+		assert false, 'skill selection alone must not produce receipt evidence'
+	}
+}
+
+// Selecting a skill records configuration only — never receipt or provenance
+// state keys, never fabricated digests.
+fn test_skill_selection_writes_no_receipt_evidence() {
+	h := evidence_harness_setup()
+	defer { evidence_harness_teardown(h) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(h.tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	rev := eng.install_skill('core/assistant') or { panic(err.msg()) }
+	assert rev >= 1
+	snap := eng.repo.snapshot()
+	for k, _ in snap.data {
+		assert !k.starts_with('receipt:'), 'selection must not write receipt keys: ${k}'
+		assert !k.starts_with('provenance:'), 'selection must not write provenance keys: ${k}'
+	}
+	assert 'core/assistant' in eng.skills_installed()
+
+	// job completion records runtime truth only — no receipt keys
+	id := eng.spawn_job('echo', ['hello']) or { panic(err.msg()) }
+	eng.job_complete(id, 0) or { panic(err.msg()) }
+	snap2 := eng.repo.snapshot()
+	for k, _ in snap2.data {
+		assert !k.starts_with('receipt:'), 'job completion must not write receipt keys: ${k}'
+		assert !k.starts_with('provenance:'), 'job completion must not write provenance keys: ${k}'
+	}
+}
+
+// Real receipts written by the core installer are surfaced with actual
+// verification: artifact digests are recomputed from the artifact bytes.
+fn test_real_receipt_verification() {
+	h := evidence_harness_setup()
+	defer { evidence_harness_teardown(h) }
+
+	// real artifact file + real digest
+	art_dir := os.join_path(h.tmp, 'artifacts')
+	os.mkdir_all(art_dir) or { panic(err.msg()) }
+	art_path := os.join_path(art_dir, 'profile.md')
+	os.write_file(art_path, '# real profile content\n') or { panic(err.msg()) }
+	digest := agent_toolkit_core.receipt_artifact_digest(art_path)
+	assert digest != 'missing'
+	assert digest.len == 16, 'core digest is 16-hex: ${digest}'
+
+	mut receipt := agent_toolkit_core.new_install_receipt('agent-toolkit-profiles', 'claude-code',
+		'user-home', 'test-version', 'src-digest-000111')
+	receipt.artifacts << agent_toolkit_core.ArtifactEntry{
+		path: art_path
+		digest: digest
+		ownership: 'created'
+	}
+	saved := agent_toolkit_core.save_install_receipt(mut receipt, '') or { panic(err.msg()) }
+	assert saved.contains('claude-code-agent-toolkit-profiles.json')
+
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(h.tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	cat := eng.receipts_catalog()
+	assert cat.len == 1, 'real receipt must surface: got ${cat.len}'
+	r := cat[0]
+	assert r.id == 'claude-code'
+	assert r.product == 'agent-toolkit-profiles'
+	assert r.version == 'test-version'
+	assert r.installed_at != '', 'installed_at comes from the real receipt file'
+	assert r.receipt_path == saved
+	assert r.verified, 'digest recomputation must succeed while artifact matches'
+
+	// tamper with the artifact → verification must fail honestly
+	os.write_file(art_path, '# tampered\n') or { panic(err.msg()) }
+	cat2 := eng.receipts_catalog()
+	assert cat2.len == 1
+	assert !cat2[0].verified, 'tampered artifact must report unverified, never silently pass'
+	assert eng.verify_receipts().len == 1, 'unverified receipt must be reported'
+}
+
+// Provenance entries come from real bundled manifests with real digests —
+// never placeholders like sha256:abc.
+fn test_provenance_is_real_manifest_evidence() {
+	h := evidence_harness_setup()
+	defer { evidence_harness_teardown(h) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(h.tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	prov := eng.provenance_catalog()
+	assert prov.len > 0, 'bundled plugins manifests must yield provenance records'
+	for p in prov {
+		assert p.artifact_path.starts_with('plugins/')
+		assert !p.source_digest.contains('abc'), 'placeholder digests are forbidden'
+		assert !p.generated_digest.contains('def'), 'placeholder digests are forbidden'
+		assert p.detail != ''
+	}
+
+	// a bundled skill has real provenance evidence from the manifests
+	sp := eng.skill_provenance('core/assistant') or {
+		panic('core/assistant must have real provenance from plugins manifests')
+	}
+	assert sp.source_digest.len > 0
+	assert !sp.source_digest.contains('abc')
+
+	// agent provenance detail reports the verification field honestly
+	detail := eng.agent_provenance_detail('code-reviewer')
+	assert detail.contains('"verified"')
+}
+
+// The plugins-digest is a real SHA-256 over canonical catalog material.
+fn test_build_preview_digest_is_real_sha256() {
+	h := evidence_harness_setup()
+	defer { evidence_harness_teardown(h) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(h.tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	p1 := eng.build_preview()
+	p2 := eng.build_preview()
+	assert p1 == p2, 'digest over canonical material must be stable'
+	digest := p1.all_after('plugins-digest:').all_before(':')
+	assert digest.len == 64, 'SHA-256 hex must be 64 chars: ${digest}'
+	for c in digest {
+		assert (c >= `0` && c <= `9`) || (c >= `a` && c <= `f`), 'digest must be hex: ${digest}'
+	}
+}
+
+// MCP evidence semantics: enabling uses the packaged template, health is
+// configured (not healthy) until a probe succeeds, and invalid JSON is
+// refused.
+fn test_mcp_enable_uses_packaged_template_and_honest_health() {
+	h := evidence_harness_setup()
+	defer { evidence_harness_teardown(h) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(h.tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	// invalid JSON must be refused by upsert
+	if _ := eng.upsert_mcp_provider('github', 'not-json{') {
+		assert false, 'invalid JSON must be rejected'
+	} else {
+		assert err.msg().contains('not valid JSON')
+	}
+
+	rev := eng.mcp_toggle('github') or { panic(err.msg()) }
+	assert rev >= 1
+	snap := eng.repo.snapshot()
+	assert snap.data['mcp:github:enabled'] == 'true'
+	assert snap.data['mcp:github:health'] == 'configured', 'enabled without probe is configured, not healthy'
+	assert snap.data['mcp:github:config'] != '', 'toggle must record the packaged template config'
+	assert !snap.data['mcp:github:config'].contains('@modelcontextprotocol/server-github'),
+		'toggle must not invent an npx stanza'
+	assert snap.data['provenance:mcp:github:source'] == 'mcp/templates/github/config.template.json',
+		'provenance must be the real packaged template path'
+
+	// enabled provider without a probe reports configured or warn, never healthy
+	hg := eng.mcp_health_detailed('github')
+	assert hg == 'configured' || hg == 'warn', 'unprobed provider must not report healthy: ${hg}'
+	// verify_mcp_receipts is a real config check
+	assert eng.verify_mcp_receipts().len == 0
+}

--- a/modules/desktop_engine/jobs_service.v
+++ b/modules/desktop_engine/jobs_service.v
@@ -414,37 +414,10 @@ pub fn (mut e Engine) job_append_log(job_id string, line string) !u64 {
 	return rev.revision
 }
 
-// job_receipt captures provenance + receipt for a job (ADR-022).
-pub struct JobReceipt {
-pub:
-	job_id     string
-	receipt    string
-	provenance string
-	verified   bool
-}
 
-// job_receipt_for returns receipt/provenance for a job — receipts/provenance hardened.
-pub fn (mut e Engine) job_receipt_for(job_id string) ?JobReceipt {
-	e.mu.lock()
-	e.api_calls++
-	e.mu.unlock()
-	snap := e.repo.snapshot()
-	key := 'receipt:job:${job_id}:installed_at'
-	if key !in snap.data {
-		return none
-	}
-	mut installed := snap.data[key] or { '' }
-	digest := snap.data['receipt:job:${job_id}:digest'] or { '' }
-	prov := snap.data['provenance:job:${job_id}:source'] or { 'job:${job_id}' }
-	return JobReceipt{
-		job_id: job_id
-		receipt: installed
-		provenance: prov
-		verified: digest != ''
-	}
-}
-
-// job_complete — mark done/failed and publish with receipt/provenance.
+// job_complete records the real runtime outcome of a job. A job run is
+// runtime truth: status, exit code and duration come from the actual run.
+// No receipt or provenance evidence is written for job completions.
 pub fn (mut e Engine) job_complete(job_id string, exit_code int) !u64 {
 	if job_id == '' {
 		return error('job_id empty')
@@ -464,16 +437,6 @@ pub fn (mut e Engine) job_complete(job_id string, exit_code int) !u64 {
 	start := start_str.i64()
 	dur := if start != 0 { int((time.now().unix() - start) * 1000) } else { 0 }
 	tx.set('jobs/${job_id}/duration_ms', dur.str())
-	// receipts/provenance hardened: write receipt + provenance atomically via Transaction
-	cmd := snap.data['jobs/${job_id}/cmd'] or { snap.data['jobs/${job_id}/args'] or { job_id } }
-	tx.set('receipt:job:${job_id}:installed_at', time.now().str())
-	tx.set('receipt:job:${job_id}:cmd', cmd)
-	tx.set('receipt:job:${job_id}:exit_code', exit_code.str())
-	tx.set('receipt:job:${job_id}:digest', 'sha256:${job_id.len + exit_code + 7}')
-	tx.set('receipt:job:${job_id}:provenance', 'job:${job_id}:${cmd}')
-	tx.set('provenance:job:${job_id}:source', 'jobs/${job_id}')
-	tx.set('provenance:job:${job_id}:digest', 'sha256:${job_id.len * 13}')
-	tx.set('provenance:job:${job_id}:generated', 'sha256:${dur + 19}')
 	rev := e.put_transaction(mut tx)!
 	kind := if exit_code == 0 {
 		eventbus.ToolkitEventKind.job_completed

--- a/modules/desktop_engine/mcp_service.v
+++ b/modules/desktop_engine/mcp_service.v
@@ -1,7 +1,6 @@
 module desktop_engine
 
 import os
-import time
 import x.json2
 
 // McpProvider mirrors mcp/templates — super-potent: provenance, receipts, health detail.
@@ -135,8 +134,9 @@ pub fn (mut e Engine) mcp_health_detailed(provider_id string) string {
 		}
 		return 'healthy'
 	}
-	// enabled providers without a special probe are healthy
-	return 'healthy'
+	// Enabled providers without a special probe are configured, not healthy:
+	// health is a probe result, never a default for being enabled.
+	return 'configured'
 }
 
 // mcp_stats returns super-potent aggregation.
@@ -157,23 +157,41 @@ pub fn (mut e Engine) mcp_stats() McpStats {
 	return s
 }
 
+// mcp_validate performs real validation: the provider must exist in the
+// packaged catalog, and any recorded configuration must parse as JSON.
 pub fn (mut e Engine) mcp_validate(provider_id string) []BuildDiagnostic {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
+	mut diags := []BuildDiagnostic{}
 	if provider_id == '' {
 		return [
 			BuildDiagnostic{ path: 'mcp.json', message: 'provider id empty', code: 'missing_id' },
 		]
 	}
-	snap := e.repo.snapshot()
-	if 'broken_mcp' in snap.data {
+	mut known := false
+	for p in e.mcp_catalog() {
+		if p.id == provider_id {
+			known = true
+			break
+		}
+	}
+	if !known {
 		return [
-			BuildDiagnostic{ path: 'mcp/${provider_id}.json', message: 'schema invalid', code: 'schema_invalid' },
+			BuildDiagnostic{ path: 'mcp/${provider_id}.json', message: 'provider not in packaged catalog', code: 'unknown_provider' },
 		]
 	}
-	// secret guard is validated via upsert, but also surface here
-	return []BuildDiagnostic{}
+	snap := e.repo.snapshot()
+	config := snap.data['mcp:${provider_id}:config'] or { '' }
+	if config != '' {
+		if _ := json2.decode[json2.Any](config) {
+		} else {
+			return [
+				BuildDiagnostic{ path: 'mcp/${provider_id}.json', message: 'recorded config is not valid JSON', code: 'schema_invalid' },
+			]
+		}
+	}
+	return diags
 }
 
 pub fn (mut e Engine) mcp_preview(provider_id string) (string, string) {
@@ -356,6 +374,12 @@ pub fn (mut e Engine) upsert_mcp_provider(provider_id string, config_json string
 	if has_raw_secret(config_json) {
 		return error('secret guard: raw token detected, use \${ENV_VAR} placeholder per SECURITY.md')
 	}
+	// real validation: the offered config must parse as JSON before it is
+	// accepted into configuration state.
+	if _ := json2.decode[json2.Any](config_json) {
+	} else {
+		return error('validation failed: config is not valid JSON')
+	}
 	diags := e.mcp_validate(provider_id)
 	if diags.len > 0 {
 		return error('validation failed: ${diags[0].message}')
@@ -367,10 +391,16 @@ pub fn (mut e Engine) upsert_mcp_provider(provider_id string, config_json string
 	mut tx := repo.begin('upsert-mcp')
 	tx.set('mcp:${provider_id}:config', config_json)
 	tx.set('mcp:${provider_id}:enabled', 'true')
-	tx.set('mcp:${provider_id}:health', 'healthy')
-	tx.set('receipt:mcp:${provider_id}:installed_at', time.now().str())
-	tx.set('receipt:mcp:${provider_id}:digest', 'sha256:${config_json.len + provider_id.len}')
-	tx.set('provenance:mcp:${provider_id}:source', 'mcp/templates/${provider_id}.json')
+	// Config recorded ≠ server healthy. Honest state until a probe succeeds.
+	tx.set('mcp:${provider_id}:health', 'configured')
+	// provenance records the packaged template this provider was discovered
+	// from (real catalog evidence), not a constructed path.
+	for p in e.mcp_catalog() {
+		if p.id == provider_id {
+			tx.set('provenance:mcp:${provider_id}:source', p.provenance)
+			break
+		}
+	}
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
@@ -386,39 +416,45 @@ pub fn (mut e Engine) remove_mcp_provider(provider_id string) !u64 {
 	mut tx := repo.begin('remove-mcp')
 	tx.set('mcp:${provider_id}:enabled', 'false')
 	tx.set('mcp:${provider_id}:health', 'unconfigured')
-	tx.set('receipt:mcp:${provider_id}:removed_at', time.now().str())
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
 
-// mcp_toggle enables/disables in one click (easy management).
+// mcp_toggle enables/disables in one click. Enabling installs the packaged
+// template content for the provider — never an invented npx stanza.
 pub fn (mut e Engine) mcp_toggle(provider_id string) !u64 {
+	env := resolve_env()
 	for p in e.mcp_catalog() {
 		if p.id == provider_id {
 			if p.enabled {
 				return e.remove_mcp_provider(provider_id)!
-			} else {
-				return e.upsert_mcp_provider(provider_id, '{"command":"npx","args":["-y","@modelcontextprotocol/server-${provider_id}"]}')!
 			}
+			template := data_file_read(env, p.template_path) or { '' }
+			if template == '' {
+				return error('no packaged template for ${provider_id} — cannot enable without real config')
+			}
+			return e.upsert_mcp_provider(provider_id, template)!
 		}
 	}
 	return error('mcp provider not found: ${provider_id}')
 }
 
-// verify_mcp_receipts checks all enabled MCP have receipts (Doctor parity).
+// verify_mcp_receipts checks that every enabled MCP provider has a recorded
+// configuration (real config-truth drift check). Enabled without config is a
+// genuine defect; no receipt is fabricated to satisfy this.
 pub fn (mut e Engine) verify_mcp_receipts() []BuildDiagnostic {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	mut diags := []BuildDiagnostic{}
+	snap := e.repo.snapshot()
 	for p in e.mcp_catalog() {
 		if p.enabled {
-			snap := e.repo.snapshot()
-			if 'receipt:mcp:${p.id}:installed_at' !in snap.data {
+			if 'mcp:${p.id}:config' !in snap.data {
 				diags << BuildDiagnostic{
-					path: 'receipts/mcp-${p.id}.json'
-					message: 'missing receipt for enabled MCP ${p.id}'
-					code: 'receipt_missing'
+					path: 'mcp/${p.id}.json'
+					message: 'enabled MCP ${p.id} has no recorded config'
+					code: 'config_missing'
 				}
 			}
 		}
@@ -426,16 +462,31 @@ pub fn (mut e Engine) verify_mcp_receipts() []BuildDiagnostic {
 	return diags
 }
 
-// mcp_provenance_json returns structured provenance for provider (ADR-022).
+// mcp_provenance_json returns structured provenance for a provider. The
+// template path is the real packaged template this provider was discovered
+// from; verified is true only when the template content is actually readable
+// from the resolved data tier.
 pub fn (mut e Engine) mcp_provenance_json(provider_id string) string {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
+	env := resolve_env()
+	mut template := ''
+	for p in e.mcp_catalog() {
+		if p.id == provider_id {
+			template = p.template_path
+			break
+		}
+	}
+	mut verified := false
+	if template != '' {
+		content := data_file_read(env, template) or { '' }
+		verified = content != ''
+	}
 	return json2.encode({
 		'provider': provider_id
-		'template': 'mcp/templates/${provider_id}.json'
-		'registry': 'mcp/registry/${provider_id}.yaml'
-		'verified': 'true'
+		'template': template
+		'verified': if verified { 'true' } else { 'false' }
 	},
 		escape_unicode: true
 	)

--- a/modules/desktop_engine/product_truth_test.v
+++ b/modules/desktop_engine/product_truth_test.v
@@ -13,9 +13,16 @@ fn test_product_truth_catalog_counts() {
 	defer {
 		os.setenv('AGENT_TOOLKIT_ROOT', prev_override, true)
 	}
+	// Receipts are read from the real user config authority; isolate
+	// XDG_CONFIG_HOME so the developer's genuine installs do not leak in.
+	prev_cfg := os.getenv('XDG_CONFIG_HOME')
 	tmp := os.join_path(os.temp_dir(), 'product-truth-${os.getpid()}')
-	os.mkdir_all(tmp) or { panic(err.msg()) }
-	defer { os.rmdir_all(tmp) or {} }
+	os.mkdir_all(os.join_path(tmp, 'xdg-config')) or { panic(err.msg()) }
+	os.setenv('XDG_CONFIG_HOME', os.join_path(tmp, 'xdg-config'), true)
+	defer {
+		os.setenv('XDG_CONFIG_HOME', prev_cfg, true)
+		os.rmdir_all(tmp) or {}
+	}
 	mut eng := new_engine(EngineConfig{
 		persist_path: os.join_path(tmp, 'state.json')
 	})

--- a/modules/desktop_engine/products_service.v
+++ b/modules/desktop_engine/products_service.v
@@ -1,6 +1,5 @@
 module desktop_engine
 
-import time
 import x.json2
 
 // ProductEntry mirrors distributions/products.yaml — super-potent with provenance/receipts.
@@ -170,9 +169,6 @@ pub fn (mut e Engine) update_product_membership(product_id string, skill_ids []s
 	mut tx := repo.begin('update-product')
 	tx.set('product:${product_id}:skills', skill_ids.join(','))
 	tx.set('products_count', e.products_catalog().len.str())
-	tx.set('receipt:product:${product_id}:updated_at', time.now().str())
-	tx.set('receipt:product:${product_id}:digest', 'sha256:${skill_ids.len * 7}')
-	tx.set('provenance:product:${product_id}:source', 'distributions/products.yaml')
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
@@ -187,40 +183,64 @@ pub fn (mut e Engine) set_pack_enabled(pack_id string, enabled bool) !u64 {
 	mut repo := e.repo
 	mut tx := repo.begin('set-pack')
 	tx.set('pack:${pack_id}:enabled', if enabled { 'true' } else { 'false' })
-	tx.set('receipt:pack:${pack_id}:toggled_at', time.now().str())
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
 
-// product_provenance returns ADR-022 provenance JSON for product.
+// product_provenance returns provenance facts for a product. The declared
+// source is real catalog truth; verified reflects actual digest verification
+// of the bundled manifest artifacts, never an unconditional claim.
 pub fn (mut e Engine) product_provenance(product_id string) string {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
+	prefix := 'plugins/${product_id}/'
+	mut artifact_count := 0
+	mut unverified := 0
+	for p in e.provenance_catalog() {
+		if p.artifact_path.starts_with(prefix) {
+			artifact_count++
+			if !p.verified {
+				unverified++
+			}
+		}
+	}
+	verified := artifact_count > 0 && unverified == 0
+	sidecar := if artifact_count > 0 { 'plugins/${product_id}/.provenance.json' } else { '' }
 	return json2.encode({
 		'product':    product_id
 		'source':     'distributions/products.yaml'
-		'provenance': 'plugins/${product_id}/.provenance.json'
-		'receipt':    'receipts/product-${product_id}.json'
-		'verified':   'true'
+		'provenance': sidecar
+		'verified':   if verified { 'true' } else { 'false' }
 	},
 		escape_unicode: true
 	)
 }
 
-// product_receipt returns install receipt JSON for product.
+// product_receipt reports real install receipt evidence for a product.
+// When no receipt exists the payload says so; no timestamp is invented.
 pub fn (mut e Engine) product_receipt(product_id string) string {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
-	installed_at := snap.data['receipt:product:${product_id}:updated_at'] or { time.now().str() }
+	for r in e.receipts_catalog() {
+		if r.product == product_id {
+			return json2.encode({
+				'schemaVersion': '1'
+				'product':       r.product
+				'target':        r.id
+				'installedAt':   r.installed_at
+				'sourceDigest':  r.digest
+				'receiptPath':   r.receipt_path
+			},
+				escape_unicode: true
+			)
+		}
+	}
 	return json2.encode({
-		'schemaVersion': '1'
-		'product':       product_id
-		'target':        'desktop'
-		'installedAt':   installed_at
-		'provenance':    'distributions/products.yaml'
+		'product':   product_id
+		'installed': 'false'
+		'note':      'no install receipt recorded for this product'
 	},
 		escape_unicode: true
 	)

--- a/modules/desktop_engine/receipts_service.v
+++ b/modules/desktop_engine/receipts_service.v
@@ -2,12 +2,16 @@ module desktop_engine
 
 import os
 import x.json2
+import crypto.sha256
+import agent_toolkit_core
 
-// ReceiptEntry is unified receipt for any install (skill/agent/mcp/target/product/update).
+// ReceiptEntry is the Engine projection of a real install receipt (S7 evidence
+// truth). A receipt exists only if the core installer wrote it under the user
+// config authority; this Engine never invents receipt rows.
 pub struct ReceiptEntry {
 pub:
-	kind         string // skill | agent | mcp | target | product | update
-	id           string
+	kind         string // install
+	id           string // install target
 	product      string
 	version      string
 	installed_at string
@@ -18,7 +22,9 @@ pub:
 	verified     bool
 }
 
-// ProvenanceEntry mirrors .provenance.json per artifact (ADR-022).
+// ProvenanceEntry mirrors .provenance.json artifact records (ADR-022).
+// source/generated digests come from the real manifest; verified means the
+// recomputed SHA-256 of the artifact bytes matches the recorded digest.
 pub struct ProvenanceEntry {
 pub:
 	artifact_path    string
@@ -30,73 +36,38 @@ pub:
 	detail           string
 }
 
-// receipts_catalog returns all receipts via StateRepository headless (no shell, super-potent unified).
+// receipts_catalog returns only real install receipts recorded by the core
+// installer under the user config authority
+// ($XDG_CONFIG_HOME/agent-toolkit/receipts). A receipt is verified by
+// recomputing each artifact digest from the artifact file on disk and comparing
+// it to the digest recorded in the receipt. An empty directory yields an
+// empty catalog; nothing is fabricated.
 pub fn (mut e Engine) receipts_catalog() []ReceiptEntry {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
 	mut out := []ReceiptEntry{}
-	for k, v in snap.data {
-		if k.starts_with('receipt:') && k.ends_with(':installed_at') {
-			parts := k.split(':')
-			if parts.len < 3 {
-				continue
-			}
-			kind := parts[1]
-			id := parts[2]
-			provenance := snap.data['provenance:${kind}:${id}:source'] or { snap.data['receipt:${kind}:${id}:digest'] or { '' } }
-			digest := snap.data['receipt:${kind}:${id}:digest'] or { snap.data['receipt:${kind}:${id}:version'] or { '' } }
-			version := snap.data['receipt:${kind}:${id}:version'] or { '1.0.0' }
-			artifacts_raw := snap.data['receipt:${kind}:${id}:artifacts'] or { '' }
-			artifacts := if artifacts_raw == '' {
-				[]string{}
-			} else {
-				artifacts_raw.split(',').map(it.trim_space())
-			}
-			receipt_path := match kind {
-				'skill' { 'receipts/skill-${id}.json' }
-				'target' { '~/.config/agent-toolkit/receipts/${id}-agent-toolkit-profiles.json' }
-				else { 'receipts/${kind}-${id}.json' }
-			}
-			out << ReceiptEntry{
-				kind: kind
-				id: id
-				product: snap.data['receipt:${kind}:${id}:product'] or { kind }
-				version: version
-				installed_at: v
-				digest: digest
-				provenance: provenance
-				receipt_path: receipt_path
-				artifacts: artifacts
-				verified: digest != ''
+	receipt_dir := agent_toolkit_core.default_receipt_dir()
+	for r in agent_toolkit_core.list_install_receipts('') {
+		mut verified := r.artifacts.len > 0
+		mut artifacts := []string{}
+		for a in r.artifacts {
+			artifacts << a.path
+			if agent_toolkit_core.receipt_artifact_digest(a.path) != a.digest {
+				verified = false
 			}
 		}
-	}
-	// supplement from filesystem receipts dir if present (checkout parity)
-	env := resolve_env()
-	receipt_dir := os.join_path(env.toolkit_root, '.config', 'agent-toolkit', 'receipts')
-	if os.is_dir(receipt_dir) {
-		files := os.ls(receipt_dir) or { []string{} }
-		for f in files {
-			if f.ends_with('.json') && out.len < 50 {
-				already := out.any(it.receipt_path.contains(f))
-				if !already {
-					out << ReceiptEntry{
-						kind: 'target'
-						id: f.all_before('.json')
-						product: 'agent-toolkit-profiles'
-						version: '1.27.0'
-						// A receipt file is evidence of a record, not proof that its
-						// artifact is present. Verify its contents before marking it.
-						installed_at: ''
-						digest: ''
-						provenance: 'fs:${receipt_dir}/${f}'
-						receipt_path: os.join_path(receipt_dir, f)
-						verified: false
-					}
-				}
-			}
+		out << ReceiptEntry{
+			kind: 'install'
+			id: r.target
+			product: r.product
+			version: r.version
+			installed_at: r.installed_at
+			digest: r.source_digest
+			provenance: ''
+			receipt_path: os.join_path(receipt_dir, agent_toolkit_core.receipt_filename(r.target, r.product))
+			artifacts: artifacts
+			verified: verified
 		}
 	}
 	return out
@@ -118,7 +89,7 @@ pub fn (mut e Engine) receipts_search(query string) []ReceiptEntry {
 	return out
 }
 
-// receipt_for returns single receipt by kind+id.
+// receipt_for returns a single real receipt by kind+id.
 pub fn (mut e Engine) receipt_for(kind string, id string) ?ReceiptEntry {
 	for r in e.receipts_catalog() {
 		if r.kind == kind && r.id == id {
@@ -128,97 +99,80 @@ pub fn (mut e Engine) receipt_for(kind string, id string) ?ReceiptEntry {
 	return none
 }
 
-// provenance_catalog returns all provenance entries (ADR-022) via filesystem + StateRepository.
+// provenance_catalog returns real provenance records from the bundled
+// plugins/<product>/.provenance.json manifests (ADR-022), read through the
+// tier-aware data_* helpers. Each artifact record is verified by recomputing
+// the SHA-256 of the artifact bytes and comparing it to the recorded
+// generatedDigest. No manifest yields no entries; no fallback is fabricated.
 pub fn (mut e Engine) provenance_catalog() []ProvenanceEntry {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	env := resolve_env()
 	mut out := []ProvenanceEntry{}
-	// from StateRepository provenance keys
-	snap := e.repo.snapshot()
-	for k, v in snap.data {
-		if k.starts_with('provenance:') && k.ends_with(':source') {
-			parts := k.split(':')
-			if parts.len < 3 {
-				continue
-			}
-			kind := parts[1]
-			id := parts[2]
-			out << ProvenanceEntry{
-				artifact_path: '${kind}/${id}'
-				source_file: v
-				source_digest: snap.data['provenance:${kind}:${id}:digest'] or { 'sha256:abc' }
-				generated_digest: snap.data['provenance:${kind}:${id}:generated'] or { 'sha256:def' }
-				generator: 'agent-toolkit-core'
-				verified: true
-				detail: 'via StateRepository receipt:provenance'
-			}
-		}
+	if !data_dir_exists(env, 'plugins') {
+		return out
 	}
-	// filesystem scan of plugins/.provenance.json sidecars
-	plugins_dir := os.join_path(env.toolkit_root, 'plugins')
-	if os.is_dir(plugins_dir) {
-		entries := os.ls(plugins_dir) or { []string{} }
-		for prod in entries {
-			prov_path := os.join_path(plugins_dir, prod, '.provenance.json')
-			if os.is_file(prov_path) {
-				txt := os.read_file(prov_path) or { '' }
-				if txt.contains('artifacts') {
-					out << ProvenanceEntry{
-						artifact_path: 'plugins/${prod}/.provenance.json'
-						source_file: prov_path
-						source_digest: 'sha256:${txt.len}'
-						generated_digest: 'sha256:${txt.len * 2}'
-						generator: 'compiler'
-						verified: true
-						detail: txt[..if txt.len > 80 { 80 } else { txt.len }]
+	prods := data_list_dir(env, 'plugins')
+	for prod in prods {
+		manifest_rel := 'plugins/${prod}/.provenance.json'
+		if !data_file_exists(env, manifest_rel) {
+			continue
+		}
+		txt := data_file_read(env, manifest_rel) or { continue }
+		m := json2.decode[agent_toolkit_core.ProvenanceManifest](txt) or { continue }
+		for rec in m.artifacts {
+			artifact_rel := 'plugins/${rec.path}'
+			mut verified := false
+			mut detail := 'artifact missing from bundled data'
+			if data_file_exists(env, artifact_rel) {
+				content := data_file_read(env, artifact_rel) or { '' }
+				if content != '' {
+					sum := sha256.hexhash(content)
+					short := if sum.len < 12 { sum } else { sum[..12] }
+					verified = short == rec.generated_digest
+					detail = if verified {
+						'digest verified against artifact bytes'
+					} else {
+						'digest drift: expected ${rec.generated_digest}, got ${short}'
 					}
 				}
 			}
-		}
-	}
-	// embedded fallback
-	if out.len == 0 {
-		out << ProvenanceEntry{
-			artifact_path: 'plugins/agent-toolkit-core/.provenance.json'
-			source_file: 'capabilities/upstream.lock'
-			source_digest: 'sha256:123'
-			generated_digest: 'sha256:456'
-			generator: 'embedded'
-			verified: true
-			detail: 'checkout only — wheel omits upstream.lock'
+			out << ProvenanceEntry{
+				artifact_path: artifact_rel
+				source_file: rec.source_file
+				source_digest: rec.source_digest
+				generated_digest: rec.generated_digest
+				generator: m.generator_version
+				verified: verified
+				detail: detail
+			}
 		}
 	}
 	return out
 }
 
-// verify_receipts returns diagnostics for all receipts drift (Doctor parity).
+// verify_receipts returns diagnostics for receipts whose artifact evidence does
+// not check out (Doctor parity). Verified flags come from real digest
+// recomputation; an unverified receipt is reported, never silently accepted.
 pub fn (mut e Engine) verify_receipts() []BuildDiagnostic {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	mut diags := []BuildDiagnostic{}
 	for r in e.receipts_catalog() {
-		if !r.verified || r.digest == '' {
+		if !r.verified {
 			diags << BuildDiagnostic{
 				path: r.receipt_path
-				message: 'receipt unverified for ${r.kind}/${r.id}'
+				message: 'receipt unverified for ${r.product}/${r.id} (artifact missing or digest drift)'
 				code: 'receipt_unverified'
-			}
-		}
-		if r.provenance == '' {
-			diags << BuildDiagnostic{
-				path: r.provenance
-				message: 'provenance missing for ${r.kind}/${r.id}'
-				code: 'provenance_missing'
 			}
 		}
 	}
 	return diags
 }
 
-// verify_provenance_full checks provenance digests vs filesystem (ADR-022).
+// verify_provenance_full checks provenance digests vs bundled bytes (ADR-022).
 pub fn (mut e Engine) verify_provenance_full() []BuildDiagnostic {
 	e.mu.lock()
 	e.api_calls++
@@ -230,13 +184,6 @@ pub fn (mut e Engine) verify_provenance_full() []BuildDiagnostic {
 				path: p.artifact_path
 				message: 'provenance unverified: ${p.detail}'
 				code: 'provenance_unverified'
-			}
-		}
-		if p.source_digest == 'missing' {
-			diags << BuildDiagnostic{
-				path: p.source_file
-				message: 'source file missing for ${p.artifact_path}'
-				code: 'source_missing'
 			}
 		}
 	}
@@ -271,7 +218,8 @@ pub fn (mut e Engine) receipts_stats() ReceiptStats {
 	}
 }
 
-// install_receipt_json_for returns ADR-022 style JSON for any receipt kind/id.
+// install_receipt_json_for returns the real recorded receipt fields for
+// kind/id, or an honest not-found payload. No receipt is synthesized.
 pub fn (mut e Engine) install_receipt_json_for(kind string, id string) string {
 	e.mu.lock()
 	e.api_calls++
@@ -298,7 +246,8 @@ pub fn (mut e Engine) install_receipt_json_for(kind string, id string) string {
 	)
 }
 
-// provenance_json_for returns structured provenance for kind/id.
+// provenance_json_for returns structured provenance for an artifact path
+// fragment, or an honest not-found payload.
 pub fn (mut e Engine) provenance_json_for(kind string, id string) string {
 	e.mu.lock()
 	e.api_calls++

--- a/modules/desktop_engine/skills_service.v
+++ b/modules/desktop_engine/skills_service.v
@@ -1,7 +1,9 @@
 module desktop_engine
 
-import time
+import os
 import x.json2
+import crypto.sha256
+import agent_toolkit_core
 
 // SkillEntry mirrors catalogs/skill-catalog.yaml shape — super-potent: triggers, origin, products, kind.
 pub struct SkillEntry {
@@ -345,7 +347,10 @@ pub fn (mut e Engine) skills_by_domain() map[string][]SkillEntry {
 	return m
 }
 
-// install_skill installs one skill via Engine transaction — now writes receipt + provenance.
+// install_skill records the skill as selected in configuration state.
+// Selection is configuration truth only: it is NOT an installation and writes
+// no receipt or provenance evidence (S7 evidence truth). Receipts exist only
+// when the core installer deploys real artifacts.
 pub fn (mut e Engine) install_skill(id string) !u64 {
 	if id == '' {
 		return error('skill id empty')
@@ -363,18 +368,11 @@ pub fn (mut e Engine) install_skill(id string) !u64 {
 	}
 	tx.set('installed_skills', set.join(','))
 	tx.set('skills_count', set.len.str())
-	// receipt: per-skill provenance + install receipt (ADR-022 parity)
-	tx.set('receipt:skill:${id}:installed_at', time.now().str())
-	tx.set('receipt:skill:${id}:version', '1.0.0')
-	tx.set('receipt:skill:${id}:digest', 'sha256:${id.len + set.len}')
-	tx.set('receipt:skill:${id}:product', 'agent-toolkit-core')
-	tx.set('provenance:skill:${id}:source', 'catalogs/skill-catalog.yaml')
-	tx.set('provenance:skill:${id}:digest', 'sha256:${id.len * 7}')
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
 
-// install_skills bulk installs — super-potent easy management.
+// install_skills bulk-selects skills — configuration truth only, no receipts.
 pub fn (mut e Engine) install_skills(ids []string) !u64 {
 	if ids.len == 0 {
 		return error('no skills selected')
@@ -393,9 +391,6 @@ pub fn (mut e Engine) install_skills(ids []string) !u64 {
 		if id !in set {
 			set << id
 		}
-		tx.set('receipt:skill:${id}:installed_at', time.now().str())
-		tx.set('receipt:skill:${id}:version', '1.0.0')
-		tx.set('receipt:skill:${id}:digest', 'sha256:${id.len + set.len}')
 	}
 	tx.set('installed_skills', set.join(','))
 	tx.set('skills_count', set.len.str())
@@ -448,75 +443,85 @@ pub fn (mut e Engine) remove_skill(id string) !u64 {
 	mut tx := repo.begin('remove-skill')
 	tx.set('installed_skills', set.join(','))
 	tx.set('skills_count', set.len.str())
-	// keep receipt for audit but mark removed
-	tx.set('receipt:skill:${id}:removed_at', time.now().str())
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
 
-// skill_receipt returns typed receipt for a skill via StateRepository (headless, no shell).
+// skill_receipt returns real receipt evidence for a skill: the artifact
+// records of core install receipts whose deployed artifacts include the
+// skill's SKILL.md. Returns none when no real receipt covers the skill —
+// selection alone is never receipt evidence.
 pub fn (mut e Engine) skill_receipt(id string) ?SkillReceiptInfo {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
-	key_at := 'receipt:skill:${id}:installed_at'
-	if key_at !in snap.data {
+	name := id.all_after('/')
+	if name == '' {
 		return none
 	}
-	return SkillReceiptInfo{
-		skill_id: id
-		installed: id in e.skills_installed()
-		installed_at: snap.data[key_at] or { '' }
-		version: snap.data['receipt:skill:${id}:version'] or { '1.0.0' }
-		product: snap.data['receipt:skill:${id}:product'] or { 'agent-toolkit-core' }
-		digest: snap.data['receipt:skill:${id}:digest'] or { '' }
-		receipt_path: 'receipts/skill-${id}.json'
+	needle := '/skills/${name}/SKILL.md'
+	for r in agent_toolkit_core.list_install_receipts('') {
+		for a in r.artifacts {
+			if a.path.contains(needle) {
+				return SkillReceiptInfo{
+					skill_id: id
+					installed: id in e.skills_installed()
+					installed_at: r.installed_at
+					version: r.version
+					product: r.product
+					digest: a.digest
+					receipt_path: os.join_path(agent_toolkit_core.default_receipt_dir(),
+						agent_toolkit_core.receipt_filename(r.target, r.product))
+				}
+			}
+		}
 	}
+	return none
 }
 
-// skill_provenance returns provenance manifest for a skill.
+// skill_provenance returns real provenance evidence for a skill from the
+// bundled plugins manifests (ADR-022). Returns none when no manifest records
+// the skill — never a fabricated fallback.
 pub fn (mut e Engine) skill_provenance(id string) ?SkillProvenanceInfo {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
-	src := snap.data['provenance:skill:${id}:source'] or { '' }
-	if src == '' {
-		// fallback: derive from catalog
-		return SkillProvenanceInfo{
-			skill_id: id
-			source_file: 'skills/${id}/SKILL.md'
-			source_digest: 'sha256:${id.len * 11}'
-			generated_digest: 'sha256:${id.len * 13}'
-			verified: true
-			detail: 'derived from catalogs/skill-catalog.yaml'
+	name := id.all_after('/')
+	if name == '' {
+		return none
+	}
+	needle := '/skills/${name}/'
+	for p in e.provenance_catalog() {
+		if p.artifact_path.contains(needle) && p.artifact_path.ends_with('/SKILL.md') {
+			return SkillProvenanceInfo{
+				skill_id: id
+				source_file: p.source_file
+				source_digest: p.source_digest
+				generated_digest: p.generated_digest
+				verified: p.verified
+				detail: p.detail
+			}
 		}
 	}
-	return SkillProvenanceInfo{
-		skill_id: id
-		source_file: src
-		source_digest: snap.data['provenance:skill:${id}:digest'] or { '' }
-		generated_digest: snap.data['provenance:skill:${id}:generated'] or { 'sha256:abc' }
-		verified: true
-		detail: 'receipt verified via StateRepository'
-	}
+	return none
 }
 
-// verify_skill_receipts checks all installed skills have receipts (Doctor parity).
+// verify_skill_receipts checks that every selected skill still resolves in the
+// catalog (real drift check). Selection without catalog backing is a genuine
+// defect worth reporting; receipts are no longer fabricated to satisfy this.
 pub fn (mut e Engine) verify_skill_receipts() []BuildDiagnostic {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	mut diags := []BuildDiagnostic{}
 	for id in e.skills_installed() {
-		if _ := e.skill_receipt(id) {
+		if _ := e.skill_detail(id) {
 			continue
 		} else {
 			diags << BuildDiagnostic{
-				path: 'receipts/skill-${id}.json'
-				message: 'missing receipt for installed skill ${id}'
-				code: 'receipt_missing'
+				path: 'skills/${id}/SKILL.md'
+				message: 'selected skill missing from resolved catalog'
+				code: 'catalog_missing'
 			}
 		}
 	}
@@ -527,30 +532,13 @@ pub fn (mut e Engine) build_check() []BuildDiagnostic {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
 	mut diags := []BuildDiagnostic{}
-	if 'broken_skill' in snap.data {
-		diags << BuildDiagnostic{
-			path: 'skills/broken/SKILL.md'
-			message: 'frontmatter name/description missing'
-			code: 'frontmatter_missing'
-		}
-	}
-	installed := e.skills_installed()
-	for sid in installed {
-		if sid.contains('broken') {
-			diags << BuildDiagnostic{
-				path: 'skills/${sid}/SKILL.md'
-				message: 'invalid YAML'
-				code: 'yaml_invalid'
-			}
-		}
-	}
-	// receipts/provenance checks — super potent Doctor parity
+	// real drift check: every selected skill must still resolve in the catalog
 	for d in e.verify_skill_receipts() {
 		diags << d
 	}
-	// stability warning for beta installs
+	// stability warning for beta selections — real catalog metadata
+	installed := e.skills_installed()
 	for sid in installed {
 		if detail := e.skill_detail(sid) {
 			if detail.stability == 'beta' {
@@ -567,18 +555,27 @@ pub fn (mut e Engine) build_check() []BuildDiagnostic {
 	return diags
 }
 
+// skills_catalog_digest computes a real SHA-256 over canonical catalog
+// material (sorted domain/id pairs). It replaces the former string-length
+// sum that was labeled a digest. No engine lock is taken here:
+// skills_catalog() locks internally (sync.Mutex is not reentrant).
+fn (mut e Engine) skills_catalog_digest() string {
+	mut ids := []string{}
+	for s in e.skills_catalog() {
+		ids << '${s.domain}/${s.id}'
+	}
+	ids.sort()
+	return sha256.hexhash(ids.join('\n'))
+}
+
 pub fn (mut e Engine) build_preview() string {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	cat := e.skills_catalog()
-	mut h := 0
-	for s in cat {
-		h += s.id.len + s.domain.len
-	}
+	digest := e.skills_catalog_digest()
 	stats := e.skills_stats()
-	// include installed + receipt provenance in digest for parity
-	return 'plugins-digest:${h}:${cat.len}:installed=${stats.installed}'
+	return 'plugins-digest:${digest}:${cat.len}:installed=${stats.installed}'
 }
 
 // build_preview_detailed returns structured digest with provenance (ADR-022).
@@ -587,14 +584,11 @@ pub fn (mut e Engine) build_preview_detailed() string {
 	e.api_calls++
 	e.mu.unlock()
 	cat := e.skills_catalog()
-	mut h := 0
-	for s in cat {
-		h += s.id.len + s.domain.len
-	}
+	digest := e.skills_catalog_digest()
 	snap := e.repo.snapshot()
 	receipts := snap.data.keys().filter(it.starts_with('receipt:skill:')).len
 	return json2.encode({
-		'digest':     'plugins-digest:${h}:${cat.len}'
+		'digest':     'plugins-digest:${digest}:${cat.len}'
 		'receipts':   receipts.str()
 		'provenance': 'catalogs/skill-catalog.yaml'
 	},


### PR DESCRIPTION
## What

S7A evidence & receipt truth: receipts and provenance now come exclusively
from real evidence, and every fabricated digest, receipt and `verified` claim
in Desktop Engine is removed.

This is the first slice of S7 (Desktop Engine truth audit). The complete
contamination inventory and authority classification is in
`docs/desktop/TRUTH_LEDGER.md` (added here).

## Why

An independent audit after #1143 found fabricated production state throughout
`desktop_engine`: length-derived digests labeled `sha256:`, `sha256:abc`
placeholders, unconditional `verified: true`, state-only "installs" writing
fake receipts, fixture-keyed validation, and an invented MCP npx config. The
product contract (`AGENTS.md`, `PRODUCT_VISION.md`) forbids exactly this:
never claim installation from state-only bookkeeping; unknown/unavailable/empty
are valid states.

## Changes

- `receipts_service.v` (rewrite):
  - Receipts come only from real core installer receipts
    (`agent_toolkit_core.list_install_receipts`) under the user config
    authority; each is verified by recomputing artifact digests from the
    artifact bytes (`receipt_artifact_digest`).
  - Provenance comes only from real `plugins/<product>/.provenance.json`
    manifests read through tier-aware `data_*` helpers; each artifact record
    is verified by recomputing SHA-256 of the bundled bytes against the
    recorded `generatedDigest`.
  - Removed: `sha256:abc`-style placeholders, unconditional `verified: true`,
    receipt-dir scan at `toolkit_root/.config` (wrong authority), raw-os scans,
    fabricated embedded fallback.
- `skills_service.v`: `install_skill`/`install_skills` are selection
  (configuration truth) — no receipt/provenance keys written. `skill_receipt`
  and `skill_provenance` return real receipt/manifest evidence or `none`.
  `build_check` runs a real catalog-drift check (selected skills must resolve
  in the catalog) instead of magic `broken_skill` keys. `build_preview`
  computes a real SHA-256 over canonical catalog material instead of a
  string-length sum.
- `agents_service.v`: `install_agent` is selection only. `agent_receipt`
  returns real receipt artifact evidence or `none`. `agent_provenance_detail`
  reports `verified` from actual manifest evidence.
- `products_service.v`: membership updates write no fake digests;
  `product_provenance`/`product_receipt` report real evidence or honest
  absence (no invented `installedAt`).
- `jobs_service.v`: job completion records runtime truth only; the fabricated
  job-receipt machinery (`JobReceipt`, length-derived digests) is removed.
- `mcp_service.v`: `mcp_toggle` enables from the packaged template content
  (never an invented npx stanza); enabled-without-probe reports `configured`,
  not `healthy`; `upsert` validates the offered config parses as JSON;
  `mcp_validate` checks the packaged catalog and the recorded config instead
  of a `broken_mcp` fixture key; provenance reports the real template path.
- Tests: new `evidence_truth_test.v` regression gates; `product_truth_test.v`
  isolates `XDG_CONFIG_HOME` so genuine user installs do not leak into
  assertions.

## Verification

- `./make.vsh test` green: 78 module tests.
- Native desktop binary builds; clean-machine headless boot resolves all
  catalogs.
- Real-user verification: the machine's 6 genuine profile-install receipts
  surface, all digest-verified against the deployed files; 223 real
  provenance entries from bundled manifests with honest drift reporting
  (215 verified, 8 drift reported as unverified).
- Fresh-engine gate: zero receipts, zero provenance inventions, no receipt
  keys written by selections or job completions.

## Notes

- This commit briefly landed on `main` due to a branch-upstream mis-set and
  was immediately reverted there (`6b188894`); this PR is the reviewed path for
  the same change.
- Left intentionally for later slices: `targets_service.v` still writes
  state-only `receipt:target:*` keys (S7B), engine doctor "sha verified" pass
  (S7E), git fabrication (S7C).

## Related

- Salvage sequence S7A per `docs/desktop/TRUTH_LEDGER.md`.
