### PR TITLE
ci: cache the pinned master V build and retry cold rebuilds (setup-v)

### DIFF
--- a/.github/actions/setup-v/action.yml
+++ b/.github/actions/setup-v/action.yml
@@ -43,7 +43,11 @@ runs:
               }
               if vcache_ok; then
                 echo "Using cached pinned V build at ${VDIR}"
-                echo "VBIN=${VDIR}/v" >> "${GITHUB_ENV}"
+                # GITHUB_ENV changes only apply to later steps; keep VBIN a
+                # shell variable so the same-step version check works with
+                # `set -u` (see #1154 CI failure: "VBIN: unbound variable").
+                VBIN="${VDIR}/v"
+                echo "VBIN=${VBIN}" >> "${GITHUB_ENV}"
                 echo "${VDIR}" >> "${GITHUB_PATH}"
                 "${VBIN}" version
                 exit 0

--- a/.github/actions/setup-v/action.yml
+++ b/.github/actions/setup-v/action.yml
@@ -8,6 +8,17 @@ inputs:
 runs:
   using: composite
   steps:
+    # The master source build is expensive and its cold rebuild is
+    # non-deterministic: vlang's makefile re-pulls vc/tcc from moving upstream
+    # HEADs, and the pinned fastc-WIP commit built successfully at ~05:15 UTC
+    # and failed identically at ~05:40 UTC on 2026-09-07. Cache the proven
+    # build per OS/arch; later jobs and runs restore it instead of rebuilding.
+    - name: Restore pinned V build
+      if: ${{ runner.os != 'Windows' }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/vlang-master
+        key: setup-v-master-78e581e70-${{ runner.os }}-${{ runner.arch }}
     - name: Install pinned V from GitHub Release
       shell: bash
       env:
@@ -22,14 +33,36 @@ runs:
               PIN="0.5.2"
               ;;
             *)
+              VDIR="${HOME}/vlang-master"
+              vcache_ok() {
+                [ -x "${VDIR}/v" ] || return 1
+                "${VDIR}/v" version >/dev/null 2>&1 || return 1
+                printf 'fn main() { println("vcache-ok") }\n' > /tmp/vcachecheck.v
+                "${VDIR}/v" -o /tmp/vcachecheck-bin /tmp/vcachecheck.v >/dev/null 2>&1 || return 1
+                [ "$(/tmp/vcachecheck-bin)" = "vcache-ok" ]
+              }
+              if vcache_ok; then
+                echo "Using cached pinned V build at ${VDIR}"
+                echo "VBIN=${VDIR}/v" >> "${GITHUB_ENV}"
+                echo "${VDIR}" >> "${GITHUB_PATH}"
+                "${VBIN}" version
+                exit 0
+              fi
               echo "Installing V from vlang/v — checkout the pinned known-good HEAD 78e581e (master drifts: v3/fastc WIP broke the build on 2026-09-03)"
-              rm -rf "${HOME}/vlang-master"
-              git clone --filter=blob:none --no-checkout https://github.com/vlang/v "${HOME}/vlang-master"
-              git -C "${HOME}/vlang-master" checkout --detach 78e581e
-              make -C "${HOME}/vlang-master" -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
-              VBIN="${HOME}/vlang-master/v"
+              rm -rf "${VDIR}"
+              git clone --filter=blob:none --no-checkout https://github.com/vlang/v "${VDIR}"
+              git -C "${VDIR}" checkout --detach 78e581e
+              # vlang's makefile re-pulls vc/tcc from moving upstream HEADs; one
+              # retry rides out transient breakage. A persistent failure is
+              # surfaced loudly so the pin can be bumped instead of silently
+              # degrading.
+              if ! make -C "${VDIR}" -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"; then
+                echo "pinned V cold build failed — retrying once with a fresh vc/tcc state" >&2
+                make -C "${VDIR}" -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+              fi
+              VBIN="${VDIR}/v"
               echo "VBIN=${VBIN}" >> "${GITHUB_ENV}"
-              echo "${HOME}/vlang-master" >> "${GITHUB_PATH}"
+              echo "${VDIR}" >> "${GITHUB_PATH}"
               "${VBIN}" version
               exit 0
               ;;

