### PR TITLE
fix(desktop): real loop runtime data and catalog-derived agent metadata (S7D)

### DIFF
--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -241,6 +241,37 @@ Evidence:
 - `./make.vsh test` green (78 module tests).
 - Native desktop binary builds.
 
+### S7D — Loops and agents catalog truth (`fix/s7d-loops-agents-truth`)
+
+Status: in progress. Loop runtime data is real or unknown, and agent catalog
+metadata comes only from the real catalog.
+
+- `loops_service.v`:
+  - The fabricated 10-template fallback catalog (fake spend, fake cron, a
+    hardcoded future `next_run`, `'success'` exits) is removed — an empty
+    catalog stays empty.
+  - `last_exit` defaults to unknown, never `'success'`.
+  - `run_loop` counts real runs per calendar day (`runs_today` + date stamp)
+    so the `max_runs_per_day` budget gate is real; history rows record honest
+    `started` status until completion tracking exists.
+  - `loops_history` never synthesizes rows with fake durations/spend;
+    `loops_audit` counts only real statuses ("started" is not "completed").
+  - `toggle_loop_cron` records scheduling intent without inventing a
+    `next_run` time; `loops_cost` labels tier estimates explicitly as
+    guidance, not measurement.
+- `agents_service.v`:
+  - Hardcoded tier lists, invented trigger strings and default-`architect`
+    ownership routing are removed. Tiers come from the catalog's real
+    `kind:` field (unknown stays unknown); roles are display mappings of the
+    real tier; triggers/owner stay empty without real catalog data.
+- Tests: `loops_agents_truth_test.v` gates (empty catalog without fabricated
+  roster; real run counting and budget enforcement; honest history/audit;
+  no invented cron times; agent metadata from the catalog only).
+
+Evidence:
+- `./make.vsh test` green (79 module tests).
+- Native desktop binary builds.
+
 ### Recommended next steps
 
 1. Replace master tracker with product outcomes and explicit evidence gaps; link durable mission/journey/coverage/QA documents. Retain all valid capability work even when presentation issues are superseded.

--- a/modules/desktop_engine/agents_service.v
+++ b/modules/desktop_engine/agents_service.v
@@ -69,9 +69,8 @@ pub fn (mut e Engine) agents_catalog() []AgentEntry {
 						source_file: 'agents/${t.all_after(':').trim_space()}/AGENT.md'
 						provenance: catalog_path
 					}
-					// infer tier from known lists
+					// tier starts unknown; the catalog's real `kind:` overrides
 					cur.tier = tier_for_agent(cur.id)
