### PR TITLE
fix(desktop): remove fabricated git data, honest workspace surfaces (S7C)

### DIFF
--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -5625,6 +5625,19 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int) {
 	}
 	if app.git_rail == 'CHANGES' {
 		changes := app.desktop.engine_git_changes()
+		st := app.desktop.engine_git_workspace_status()
+		if !st.is_repo || !st.backend_available {
+			// honest availability before fabricated-looking empty counts
+			note := if st.root == '' {
+				'no active workspace — open one to inspect git'
+			} else if !st.is_repo {
+				'no git repository in the active workspace'
+			} else {
+				'repository detected — git read backend not available yet'
+			}
+			app.gg.draw_text(x + 8, y0, note, gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
+			return
+		}
 		app.gg.draw_text(x + 8, y0, '${changes.len} changed • staged flag • brokered', gg.TextCfg{ color: app.pnl_text, size: 11 })
 		row_h := 20
 		visible := (inner_h - 20) / row_h
@@ -5671,6 +5684,18 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int) {
 		}
 	} else if app.git_rail == 'HISTORY' {
 		graph := app.desktop.engine_git_graph(20)
+		st := app.desktop.engine_git_workspace_status()
+		if !st.is_repo || !st.backend_available {
+			note := if st.root == '' {
+				'no active workspace — open one to inspect git'
+			} else if !st.is_repo {
+				'no git repository in the active workspace'
+			} else {
+				'repository detected — git read backend not available yet'
+			}
+			app.gg.draw_text(x + 8, y0, note, gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
+			return
+		}
 		app.gg.draw_text(x + 8, y0, 'commit graph • ${graph.commits.len} commits • lanes ${graph.max_lane + 1}', gg.TextCfg{ color: app.pnl_text, size: 11 })
 		row_h := 22
 		visible := (inner_h - 40) / row_h

--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -236,6 +236,37 @@ CI-validated) instead of a private seven-item list, and installation is real.
   install evidence, honest dry-run); `product_truth_test.v` (desktop_engine and
   desktop) lock the registry contract; `capability_plane_test.v` performs a
   real isolated install; `doctor_fix_test.v` locks the honest preview.
+### S7C — Git truth (`fix/s7c-git-truth`)
+
+Status: in progress. All fabricated Git data is removed; the Git surface is
+honest about availability until a real read backend exists.
+
+- `git_service.v` (rewrite):
+  - Removed every fabricated value: fake authors (`alice`…`dave`), synthetic
+    hashes/timestamps/commit messages, fabricated branch rosters, synthetic
+    graph lanes, hardcoded diff hunks and relabeled compare diffs.
+  - `git_workspace_root()` / `git_workspace_status()` provide a typed
+    availability marker: active workspace root, real `.git` probe, and
+    backend availability. A real repository is honestly detected, but no
+    data is invented for it while no read backend is wired.
+  - All data APIs (`git_changes`, `git_history`, `git_commit_graph`,
+    `git_diff`, `git_compare`) return empty until real data exists.
+- `workspace_service.v`:
+  - `active_workspace_root()` never falls back to `toolkit_root` — no
+    workspace means unavailable.
+  - `workspace_tree()`/`workspace_stats()` are empty without a configured
+    workspace (never cwd-derived); the placeholder `README.md` node and the
+    invented "init memory" ledger entry are removed.
+  - `git_status_for` no longer guesses "modified" from filename patterns —
+    unknown stays unknown until a git backend exists.
+- GUI: the Git rails panel renders the honest availability note (no active
+  workspace / no repository / backend not available) instead of empty
+  counts that could read as "no changes".
+- Tests: `git_truth_test.v` gates (no fabrication across no-workspace,
+  non-repo and real-repo-without-backend states; workspace surfaces honest
+  without a workspace). `runtime_plane_test.v` and `modules/desktop/runtime_test.v`
+  now exercise a real configured workspace instead of pinning fabricated
+  conveniences.
 
 Evidence:
 - `./make.vsh test` green (78 module tests).

