### PR TITLE
fix(desktop): honest updates, memory, swarms, jobs and doctor checks (S7E)

### DIFF
--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -4007,7 +4007,7 @@ fn draw_mcp(mut app GuiApp, w int, h int) {
 	}
 	// footer — receipts verification + provenance + secret guard + install preview (super-potent)
 	verify := app.desktop.engine_verify_receipts().filter(it.path.contains('mcp'))
-	app.gg.draw_text(fx + 20, fy + fh - 28, 'MCP config: mcp/templates/<id>.json via Engine upsert (TX) · secret guard blocks raw ghp_/sk- → \${ENV_VAR} · provenance verified', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
+	app.gg.draw_text(fx + 20, fy + fh - 28, 'MCP config: packaged template via Engine upsert (TX) · secret guard blocks raw ghp_/sk- → \${ENV_VAR} · provenance: packaged template path', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
 	app.gg.draw_text(fx + 20, fy + fh - 14, 'Click a row for masked drawer · toggle on the right · ${verify.len} receipt warnings · Enter toggles first provider', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
 	// provider drawer — modal card, masked template + probe + open-template (#1106)
 	if app.mcp_drawer != '' {
@@ -4295,7 +4295,7 @@ fn draw_doctor(mut app GuiApp, w int, h int) {
 		app.gg.draw_text(fx + fw - 60, y0 + vis * row_h + 2, '+${checks_engine.len - vis} more', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
 	}
 	// footer — receipts/provenance verification + provenance paths
-	app.gg.draw_text(fx + 20, fy + fh - 20, 'Click fix → for dry-run · chip fixes its category · receipts/provenance verified. All checks are English, no fallback.', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
+	app.gg.draw_text(fx + 20, fy + fh - 20, 'Click fix → for dry-run · chip fixes its category · repairs are real where a repair exists; the rest record audit stamps. All checks are English.', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
 	app.gg.draw_text(fx + fw - 160, fy + fh - 20, '${verify_diags.len} verify warnings', gg.TextCfg{
 		color: if verify_diags.len > 0 {
 			app.pnl_danger} else {
@@ -8202,7 +8202,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 						}
 						app.engine_rev = rev
 						app.api_calls = app.desktop.engine_api_calls()
-						app.inspector_msg = 'MCP ${p.id} toggled rev=${rev} • secret guard + provenance verified'
+						app.inspector_msg = 'MCP ${p.id} toggled rev=${rev} • secret guard passed; config from packaged template'
 						return
 					}
 				}
@@ -8241,7 +8241,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 						}
 						app.engine_rev = rev
 						app.api_calls = app.desktop.engine_api_calls()
-						app.inspector_msg = 'MCP ${p.id} toggled rev=${rev} • secret guard + provenance verified • Engine TX'
+						app.inspector_msg = 'MCP ${p.id} toggled rev=${rev} • secret guard passed; config from packaged template • Engine TX'
 						return
 					}
 				}
@@ -8252,7 +8252,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 			}
 			// Doctor panel — f fixes all via Engine TX, Enter opens dry-run preview
-			// (Enter again confirms, Esc cancels), receipts/provenance verified
+			// (Enter again confirms, Esc cancels), real repair + audit stamp
 			if app.selected_panel == 5 {
 				// (Esc-cancel lives in the global Esc block above — it runs first.)
 				if e.char_code == `f` || e.char_code == `F` {
@@ -9555,7 +9555,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 							// show receipt/provenance for selected even without toggle
 							if app.desktop != unsafe { nil } {
 								if r := app.desktop.engine_skill_receipt(sel.id) {
-									app.inspector_msg = 'Receipt: ${r.skill_id} ${r.installed_at} digest=${r.digest} • provenance verified'
+									app.inspector_msg = 'Receipt: ${r.skill_id} ${r.installed_at} digest=${r.digest} • real install receipt evidence'
 								} else {
 									app.inspector_msg = 'Selected ${sel.id} — click install → Engine TX + receipt ~/.config/agent-toolkit/receipts'
 								}
@@ -9636,7 +9636,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 								app.engine_rev = rev
 							}
 							app.api_calls = app.desktop.engine_api_calls()
-							app.inspector_msg = 'MCP ${p.id} toggled rev=${rev} • ${prov_json} • Engine TX provenance verified'
+							app.inspector_msg = 'MCP ${p.id} toggled rev=${rev} • ${prov_json} • Engine TX'
 						}
 					} else {
 						// row body → masked drawer (#1106)
@@ -9683,7 +9683,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 					app.inspector_msg = if rev == 0 {
 						'Doctor: all fixable already pass ✓'
 					} else {
-						'Doctor Fix All rev=${rev} — receipts/provenance verified via Engine TX'
+						'Doctor Fix All rev=${rev} — real repairs + audit stamps via Engine TX'
 					}
 				}
 				return

--- a/docs/desktop/BACKLOG_AUDIT.md
+++ b/docs/desktop/BACKLOG_AUDIT.md
@@ -303,6 +303,44 @@ Evidence:
 - `./make.vsh test` green (79 module tests).
 - Native desktop binary builds.
 
+### S7E — Remaining Engine truth sweep (`fix/s7e-engine-truth`)
+
+Status: in progress. The remaining fabricated surfaces — updates, memory,
+swarms, job outcomes and Doctor claims — are honest.
+
+- `update_service.v` (rewrite): no real release-feed reader exists, so
+  `check_update` makes no offer (never invents a version/URL/digest),
+  `apply`/`rollback` are unavailable (a state-only version change is not an
+  update), `verify` computes a real SHA-256 of the actual content,
+  `manifest_verify` is a real JSON structural parse, history reports only
+  genuinely recorded updates, and the current version comes from the core
+  resolver instead of `1.27.0`.
+- `memory_service.v`: palace entries come only from the active workspace
+  knowledge directory (workspace authority — never `toolkit_root`/cwd); the
+  8 demo palace nodes are removed.
+- `swarm_service.v`: launch records `requested` (no backend is contacted);
+  budgets are unknown until a real runner reports them; logs are empty
+  without real logs.
+- `jobs_service.v`: exit codes are unknown (-1) until a real completion;
+  supervisor spawn failures are recorded as failed jobs instead of being
+  swallowed as success.
+- `engine.v` doctor: `provenance:sha` reports the real computed SHA-256 of
+  the lock file bytes; the fabricated `swarm:apiVersion` health check is
+  removed; the DI capability-plane check warns honestly about placeholder
+  factories; the context-cost check cites the real core constant; the
+  unmeasured `shell_exec=0` claim is gone; the skills audit reports the real
+  resolved count without a magic threshold.
+- `workspace_service.v`: save timestamps are real.
+- GUI: static "provenance verified" chrome claims replaced with factual copy.
+- Tests: `engine_truth_test.v` gates (no invented update offer/state, real
+  digest verification, real manifest parsing, workspace-rooted memory,
+  requested-not-running swarms, unknown exit codes, computed doctor
+  digests).
+
+Evidence:
+- `./make.vsh test` green (80 module tests).
+- Native desktop binary builds.
+
 ### Recommended next steps
 
 1. Replace master tracker with product outcomes and explicit evidence gaps; link durable mission/journey/coverage/QA documents. Retain all valid capability work even when presentation issues are superseded.

--- a/docs/desktop/TRUTH_LEDGER.md
+++ b/docs/desktop/TRUTH_LEDGER.md
@@ -25,6 +25,18 @@ and unverified are valid states.
 | Runtime artifacts | `Engine.runtime_path` (derived from persist_path) | `os` (mutable scratch) |
 | Active workspace | harness root / `recent_workspace` — never `toolkit_root` | `os` with validated paths |
 
+## Status (updated 2026-09-06)
+
+| Slice | Scope | Status |
+|---|---|---|
+| S7A | Evidence & receipt truth | Landed (PR #1144) |
+| S7B | Targets & installation truth | Landed (PR #1146) |
+| S7C | Git truth | PR #1147 |
+| S7D | Loops & agents catalog truth | PR #1148 |
+| S7E | Remaining sweep + gates | In review |
+| S7F | Tracker reconciliation | In progress (#1097 closed, #1106/#1108 closed with evidence, #1101/#1111 rewritten to remaining gaps) |
+| S4 | Shared action/entity registry | Deferred to #1119 — begin only after S7 lands so actions expose trustworthy semantics |
+
 ## Contamination inventory and replacements
 
 Severity: B = blocker, H = high, M = medium. Status: pending slices S7A–S7F.

--- a/modules/desktop_engine/engine.v
+++ b/modules/desktop_engine/engine.v
@@ -5,6 +5,7 @@ import context
 import x.async
 import time
 import x.json2
+import crypto.sha256
 import os
 import agent_toolkit_core
 import desktop_engine.state
@@ -489,15 +490,17 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 		category: 'engine'
 		name: 'persist'
 		status: 'pass'
-		message: 'persist_path=${e.repo.snapshot().revision} revision=${e.repo.revision_nr()}'
+		message: 'state repository active, revision=${e.repo.revision_nr()}'
 		fixable: false
 	}
 	checks << DoctorCheck{
 		id: 'capability_plane'
 		category: 'engine'
 		name: 'capability_plane'
-		status: 'pass'
-		message: 'capability plane DI has skills_catalog=${e.di.has('skills_catalog')} agents_catalog=${e.di.has('agents_catalog')}'
+		// honest: the DI factories are placeholders that resolve to nil —
+		// registering them is bookkeeping, not a wired capability plane
+		status: 'warn'
+		message: 'capability plane DI services are placeholder registrations (skills_catalog=${e.di.has('skills_catalog')} agents_catalog=${e.di.has('agents_catalog')})'
 		fixable: false
 	}
 	checks << DoctorCheck{
@@ -505,7 +508,7 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 		category: 'engine'
 		name: 'api_calls'
 		status: if e.api_calls > 0 { 'pass' } else { 'warn' }
-		message: 'engine_api_call=${e.api_calls} shell_exec=0'
+		message: 'engine_api_call=${e.api_calls}'
 		fixable: false
 	}
 	// ── profiles / targets ──
@@ -566,14 +569,6 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 				'${name} not found — install for swarm backend'}
 			fixable: false
 		}
-	}
-	checks << DoctorCheck{
-		id: 'swarm:apiVersion'
-		category: 'swarm'
-		name: 'apiVersion'
-		status: 'pass'
-		message: 'agent-toolkit.dev/v1alpha1'
-		fixable: false
 	}
 	// ── MCP ──
 	for m in e.mcp_catalog() {
@@ -649,7 +644,7 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 		category: 'context-cost'
 		name: 'clip'
 		status: 'pass'
-		message: '2000 (memory inject budget)'
+		message: '${agent_toolkit_core.context_budget_default} (memory inject budget, core constant)'
 		fixable: false
 	}
 	// ── audit / skills ──
@@ -658,8 +653,8 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 		id: 'audit:skills'
 		category: 'audit'
 		name: 'skills'
-		status: if skill_cnt >= 116 { 'pass' } else { 'warn' }
-		message: '${skill_cnt} skills validated from the resolved catalog'
+		status: if skill_cnt > 0 { 'pass' } else { 'warn' }
+		message: '${skill_cnt} skills resolved from the catalog'
 		fixable: true
 	}
 	// ── provenance ──
@@ -674,14 +669,20 @@ pub fn (mut e Engine) doctor() []DoctorCheck {
 			message: lock_rel
 			fixable: false
 		}
-		// sha
-		checks << DoctorCheck{
-			id: 'provenance:sha'
-			category: 'provenance'
-			name: 'sha'
-			status: 'pass'
-			message: 'sha verified via upstream.lock'
-			fixable: false
+		// real digest of the actual lock file bytes (core parity): the check
+		// computes and reports the SHA-256 — it never claims a verification
+		// against a reference that was not consulted
+		lock_txt := data_file_read(env, lock_rel) or { '' }
+		if lock_txt != '' {
+			full := sha256.hexhash(lock_txt)
+			checks << DoctorCheck{
+				id: 'provenance:sha'
+				category: 'provenance'
+				name: 'sha'
+				status: 'pass'
+				message: 'sha256:${full}'
+				fixable: false
+			}
 		}
 		// expiry via mtime only for filesystem tiers; embedded has no stable mtime
 		if env.tier != 'embedded' {

--- a/modules/desktop_engine/engine_truth_test.v
+++ b/modules/desktop_engine/engine_truth_test.v
@@ -1,0 +1,148 @@
+module desktop_engine
+
+import os
+import crypto.sha256
+
+// S7E truth gates for the remaining Engine surfaces: updates, memory,
+// swarms, jobs and Doctor. Each value is real evidence or explicitly
+// unknown/unavailable — never a plausible fabrication.
+
+fn engine_truth_engine(tmp string) &Engine {
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init() or { panic(err.msg()) }
+	eng.start() or { panic(err.msg()) }
+	return eng
+}
+
+// The update service has no real feed reader: no offer is invented, apply is
+// unavailable (a state-only version change is not an update), and verify
+// performs a real SHA-256 over the actual content.
+fn test_update_service_is_honest_without_a_feed() {
+	tmp := os.join_path(os.temp_dir(), 'update-truth-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := engine_truth_engine(tmp)
+	defer { eng.stop() or {} }
+
+	if _ := eng.check_for_update('1.0.0', 'stable') {
+		assert false, 'no real feed exists — an offer must not be invented'
+	}
+	assert eng.apply_update('9.9.9') == false, 'apply is unavailable until a real updater exists'
+	snap := eng.repo.snapshot()
+	for k, _ in snap.data {
+		assert !k.contains('update:applied') && !k.contains('receipt:update'),
+			'apply must not record fabricated update state: ${k}'
+	}
+	assert eng.update_history().len == 0, 'no recorded updates means empty history'
+
+	// real digest verification: hash of the actual content
+	assert eng.update_verify('real content', sha256_of('real content')) == true
+	assert eng.update_verify('real content', sha256_of('other content')) == false
+	assert eng.update_verify('', 'deadbeef') == false
+
+	// manifest verification is a real JSON structural parse
+	mut svc := new_update_service_engine(eng.repo, eng.bus)
+	assert svc.manifest_verify('{"version":"1.0","sha256":"abc","provenance":"p"}') == true
+	assert svc.manifest_verify('not json') == false
+	assert svc.manifest_verify('{"version":"1.0"}') == false, 'missing fields must fail'
+	assert svc.manifest_verify('the version and sha256 and provenance words in plain text') == false,
+		'substring presence is not validation'
+}
+
+fn sha256_of(s string) string {
+	return sha256.hexhash(s)
+}
+
+// Memory entries come only from the real workspace knowledge directory —
+// no demo palace nodes and no toolkit-root (or cwd) leakage.
+fn test_memory_palace_is_workspace_truth() {
+	tmp := os.join_path(os.temp_dir(), 'memory-truth-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := engine_truth_engine(tmp)
+	defer { eng.stop() or {} }
+
+	// no workspace → empty palace, never 8 demo nodes
+	assert eng.memory_palace_entries().len == 0, 'no workspace means no memory entries'
+
+	// a real workspace with real knowledge yields real entries
+	ws := os.join_path(tmp, 'ws')
+	os.mkdir_all(os.join_path(ws, 'knowledge', 'learnings')) or { panic(err.msg()) }
+	os.write_file(os.join_path(ws, 'knowledge', 'learnings', 'real.md'), '# Real Learning\ncontent\n') or { panic(err.msg()) }
+	eng.switch_workspace(ws) or { panic(err.msg()) }
+	entries := eng.memory_palace_entries()
+	assert entries.len == 1, 'real knowledge yields real entries: got ${entries.len}'
+	assert entries[0].title == 'Real Learning'
+	assert entries[0].kind == 'learning'
+}
+
+// A swarm launch records the request honestly: 'requested' (no backend is
+// contacted), no invented budget, and no synthesized log lines.
+fn test_swarm_launch_is_requested_not_running() {
+	tmp := os.join_path(os.temp_dir(), 'swarm-truth-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := engine_truth_engine(tmp)
+	defer { eng.stop() or {} }
+
+	run_id := eng.swarm_launch(SwarmLaunchArgs{
+		recipe: swarm_recipe_from_string('pair')
+		backend: swarm_backend_from_string('herdr')
+		task: 'verify swarm truth'
+	}) or { panic(err.msg()) }
+	snap := eng.repo.snapshot()
+	assert snap.data['swarm/runs/${run_id}/status'] == 'requested',
+		'no backend is contacted at launch — requested, not running: ${snap.data['swarm/runs/${run_id}/status']}'
+	assert 'swarm/runs/${run_id}/budget_total' !in snap.data, 'budget is unknown until a real runner reports it'
+	assert eng.swarm_logs(run_id).len == 0, 'no logs means no logs'
+}
+
+// A job's exit code is unknown until a real completion records it; Doctor
+// reports computed digests instead of unearned verification claims.
+fn test_jobs_and_doctor_report_real_values() {
+	repo_root := os.dir(os.dir(os.dir(@FILE)))
+	prev_root := os.getenv('AGENT_TOOLKIT_ROOT')
+	os.setenv('AGENT_TOOLKIT_ROOT', repo_root, true)
+	defer { os.setenv('AGENT_TOOLKIT_ROOT', prev_root, true) }
+	tmp := os.join_path(os.temp_dir(), 'jobs-doctor-truth-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := engine_truth_engine(tmp)
+	defer { eng.stop() or {} }
+
+	// exit code unknown (-1 sentinel) until completion
+	id := eng.spawn_job('echo', ['hello']) or { panic(err.msg()) }
+	rec := eng.jobs_catalog().filter(it.id == id)[0]
+	assert rec.exit_code == -1, 'exit code is unknown until completion: ${rec.exit_code}'
+	eng.job_complete(id, 0) or { panic(err.msg()) }
+	rec2 := eng.jobs_catalog().filter(it.id == id)[0]
+	assert rec2.exit_code == 0
+	assert rec2.status == .done
+
+	// doctor: no fabricated swarm apiVersion check; real computed lock digest;
+	// honest placeholder warnings for the DI plane
+	checks := eng.doctor()
+	ids := checks.map(it.id)
+	assert 'swarm:apiVersion' !in ids, 'the fabricated apiVersion health claim is gone'
+	for c in checks {
+		assert !c.message.contains('sha verified via'), 'verification claims must be earned: ${c.id}'
+		assert !c.message.contains('shell_exec=0'), 'unmeasured claims must not be asserted: ${c.id}'
+	}
+	sha_check := checks.filter(it.id == 'provenance:sha')
+	assert sha_check.len == 1
+	digest := sha_check[0].message.all_after('sha256:')
+	assert digest.len == 64, 'lock digest is the real SHA-256 of the actual bytes: ${digest}'
+	for c in digest_runes(digest) {
+		assert c, 'digest must be hex'
+	}
+}
+
+fn digest_runes(s string) []bool {
+	mut out := []bool{}
+	for c in s {
+		out << (c >= `0` && c <= `9`) || (c >= `a` && c <= `f`)
+	}
+	return out
+}

--- a/modules/desktop_engine/jobs_service.v
+++ b/modules/desktop_engine/jobs_service.v
@@ -127,7 +127,9 @@ pub fn (mut e Engine) jobs_catalog() []JobRecord {
 			'canceled' { JobStatus.canceled }
 			else { JobStatus.queued }
 		}
-		exit_str := snap.data['jobs/${id}/exit_code'] or { '0' }
+		// exit code is unknown until job_complete records the real outcome —
+		// -1 is the unknown sentinel, never a fabricated success (0)
+		exit_str := snap.data['jobs/${id}/exit_code'] or { '-1' }
 		exit_code := exit_str.int()
 		start_str := snap.data['jobs/${id}/started_at'] or { '0' }
 		started := start_str.i64()
@@ -234,7 +236,7 @@ pub fn (mut e Engine) spawn_job(cmd string, args []string) !string {
 	tx.set('jobs/${id}/args', args.join(' '))
 	tx.set('jobs/${id}/status', 'queued')
 	tx.set('jobs/${id}/started_at', time.now().unix().str())
-	tx.set('jobs/${id}/exit_code', '0')
+	// exit code stays unset until a real completion records it
 	tx.set('jobs/${id}/retry', '0')
 	rev := e.put_transaction(mut tx)!
 	e.bus.publish(eventbus.ToolkitEvent{
@@ -258,7 +260,29 @@ pub fn (mut e Engine) spawn_job(cmd string, args []string) !string {
 		})
 	})
 	if mut sup := e.supervisor {
-		spawned := sup.spawn_job(cmd, args) or { id }
+		// a supervisor spawn failure is a real failure — record it honestly
+		// instead of returning the queued id as if the job launched
+		mut failed_msg := ''
+		spawned := sup.spawn_job(cmd, args) or {
+			failed_msg = err.msg()
+			''
+		}
+		if failed_msg != '' {
+			mut txf := repo.begin('job-spawn-failed')
+			txf.set('jobs/${id}/status', 'failed')
+			txf.set('jobs/${id}/error', failed_msg)
+			e.put_transaction(mut txf) or {}
+			e.bus.publish(eventbus.ToolkitEvent{
+				kind: .process_log
+				revision: 0
+				path: 'jobs:${id}'
+				payload: json2.encode({
+					'id':  id
+					'msg': 'spawn failed: ${failed_msg}'
+				})
+			})
+			return error('spawn failed: ${failed_msg}')
+		}
 		// update status to running via supervisor spawn
 		mut tx2 := repo.begin('job-running')
 		tx2.set('jobs/${spawned}/status', 'running')

--- a/modules/desktop_engine/memory_service.v
+++ b/modules/desktop_engine/memory_service.v
@@ -25,41 +25,46 @@ pub fn (mut e Engine) memory_palace_entries() []MemoryPalaceEntry {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
-	env := resolve_env()
-	base := os.join_path(env.toolkit_root, 'knowledge')
+	// Knowledge is workspace data: entries come from the active workspace's
+	// knowledge/ directory (real filesystem workspace authority), never from
+	// the bundled toolkit root (an embedded toolkit has no filesystem tree).
+	base := e.active_workspace_root()
 	mut out := []MemoryPalaceEntry{}
-	if os.is_dir(base) {
-		files := os.walk_ext(base, '.md', hidden: false)
-		for f in files {
-			content := os.read_file(f) or { continue }
-			rel := if f.starts_with(env.toolkit_root) {
-				f[env.toolkit_root.len..].trim_string_left('/')
-			} else {
-				f
-			}
-			kind := if rel.contains('learnings') {
-				'learning'
-			} else if rel.contains('processes') {
-				'process'
-			} else if rel.contains('todos') { 'todo' } else { 'general' }
-			lines := content.split_into_lines()
-			mut title := rel
-			for line in lines {
-				if line.trim_space().starts_with('# ') {
-					title = line.trim_space()[2..].trim_space()
-					break
+	if base != '' {
+		knowledge := os.join_path(base, 'knowledge')
+		if os.is_dir(knowledge) {
+			files := os.walk_ext(knowledge, '.md', hidden: false)
+			for f in files {
+				content := os.read_file(f) or { continue }
+				rel := if f.starts_with(base) {
+					f[base.len..].trim_string_left('/')
+				} else {
+					f
 				}
-			}
-			tags := extract_tags(content)
-			vector := embed_text(title + ' ' + content)
-			out << MemoryPalaceEntry{
-				path: rel
-				title: title
-				body: content
-				kind: kind
-				tags: tags
-				vector: vector
-				hash: vector_hash(vector)
+				kind := if rel.contains('learnings') {
+					'learning'
+				} else if rel.contains('processes') {
+					'process'
+				} else if rel.contains('todos') { 'todo' } else { 'general' }
+				lines := content.split_into_lines()
+				mut title := rel
+				for line in lines {
+					if line.trim_space().starts_with('# ') {
+						title = line.trim_space()[2..].trim_space()
+						break
+					}
+				}
+				tags := extract_tags(content)
+				vector := embed_text(title + ' ' + content)
+				out << MemoryPalaceEntry{
+					path: rel
+					title: title
+					body: content
+					kind: kind
+					tags: tags
+					vector: vector
+					hash: vector_hash(vector)
+				}
 			}
 		}
 	}
@@ -78,21 +83,7 @@ pub fn (mut e Engine) memory_palace_entries() []MemoryPalaceEntry {
 			}
 		}
 	}
-	if out.len == 0 {
-		for i in 0 .. 8 {
-			body := 'Palace node ${i} — semantic recall via hashed embedding, brokered fs, git rails, file-tree IDE'
-			vec := embed_text(body)
-			out << MemoryPalaceEntry{
-				path: 'knowledge/learnings/node-${i}.md'
-				title: 'Palace Node ${i}'
-				body: body
-				kind: 'learning'
-				tags: ['palace', 'semantic', 'recall']
-				vector: vec
-				hash: vector_hash(vec)
-			}
-		}
-	}
+	// an empty palace is empty — no demo nodes with invented bodies
 	return out
 }
 

--- a/modules/desktop_engine/swarm_service.v
+++ b/modules/desktop_engine/swarm_service.v
@@ -425,9 +425,12 @@ pub fn (mut e Engine) swarm_launch(args SwarmLaunchArgs) !string {
 	tx.set('swarm/runs/${run_id}/recipe', args.recipe.str())
 	tx.set('swarm/runs/${run_id}/backend', args.backend.str())
 	tx.set('swarm/runs/${run_id}/task', args.task)
-	tx.set('swarm/runs/${run_id}/status', 'running')
+	// The launch records the request; the backend (herdr/tmux) is only
+	// probed by Doctor — no backend is contacted here, so the honest status
+	// is 'requested', never 'running'. Budget is not invented: it is unknown
+	// until a real runner reports it.
+	tx.set('swarm/runs/${run_id}/status', 'requested')
 	tx.set('swarm/runs/${run_id}/created_at', time.now().unix().str())
-	tx.set('swarm/runs/${run_id}/budget_total', '100')
 	tx.set('swarm/runs/${run_id}/budget_spent', '0')
 	rev := e.put_transaction(mut tx)!
 	e.bus.publish(eventbus.ToolkitEvent{
@@ -542,8 +545,8 @@ pub fn (mut e Engine) swarm_logs(run_id string) []string {
 	snap := e.repo.snapshot()
 	raw := snap.data['swarm/${run_id}/logs'] or { snap.data['jobs/${run_id}/logs'] or { '' } }
 	if raw == '' {
-		// synthesize from runs if no logs yet
-		return ['swarm ${run_id} launched', 'awaiting handoff via GOD mailbox']
+		// no logs means no logs — never synthesized activity lines
+		return []string{}
 	}
 	return raw.split('\n')
 }

--- a/modules/desktop_engine/update_service.v
+++ b/modules/desktop_engine/update_service.v
@@ -3,10 +3,12 @@ module desktop_engine
 import desktop_engine.state
 import desktop_engine.eventbus
 import x.json2
+import crypto.sha256
 import os
-import time
+import agent_toolkit_core
 
-// UpdateInfo mirrors desktop/update UpdateInfo for Engine-owned feed logic — super-potent with provenance/receipt.
+// UpdateInfoEngine describes a real, verified update offer. It exists only
+// when a real release feed provided it — never from hardcoded defaults.
 pub struct UpdateInfoEngine {
 pub:
 	latest        string
@@ -18,177 +20,126 @@ pub:
 	manifest_path string
 }
 
-// UpdateServiceEngine is the Engine-owned feed logic (Desktop owns UI).
+// UpdateServiceEngine is the Engine-owned update seam. There is no real
+// release-feed reader yet: check_update reports no offer, apply/rollback are
+// unavailable, and history reports only genuinely recorded updates. A
+// state-only version change is not an update (WORKFLOW_COVERAGE).
 pub struct UpdateServiceEngine {
 mut:
 	repo            &state.StateRepository
 	bus             &eventbus.ToolkitEventBus
-	current_version string = '1.27.0'
-	feed_version    string = '1.27.1'
-	feed_sha256     string = 'abc123sha256'
-	feed_provenance string = 'manifest:sha256:abc123'
+	current_version string
 }
 
-// new_update_service_engine creates service.
+// new_update_service_engine creates the service with the real resolved
+// toolkit version — never a hardcoded one.
 pub fn new_update_service_engine(repo &state.StateRepository, bus &eventbus.ToolkitEventBus) &UpdateServiceEngine {
 	return &UpdateServiceEngine{
 		repo: repo
 		bus: bus
+		current_version: agent_toolkit_core.resolve_toolkit_version()
 	}
 }
 
-// check_update respects channel and opt-in (headless stub reuses manifest.json pattern) — super-potent with artifact receipts.
+// check_update consults the configured channel and pin state. Without a real
+// release-feed reader there is no offer to make: it returns none rather than
+// inventing a feed version, URL or digest. Wiring a real feed is a feature
+// follow-up; the channel/pin configuration semantics are preserved.
 pub fn (mut s UpdateServiceEngine) check_update(current string, channel string) ?UpdateInfoEngine {
 	ch := if channel == '' { 'stable' } else { channel }
-	if current == s.feed_version {
-		return none
-	}
-	if ch == 'stable' && s.feed_version.contains('-next') {
-		return none
-	}
-	if ch == 'pinned' && s.feed_version != current {
-		return none
-	}
-	// feed respects receipts: if current is pinned via receipt, don't offer
+	_ = ch
+	_ = current
+	// pinned installs never receive offers
 	if s.repo.snapshot().data['update:pinned'] == 'true' {
 		return none
 	}
-	return UpdateInfoEngine{
-		latest: s.feed_version
-		url: 'https://github.com/ulises-jeremias/agent-toolkit/releases/download/v${s.feed_version}/agent-toolkit'
-		sha256: s.feed_sha256
-		provenance: s.feed_provenance
-		channel: ch
-		receipt_path: '~/.config/agent-toolkit/receipts/update-${s.feed_version}.json'
-		manifest_path: 'manifest:sha256:abc123'
-	}
+	// No real feed reader is wired: an update offer requires verified feed
+	// data (version + artifact URL + digest + provenance). None is honest.
+	return none
 }
 
-// verify checks SHA256 + provenance vs manifest.json (ADR-022) — super-potent: full provenance chain.
+// verify performs a REAL digest verification: SHA-256 of the actual content
+// bytes must equal the expected digest. The former implementation ignored
+// the content entirely and compared against a hardcoded string.
 pub fn (s UpdateServiceEngine) verify(content string, expected_sha256 string) bool {
-	if expected_sha256 != s.feed_sha256 {
+	if content.len == 0 || expected_sha256.len == 0 {
 		return false
 	}
-	// also verify provenance manifest exists
-	if !s.verify_provenance() {
-		return false
-	}
-	return true
+	sum := sha256.hexhash(content)
+	return sum == expected_sha256
 }
 
-// verify_provenance checks manifest.json provenance (ADR-022) exists and digest matches.
-pub fn (s UpdateServiceEngine) verify_provenance() bool {
-	if s.feed_provenance == '' {
+// verify_provenance reports whether real provenance evidence exists for an
+// update artifact. Without a real manifest there is none — a substring
+// check is not verification.
+pub fn (s UpdateServiceEngine) verify_provenance(manifest_path string) bool {
+	if manifest_path == '' {
 		return false
 	}
-	if !s.feed_provenance.contains('sha256:') {
-		return false
-	}
-	return true
+	return os.is_file(manifest_path)
 }
 
-// apply simulates atomic replace (XDG_CACHE_HOME/agent-toolkit/updates) — now writes receipt + provenance.
+// apply is unavailable until a real updater exists. An update requires
+// downloading and verifying a real artifact and replacing the installed
+// binary; writing a version into state is not an update, so apply performs
+// no mutation and reports false.
 pub fn (mut s UpdateServiceEngine) apply(version string) bool {
-	mut tx := s.repo.begin('update-engine')
-	tx.set('VERSION', version)
-	tx.set('update:applied_version', version)
-	tx.set('update:applied_at', time.now().str())
-	tx.set('update:sha256', s.feed_sha256)
-	tx.set('update:provenance', s.feed_provenance)
-	tx.set('receipt:update:${version}:installed_at', time.now().str())
-	tx.set('receipt:update:${version}:digest', s.feed_sha256)
-	tx.set('provenance:update:${version}:source', 'manifest:sha256:abc123')
-	tx.commit() or { return false }
-	s.current_version = version
-	s.bus.publish(eventbus.ToolkitEvent{
-		kind: .state_changed
-		revision: s.repo.revision_nr()
-		path: 'update:engine:applied'
-		payload: version
-	})
-	return true
+	_ = version
+	return false
 }
 
-// rollback reverts to prior version via receipt (easy management).
+// rollback is unavailable until a real updater with real artifacts exists.
 pub fn (mut s UpdateServiceEngine) rollback(version string) bool {
-	prev := s.repo.snapshot().data['update:applied_version'] or { '' }
-	if prev == '' || prev == version {
-		return false
-	}
-	mut tx := s.repo.begin('update-rollback')
-	tx.set('VERSION', prev)
-	tx.set('update:rollback_to', prev)
-	tx.set('update:rollback_at', time.now().str())
-	tx.commit() or { return false }
-	s.current_version = prev
-	s.bus.publish(eventbus.ToolkitEvent{
-		kind: .state_changed
-		revision: s.repo.revision_nr()
-		path: 'update:engine:rollback'
-		payload: prev
-	})
-	return true
+	_ = version
+	return false
 }
 
-// history returns update receipts (provenance-aware).
+// history returns only genuinely recorded updates. With no recorded update
+// history the result is empty — never a fabricated feed entry.
 pub fn (mut s UpdateServiceEngine) history() []UpdateInfoEngine {
 	snap := s.repo.snapshot()
 	mut out := []UpdateInfoEngine{}
-	for k, v in snap.data {
-		if k.starts_with('receipt:update:') && k.ends_with(':installed_at') {
-			ver := k.all_after('receipt:update:').all_before(':installed_at')
+	for k, _ in snap.data {
+		if k.starts_with('update:applied:') && k.ends_with(':recorded') {
+			ver := k.all_after('update:applied:').all_before(':recorded')
 			out << UpdateInfoEngine{
 				latest: ver
-				url: 'https://github.com/ulises-jeremias/agent-toolkit/releases/download/v${ver}/agent-toolkit'
-				sha256: snap.data['receipt:update:${ver}:digest'] or { s.feed_sha256 }
-				provenance: snap.data['provenance:update:${ver}:source'] or { s.feed_provenance }
-				channel: 'stable'
-				receipt_path: '~/.config/agent-toolkit/receipts/update-${ver}.json'
-				manifest_path: s.feed_provenance
+				channel: snap.data['update:applied:${ver}:channel'] or { 'unknown' }
 			}
-			_ = v
-		}
-	}
-	if out.len == 0 {
-		out << UpdateInfoEngine{
-			latest: s.feed_version
-			url: 'https://github.com/ulises-jeremias/agent-toolkit/releases/download/v${s.feed_version}/agent-toolkit'
-			sha256: s.feed_sha256
-			provenance: s.feed_provenance
-			channel: 'stable'
-			receipt_path: '~/.config/agent-toolkit/receipts/update-${s.feed_version}.json'
-			manifest_path: s.feed_provenance
 		}
 	}
 	return out
 }
 
-// manifest_json returns ADR-022 manifest stub — super-potent with receipts.
+// manifest_json reports the honest availability state of the update
+// service. No manifest is fabricated.
 pub fn (s UpdateServiceEngine) manifest_json() string {
 	return json2.encode({
-		'version':    s.feed_version
-		'sha256':     s.feed_sha256
-		'provenance': s.feed_provenance
-		'receipt':    '~/.config/agent-toolkit/receipts/update-${s.feed_version}.json'
-		'channel':    'stable'
-	})
+		'available': 'false'
+		'note':      'no release-feed reader wired — no update manifest exists'
+		'current':   s.current_version
+	},
+		escape_unicode: true
+	)
 }
 
-// manifest_verify validates manifest provenance (core parity).
+// UpdateManifest is the required shape of an update manifest: a real
+// version, artifact digest and provenance reference.
+struct UpdateManifest {
+	version    string
+	sha256     string
+	provenance string
+}
+
+// manifest_verify structurally validates an offered manifest: it must parse
+// as JSON and carry version, sha256 and provenance fields. Substring
+// presence on arbitrary text is not validation.
 pub fn (s UpdateServiceEngine) manifest_verify(text string) bool {
-	if !text.contains('version') {
-		return false
-	}
-	if !text.contains('sha256') {
-		return false
-	}
-	if !text.contains('provenance') {
-		return false
-	}
-	return true
+	r := json2.decode[UpdateManifest](text) or { return false }
+	return r.version != '' && r.sha256 != '' && r.provenance != ''
 }
 
-// cache_path returns XDG cache path for staged updates.
+// cache_path returns the XDG cache path for staged update artifacts.
 pub fn cache_path(version string) string {
 	base := os.getenv('XDG_CACHE_HOME')
 	home := os.home_dir()
@@ -196,9 +147,9 @@ pub fn cache_path(version string) string {
 	return os.join_path(cache, 'agent-toolkit', 'updates', version, 'agent-toolkit')
 }
 
-// Engine wrappers for super-potent desktop management via Engine API (no shell).
+// Engine wrappers for desktop management via the Engine API (no shell).
 
-// check_for_update via Engine (headless, provenance-aware).
+// check_for_update via Engine. None means no verified offer exists.
 pub fn (mut e Engine) check_for_update(current string, channel string) ?UpdateInfoEngine {
 	e.mu.lock()
 	e.api_calls++
@@ -207,23 +158,17 @@ pub fn (mut e Engine) check_for_update(current string, channel string) ?UpdateIn
 	return svc.check_update(current, channel)
 }
 
-// apply_update via Engine with receipt/provenance (super-potent).
+// apply_update via Engine — unavailable until a real updater exists; a
+// state-only version change is not an update.
 pub fn (mut e Engine) apply_update(version string) bool {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	mut svc := new_update_service_engine(e.repo, e.bus)
-	ok := svc.apply(version)
-	if ok {
-		// also persist via Engine transaction for parity
-		mut tx := e.repo.begin('apply-update-engine')
-		tx.set('update:engine:applied', version)
-		tx.commit() or {}
-	}
-	return ok
+	return svc.apply(version)
 }
 
-// update_history via Engine.
+// update_history via Engine — only genuinely recorded updates.
 pub fn (mut e Engine) update_history() []UpdateInfoEngine {
 	e.mu.lock()
 	e.api_calls++
@@ -232,11 +177,13 @@ pub fn (mut e Engine) update_history() []UpdateInfoEngine {
 	return svc.history()
 }
 
-// update_verify provenance + sha via Engine.
-pub fn (mut e Engine) update_verify(version string, sha256 string) bool {
+// update_verify performs a real SHA-256 verification of the provided
+// artifact content against the expected digest via Engine. Without the real
+// artifact bytes the verification is false — never a hardcoded pass.
+pub fn (mut e Engine) update_verify(content string, expected_sha256 string) bool {
 	e.mu.lock()
 	e.api_calls++
 	e.mu.unlock()
 	mut svc := new_update_service_engine(e.repo, e.bus)
-	return svc.verify(version, sha256)
+	return svc.verify(content, expected_sha256)
 }

--- a/modules/desktop_engine/workspace_service.v
+++ b/modules/desktop_engine/workspace_service.v
@@ -738,7 +738,7 @@ pub fn (mut e Engine) save_editor_tab(tab EditorTab) !u64 {
 	os.write_file(clean, tab.content) or { return error('write failed: ${err}') }
 	mut repo := e.repo
 	mut tx := repo.begin('save-tab')
-	tx.set('workspace/tabs/${tab.path}/saved_at', '0')
+	tx.set('workspace/tabs/${tab.path}/saved_at', time.now().unix().str())
 	tx.set('workspace/tabs/${tab.path}/dirty', 'false')
 	rev := e.put_transaction(mut tx)!
 	return rev.revision


### PR DESCRIPTION
## What

S7E remaining Engine truth sweep: the last fabricated surfaces — updates,
memory, swarms, job outcomes and Doctor claims — are now honest.

## Why

The S7 audit (docs/desktop/TRUTH_LEDGER.md) found: an entirely hardcoded
update feed (`1.27.1` version, `abc123sha256` digest, `verify()` that ignored
content, `apply()` that only wrote state); memory entries read from
`toolkit_root` (cwd for embedded binaries) plus 8 demo "palace" nodes; swarm
launches marked `running` without contacting any backend with an invented
budget of 100 and synthesized log lines; job exit codes defaulting to success
(0) and supervisor spawn failures swallowed; and Doctor checks claiming
"sha verified" without verification, asserting an unmeasured `shell_exec=0`,
passing a fabricated `apiVersion` health check, warning below a magic `116`
skills threshold, and describing nil DI factories as a passing capability
plane.

## Changes

- `update_service.v` (rewrite): without a real release-feed reader,
  `check_update` makes no offer (never invents a version/URL/digest);
  `apply`/`rollback` are unavailable — a state-only version change is not an
  update; `verify` computes a real SHA-256 of the actual content;
  `manifest_verify` is a real JSON structural parse (typed decode, required
  fields); `history` reports only genuinely recorded updates; the current
  version resolves from core instead of `1.27.0`.
- `memory_service.v`: palace entries come only from the active workspace
  knowledge directory (workspace authority); demo nodes removed.
- `swarm_service.v`: launch records `requested` (no backend contacted);
  budget unknown until a real runner reports it; logs empty without real
  logs.
- `jobs_service.v`: exit codes unknown (-1 sentinel) until a real completion;
  supervisor spawn failures recorded as failed jobs (real error returned).
- `engine.v` doctor: `provenance:sha` reports the real computed SHA-256 of
  the lock file bytes; fabricated `swarm:apiVersion` check removed; DI
  capability-plane check warns honestly about placeholder factories;
  context-cost cites the real core constant (`context_budget_default`);
  unmeasured `shell_exec=0` claim removed; skills audit reports the real
  resolved count without a magic threshold.
- `workspace_service.v`: save timestamps are real (`time.now`).
- GUI: static "provenance verified" chrome claims replaced with factual copy
  (packaged-template provenance, real receipt evidence, real repairs +
  audit stamps).
- Tests: `engine_truth_test.v` gates — no invented update offer or state;
  real digest verification (match/mismatch/empty); real manifest parsing
  (rejects plain text and missing fields); workspace-rooted memory; 
  requested-not-running swarms; unknown job exit codes; computed doctor
  digests and removed fabricated claims.

## Verification

- `./make.vsh test` green (80 module tests).
- Native desktop binary builds.

## Notes

- A real release-feed reader and a real updater are feature follow-ups; the
  honest-unavailable seam (`check_update` → none, `apply` → false) is the
  truthful state until then (WORKFLOW_COVERAGE: audit update_service and
  channel policy before enabling apply).
- Stacks after #1147 (S7C) and #1148 (S7D); includes their loop/agent
  commit in-branch only until S7D merges.

## Related

- Salvage S7E per `docs/desktop/TRUTH_LEDGER.md`.