--- a/.github/actions/setup-v/action.yml
+++ b/.github/actions/setup-v/action.yml
@@ -18,7 +18,7 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/vlang-master
-        key: setup-v-master-78e581e70-${{ runner.os }}-${{ runner.arch }}
+        key: setup-v-master-c0e47bf25-${{ runner.os }}-${{ runner.arch }}
     - name: Install pinned V from GitHub Release
       shell: bash
       env:
@@ -48,10 +48,10 @@ runs:
                 "${VBIN}" version
                 exit 0
               fi
-              echo "Installing V from vlang/v — checkout the pinned known-good HEAD 78e581e (master drifts: v3/fastc WIP broke the build on 2026-09-03)"
+              echo "Installing V from vlang/v — checkout the pinned known-good HEAD c0e47bf (bumped 2026-09-07: 78e581e predates the v1_fallback bootstrap change and no longer builds against current vc)"
               rm -rf "${VDIR}"
               git clone --filter=blob:none --no-checkout https://github.com/vlang/v "${VDIR}"
-              git -C "${VDIR}" checkout --detach 78e581e
+              git -C "${VDIR}" checkout --detach c0e47bf255954df8b5453274b73d1a89a343f408
               # vlang's makefile re-pulls vc/tcc from moving upstream HEADs; one
               # retry rides out transient breakage. A persistent failure is
               # surfaced loudly so the pin can be bumped instead of silently