--- a/modules/desktop/runtime_test.v
+++ b/modules/desktop/runtime_test.v
@@ -37,7 +37,15 @@ fn test_runtime_viewmodels_via_engine_no_shell() {
 	board := lvm.mission_board()
 	assert board.len > 0
 	mut wvm := workspace.new_workspace_viewmodel(mut eng)
-	assert wvm.all_nodes().len >= 4
+	// no workspace configured → honest empty tree (never toolkit-root-derived)
+	assert wvm.all_nodes().len == 0, 'no configured workspace yields an empty tree'
+	// configure a real workspace → nodes reflect real directories
+	ws := os.join_path(tmp, 'ws')
+	os.mkdir_all(os.join_path(ws, 'knowledge')) or { panic(err.msg()) }
+	os.write_file(os.join_path(ws, 'knowledge', 'note.md'), '# real\n') or { panic(err.msg()) }
+	eng.switch_workspace(ws) or { panic(err.msg()) }
+	wvm.refresh()
+	assert wvm.all_nodes().len >= 1, 'real workspace yields real nodes'
 	_ = wvm.memory('')
 	harness := tmp
 	os.mkdir_all(os.join_path(tmp, 'knowledge')) or {}

--- a/modules/desktop/window.v
+++ b/modules/desktop/window.v
@@ -442,6 +442,10 @@ pub fn (mut d Desktop) engine_git_changes() []desktop_engine.GitChange {
 	return d.engine.git_changes()
 }
 
+pub fn (mut d Desktop) engine_git_workspace_status() desktop_engine.GitWorkspaceStatus {
+	return d.engine.git_workspace_status()
+}
+
 pub fn (mut d Desktop) engine_git_history(limit int) []desktop_engine.GitCommit {
 	return d.engine.git_history(limit)
 }

--- a/modules/desktop_engine/git_service.v
+++ b/modules/desktop_engine/git_service.v
@@ -53,184 +53,95 @@ pub:
 	max_lane int
 }
 
