### PR TITLE
fix(desktop): registry-derived targets and real installation (S7B)

### DIFF
--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -6435,7 +6435,7 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 			tgts := if app.desktop != unsafe { nil } {
 				app.desktop.engine_targets().map(it.id)
 			} else {
-				['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli']
+				['claude-code', 'cursor', 'opencode', 'copilot-cli', 'pi', 'windsurf', 'codex', 'muse-code']
 			}
 			for i, t in tgts {
 				y := content_y + 30 + i * 20
@@ -8567,7 +8567,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 					}
 					2 {
 						// targets bulk enable minimal 3
-						ids := ['claude-code', 'opencode', 'cli']
+						ids := ['claude-code', 'opencode', 'cursor']
 						rev := app.desktop.onboarding_set_targets_bulk(ids) or {
 							app.onboarding_msg = 'targets failed: ${err}'
 							0
@@ -9345,7 +9345,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				mut fh2b := fh
 				content_h := fh2b - (content_y - fy) - 52
 				if mx >= fx + 20 && mx <= fx + 110 && my >= content_y + content_h - 40 && my <= content_y + content_h - 22 {
-					ids := ['claude-code', 'opencode', 'cli']
+					ids := ['claude-code', 'opencode', 'cursor']
 					rev := app.desktop.onboarding_set_targets_bulk(ids) or {
 						app.onboarding_msg = 'targets failed: ${err}'
 						0

--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -208,6 +208,38 @@ Evidence:
   catalogs.
 - Real-user verification: 6 genuine profile-install receipts surface, all
   digest-verified; 223 real provenance entries with honest drift reporting.
+### S7B — Targets and installation truth (`fix/s7b-targets-install-truth`)
+
+Status: in progress. The supported-target roster is now derived from the
+canonical registry (`capabilities/targets/registry.yaml`, embedded and
+CI-validated) instead of a private seven-item list, and installation is real.
+
+- `targets_service.v`:
+  - `targets_registry()` parses the canonical registry tier-aware.
+  - `targets()` separates supported (registry), detected (real config-dir/PATH
+    detection), and enabled (explicit configuration only — a fresh environment
+    enables nothing by default).
+  - `install()` / `install_with_options()` run the canonical core installer
+    (`agent_toolkit_core.run_install`): real profile files deployed to the
+    selected tools, real receipts written under the user config authority,
+    honest partial-failure reporting. Dry-run is the core's real dry-run.
+  - `list_install_receipts()` / `install_receipt_json()` report only real
+    receipts; `verify_install_receipts()` checks real artifact drift.
+  - `doctor_fix_stamp` no longer fabricates receipt evidence; `doctor_fix_all`
+    performs real per-check repairs instead of blanket-stamping.
+- `engine.v` doctor: profile checks only for targets with bundled profiles,
+  with real detection surfaced; receipt checks come from real receipts, and
+  enabled-without-receipt is an honest actionable warn.
+- `onboarding_service.v`: valid target list comes from the registry.
+- GUI: quick-action rosters use real registry ids (no `cli`/`cursor-plugins`).
+- Tests: `targets_truth_test.v` (registry roster, no default-enabled, real
+  install evidence, honest dry-run); `product_truth_test.v` (desktop_engine and
+  desktop) lock the registry contract; `capability_plane_test.v` performs a
+  real isolated install; `doctor_fix_test.v` locks the honest preview.
+
+Evidence:
+- `./make.vsh test` green (78 module tests).
+- Native desktop binary builds.
 
 ### Recommended next steps
 

--- a/modules/desktop/product_truth_test.v
+++ b/modules/desktop/product_truth_test.v
@@ -2,11 +2,15 @@ module desktop
 
 import os
 
-// R2 product-truth: the GUI target roster and counts render from this proxy
-// (draw_targets, targets_total, onboarding enable-all) instead of a hardcoded
-// platform list — the old GUI list drifted (copilot/muse-code vs
-// cursor-plugins/cli). Locks the proxy to the Engine catalog.
+// S7B target truth: the GUI target roster renders from this proxy — the
+// Engine catalog derived from the canonical registry
+// (capabilities/targets/registry.yaml). Locks the proxy to that roster and
+// to honest no-default-enabled configuration.
 fn test_desktop_engine_targets_proxy_matches_engine_catalog() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
 	tmp := os.join_path(os.temp_dir(), 'desktop-targets-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	defer { os.rmdir_all(tmp) or {} }
@@ -22,10 +26,13 @@ fn test_desktop_engine_targets_proxy_matches_engine_catalog() {
 	d.boot() or { panic(err.msg()) }
 	defer { d.shutdown() or {} }
 	tgts := d.engine_targets()
-	assert tgts.len == 7, 'engine_targets proxy must expose 7: got ${tgts.len}'
+	assert tgts.len == 11, 'engine_targets proxy must expose the registry roster: got ${tgts.len}'
 	ids := tgts.map(it.id)
-	for want in ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli'] {
-		assert want in ids, 'target ${want} missing from proxy: ${ids}'
+	for want in ['claude-code', 'cursor', 'opencode', 'gemini-cli', 'copilot-cli', 'copilot-repository', 'pi', 'windsurf', 'codex', 'muse-code', 'agent-plugins'] {
+		assert want in ids, 'registry target ${want} missing from proxy: ${ids}'
+	}
+	for t in tgts {
+		assert !t.enabled, 'fresh config must not enable targets by default: ${t.id}'
 	}
 	assert d.engine_api_calls() > 0
 }

--- a/modules/desktop_engine/capability_plane_test.v
+++ b/modules/desktop_engine/capability_plane_test.v
@@ -126,8 +126,22 @@ fn test_capability_plane_agents_doctor_targets_via_engine() {
 	assert rev2 >= 1
 	d := eng.diff(['claude-code'], ['claude-code', 'cursor'])
 	assert d.added.len == 1 && d.added[0] == 'cursor'
-	rev3 := eng.install(['claude-code']) or { panic(err.msg()) }
+	// real install into an isolated home + receipt dir: deployed files and a
+	// real receipt are the evidence — never state-only bookkeeping
+	prev_cfg := os.getenv('XDG_CONFIG_HOME')
+	home := os.join_path(tmp, 'home')
+	os.mkdir_all(home) or { panic(err.msg()) }
+	os.setenv('XDG_CONFIG_HOME', os.join_path(tmp, 'xdg-config'), true)
+	defer { os.setenv('XDG_CONFIG_HOME', prev_cfg, true) }
+	rev3 := eng.install_with_options(InstallOptionsEngine{
+		targets: ['claude-code']
+		home_dir: home
+	}) or { panic(err.msg()) }
 	assert rev3 >= 1
+	assert os.exists(os.join_path(home, '.claude')), 'real install deploys profile files'
+	recs := eng.list_install_receipts()
+	assert recs.any(it.target == 'claude-code' && it.installed_at != ''), 'real receipt must surface'
+	assert eng.install_receipt_json('claude-code').contains('installedAt'), 'receipt json reports real evidence'
 	assert eng.is_first_run() == true || eng.is_first_run() == false
 	assert eng.resolve_paths().len == 2
 	assert eng.api_call_count() > 0

--- a/modules/desktop_engine/doctor_fix_test.v
+++ b/modules/desktop_engine/doctor_fix_test.v
@@ -28,7 +28,7 @@ fn test_doctor_fix_preview_and_repair_flip() {
 
 	// preview describes the repair and writes nothing
 	prev := eng.doctor_fix_preview('profile:cursor') or { panic(err.msg()) }
-	assert prev.len == 3
+	assert prev.len == 2
 	assert prev[0] == 'set target:cursor:enabled = true'
 	still_disabled := eng.targets().filter(it.id == 'cursor')[0]
 	assert still_disabled.enabled == false

--- a/modules/desktop_engine/engine.v
+++ b/modules/desktop_engine/engine.v
@@ -6,6 +6,7 @@ import x.async
 import time
 import x.json2
 import os
+import agent_toolkit_core
 import desktop_engine.state
 import desktop_engine.eventbus
 
@@ -508,27 +509,45 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 		fixable: false
 	}
 	// ── profiles / targets ──
+	// Doctor only checks targets Agent Toolkit can actually configure (those
+	// with a bundled profile). Detection is real; "not enabled" is a valid
+	// configuration state that the fix action can change.
 	for t in e.targets() {
+		if t.path == '' {
+			continue
+		}
 		checks << DoctorCheck{
 			id: 'profile:${t.id}'
 			category: 'profiles'
 			name: t.id
 			status: if t.enabled { 'pass' } else { 'warn' }
-			message: '${t.id} ${t.status} at ${t.path} layer=${t.layer}'
+			message: '${t.id} ${t.status}${if t.detected { ' [detected on system]' } else { '' }} — profile at ${t.path} (${t.layer})'
 			fixable: true
 		}
 	}
-	// stale receipt check (core parity #872)
-	snap := e.repo.snapshot()
-	for t in ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf'] {
-		key := 'receipt:target:${t}:installed_at'
-		if key in snap.data {
+	// real install-receipt evidence per profile target: a receipt exists only
+	// when the core installer actually recorded one; enabled-without-receipt is
+	// a genuine actionable signal.
+	for t in e.targets() {
+		if t.path == '' {
+			continue
+		}
+		if r := agent_toolkit_core.load_install_receipt(install_tool_name(t.id), agent_toolkit_core.profiles_product, '') {
 			checks << DoctorCheck{
-				id: 'receipt:${t}'
+				id: 'receipt:${t.id}'
 				category: 'profiles'
-				name: 'receipt:${t}'
+				name: 'receipt:${t.id}'
 				status: 'pass'
-				message: 'receipt for ${t} at ${snap.data[key]}'
+				message: 'install receipt v${r.version} at ${r.installed_at}'
+				fixable: false
+			}
+		} else if t.enabled {
+			checks << DoctorCheck{
+				id: 'receipt:${t.id}'
+				category: 'profiles'
+				name: 'receipt:${t.id}'
+				status: 'warn'
+				message: 'enabled without an install receipt — run install to deploy real profiles'
 				fixable: false
 			}
 		}

--- a/modules/desktop_engine/onboarding_service.v
+++ b/modules/desktop_engine/onboarding_service.v
@@ -286,7 +286,8 @@ pub fn (mut e Engine) onboarding_set_targets_bulk(enabled_ids []string) !u64 {
 	if enabled_ids.len == 0 {
 		return error('no targets selected — at least one required')
 	}
-	valid := ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli']
+	// valid targets come from the canonical registry — no private roster
+	valid := e.targets_registry().map(it.id)
 	for tid in enabled_ids {
 		if tid !in valid {
 			return error('unsupported target: ${tid}')

--- a/modules/desktop_engine/product_truth_test.v
+++ b/modules/desktop_engine/product_truth_test.v
@@ -52,10 +52,13 @@ fn test_product_truth_catalog_counts() {
 	assert eng.mcp_catalog().len == 7, 'MCP providers must be 7'
 
 	tgts := eng.targets()
-	assert tgts.len == 7, 'targets must be 7: got ${tgts.len}'
+	assert tgts.len == 11, 'registry targets must be 11: got ${tgts.len}'
 	ids := tgts.map(it.id)
-	for want in ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli'] {
-		assert want in ids, 'target ${want} missing from Engine catalog: ${ids}'
+	for want in ['claude-code', 'cursor', 'opencode', 'gemini-cli', 'copilot-cli', 'copilot-repository', 'pi', 'windsurf', 'codex', 'muse-code', 'agent-plugins'] {
+		assert want in ids, 'registry target ${want} missing from Engine catalog: ${ids}'
+	}
+	for t in tgts {
+		assert !t.enabled, 'fresh config must not enable targets by default: ${t.id}'
 	}
 
 	assert eng.products_catalog().len == 5, 'products must be 5'

--- a/modules/desktop_engine/targets_service.v
+++ b/modules/desktop_engine/targets_service.v
@@ -3,18 +3,23 @@ module desktop_engine
 import os
 import time
 import x.json2
+import agent_toolkit_core
 
-// TargetEntry mirrors install.v profiles — super-potent with receipt/provenance.
+// TargetEntry is the Engine projection of a supported target from the
+// canonical registry (capabilities/targets/registry.yaml). enabled is
+// explicit configuration truth (never a default); detected is a real system
+// detection; receipt is real install evidence.
 pub struct TargetEntry {
 pub:
 	id         string
 	name       string
 	enabled    bool
-	layer      string
-	path       string
-	status     string
-	receipt    string // receipt path if installed
-	provenance string // provenance path
+	layer      string // registry capability tier
+	path       string // bundled profiles/<id>/ when shipped, else ''
+	status     string // enabled | detected | available
+	receipt    string // real receipt path when one exists, else ''
+	provenance string // bundled profiles source when shipped, else ''
+	detected   bool
 }
 
 // TargetDiff mirrors diff preview typed struct.
@@ -25,13 +30,16 @@ pub:
 	modified []string
 }
 
-// InstallOptions mirrors core InstallOptions for Engine-owned install flow (headless, no shell).
+// InstallOptions mirrors core InstallOptions for Engine-owned install flow
+// (headless, no shell). home_dir/receipt_dir exist for test injection; the
+// defaults target the real user home and config authority.
 pub struct InstallOptionsEngine {
 pub:
 	targets     []string
 	dry_run     bool
 	force       bool
 	receipt_dir string
+	home_dir    string // '' → real user home
 }
 
 // InstallReceiptInfo mirrors core InstallReceipt for desktop management.
@@ -47,34 +55,144 @@ pub:
 	provenance_path string
 }
 
+// TargetRegistryEntry is one parsed row of the canonical target registry.
+pub struct TargetRegistryEntry {
+pub mut:
+	id           string
+	display_name string
+	tier         string
+	maturity     string
+}
+
+// targets_registry parses the canonical target registry
+// (capabilities/targets/registry.yaml) through the tier-aware data reader.
+// This is the single source for supported targets — the Engine maintains no
+// private roster.
+pub fn (mut e Engine) targets_registry() []TargetRegistryEntry {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	env := resolve_env()
+	mut out := []TargetRegistryEntry{}
+	txt := data_file_read(env, 'capabilities/targets/registry.yaml') or { return out }
+	mut cur := TargetRegistryEntry{}
+	mut in_targets := false
+	for line in txt.split_into_lines() {
+		t := line.trim_space()
+		if t == 'targets:' {
+			in_targets = true
+			continue
+		}
+		if !in_targets {
+			continue
+		}
+		if t.starts_with('- id:') {
+			if cur.id != '' {
+				out << cur
+			}
+			cur = TargetRegistryEntry{ id: t.all_after('- id:').trim_space() }
+			continue
+		}
+		if cur.id == '' {
+			continue
+		}
+		if t.starts_with('display_name:') {
+			cur.display_name = t.all_after('display_name:').trim_space()
+		} else if t.starts_with('tier:') {
+			cur.tier = t.all_after('tier:').trim_space()
+		} else if t.starts_with('maturity:') {
+			cur.maturity = t.all_after('maturity:').trim_space()
+		}
+	}
+	if cur.id != '' {
+		out << cur
+	}
+	return out
+}
+
+// target_detected performs a real system detection using the same signals as
+// the core installer: the tool's config directory under the user home or the
+// tool executable on PATH. No detection is fabricated — unknown targets are
+// simply not detected.
+pub fn target_detected(id string) bool {
+	home := os.home_dir()
+	mut on_path := ''
+	match id {
+		'claude-code' {
+			on_path = os.find_abs_path_of_executable('claude') or { '' }
+			return os.exists(os.join_path(home, '.claude')) || on_path != ''
+		}
+		'cursor' {
+			on_path = os.find_abs_path_of_executable('cursor') or { '' }
+			return os.exists(os.join_path(home, '.cursor')) || on_path != ''
+		}
+		'opencode' {
+			on_path = os.find_abs_path_of_executable('opencode') or { '' }
+			return os.exists(os.join_path(home, '.config', 'opencode')) || on_path != ''
+		}
+		'gemini-cli' {
+			on_path = os.find_abs_path_of_executable('gemini') or { '' }
+			return os.exists(os.join_path(home, '.gemini')) || on_path != ''
+		}
+		'copilot-cli' {
+			on_path = os.find_abs_path_of_executable('copilot') or { '' }
+			return os.exists(os.join_path(home, '.config', 'github-copilot')) || on_path != ''
+		}
+		'pi' {
+			on_path = os.find_abs_path_of_executable('pi') or { '' }
+			return on_path != ''
+		}
+		'windsurf' {
+			on_path = os.find_abs_path_of_executable('windsurf') or { '' }
+			return os.exists(os.join_path(home, '.codeium')) || on_path != ''
+		}
+		'codex' {
+			on_path = os.find_abs_path_of_executable('codex') or { '' }
+			return os.exists(os.join_path(home, '.codex')) || on_path != ''
+		}
+		'muse-code' {
+			on_path = os.find_abs_path_of_executable('muse') or { '' }
+			return os.exists(os.join_path(home, '.config', 'muse')) || on_path != ''
+		}
+		else {
+			// copilot-repository is per-project; agent-plugins is a portable
+			// format — neither has a user-level runtime to detect.
+			return false
+		}
+	}
+}
+
+// targets returns the supported-target catalog derived from the canonical
+// registry. enabled comes only from explicit configuration state; a fresh
+// environment enables nothing by default.
 pub fn (mut e Engine) targets() []TargetEntry {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	env := resolve_env()
-	base := env.toolkit_root
+	snap := e.repo.snapshot()
 	mut out := []TargetEntry{}
-	profiles := ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli']
-	for p in profiles {
-		enabled_str := e.repo.snapshot().data['target:${p}:enabled'] or { '' }
-		enabled := if enabled_str == '' {
-			p == 'claude-code' || p == 'cli'
-		} else {
-			enabled_str == 'true'
+	for r in e.targets_registry() {
+		enabled := snap.data['target:${r.id}:enabled'] == 'true'
+		detected := target_detected(r.id)
+		// canonical bundled profile dir (profiles/copilot serves copilot-cli)
+		profiles_rel := 'profiles/${install_tool_name(r.id)}'
+		path := if data_dir_exists(env, profiles_rel) { profiles_rel } else { '' }
+		mut receipt := ''
+		if rr := agent_toolkit_core.load_install_receipt(install_tool_name(r.id), agent_toolkit_core.profiles_product, '') {
+			receipt = os.join_path(agent_toolkit_core.default_receipt_dir(), agent_toolkit_core.receipt_filename(rr.target, rr.product))
 		}
-		layer := if env.tier == 'override' { 'Project' } else { 'Toolkit' }
-		snap := e.repo.snapshot()
-		receipt := snap.data['receipt:target:${p}:path'] or { '' }
-		prov := snap.data['provenance:target:${p}:source'] or { 'profiles/${p}/config.yaml' }
+		status := if enabled { 'enabled' } else if detected { 'detected' } else { 'available' }
 		out << TargetEntry{
-			id: p
-			name: p
+			id: r.id
+			name: if r.display_name != '' { r.display_name } else { r.id }
 			enabled: enabled
-			layer: layer
-			path: '${base}/profiles/${p}'
-			status: if enabled { 'enabled' } else { 'disabled' }
+			layer: if r.tier != '' { 'tier ${r.tier}' } else { 'registry' }
+			path: path
+			status: status
 			receipt: receipt
-			provenance: prov
+			provenance: path
+			detected: detected
 		}
 	}
 	return out
@@ -84,8 +202,8 @@ pub fn (mut e Engine) set_target_enabled(target_id string, enabled bool) !u64 {
 	if target_id == '' {
 		return error('target id empty')
 	}
-	valid := ['claude-code', 'cursor', 'opencode', 'pi', 'windsurf', 'cursor-plugins', 'cli']
-	if target_id !in valid {
+	supported := e.targets_registry().map(it.id)
+	if target_id !in supported {
 		return error('unsupported target: ${target_id}')
 	}
 	e.mu.lock()
@@ -94,10 +212,6 @@ pub fn (mut e Engine) set_target_enabled(target_id string, enabled bool) !u64 {
 	mut repo := e.repo
 	mut tx := repo.begin('set-target')
 	tx.set('target:${target_id}:enabled', if enabled { 'true' } else { 'false' })
-	// receipt provenance for toggle
-	if enabled {
-		tx.set('receipt:target:${target_id}:enabled_at', time.now().str())
-	}
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
@@ -151,142 +265,161 @@ pub fn (mut e Engine) install_preview(targets []string) TargetDiff {
 	return e.diff(before, after)
 }
 
-// install_dry_run returns human-readable preview (like core install --dry-run).
+// install_dry_run returns the canonical core installer's real dry-run
+// preview for these targets. Nothing is written and no receipt is claimed.
 pub fn (mut e Engine) install_dry_run(targets []string) string {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	d := e.install_preview(targets)
-	mut lines := []string{}
-	lines << 'agent-toolkit install --dry-run'
-	lines << 'targets: ${targets.join(', ')}'
-	if d.added.len > 0 { lines << 'will add: ${d.added.join(', ')}' }
-	if d.removed.len > 0 { lines << 'will remove: ${d.removed.join(', ')}' }
-	if d.added.len == 0 && d.removed.len == 0 { lines << 'no changes — already up to date' }
-	lines << 'receipt: ~/.config/agent-toolkit/receipts/<target>-agent-toolkit-profiles.json'
-	lines << 'provenance: plugins/<product>/.provenance.json'
-	return lines.join('\n')
+	report := agent_toolkit_core.run_install(agent_toolkit_core.InstallOptions{
+		tools: targets
+		dry_run: true
+		home_dir: os.home_dir()
+	})
+	return report.message
 }
 
+// install performs a REAL profile installation through the canonical core
+// installer: profile files are deployed to the selected tools' config
+// locations and real receipts are written under the user config authority.
+// Configuration state records what actually installed; partial failures are
+// reported accurately. No install state is fabricated.
 pub fn (mut e Engine) install(targets []string) !u64 {
-	if targets.len == 0 {
+	return e.install_with_options(InstallOptionsEngine{
+		targets: targets
+	})
+}
+
+// install_tool_name maps a registry target id to the core installer tool
+// name where they differ. The bundled profile directory name is canonical
+// (profiles/copilot serves the copilot-cli registry entry).
+fn install_tool_name(id string) string {
+	return match id {
+		'copilot-cli' { 'copilot' }
+		else { id }
+	}
+}
+
+// install_with_options is the full Engine install flow: canonical core
+// run_install with dry-run/force/receipt-dir/home injection, then a
+// configuration transaction for the targets that actually installed.
+pub fn (mut e Engine) install_with_options(opts InstallOptionsEngine) !u64 {
+	if opts.targets.len == 0 {
 		return error('no targets selected')
+	}
+	supported := e.targets_registry().map(it.id)
+	mut installable := []string{}
+	for t in e.targets() {
+		if t.path != '' && install_tool_name(t.id) in agent_toolkit_core.install_valid_tools {
+			installable << t.id
+		}
+	}
+	for t in opts.targets {
+		if t !in supported {
+			return error('unsupported target: ${t}')
+		}
+		if t !in installable {
+			return error('no bundled profile installer for ${t} — compiler targets are built via the CLI')
+		}
+	}
+	home := if opts.home_dir != '' { opts.home_dir } else { os.home_dir() }
+	report := agent_toolkit_core.run_install(agent_toolkit_core.InstallOptions{
+		tools: opts.targets.map(install_tool_name(it))
+		dry_run: opts.dry_run
+		force: opts.force
+		receipt_dir: opts.receipt_dir
+		home_dir: home
+	})
+	if opts.dry_run {
+		// a real preview was computed and nothing was written
+		return 0
+	}
+	installed := opts.targets.filter(install_tool_name(it) !in report.failures)
+	if installed.len == 0 {
+		return error('install failed: ${report.failures.join(', ')}')
 	}
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	mut repo := e.repo
 	mut tx := repo.begin('install')
-	tx.set('install:targets', targets.join(','))
-	tx.set('install:timestamp', '${repo.snapshot().timestamp}')
-	tx.set('receipt:generated', 'true')
-	// per-target receipts + provenance (ADR-022 parity)
-	for t in targets {
-		tx.set('receipt:target:${t}:installed_at', time.now().str())
-		tx.set('receipt:target:${t}:version', '1.27.0')
-		tx.set('receipt:target:${t}:digest', 'sha256:${t.len * 13}')
-		tx.set('receipt:target:${t}:path', '~/.config/agent-toolkit/receipts/${t}-agent-toolkit-profiles.json')
-		tx.set('provenance:target:${t}:source', 'profiles/${t}')
-		tx.set('receipt:target:${t}:artifacts', 'profiles/${t}/config.yaml')
+	tx.set('install:targets', installed.join(','))
+	for t in installed {
 		tx.set('target:${t}:enabled', 'true')
 	}
 	rev := e.put_transaction(mut tx)!
+	if report.failures.len > 0 {
+		// partial success: configuration recorded, remaining failures reported
+		return error('partial install: failed ${report.failures.join(', ')}')
+	}
 	return rev.revision
 }
 
-// install_with_options mirrors core run_install with dry_run/force/receipt handling.
-pub fn (mut e Engine) install_with_options(opts InstallOptionsEngine) !u64 {
-	if opts.dry_run {
-		// dry-run writes nothing, just preview
-		_ = e.install_dry_run(opts.targets)
-		return 0
-	}
-	return e.install(opts.targets)!
-}
-
-// list_install_receipts returns all target receipts via StateRepository (headless).
+// list_install_receipts returns real install receipts from the user config
+// authority. State bookkeeping is never surfaced as a receipt.
 pub fn (mut e Engine) list_install_receipts() []InstallReceiptInfo {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
 	mut out := []InstallReceiptInfo{}
-	for k, v in snap.data {
-		if k.starts_with('receipt:target:') && k.ends_with(':installed_at') {
-			tgt := k.all_after('receipt:target:').all_before(':installed_at')
-			out << InstallReceiptInfo{
-				target: tgt
-				product: snap.data['receipt:target:${tgt}:version'] or { 'agent-toolkit-profiles' }
-				version: snap.data['receipt:target:${tgt}:version'] or { '1.27.0' }
-				installed_at: v
-				source_digest: snap.data['receipt:target:${tgt}:digest'] or { '' }
-				artifacts: (snap.data['receipt:target:${tgt}:artifacts'] or { '' }).split(',').filter(it != '')
-				receipt_path: snap.data['receipt:target:${tgt}:path'] or { '' }
-				provenance_path: snap.data['provenance:target:${tgt}:source'] or { '' }
-			}
-		}
-	}
-	// also surface skill/mcp receipts for unified view
-	for k, v in snap.data {
-		if k.starts_with('receipt:skill:') && k.ends_with(':installed_at') {
-			id := k.all_after('receipt:skill:').all_before(':installed_at')
-			out << InstallReceiptInfo{
-				target: 'skill:${id}'
-				product: snap.data['receipt:skill:${id}:product'] or { 'agent-toolkit-core' }
-				version: snap.data['receipt:skill:${id}:version'] or { '1.0.0' }
-				installed_at: v
-				source_digest: snap.data['receipt:skill:${id}:digest'] or { '' }
-				receipt_path: 'receipts/skill-${id}.json'
-				provenance_path: snap.data['provenance:skill:${id}:source'] or { '' }
-			}
+	for r in agent_toolkit_core.list_install_receipts('') {
+		out << InstallReceiptInfo{
+			target: r.target
+			product: r.product
+			version: r.version
+			installed_at: r.installed_at
+			source_digest: r.source_digest
+			artifacts: r.artifacts.map(it.path)
+			receipt_path: os.join_path(agent_toolkit_core.default_receipt_dir(), agent_toolkit_core.receipt_filename(r.target, r.product))
+			provenance_path: ''
 		}
 	}
 	return out
 }
 
-// verify_install_receipts checks receipts for drift (Doctor parity).
+// verify_install_receipts checks real receipts for artifact drift (Doctor
+// parity). A receipt whose artifact is missing from disk is reported.
 pub fn (mut e Engine) verify_install_receipts() []BuildDiagnostic {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	mut diags := []BuildDiagnostic{}
 	for r in e.list_install_receipts() {
-		if r.installed_at == '' {
-			diags << BuildDiagnostic{
-				path: r.receipt_path
-				message: 'receipt timestamp missing for ${r.target}'
-				code: 'receipt_corrupt'
-			}
-		}
-		if r.source_digest == '' {
-			diags << BuildDiagnostic{
-				path: r.provenance_path
-				message: 'provenance digest missing for ${r.target}'
-				code: 'provenance_missing'
+		for a in r.artifacts {
+			if agent_toolkit_core.receipt_artifact_digest(a) == 'missing' {
+				diags << BuildDiagnostic{
+					path: a
+					message: 'receipt artifact missing for ${r.target}'
+					code: 'artifact_missing'
+				}
 			}
 		}
 	}
 	return diags
 }
 
-// install_receipt_json returns ADR-022 style JSON for a target (easy audit).
+// install_receipt_json returns the real recorded receipt for a target, or an
+// honest not-found payload. No receipt is synthesized.
 pub fn (mut e Engine) install_receipt_json(target_id string) string {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	snap := e.repo.snapshot()
-	installed_at := snap.data['receipt:target:${target_id}:installed_at'] or { time.now().str() }
-	version := snap.data['receipt:target:${target_id}:version'] or { '1.27.0' }
-	digest := snap.data['receipt:target:${target_id}:digest'] or { 'sha256:abc' }
+	if r := agent_toolkit_core.load_install_receipt(target_id, agent_toolkit_core.profiles_product, '') {
+		return json2.encode({
+			'schemaVersion': '1'
+			'product':       r.product
+			'target':        r.target
+			'scope':         r.scope
+			'version':       r.version
+			'installedAt':   r.installed_at
+			'sourceDigest':  r.source_digest
+			'provenance':    ''
+		},
+			escape_unicode: true
+		)
+	}
 	return json2.encode({
-		'schemaVersion': '1'
-		'product':       'agent-toolkit-profiles'
-		'target':        target_id
-		'scope':         'project'
-		'version':       version
-		'installedAt':   installed_at
-		'sourceDigest':  digest
-		'provenance':    snap.data['provenance:target:${target_id}:source'] or { 'profiles/${target_id}' }
+		'error': 'no install receipt recorded for ${target_id}'
 	},
 		escape_unicode: true
 	)
@@ -347,8 +480,8 @@ pub fn (mut e Engine) doctor_fix(check_id string) !u64 {
 	return e.doctor_fix_stamp(check_id)!
 }
 
-// doctor_fix_enable_target enables a disabled profile target and records the
-// audit stamp in the same transaction (mirror set_target_enabled + receipt).
+// doctor_fix_enable_target enables a disabled profile target in configuration
+// and records the audit stamp in the same transaction.
 fn (mut e Engine) doctor_fix_enable_target(target_id string) !u64 {
 	e.mu.lock()
 	e.api_calls++
@@ -356,14 +489,14 @@ fn (mut e Engine) doctor_fix_enable_target(target_id string) !u64 {
 	mut repo := e.repo
 	mut tx := repo.begin('doctor-fix')
 	tx.set('target:${target_id}:enabled', 'true')
-	tx.set('receipt:target:${target_id}:enabled_at', time.now().str())
 	tx.set('doctor:fix:profile:${target_id}', 'fixed')
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
 
 // doctor_fix_stamp records the audit trail for checks without an automated
-// repair (or already passing) — idempotent success, never an error.
+// repair (or already passing) — idempotent success, never an error. It never
+// fabricates receipt evidence: a missing receipt stays missing.
 fn (mut e Engine) doctor_fix_stamp(check_id string) !u64 {
 	e.mu.lock()
 	e.api_calls++
@@ -371,11 +504,6 @@ fn (mut e Engine) doctor_fix_stamp(check_id string) !u64 {
 	mut repo := e.repo
 	mut tx := repo.begin('doctor-fix')
 	tx.set('doctor:fix:${check_id}', 'fixed')
-	// auto-fix receipts: if check is receipt missing, create it
-	if check_id.starts_with('receipt:') || check_id.contains('receipt') {
-		tx.set('receipt:generated', 'true')
-		tx.set('receipt:auto_fixed_at', time.now().str())
-	}
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }
@@ -406,7 +534,6 @@ pub fn (mut e Engine) doctor_fix_preview(check_id string) ![]string {
 	if check_id.starts_with('profile:') {
 		tid := check_id.all_after('profile:')
 		return ['set target:${tid}:enabled = true',
-			'set receipt:target:${tid}:enabled_at = <now>',
 			'set doctor:fix:profile:${tid} = fixed']
 	}
 	if check_id.starts_with('mcp:') && check_id != 'mcp:docker' {
@@ -417,7 +544,7 @@ pub fn (mut e Engine) doctor_fix_preview(check_id string) ![]string {
 					return ['set doctor:fix:mcp:${mid} = fixed (audit trail)',
 						'note: provider reports ${p.health} — toggle would REMOVE it, so no config change is made']
 				}
-				return ['upsert default MCP config for ${mid} (npx @modelcontextprotocol/server-${mid})',
+				return ['enable ${mid} from its packaged template config',
 					'set doctor:fix:mcp:${mid} = fixed']
 			}
 		}
@@ -439,6 +566,9 @@ fn doctor_manual_hint(check_id string) string {
 	}
 	if check_id == 'mcp:docker' {
 		return 'install docker: https://docs.docker.com/get-docker/'
+	}
+	if check_id.starts_with('receipt:') {
+		return 'run install for this target to record a real receipt'
 	}
 	return 'see the check message, then re-check'
 }
@@ -464,26 +594,26 @@ pub fn (mut e Engine) doctor_fix_category(cat string) !u64 {
 	return rev
 }
 
-// doctor_fix_all fixes all fixable Doctor checks in one transaction — super-potent.
+// doctor_fix_all performs the real per-check repairs via doctor_fix —
+// repairs where a repair exists, audit stamps otherwise. It never blanket-
+// stamps checks as fixed without performing the repair.
 pub fn (mut e Engine) doctor_fix_all() !u64 {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	checks := e.doctor()
-	mut repo := e.repo
-	mut tx := repo.begin('doctor-fix-all')
+	mut rev := u64(0)
 	mut fixed := 0
 	for c in checks {
 		if c.fixable && (c.status == 'warn' || c.status == 'fail') {
-			tx.set('doctor:fix:${c.id}', 'fixed')
+			rev = e.doctor_fix(c.id)!
 			fixed++
 		}
 	}
 	if fixed == 0 {
 		return 0
 	}
-	rev := e.put_transaction(mut tx)!
-	return rev.revision
+	return rev
 }
 
 pub fn (mut e Engine) resolve_paths() []string {
@@ -494,7 +624,9 @@ pub fn (mut e Engine) resolve_paths() []string {
 	return [env.toolkit_root, env.tier]
 }
 
-// resolve_paths_detailed returns structured path info with receipt/provenance.
+// resolve_paths_detailed returns structured path info from the real
+// authorities: bundled data root, user config receipt dir and the resolved
+// toolkit version.
 pub fn (mut e Engine) resolve_paths_detailed() string {
 	e.mu.lock()
 	e.api_calls++
@@ -503,9 +635,9 @@ pub fn (mut e Engine) resolve_paths_detailed() string {
 	return json2.encode({
 		'toolkit_root': env.toolkit_root
 		'tier':         env.tier
-		'receipt_dir':  '~/.config/agent-toolkit/receipts'
+		'receipt_dir':  agent_toolkit_core.default_receipt_dir()
 		'provenance':   'plugins/*/.provenance.json'
-		'cache':        cache_path('1.27.0')
+		'version':      agent_toolkit_core.resolve_toolkit_version()
 	},
 		escape_unicode: true
 	)

--- a/modules/desktop_engine/targets_truth_test.v
+++ b/modules/desktop_engine/targets_truth_test.v
@@ -1,0 +1,146 @@
+module desktop_engine
+
+import os
+
+// S7B target/install truth gates: the supported roster comes from the
+// canonical registry, nothing is enabled by default, detection is real, and
+// install evidence is real deployed files plus a real receipt.
+
+fn targets_truth_setup() (string, string) {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	prev_cfg := os.getenv('XDG_CONFIG_HOME')
+	tmp := os.join_path(os.temp_dir(), 'targets-truth-${os.getpid()}')
+	os.mkdir_all(os.join_path(tmp, 'xdg-config')) or { panic(err.msg()) }
+	os.setenv('XDG_CONFIG_HOME', os.join_path(tmp, 'xdg-config'), true)
+	return tmp, prev_root
+}
+
+fn targets_truth_teardown(tmp string, prev_root string, prev_cfg string) {
+	os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true)
+	os.setenv('XDG_CONFIG_HOME', prev_cfg, true)
+	os.rmdir_all(tmp) or {}
+}
+
+// The roster comes from capabilities/targets/registry.yaml with real display
+// names; a fresh configuration enables nothing by default.
+fn test_targets_come_from_canonical_registry() {
+	tmp, prev_root := targets_truth_setup()
+	prev_cfg := os.getenv('XDG_CONFIG_HOME')
+	defer { targets_truth_teardown(tmp, prev_root, prev_cfg) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	reg := eng.targets_registry()
+	assert reg.len == 11, 'registry must list 11 targets: got ${reg.len}'
+	mut by_id := map[string]TargetRegistryEntry{}
+	for r in reg {
+		by_id[r.id] = r
+	}
+	assert by_id['claude-code'].display_name == 'Claude Code'
+	assert by_id['cursor'].tier == 'A'
+	assert by_id['windsurf'].maturity == 'limited'
+
+	tgts := eng.targets()
+	assert tgts.len == 11
+	for t in tgts {
+		assert !t.enabled, 'fresh config must not enable ${t.id} by default'
+		assert t.status == 'detected' || t.status == 'available', 'fresh status must be detected/available: ${t.id}=${t.status}'
+		assert t.receipt == '', 'no receipt evidence without a real install: ${t.id}'
+	}
+	// targets with bundled profiles carry the real bundled path
+	mut with_profiles := 0
+	for t in tgts {
+		if t.path != '' {
+			assert t.path.starts_with('profiles/'), 'bundled profile path: ${t.path}'
+			with_profiles++
+		}
+	}
+	assert with_profiles >= 5, 'bundled profile targets must be present: ${with_profiles}'
+}
+
+// set_target_enabled only accepts registry targets and writes explicit
+// configuration only — no receipt keys.
+fn test_set_target_enabled_is_explicit_config() {
+	tmp, prev_root := targets_truth_setup()
+	prev_cfg := os.getenv('XDG_CONFIG_HOME')
+	defer { targets_truth_teardown(tmp, prev_root, prev_cfg) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	if _ := eng.set_target_enabled('not-a-target', true) {
+		assert false, 'unknown target must be rejected'
+	} else {
+		assert err.msg().contains('unsupported target')
+	}
+	rev := eng.set_target_enabled('cursor', true) or { panic(err.msg()) }
+	assert rev >= 1
+	assert eng.targets().filter(it.id == 'cursor')[0].enabled == true
+	snap := eng.repo.snapshot()
+	for k, _ in snap.data {
+		assert !k.starts_with('receipt:target:'), 'enabling must not write receipt keys: ${k}'
+	}
+}
+
+// install deploys real profile files through the core installer and records
+// a real receipt; dry-run writes nothing; unsupported installs fail honestly.
+fn test_real_install_and_honest_dry_run() {
+	tmp, prev_root := targets_truth_setup()
+	prev_cfg := os.getenv('XDG_CONFIG_HOME')
+	defer { targets_truth_teardown(tmp, prev_root, prev_cfg) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	// compiler target without a bundled profile installer is refused
+	if _ := eng.install_with_options(InstallOptionsEngine{ targets: ['codex'] }) {
+		assert false, 'codex has no bundled profile installer and must be refused'
+	} else {
+		assert err.msg().contains('no bundled profile installer')
+	}
+
+	// dry-run computes the real preview and writes nothing
+	dry_home := os.join_path(tmp, 'dry-home')
+	os.mkdir_all(dry_home) or { panic(err.msg()) }
+	rev0 := eng.install_with_options(InstallOptionsEngine{
+		targets: ['claude-code']
+		dry_run: true
+		home_dir: dry_home
+	}) or { panic(err.msg()) }
+	assert rev0 == 0
+	assert !os.exists(os.join_path(dry_home, '.claude')), 'dry-run must not deploy files'
+
+	// real install deploys files and records a real receipt
+	home := os.join_path(tmp, 'home')
+	os.mkdir_all(home) or { panic(err.msg()) }
+	rev := eng.install_with_options(InstallOptionsEngine{
+		targets: ['claude-code']
+		home_dir: home
+	}) or { panic(err.msg()) }
+	assert rev >= 1
+	assert os.exists(os.join_path(home, '.claude')), 'real install deploys profile files'
+	recs := eng.list_install_receipts()
+	assert recs.len == 1, 'exactly the real receipt surfaces: got ${recs.len}'
+	assert recs[0].target == 'claude-code'
+	assert recs[0].installed_at != '', 'installed_at is real receipt evidence'
+	assert recs[0].artifacts.len > 0, 'real receipt records real artifacts'
+	assert eng.verify_install_receipts().len == 0, 'fresh install has no drift'
+	assert eng.install_receipt_json('claude-code').contains('installedAt')
+
+	// target row now carries real receipt evidence and config truth
+	row := eng.targets().filter(it.id == 'claude-code')[0]
+	assert row.enabled, 'install records configuration truth'
+	assert row.receipt != '', 'target row carries the real receipt path'
+}


### PR DESCRIPTION
## What

S7B targets & installation truth: the supported-target roster is derived from
the canonical registry and installation is real.

## Why

`targets_service.v` maintained a duplicated seven-item roster, defaulted
`claude-code`/`cli` to enabled with no configuration, performed state-only
"installs" that wrote fake receipts (`1.27.0`, `sha256:${len*13}`, `sha256:abc`),
fabricated timestamps in `install_receipt_json`, and stamped doctor checks
`fixed` (including fabricating receipt evidence) without performing repairs.
This violates the product truth contract and the S7 ledger
(`docs/desktop/TRUTH_LEDGER.md`).

## Changes

- `targets_service.v`:
  - `targets_registry()` parses `capabilities/targets/registry.yaml` (embedded,
    CI-validated) tier-aware — the single source for supported targets.
  - `targets()` separates **supported** (registry), **detected** (real
    config-dir/PATH detection per tool) and **enabled** (explicit
    configuration only; nothing is enabled by default on a fresh environment).
  - `install()` / `install_with_options()` run the canonical core installer
    (`agent_toolkit_core.run_install`): real profile files deployed to the
    selected tools' config locations, real receipts under the user config
    authority, accurate partial-failure reporting. Dry-run is the core's real
    dry-run (nothing written, no receipt claimed).
  - `list_install_receipts()` / `install_receipt_json()` report only real
    receipts; `verify_install_receipts()` checks real artifact drift.
  - `doctor_fix_stamp` never fabricates receipt evidence; `doctor_fix_all`
    performs real per-check repairs instead of blanket-stamping `fixed`.
  - `resolve_paths_detailed()` reports the real receipt dir and resolved
    toolkit version instead of hardcoded `1.27.0`.
- `engine.v` doctor: profile checks only cover targets with bundled profiles
  and surface real detection; receipt checks read real receipts; enabled
  without an install receipt is an honest, actionable warn.
- `onboarding_service.v`: the valid target list comes from the registry.
- GUI (`main.v`): quick-action and fallback rosters use real registry ids
  (`cli`/`cursor-plugins` no longer exist as targets).
- Tests: `targets_truth_test.v` gates (registry roster with real display
  names, no default-enabled, real install deploys files + receipt, dry-run
  writes nothing, compiler targets refused honestly);
  `product_truth_test.v` (both desktop_engine and desktop modules) lock the
  registry contract; `capability_plane_test.v` performs a real isolated
  install; `doctor_fix_test.v` locks the honest fix preview.

## Verification

- `./make.vsh test` green: 78 module tests.
- Native desktop binary builds.
- Real isolated install verified: `~/.claude` profile files deployed and a
  real receipt recorded with real artifacts.

## Notes

- Stacks cleanly after #1144 (S7A); `product_truth_test.v` touches different
  regions in each PR.
- `modules/desktop/world/targets/targets.v` still contains a fabricated rig
  roster but is unreachable from the production binary — tracked for the S7E
  sweep.

## Related

- Salvage S7B per `docs/desktop/TRUTH_LEDGER.md`.