-					cur.role = role_for_agent(cur.id)
 					in_delegates = false
 					in_collab = false
 				} else if t.starts_with('name:') && cur.id != '' && cur.description == '' {
@@ -106,12 +105,12 @@ pub fn (mut e Engine) agents_catalog() []AgentEntry {
 				entries << cur
 			}
 			if entries.len > 0 {
-				// Enrich only real catalog entries with derived routing metadata.
+				// Enrich only with real derivations: the display role maps from
+				// the catalog's real `kind:` tier. Triggers and holistic owner
+				// come only from real catalog data — never invented routing
+				// metadata attached to real entries.
 				for i in 0 .. entries.len {
-					entries[i].triggers = triggers_for_agent(entries[i].id)
-					if entries[i].holistic_owner == '' {
-						entries[i].holistic_owner = infer_owner(entries[i].id)
-					}
+					entries[i].role = role_for_tier(entries[i].tier)
 				}
 				return entries
 			}
@@ -120,69 +119,26 @@ pub fn (mut e Engine) agents_catalog() []AgentEntry {
 	return []AgentEntry{}
 }
 
+// tier_for_agent only applies the archived naming convention; the canonical
+// tier comes from the catalog's real `kind:` field. A missing kind stays
+// unknown rather than guessed from hardcoded id lists.
 fn tier_for_agent(id string) string {
-	if id in ['assistant', 'planner', 'implementer', 'client-workflow-bootstrap'] {
-		return 'orchestrator'
-	}
-	if id in ['tdd-guide', 'security-reviewer', 'agentic-security-reviewer', 'build-error-resolver',
-		'client-workflow-bootstrap', 'tool-insights', 'code-reviewer', 'e2e-runner'] {
-		return 'specialist'
-	}
-	// fallback: holistic for known holistic list
-	holistics := ['assistant', 'architect', 'designer', 'platform-engineer', 'qa-engineer',
-		'researcher', 'security-engineer', 'data-engineer', 'reviewer', 'code-reviewer', 'e2e-runner']
-	if id in holistics {
-		return 'holistic'
-	}
 	if id.starts_with('old-') {
 		return 'archived'
 	}
-	return 'holistic'
+	return ''
 }
 
-fn role_for_agent(id string) string {
-	t := tier_for_agent(id)
-	return match t {
+// role_for_tier maps a real catalog tier to its display label. An unknown
+// tier has no label — never a guessed one.
+fn role_for_tier(tier string) string {
+	return match tier {
 		'orchestrator' { 'Orchestrator' }
 		'specialist' { 'Specialist' }
 		'archived' { 'Archived' }
-		else { 'Holistic' }
+		'holistic' { 'Holistic' }
+		else { '' }
 	}
-}
-
-fn triggers_for_agent(id string) string {
-	return match id {
-		'assistant' { 'scan README, docs, AGENTS, dev-companion, workflow-generic-project' }
-		'architect' { 'system design, patterns, blast-radius, C4, architecture-diagram' }
-		'designer' { 'frontend-design, Figma, web-design-guidelines, design-improvement' }
-		'platform-engineer' { 'CI/CD, forge, gh-fix-ci, herdr, cli-for-agents, loops' }
-		'qa-engineer' { 'verification, E2E, Playwright, lint gates' }
-		'researcher' { 'spike, inventory, evidence-intake, framework exploration' }
-		'security-engineer' { 'threat-modeling, mcp-audit, supply-chain, OWASP' }
-		'data-engineer' { 'dbt-validation, snowflake-validation, notebooks' }
-		'reviewer' { 'deep-review, deslop, unslop, blast-radius' }
-		'code-reviewer' { 'code quality, severity-ranked findings' }
-		'e2e-runner' { 'Playwright, POM, flake avoidance' }
-		'planner' { 'planning, estimation, task breakdown' }
-		'implementer' { 'feature, bug, refactor, TDD' }
-		else { 'general delegation via assistant' }
-	}
-}
-
-fn infer_owner(id string) string {
-	if id == 'tdd-guide' {
-		return 'implementer'
-	}
-	if id in ['security-reviewer', 'agentic-security-reviewer'] {
-		return 'security-engineer'
-	}
-	if id == 'build-error-resolver' {
-		return 'platform-engineer'
-	}
-	if id in ['code-reviewer', 'e2e-runner'] {
-		return 'reviewer'
-	}
-	return 'architect'
 }
 
 // agent fuzzy search — super-potent management: query + tier filter.

--- a/modules/desktop_engine/loops_agents_truth_test.v
+++ b/modules/desktop_engine/loops_agents_truth_test.v
@@ -1,0 +1,113 @@
+module desktop_engine
+
+import os
+
+// S7D truth gates: loops never fabricate a catalog, history or spend, and
+// agent catalog metadata comes only from real catalog data.
+
+// A valid toolkit root without loops yields an empty loop catalog — never a
+// fabricated template roster with fake spend, cron or exit status.
+fn test_loops_catalog_never_fabricates() {
+	tmp := os.join_path(os.temp_dir(), 'loops-truth-${os.getpid()}')
+	os.mkdir_all(os.join_path(tmp, 'profiles')) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', tmp, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	cat := eng.loops_catalog()
+	assert cat.len == 0, 'no bundled loops must yield an empty catalog: got ${cat.len}'
+	assert eng.loops_history('anything').len == 0, 'no synthetic history rows'
+
+	// a real loop with no runs has unknown exit, no cron and no next_run
+	entry := LoopEntry{
+		name: 'truth-loop'
+		goal: 'verify loop truth'
+		tier: .l1
+		stage: 'l1'
+		cadence: '1d'
+		schedule: cadence_to_cron('1d')
+		budget: LoopBudget{ max_tokens: 80000, max_runs_per_day: 2, max_wall_seconds: 900 }
+		budget_total: 80000
+	}
+	rev := eng.upsert_loop(entry) or { panic(err.msg()) }
+	assert rev >= 1
+	detail := eng.loop_detail('truth-loop') or { panic('loop missing') }
+	assert detail.last_exit == '', 'no runs means unknown exit, not success'
+	assert detail.cron_enabled == false
+	assert detail.next_run == ''
+	assert detail.budget_spent == 0, 'no runs means zero spend'
+
+	// runs record real history rows with honest status
+	id1 := eng.run_loop('truth-loop') or { panic(err.msg()) }
+	assert id1.len > 0
+	hist := eng.loops_history('truth-loop')
+	assert hist.len == 1, 'one real run row'
+	assert hist[0].status == 'started', 'a recorded start is started, not done'
+
+	// runs_today counts real runs and the budget gate enforces it
+	id2 := eng.run_loop('truth-loop') or { panic(err.msg()) }
+	assert id2.len > 0
+	if _ := eng.run_loop('truth-loop') {
+		assert false, 'third run must hit the max_runs_per_day budget gate'
+	} else {
+		assert err.msg().contains('budget_exhausted')
+	}
+	snap := eng.repo.snapshot()
+	assert snap.data['loops/truth-loop/runs_today'] == '2', 'runs_today counts real runs'
+
+	// cron toggle records intent without inventing a schedule time
+	rev2 := eng.toggle_loop_cron('truth-loop', true) or { panic(err.msg()) }
+	assert rev2 >= 1
+	snap2 := eng.repo.snapshot()
+	assert snap2.data['loops/truth-loop/cron'] == 'true'
+	assert snap2.data['loops/truth-loop/next_run'] == '', 'no scheduler means no invented next_run'
+
+	// audit counts only real statuses — started rows are not successes
+	audit := eng.loops_audit('truth-loop')
+	assert audit.len == 1
+	assert audit[0].runs == 2
+	assert audit[0].completed == 0, 'started runs must not count as completed'
+	assert audit[0].success_rate == '—'
+}
+
+// Agent metadata comes only from the real catalog: roles map from the real
+// kind tier, and no invented trigger strings or ownership routing are
+// attached to real entries.
+fn test_agent_metadata_comes_from_catalog() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
+	tmp := os.join_path(os.temp_dir(), 'agents-truth-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+
+	cat := eng.agents_catalog()
+	assert cat.len >= 18
+	mut by_id := map[string]AgentEntry{}
+	for a in cat {
+		by_id[a.id] = a
+	}
+	// roles are real derivations from the catalog kind field
+	assert by_id['assistant'].role == 'Orchestrator', 'assistant kind is orchestrator in the catalog'
+	assert by_id['architect'].role == 'Holistic'
+	assert by_id['agentic-security-reviewer'].role == 'Specialist'
+	for a in cat {
+		assert a.triggers == '', 'triggers must come from real catalog data, not invented strings: ${a.id}'
+		assert a.holistic_owner == '', 'holistic owner must come from real catalog data: ${a.id}'
+		assert a.tier in ['holistic', 'specialist', 'orchestrator'], 'tier comes from the catalog kind: ${a.id}=${a.tier}'
+	}
+}

--- a/modules/desktop_engine/loops_service.v
+++ b/modules/desktop_engine/loops_service.v
@@ -201,7 +201,7 @@ pub fn (mut e Engine) loops_catalog() []LoopEntry {
 				cron_enabled: (snap.data['loops/${n}/cron'] or { 'false' }) == 'true'
 				next_run: snap.data['loops/${n}/next_run'] or { '' }
 				last_run: snap.data['loops/${n}/last_run'] or { '' }
-				last_exit: snap.data['loops/${n}/last_exit'] or { 'success' }
+				last_exit: snap.data['loops/${n}/last_exit'] or { '' }
 				verifier: fs_verifier
 				allowlist: (snap.data['loops/${n}/allowlist'] or { '' }).split(',').filter(it.trim_space().len > 0)
 				deny: (snap.data['loops/${n}/deny'] or { '' }).split(',').filter(it.trim_space().len > 0)
@@ -219,36 +219,9 @@ pub fn (mut e Engine) loops_catalog() []LoopEntry {
 		})
 		return out
 	}
-	templates := ['goal-observe', 'goal-plan', 'goal-implement', 'goal-review', 'goal-security',
-		'goal-docs', 'goal-release', 'goal-triage', 'goal-onboard', 'goal-harness']
-	mut out := []LoopEntry{}
-	for i, name in templates {
-		tier := match i % 3 {
-			0 { LoopTier.l1 }
-			1 { LoopTier.l2 }
-			else { LoopTier.l3 }
-		}
-		bud := loop_budget_defaults(tier)
-		out << LoopEntry{
-			name: name
-			goal: 'Template goal for ${name}'
-			description: 'Template loop for ${name} — easy to manage via Engine.create_loop()'
-			tier: tier
-			stage: tier.str()
-			cadence: if tier == .l1 {
-				'1d'} else if tier == .l2 { '15m' } else { '1d' }
-			schedule: cadence_to_cron(if tier == .l2 { '15m' } else { '1d' })
-			budget: bud
-			budget_total: bud.max_tokens
-			budget_spent: (i * 7) % bud.max_tokens
-			allowlist: ['skill-${i}']
-			deny: []string{}
-			cron_enabled: i % 2 == 0
-			next_run: if i % 2 == 0 { '2026-09-01T00:00:00Z' } else { '' }
-			last_exit: 'success'
-		}
-	}
-	return out
+	// No state loops and no bundled loops: the catalog is empty — never a
+	// fabricated template roster with fake spend, cron or exit status.
+	return []LoopEntry{}
 }
 
 pub fn (mut e Engine) loop_validate(name string, content string) []BuildDiagnostic {
@@ -477,13 +450,19 @@ pub fn (mut e Engine) run_loop(name string) !string {
 		return error('loop not found: ${name}')
 	}
 	job_id := e.spawn_job('agent-toolkit', ['loop', 'run', name])!
-	// record run history start
+	// record run history start; runs_today counts real runs per calendar day
+	rec_snap := e.repo.snapshot()
 	mut repo := e.repo
 	mut tx := repo.begin('loop-run')
 	run_id := 'run-${time.now().unix_nano() % 1000000:06d}'
 	tx.set('history/${name}/${run_id}', time.now().unix().str())
 	tx.set('loops/${name}/last_run', time.now().unix().str())
-	tx.set('loops/${name}/runs_today', (1).str())
+	today := time.now().ymmdd()
+	prev_day := rec_snap.data['loops/${name}/runs_today_date'] or { '' }
+	prev := (rec_snap.data['loops/${name}/runs_today'] or { '0' }).int()
+	runs_today := if prev_day == today { prev + 1 } else { 1 }
+	tx.set('loops/${name}/runs_today', runs_today.str())
+	tx.set('loops/${name}/runs_today_date', today)
 	rev := e.put_transaction(mut tx) or { return job_id }
 	e.bus.publish(eventbus.ToolkitEvent{
 		kind: .loop_outer_tick
@@ -511,8 +490,10 @@ pub fn (mut e Engine) toggle_loop_cron(name string, enabled bool) !u64 {
 	if enabled {
 		detail := e.loop_detail(name) or { LoopEntry{ cadence: '1d' } }
 		cad := detail.cadence
-		tx.set('loops/${name}/next_run', time.now().add(60 * time.minute).str())
+		// The schedule is derived from the real cadence. No next_run time is
+		// invented: an actual scheduler must compute it when one is installed.
 		tx.set('loops/${name}/schedule', cadence_to_cron(cad))
+		tx.set('loops/${name}/next_run', '')
 	} else {
 		tx.set('loops/${name}/next_run', '')
 	}
@@ -538,26 +519,17 @@ pub fn (mut e Engine) loops_history(loop_name string) []LoopHistory {
 	for k, v in snap.data {
 		if k.starts_with('history/${loop_name}/') {
 			run_id := k.all_after('history/${loop_name}/')
+			// A recorded history row marks a real run start; completion status
+			// comes from recorded state when present, otherwise 'started'.
 			out << LoopHistory{
 				run_id: run_id
 				loop_name: loop_name
 				started_at: v.i64()
-				status: 'done'
+				status: snap.data['history_status/${loop_name}/${run_id}'] or { 'started' }
 			}
 		}
 	}
-	if out.len == 0 {
-		for i in 0 .. 3 {
-			out << LoopHistory{
-				run_id: 'run-${i}'
-				loop_name: loop_name
-				started_at: time.now().unix() - i * 3600
-				duration_ms: 1000 + i * 200
-				budget_spent: 10 + i * 5
-				status: 'done'
-			}
-		}
-	}
+	// no history means no runs — never synthetic rows with fake durations
 	// sort newest first
 	out.sort_with_compare(fn (a &LoopHistory, b &LoopHistory) int {
 		if a.started_at > b.started_at {
@@ -667,17 +639,11 @@ pub fn (mut e Engine) loops_audit(name string) []LoopAudit {
 				completed++
 			} else if h.status == 'failed' {
 				failed++
-			} else {
-				// treat synthetic history as completed
-				completed++
 			}
+			// other statuses (e.g. 'started') count as runs, not as successes
 		}
-		mut total := completed + failed
-		if hist.len > 0 && completed == 0 && failed == 0 {
-			completed = hist.len
-			total = hist.len
-		}
-		rate := if total > 0 { '${completed * 100 / total}%' } else { '—' }
+		total := hist.len
+		rate := if total > 0 && completed + failed > 0 { '${completed * 100 / (completed + failed)}%' } else { '—' }
 		detail := e.loop_detail(n) or { LoopEntry{ name: n, budget: loop_budget_defaults(.l1) } }
 		mut bud := detail.budget
 		if bud.max_tokens == 0 {
@@ -715,10 +681,12 @@ pub fn (mut e Engine) loops_cost(name string) ?LoopCost {
 		.l2 { 'medium' }
 		.l3 { 'high' }
 	}
+	// Tier guidance estimate, explicitly labeled — never presented as a
+	// measured value. Measured spend comes from run history when recorded.
 	est := match detail.tier {
-		.l1 { '~20k tok/run' }
-		.l2 { '~80k tok/run' }
-		.l3 { '~300k tok/run' }
+		.l1 { '~20k tok/run (tier guidance estimate, not measured)' }
+		.l2 { '~80k tok/run (tier guidance estimate, not measured)' }
+		.l3 { '~300k tok/run (tier guidance estimate, not measured)' }
 	}
 	return LoopCost{
 		name: detail.name


### PR DESCRIPTION
## What

S7D loops & agents catalog truth: loop runtime data is real or unknown, and
agent catalog metadata comes only from the real catalog.

## Why

`loops_service.v` fabricated a 10-template fallback catalog with invented
spend (`(i * 7) % budget`), fake cron enablement, a hardcoded future
`next_run` timestamp (`2026-09-01T00:00:00Z`) and `'success'` exits; synthesized
history rows with fake durations; counted "synthetic history as completed" in
audits; always wrote `runs_today = 1` so the budget gate could never enforce;
and invented `next_run = now+60m` on cron toggle without any scheduler.
`agents_service.v` attached invented trigger strings and default-`architect`
ownership routing to real catalog entries, and classified agents by hardcoded
id lists instead of the catalog's real `kind:` field.

## Changes

- `loops_service.v`:
  - Fabricated fallback catalog removed — an empty catalog stays empty.
  - `last_exit` defaults to unknown, never `'success'`.
  - `run_loop` counts real runs per calendar day (`runs_today` + date stamp) so
    `max_runs_per_day` is a real gate; history rows record honest `started`
    status until completion tracking exists.
  - `loops_history` never synthesizes rows; `loops_audit` counts only real
    statuses ("started" is not "completed").
  - `toggle_loop_cron` records scheduling intent (real cadence→cron
    derivation) without inventing a `next_run` time.
  - `loops_cost` estimates are explicitly labeled tier guidance, not
    measurements.
- `agents_service.v`: hardcoded tier lists, invented triggers and
  default-`architect` ownership removed. Tiers come from the catalog's real
  `kind:` field (unknown stays unknown); roles are display mappings of the
  real tier.
- Tests: `loops_agents_truth_test.v` gates — empty catalog without fabricated
  roster, real run counting with budget enforcement, honest history/audit, no
  invented cron times, agent metadata from the catalog only.

## Verification

- `./make.vsh test` green.
- Native desktop binary builds.
- Gates verified against a valid toolkit root without loops (empty catalog),
  real run counting (2 runs then budget-exhausted on the 3rd), and the real
  agent catalog (roles match `kind:`; no invented metadata).

## Related

- Salvage S7D per `docs/desktop/TRUTH_LEDGER.md`; stacks after #1144 (S7A)
  and #1146 (S7B).