-pub fn (mut e Engine) git_changes() []GitChange {
+// GitWorkspaceStatus is the honest availability marker for the Git surface.
+// Git data comes only from a real read backend over the active workspace
+// repository; until that backend exists, is_repo may be true while
+// backend_available is false and all Git data APIs return empty results.
+pub struct GitWorkspaceStatus {
+pub:
+	root              string // active workspace root ('' when none configured)
+	is_repo            bool // a real .git directory exists under root
+	backend_available  bool // a real Git read backend is wired
+}
+
+// git_workspace_root returns the active workspace root from configuration
+// truth (recent_workspace). The bundled toolkit root is never used as a
+// workspace: an embedded toolkit has no filesystem workspace.
+pub fn (mut e Engine) git_workspace_root() string {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	snap := e.repo.snapshot()
-	mut out := []GitChange{}
-	out << GitChange{ path: 'modules/desktop_engine/skills_service.v', status: 'modified', staged: false, hunks: 2 }
-	out << GitChange{ path: 'cmd/agent-toolkit-desktop/main.v', status: 'modified', staged: true, hunks: 4 }
-	out << GitChange{ path: 'modules/desktop/skills/skills_viewmodel.v', status: 'modified', staged: false, hunks: 1 }
-	if 'dirty_files' in snap.data {
-		extra := snap.data['dirty_files'].split(',').map(it.trim_space()).filter(it != '')
-		for p in extra {
-			if p == '' {
-				continue
-			}
-			mut found := false
-			for c in out {
-				if c.path == p {
-					found = true
-					break
-				}
-			}
-			if !found { out << GitChange{ path: p, status: 'modified', staged: false, hunks: 1 } }
-		}
-	}
-	if 'watcher_last_path' in snap.data {
-		wp := snap.data['watcher_last_path']
-		if wp != '' && wp.contains('.v') {
-			out << GitChange{ path: wp.all_after(snap.data['toolkit_root'] or { '' }), status: 'untracked', staged: false, hunks: 0 }
-		}
-	}
-	return out
+	return snap.data['recent_workspace'] or { '' }
 }
 
+// git_workspace_status reports the real availability of Git data for the
+// active workspace: whether a repository exists and whether a read backend
+// is wired. It never fabricates repository state.
+pub fn (mut e Engine) git_workspace_status() GitWorkspaceStatus {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	root := e.repo.snapshot().data['recent_workspace'] or { '' }
+	if root == '' {
+		return GitWorkspaceStatus{ root: '', is_repo: false, backend_available: false }
+	}
+	is_repo := os.is_dir(os.join_path(root, '.git'))
+	return GitWorkspaceStatus{ root: root, is_repo: is_repo, backend_available: false }
+}
+
+// git_changes returns the working-tree changes of the active workspace
+// repository. With no workspace repository or until a real Git read backend
+// is wired, the result is empty — real absence, never seeded fixtures.
+// Use git_workspace_status() to distinguish "no changes" from "unavailable".
+pub fn (mut e Engine) git_changes() []GitChange {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	return []GitChange{}
+}
+
+// git_history returns the commit history of the active workspace repository.
+// Empty until a real backend exists — no synthetic hashes, authors or dates.
 pub fn (mut e Engine) git_history(limit int) []GitCommit {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	n := if limit <= 0 || limit > 50 { 20 } else { limit }
-	mut out := []GitCommit{cap: n}
-	env := resolve_env()
-	git_dir := os.join_path(env.toolkit_root, '.git')
-	if os.is_dir(git_dir) {}
-	authors := ['alice', 'bob', 'carol', 'dave']
-	branches := ['main', 'feat/ide', 'feat/git-rails', 'fix/brokered-fs']
-	for i in 0 .. n {
-		hex := 'abcdef0123456789'
-		mut h := ''
-		for j in 0 .. 7 {
-			h += hex[(i * 7 + j) % hex.len].ascii_str()
-		}
-		parents := if i == n - 1 {
-			[]string{}
-		} else if i % 5 == 0 && i + 2 < n {
-			[h_next(i + 1), h_next(i + 2)]
-		} else {
-			[h_next(i + 1)]
-		}
-		out << GitCommit{
-			hash: h
-			message: git_message_for(i)
-			author: authors[i % authors.len]
-			timestamp: 1700000000 + i * 3600
-			parents: parents
-			branch: branches[i % branches.len]
-			refs: if i == 0 {
-				['HEAD', 'main']} else if i % 8 == 0 { ['tag v1.${i / 8}.0'] } else { []string{} }
-		}
-	}
-	return out
+	_ = limit
+	return []GitCommit{}
 }
 
-fn h_next(i int) string {
-	hex := 'abcdef0123456789'
-	mut h := ''
-	for j in 0 .. 7 {
-		h += hex[(i * 7 + j) % hex.len].ascii_str()
-	}
-	return h
-}
-
-fn git_message_for(i int) string {
-	msgs := [
-		'feat(desktop): file-tree IDE + git rails',
-		'feat(skills): 227 catalog searchable',
-		'feat(memory): palace semantic recall',
-		'fix(fs): brokered harness_root escape guard',
-		'feat(editor): syntax tabs V/md/yaml',
-		'feat(git): CHANGES/HISTORY/COMPARE + commit graph',
-		'feat(diff): hunk view with lanes',
-		'docs: update IDE rails',
-		'refactor: draw_skills/draw_workspace potent',
-		'chore: bump to 227',
-	]
-	return msgs[i % msgs.len] + ' (#${1000 + i})'
-}
-
+// git_commit_graph returns the commit graph of the active workspace
+// repository. Empty until a real backend exists — no synthetic lanes.
 pub fn (mut e Engine) git_commit_graph(limit int) CommitGraph {
-	commits := e.git_history(limit)
-	mut lanes := []int{len: commits.len}
-	mut max_lane := 0
-	for i, c in commits {
-		mut lane := i % 3
-		if c.parents.len > 1 {
-			lane = 1
-		}
-		lanes[i] = lane
-		if lane > max_lane {
-			max_lane = lane
-		}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	_ = limit
+	return CommitGraph{
+		commits: []GitCommit{}
+		lanes: []int{}
+		max_lane: 0
 	}
-	return CommitGraph{ commits: commits, lanes: lanes, max_lane: max_lane }
 }
 
+// git_diff returns the diff hunks for a target in the active workspace
+// repository. Empty until a real backend exists — no hand-authored hunks.
 pub fn (mut e Engine) git_diff(target string) []DiffHunk {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	if target == '' || target == 'CHANGES' {
-		return [
-			DiffHunk{
-				file: 'modules/desktop_engine/skills_service.v'
-				old_start: 57
-				old_count: 4
-				new_start: 57
-				new_count: 6
-				lines: [
-					DiffLine{.header, '@@ -57,4 +57,6 @@', 0, 0},
-					DiffLine{.context, ' if entries.len >= 116 {', 57, 57},
-					DiffLine{.deletion, '-                return entries', 58, 0},
-					DiffLine{.addition, '+                if entries.len >= 227 {', 0, 58},
-					DiffLine{.addition, '+                    return entries[..227]', 0, 59},
-					DiffLine{.context, ' }', 59, 60},
-				]
-			},
-			DiffHunk{
-				file: 'cmd/agent-toolkit-desktop/main.v'
-				old_start: 1219
-				old_count: 8
-				new_start: 1219
-				new_count: 12
-				lines: [
-					DiffLine{.header, '@@ -1219,8 +1219,12 @@ fn draw_skills', 0, 0},
-					DiffLine{.context, ' fx := 208', 1219, 1219},
-					DiffLine{.deletion, '-    app.gg.draw_text(fx+12, "SKILLS 116")', 1220, 0},
-					DiffLine{.addition, '+    // 227 searchable via skills_search fuzzy', 0, 1220},
-					DiffLine{.addition, '+    cat := app.engine.skills_search(query, domain)', 0, 1221},
-					DiffLine{.context, ' }', 1221, 1223},
-				]
-			},
-		]
-	}
-	return [
-		DiffHunk{
-			file: 'modules/desktop_engine/git_service.v'
-			old_start: 1
-			old_count: 3
-			new_start: 1
-			new_count: 5
-			lines: [
-				DiffLine{.header, '@@ -1,3 +1,5 @@', 0, 0},
-				DiffLine{.addition, '+// brokered via Engine', 0, 1},
-				DiffLine{.context, ' module desktop_engine', 1, 2},
-			]
-		},
-	]
+	_ = target
+	return []DiffHunk{}
 }
 
+// git_compare returns the diff between two refs. Empty until a real
+// backend exists — no relabeled fixture diffs.
 pub fn (mut e Engine) git_compare(base string, target string) []DiffHunk {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	if base == '' || target == '' {
-		return e.git_diff('')
-	}
-	mut hunks := e.git_diff('')
-	for mut h in hunks {
-		h.file = h.file + ' (${base}..${target})'
-	}
-	return hunks
+	_ = base
+	_ = target
+	return []DiffHunk{}
 }

--- a/modules/desktop_engine/git_truth_test.v
+++ b/modules/desktop_engine/git_truth_test.v
@@ -1,0 +1,78 @@
+module desktop_engine
+
+import os
+
+// S7C Git truth gates: no fabricated Git data, honest availability markers,
+// and workspace surfaces that never fall back to the toolkit root or cwd.
+
+fn git_truth_engine(tmp string) &Engine {
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init() or { panic(err.msg()) }
+	eng.start() or { panic(err.msg()) }
+	return eng
+}
+
+// Git APIs never invent changes, history, graphs or diffs — with no
+// workspace, a non-repo workspace, or until a read backend exists, results
+// are empty and the availability marker says why.
+fn test_git_never_fabricates() {
+	tmp := os.join_path(os.temp_dir(), 'git-truth-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := git_truth_engine(tmp)
+	defer { eng.stop() or {} }
+
+	// no workspace configured
+	st := eng.git_workspace_status()
+	assert st.root == ''
+	assert st.is_repo == false
+	assert st.backend_available == false
+	assert eng.git_changes().len == 0
+	assert eng.git_history(20).len == 0
+	assert eng.git_commit_graph(20).commits.len == 0
+	assert eng.git_diff('').len == 0
+	assert eng.git_compare('HEAD~1', 'HEAD').len == 0
+
+	// a real workspace that is NOT a git repository
+	ws := os.join_path(tmp, 'workspace')
+	os.mkdir_all(os.join_path(ws, 'knowledge')) or { panic(err.msg()) }
+	os.write_file(os.join_path(ws, 'knowledge', 'README.md'), '# real\n') or { panic(err.msg()) }
+	eng.switch_workspace(ws) or { panic(err.msg()) }
+	st2 := eng.git_workspace_status()
+	assert st2.is_repo == false, 'plain dir must not be reported as a repo'
+	assert eng.git_changes().len == 0
+
+	// a directory that contains .git is honestly detected as a repository,
+	// but without a read backend no data is invented
+	repo := os.join_path(tmp, 'repo-ws')
+	os.mkdir_all(os.join_path(repo, '.git')) or { panic(err.msg()) }
+	eng.switch_workspace(repo) or { panic(err.msg()) }
+	st3 := eng.git_workspace_status()
+	assert st3.is_repo == true
+	assert st3.backend_available == false
+	assert eng.git_changes().len == 0, 'repo without backend must not show fabricated changes'
+	assert eng.git_history(20).len == 0, 'no synthetic history even in a real repo'
+	assert eng.git_diff('HEAD').len == 0, 'no hand-authored hunks even in a real repo'
+}
+
+// Workspace surfaces never fall back to the toolkit root or cwd: with no
+// configured workspace the tree is empty, stats are zero and file-tree git
+// badges are unknown rather than filename-pattern guesses.
+fn test_workspace_surfaces_honest_without_workspace() {
+	tmp := os.join_path(os.temp_dir(), 'ws-truth-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := git_truth_engine(tmp)
+	defer { eng.stop() or {} }
+
+	assert eng.active_workspace_root() == '', 'no workspace means unavailable, never toolkit root'
+	tree := eng.workspace_tree()
+	assert tree.len == 0, 'no placeholder nodes without a workspace: got ${tree.len}'
+	stats := eng.workspace_stats()
+	assert stats.knowledge_files == 0
+	assert stats.repos_count == 0
+	assert stats.projects_count == 0
+	assert stats.packs_count == 0
+}

--- a/modules/desktop_engine/runtime_plane_test.v
+++ b/modules/desktop_engine/runtime_plane_test.v
@@ -93,10 +93,26 @@ fn test_runtime_plane_workspace_via_engine_no_shell() {
 	eng.init()!
 	eng.start()!
 	defer { eng.stop() or {} }
+	// honest workspace: with no workspace configured the tree and ledger are
+	// empty — never toolkit-root-derived nodes or invented memory entries
 	tree := eng.workspace_tree()
-	assert tree.len >= 4
+	assert tree.len == 0, 'no configured workspace yields an empty tree'
 	ledger := eng.memory_ledger('')
-	assert ledger.len >= 1
+	assert ledger.len == 0, 'no fabricated memory entries'
+	// configure a real workspace → the tree reflects real directories
+	ws := os.join_path(tmp, 'ws')
+	os.mkdir_all(os.join_path(ws, 'knowledge')) or { panic(err.msg()) }
+	os.write_file(os.join_path(ws, 'knowledge', 'note.md'), '# real\n') or { panic(err.msg()) }
+	eng.switch_workspace(ws) or { panic(err.msg()) }
+	tree2 := eng.workspace_tree()
+	assert tree2.len >= 1, 'a real workspace yields real nodes'
+	mut found_note := false
+	for n in tree2 {
+		if n.path.contains('note.md') {
+			found_note = true
+		}
+	}
+	assert found_note, 'real workspace file must appear in the tree'
 	harness := tmp
 	bad := os.join_path(os.temp_dir(), 'escape')
 	if _ := eng.open_path_validated(harness, bad) {

--- a/modules/desktop_engine/workspace_service.v
+++ b/modules/desktop_engine/workspace_service.v
@@ -75,7 +75,9 @@ fn (mut e Engine) active_workspace_root() string {
 			return clean
 		}
 	}
-	return resolve_env().toolkit_root
+	// No configured workspace: the active workspace is unavailable, never the
+	// bundled toolkit root (an embedded toolkit has no filesystem workspace).
+	return ''
 }
 
 pub fn (mut e Engine) workspace_tree() []WorkspaceNode {
@@ -83,6 +85,10 @@ pub fn (mut e Engine) workspace_tree() []WorkspaceNode {
 	e.api_calls++
 	e.mu.unlock()
 	base := e.active_workspace_root()
+	if base == '' {
+		// no active workspace: the tree is empty, never rooted at cwd
+		return []WorkspaceNode{}
+	}
 	harness_candidates := [
 		os.join_path(base, 'knowledge'),
 		os.join_path(base, 'repos'),
@@ -130,9 +136,7 @@ pub fn (mut e Engine) workspace_tree() []WorkspaceNode {
 			}
 		}
 	}
-	if out.len == 0 {
-		out << WorkspaceNode{ path: 'knowledge/README.md', label: 'README.md', kind: .file, revision: rev }
-	}
+	// an empty workspace renders as an empty tree — no placeholder nodes
 	return out
 }
 
@@ -156,9 +160,7 @@ pub fn (mut e Engine) memory_ledger(project_id string) []MemoryEntry {
 			}
 		}
 	}
-	if out.len == 0 {
-		out << MemoryEntry{ ts: snap.timestamp, actor: 'system', entry: 'init memory', project_id: project_id }
-	}
+	// an empty ledger is empty — no invented "init memory" entry
 	return out
 }
 
@@ -268,16 +270,13 @@ fn build_tree_recursive(root string, cur string, depth int, max_depth int, mut e
 	return out
 }
 
+// git_status_for returns the git status badge for a workspace file. Git
+// status comes only from a real Git read backend over the active workspace
+// repository; until that backend exists the status is unknown ('') — never
+// a filename-pattern guess that renders as "modified".
 fn git_status_for(path string, mut e Engine) string {
-	snap := e.repo.snapshot()
-	if 'dirty_files' in snap.data {
-		if snap.data['dirty_files'].contains(path.all_after_last('/')) {
-			return 'modified'
-		}
-	}
-	if path.ends_with('main.v') || path.contains('skills_service') {
-		return 'modified'
-	}
+	_ = path
+	_ = e
 	return ''
 }
 
@@ -471,6 +470,10 @@ pub fn (mut e Engine) workspace_stats() WorkspaceStats {
 	e.api_calls++
 	e.mu.unlock()
 	base := e.active_workspace_root()
+	if base == '' {
+		// no active workspace: all counts are unknown/zero, never cwd-derived
+		return WorkspaceStats{}
+	}
 	mut ks := 0
 	kp := os.join_path(base, 'knowledge')
 	if os.is_dir(kp) {


### PR DESCRIPTION
## What

S7C Git truth: all fabricated Git data is removed and the Git surface is
honest about availability until a real read backend exists.

## Why

`git_service.v` fabricated the entire Git surface: demo authors
(`alice`/`bob`/`carol`/`dave`), synthetic hashes and timestamps, invented
commit messages and branch rosters, index-arithmetic graph lanes and hardcoded
diff hunks returned for any target — with the only real `.git` probe discarded
as dead code. `workspace_service.v` fell back to `toolkit_root` as the
"workspace", rendered placeholder nodes, invented an "init memory" ledger
entry, and stamped files "modified" based on filename patterns. All of this
violates the truth contract in `docs/desktop/TRUTH_LEDGER.md`.

## Changes

- `git_service.v` (rewrite):
  - Every fabricated value removed.
  - New typed `GitWorkspaceStatus{root, is_repo, backend_available}` +
    `git_workspace_root()` / `git_workspace_status()`: the active workspace
    root from configuration truth, a real `.git` directory probe, and explicit
    read-backend availability.
  - Data APIs (`git_changes`, `git_history`, `git_commit_graph`, `git_diff`,
    `git_compare`) return empty until real data exists. A directory containing
    `.git` is honestly reported as a repository, but no data is invented for
    it while no read backend is wired.
- `workspace_service.v`:
  - `active_workspace_root()` never falls back to `toolkit_root` — no
    workspace means unavailable (an embedded toolkit has no filesystem
    workspace).
  - `workspace_tree()` / `workspace_stats()` are empty without a configured
    workspace (never cwd-derived); the placeholder `README.md` node and the
    invented "init memory" ledger entry are gone.
  - `git_status_for` returns unknown (`''`) instead of filename-pattern
    "modified" badges.
- GUI (`main.v`, `window.v`): the Git rails panel renders the honest
  availability note — "no active workspace" / "no git repository in the
  active workspace" / "repository detected — git read backend not available
  yet" — instead of empty counts that could read as "no changes".
- Tests: new `git_truth_test.v` gates; `runtime_plane_test.v` and
  `modules/desktop/runtime_test.v` now exercise a real configured workspace
  instead of pinning the fabricated conveniences.

## Design decision

A real synchronous Git read backend was considered and deferred: the
ProcessSupervisor seam is asynchronous (channel-based log capture, unsuited
for synchronous render-path reads), and direct `os.execute` would violate the
Engine's no-shell discipline. The typed availability marker makes the gap
explicit and safe; a real backend (via the supervisor or a `.git` reader) is
a feature follow-up, not a truth fix.

## Verification

- `./make.vsh test` green: 78 module tests.
- Native desktop binary builds.
- Gates verified across three states: no workspace, non-repo workspace, and a
  real `.git` directory without a backend — no fabrication in any.

## Related

- Salvage S7C per `docs/desktop/TRUTH_LEDGER.md`; stacks after #1144 (S7A)
  and #1146 (S7B).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git Changes and History no longer display fabricated commits, diffs, branches, or file changes.
  - The interface now clearly indicates when no workspace, repository, or Git read capability is available.
  - Workspace views no longer fall back to unrelated directories or show placeholder files and memory entries.
  - Git status remains unknown until a real Git backend can provide accurate information.
- **Tests**
  - Added coverage confirming empty states and accurate results for configured real workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->