--- a/docs/desktop/S4_HANDOFF.md
+++ b/docs/desktop/S4_HANDOFF.md
@@ -1,0 +1,145 @@
+# S4 Implementation Handoff — Shared Action & Entity Registry
+
+You are taking over Agent Toolkit Desktop to implement **S4 (#1119) — the
+shared typed action & entity registry**. This handoff was produced at the end
+of the S7 truth-audit + design-contract reconciliation phase. Verify all
+state before acting; do not trust it blindly.
+
+## 1. Starting point
+
+- Repository: `ulises-jeremias/agent-toolkit`
+  (`/home/ulisesjcf/.ai-workspace/repos/agent-toolkit`).
+- Main at handoff preparation: `741d7b46` (design contract merge), with
+  `fix/setup-v-cache` (#1154) being merged on top — **fetch and use the fresh
+  canonical main**; the first post-merge Validate run populates the new
+  pinned-V build cache.
+- S7 truth audit is complete (S7A–S7E: #1144, #1146, #1147, #1148, #1149;
+  fixture recapture #1150; S7F docs #1152). Every Desktop Engine value comes
+  from authoritative evidence or is explicitly unknown/unavailable
+  (`docs/desktop/TRUTH_LEDGER.md`, enforced by `modules/desktop_engine/*_truth_test.v`).
+- Governing contracts (read before coding):
+  - `AGENTS.md` — execution contract + canonical document map (refactored by
+    #1145; links every doc below).
+  - `docs/desktop/PRODUCT_VISION.md`, `UX_ARCHITECTURE.md` (§Shared action and
+    entity model is the governing architecture for S4), `DESIGN.md` (visual
+    grammar; palette/forms follow §10/§11), `WORKFLOW_COVERAGE.md`
+    ("Dead/split action discovery" blocker), `VISUAL_QA.md` (evidence loop),
+    `TRUTH_LEDGER.md`.
+
+## 2. Current palette architecture (what exists today)
+
+Two authorities coexist:
+
+1. **Static production list** — `palette_items()` in
+   `cmd/agent-toolkit-desktop/main.v` (~line 1611): hardcoded
+   `PaletteItem{id, label, desc, key}` rows — navigation entries plus
+   **CLI-command entries with fixed flags** (e.g. `"Install — full: agent-toolkit
+   install --tools claude-code,cursor --force"`, `"Update"`, `"Uninstall"`,
+   `"mcp_health"`, `"loop_run"`, `"swarm_start"`, `"memory"`). Its own comment
+   (main.v ~7624) calls the numbers hardcoded/historical. A private fuzzy
+   scorer (`palette_best_score`, main.v ~1697) mirrors the module's scorer.
+2. **Typed module (not wired to production)** —
+   `modules/desktop/palette/palette.v`: `PaletteAction` struct,
+   `PaletteViewModel.build_actions()` already enumerates Engine catalogs
+   (nav routes, skills, agents, products, targets…) with fuzzy scoring
+   (`action_best_score`), a virtualized list, and `execute_selected()` via
+   `nav.Router`. Tested by `modules/desktop/palette/palette_test.v`. The
+   production shell (main.v) does not import it — the production palette UI
+   renders the static list instead.
+
+Entity results in the typed module currently open their destination panel;
+they do not deep-link or carry per-entity actions. That is part of what S4
+adds.
+
+## 3. Duplicate authority that must be migrated (incrementally)
+
+Per #1119's migration plan (do NOT big-bang `main.v`):
+
+1. Wire the typed registry as the production palette's data source (keep the
+   current interaction/UX; swap the data source).
+2. Migrate navigation + entity entries first (Engine catalogs already feed
+   `build_actions()`).
+3. Replace each hardcoded CLI-command entry with its typed Engine action:
+   install → `engine.install_with_options` (S7B: real files + real receipts),
+   target enable → `engine.set_target_enabled`, MCP enable →
+   `engine.upsert_mcp_provider`/`mcp_toggle` (packaged template),
+   doctor repair → `engine.doctor_fix` (+ `doctor_fix_preview` dry-run),
+   loop run → `engine.run_loop`, swarm launch → `engine.swarm_launch`
+   (records `requested`), update → stays honest-unavailable (no real feed
+   reader), memory → memory operations, uninstall/diff → core seams as
+   available; anything without a typed seam stays out of the registry until
+   one exists (never shell out to the CLI).
+4. Delete `palette_items()` + `palette_best_score` once nothing consumes them.
+5. Extend `modules/desktop/palette/palette.v` rather than creating a third
+   implementation.
+
+## 4. Likely S4 slices (suggested PR decomposition)
+
+- **S4A — Registry core**: single typed registry source (Engine catalogs +
+  config + runtime + evidence), availability with reason, entity identity
+  (type + canonical id + workspace context + display metadata), wired into the
+  production palette as its data source. Navigation + catalog entities migrate
+  first; static list demoted.
+- **S4B — Contextual actions + typed arguments**: per-entity actions with
+  typed arguments (selection/scope/target/tool), validation, dry-run preview
+  where the Engine supports it (`install_with_options{dry_run}`,
+  `doctor_fix_preview`, MCP upsert diff), execution result + recovery info.
+- **S4C — CLI-command migration + retirement**: migrate the remaining static
+  entries to typed actions; delete `palette_items()`/`palette_best_score`;
+  coverage script evolves to task coverage.
+- **S4D — Undo/recent actions (only where truthful)**: config toggles record
+  prior value for real undo; destructive/irreversible actions require explicit
+  confirmation with preview; recent actions recorded from real executions.
+
+Keep every slice independently shippable with its own green Required CI.
+
+## 5. Relevant tests and gates
+
+- `modules/desktop/palette/palette_test.v` — extend for registry semantics
+  (availability-with-reason, entity identity, argument validation).
+- New registry test file (e.g. `modules/desktop_engine/registry_truth_test.v`
+  or a desktop-module test): fresh engine → catalog entries + navigation only,
+  no fabricated rows; executed actions produce real state (receipt/config/
+  runtime) per the S7 gates.
+- Existing truth gates that must stay green:
+  `evidence_truth_test.v`, `targets_truth_test.v`, `git_truth_test.v`,
+  `loops_agents_truth_test.v`, `engine_truth_test.v` — these lock the
+  semantics your actions will invoke (install writes real receipts; enabling
+  MCP uses packaged templates; doctor fixes are real repairs; updates are
+  honest-unavailable).
+- `scripts/gui-coverage.py` — evolve from CLI-row parity to task/workflow
+  coverage of the registry's critical workflows.
+- Full gates: `./make.vsh test`, production desktop build
+  (`VJOBS=2 VMODULES="$PWD/modules" v -d gg_text_buff_size=4096 -o
+  build/agent-toolkit-desktop-native cmd/agent-toolkit-desktop`), clean-machine
+  headless boot, Golden UI (fixtures current as of #1150; recapture only for
+  intentional visual change with the drift map documented).
+
+## 6. Known risks
+
+- **`main.v` is ~10.5k lines** — the palette draw/hit-test code near
+  `palette_items()` is entangled with panel rendering; extract carefully,
+  one migration at a time, keeping geometry shared between draw and hit-test.
+- **Truth regressions are release blockers** — any registry result that is
+  fabricated-but-plausible violates the S7 contract and the S7 gates will
+  (and must) fail. When in doubt, render unavailable with a reason.
+- **The static list contains entries with no truthful backing** (e.g.
+  "Update — agent-toolkit update"): migrate them to honest-unavailable or
+  omit them; do not carry them into the registry as fake actions.
+- **CI infrastructure note**: pinned V (master @ 78e581e) cold rebuilds are
+  non-deterministic upstream (vc/tcc moving HEADs); #1154 added a build cache
+  + retry to `.github/actions/setup-v`. If a cold rebuild fails persistently,
+  bump the pinned commit AND the cache key together (both literals live in
+  the action).
+- **Golden fixtures** reflect the current UI; intentional visual changes to
+  the palette must include a drift map and recapture (policy in
+  `VISUAL_QA.md`), never a silent fixture update.
+
+## 7. Immediate first steps
+
+1. Fetch fresh main; confirm the pinned-V cache behavior is stable
+   (#1154 merged; Validate green on the two most recent main runs).
+2. Read `UX_ARCHITECTURE.md` §Shared action and entity model, `DESIGN.md`
+   §10–11, and #1119's rewritten body.
+3. Start S4A from a fresh branch off canonical main; keep PRs focused;
+   Required CI green before any merge; no direct pushes to main.


### PR DESCRIPTION
## What

`.github/actions/setup-v` gains:

1. an `actions/cache` step for the built `~/vlang-master` tree, keyed on the pinned V commit + OS + arch, reused after a real compile smoke check (`v version` + compile-and-run a tiny program);
2. a single retry for cold rebuilds before surfacing the failure;
3. **the pinned V commit bumped 78e581e → c0e47bf** (current master) with the cache key bumped to match;
4. `docs/desktop/S4_HANDOFF.md` — the S4 implementation handoff artifact (docs-only addition riding along for the next phase).

## Why

Main's Validate run 34085787984 failed only in the two Swarm e2e jobs, at
"Setup pinned V": the pinned commit 78e581e built successfully in the
V-modules jobs at ~05:11–05:17 UTC and failed identically at ~05:36+ UTC.

Root cause (verified via upstream APIs and local reproduction): vlang's
makefile re-pulls `vc` from the **moving** `vlang/vc` HEAD. vc moved to
9f82f2e at 2026-09-07T05:31Z — between the passing and failing builds —
and that sync transpiles v-master `5ac05955`, whose bootstrap compiler
requires the new `v1_fallback` machinery that the 78e581e tree (Aug 31)
does not contain. The result is a bootstrap compiler that silently no-ops
(reproduced locally with byte-identical inputs), so the old pin is
unbuildable against current vc regardless of runner state.

## Fix

- Bump the pin to `c0e47bf` (current master): verified locally to bootstrap
  from source with current vc **and** to compile the agent-toolkit
  `desktop_engine` truth-gate tests.
- Cache the proven build per OS/arch (smoke-checked before reuse) so later
  jobs — including the late-running Swarm e2e jobs — restore it instead of
  gambling on cold rebuilds; this also saves ~3.5 minutes per job.
- One retry on cold rebuilds before failing loudly.

## Known follow-up

- The fastc-WIP era means master pins can decay again; if a cold rebuild
  fails persistently, bump the pinned commit AND the cache key together
  (both literals live in `.github/actions/setup-v/action.yml`).

## Validation

- YAML parsed; reuse path guarded by a compile-and-run smoke check so a
  broken cached tree cannot propagate silently.
- Local: V c0e47bf bootstraps; `evidence_truth_test.v` +
  `targets_truth_test.v` (full desktop_engine + core compile surface) pass.
- This PR's CI exercises the cold build on fresh runners; the next main run
  exercises cache reuse end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Setup runs can now reuse a verified cached build on supported platforms, reducing repeated build time.
  - Cached builds are validated before reuse to help prevent failures from stale or incomplete binaries.
  - If a build fails, the setup process automatically retries once before reporting failure.
  - Updated builds use a newer pinned version, improving consistency and reliability across setup runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->