### PR TITLE
feat(desktop): S4A — shared typed action & entity registry core (#1119)

### DIFF
--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -1,6 +1,8 @@
 module main
 
 import desktop
+import desktop.nav
+import desktop.palette
 import desktop_engine
 import gg
 import ghostty
@@ -25,129 +27,89 @@ import pty as pty_mod
 // Signature: perforated tractor-feed edge dots + brass binder rivet (2px) + manila folder tab
 const col_ink = ui_text(ui_theme()) // theme: text.primary
 
-
 const col_ink700 = ui_text(ui_theme()) // theme: text.primary
-
 
 const col_ink500 = ui_muted(ui_theme()) // theme: text.secondary
 
-
 const col_ink300 = ui_line_paper(ui_theme()) // theme: quiet paper rule
-
 
 const col_charcoal = ui_cabinet(ui_theme()) // theme: surface.cabinet
 
-
 const col_charcoal2 = ui_text(ui_theme()) // theme: text.primary
-
 
 const col_paper = ui_paper(ui_theme()) // theme: surface.paper
 
-
 const col_paper_dim = ui_canvas(ui_theme()) // theme: surface.canvas
-
 
 const col_brass = ui_selection(ui_theme()) // theme: signal.selection
 
-
 const col_brass_dim = ui_selection(ui_theme()) // theme: signal.selection
-
 
 const col_oxide = ui_danger(ui_theme()) // theme: signal.danger
 
-
 const col_slate = ui_muted(ui_theme()) // theme: text.secondary
-
 
 const col_slate_dim = ui_muted(ui_theme()) // theme: text.secondary
 
-
 const col_line = ui_line_cabinet(ui_theme()) // theme: quiet cabinet rule
 
-
 const col_line_light = ui_line_paper(ui_theme()) // theme: quiet paper rule
-
 
 // paper tokens — warm office stock
 const col_cream50 = ui_paper(ui_theme()) // theme: surface.paper
 
-
 const col_cream100 = ui_paper(ui_theme()) // theme: surface.paper
-
 
 const col_cream200 = ui_canvas(ui_theme()) // theme: surface.canvas
 
-
 const col_paper100 = ui_paper(ui_theme()) // theme: surface.paper
-
 
 const col_coral = ui_danger(ui_theme()) // theme: signal.danger
 
-
 const col_mint = ui_success(ui_theme()) // theme: signal.success
-
 
 const col_sky = ui_muted(ui_theme()) // theme: text.secondary
 
-
 const col_lemon = ui_selection(ui_theme()) // theme: signal.selection
-
 
 const col_lilac = ui_muted(ui_theme()) // theme: text.secondary
 
-
 const col_peach = ui_selection(ui_theme()) // theme: signal.selection
-
 
 const col_status_idle = ui_muted(ui_theme()) // theme: text.secondary
 
-
 const col_status_thinking = ui_muted(ui_theme()) // theme: text.secondary
-
 
 const col_status_working = ui_selection(ui_theme()) // theme: signal.selection
 
-
 const col_status_waiting = ui_muted(ui_theme()) // theme: text.secondary
-
 
 const col_status_blocked = ui_danger(ui_theme()) // theme: signal.danger
 
-
 const col_status_success = ui_success(ui_theme()) // theme: signal.success
-
 
 const col_wood_light = ui_canvas(ui_theme()) // theme: surface.canvas
 
-
 const col_wood_dark = ui_line_paper(ui_theme()) // theme: quiet paper rule
 
-
 const col_path = ui_canvas(ui_theme()) // theme: surface.canvas
-
 
 // ── cozy paper-ledger tokens (design pass 1.29) — warm secondary ink for paper,
 // hover tints and folder-tab manila. Contrast: ink_soft on cream ≥ 4.5:1. ──
 const col_ink_soft = ui_muted(ui_theme()) // theme: text.secondary
 
-
 const col_paper_hover = ui_hover_tint(ui_theme()) // theme: selection hover wash
-
 
 const col_manila_tab = ui_canvas(ui_theme()) // theme: surface.canvas
 
-
 const col_sage_soft = ui_success(ui_theme()) // theme: signal.success
 
-
 const col_steel_ink = ui_muted(ui_theme()) // theme: text.secondary
-
 
 // text on constant-dark surfaces (cabinet, terminal wells) — identical cream
 // in both themes because the surface never themes; use instead of app.pnl_*
 // wherever the background is a dark const, or Ink goes blind.
 const col_text_on_cabinet = ui_on_cabinet(ui_theme()) // theme: text.on_cabinet
-
 
 // ── brand typography — Fraunces display + IBM Plex Sans body + IBM Plex Mono data.
 // OFL-licensed TTFs ship in assets/fonts/; resolved relative to the binary so the
@@ -941,8 +903,11 @@ mut:
 	palette_open     bool
 	palette_query    string
 	palette_selected int
-	mouse_x          int
-	mouse_y          int
+	// S4A (#1119): shared typed action & entity registry — the palette's data
+	// source. Static rows remain only for entries not yet migrated.
+	palette_reg &palette.Registry = unsafe { nil }
+	mouse_x     int
+	mouse_y     int
 	// dedupe: C backends set char_code on key_down AND send .char — keep one per frame
 	last_keydown_char    u32
 	last_keydown_frame   int
@@ -1609,20 +1574,10 @@ fn panel_desc(i int) string {
 }
 
 fn palette_items() []PaletteItem {
+	// S4A (#1119): navigation rows migrated to the shared typed registry
+	// (modules/desktop/palette/registry.v). Only entries not yet migrated to
+	// typed registry actions remain here; each is retired in S4B/S4C.
 	return [
-		PaletteItem{'world', 'Go to World', 'Office floor, desks and handoffs', '1'},
-		PaletteItem{'skills', 'Go to Skills', 'Search and install skills', '2'},
-		PaletteItem{'agents', 'Go to Agents', 'Browse holistic and specialist', '3'},
-		PaletteItem{'mcp', 'Go to MCP', 'Providers and health', '4'},
-		PaletteItem{'targets', 'Go to Targets', 'Enable platforms', '5'},
-		PaletteItem{'doctor', 'Go to Doctor', 'Fix checks', '6'},
-		PaletteItem{'jobs', 'Go to Jobs', 'Live processes', '7'},
-		PaletteItem{'loops', 'Go to Loops', 'Missions and schedules — inner/outer', '8'},
-		PaletteItem{'swarm', 'Go to Swarm', 'GOD mailbox, Herdr/tmux, pair/team/full, approvals spend/scope/destructive', '9'},
-		PaletteItem{'workspace', 'Go to Workspace', 'Context and memory', '0'},
-		PaletteItem{'products', 'Go to Products', 'Manage products/packs membership & digest', 'p'},
-		PaletteItem{'onboarding', 'Go to Onboarding', 'Super-potent wizard: workspace, personas, capability, target, product', 'o'},
-		PaletteItem{'insights', 'Go to Insights', 'Telemetry — cost ledger, tool waterfall, OTel spans, budgets spark, CI watcher', 'i'},
 		PaletteItem{'command_palette', 'Command palette', 'Fuzzy search ( / ) — todo administrable', '/'},
 		PaletteItem{'serve', 'Start API server', 'agent-toolkit serve --port 3847', 's'},
 		PaletteItem{'doctor_fix', 'Run doctor --fix', 'Repair missing profiles', 'd'},
@@ -1649,100 +1604,132 @@ fn palette_items() []PaletteItem {
 	]
 }
 
-// fuzzy_score computes match score for query against candidate string.
-// Returns -1 if no match, higher is better. Case-insensitive, substring and
-// subsequence aware, with bonuses for consecutive and word-boundary hits.
-// Pure function, no I/O, deterministic. Mirrors desktop/palette fuzzy.
-fn fuzzy_score(query string, target string) int {
-	if query == '' {
-		return 1000
+// fuzzy_score and palette_best_score were removed in S4A (#1119): the palette
+// module's scorer (desktop.palette.fuzzy_score / action_best_score) is the
+// single scoring authority shared by registry actions and legacy rows.
+
+// PaletteRow is the merged palette row model: registry-sourced actions (S4A)
+// plus legacy static rows for entries not yet migrated to the registry.
+struct PaletteRow {
+	id    string
+	label string
+	desc  string
+	keys  string
+	score int
+	// registry entity fields (zero values for legacy rows)
+	is_entity          bool
+	kind               palette.EntityKind
+	entity_id          string
+	panel              nav.PanelId
+	available          bool
+	unavailable_reason string
+}
+
+// panel_index_for maps a registry panel destination to the production panel
+// index used by GuiApp.selected_panel (0 world … 12 insights).
+fn panel_index_for(p nav.PanelId) int {
+	return match p {
+		.world_view { 0 }
+		.skills { 1 }
+		.agents { 2 }
+		.mcp { 3 }
+		.targets { 4 }
+		.doctor { 5 }
+		.jobs { 6 }
+		.loops { 7 }
+		.swarm { 8 }
+		.workspace { 9 }
+		.products { 10 }
+		.onboarding { 11 }
+		.insights { 12 }
+		else { -1 }
 	}
-	q := query.to_lower()
-	t := target.to_lower()
-	if t == q {
-		return 10000
+}
+
+// nav_tr_key returns the i18n key suffix ('palette.<key>') for a registry
+// navigation row so localized labels keep working after the migration.
+fn nav_tr_key(p nav.PanelId) string {
+	return match p {
+		.world_view { 'world' }
+		.skills { 'skills' }
+		.agents { 'agents' }
+		.mcp { 'mcp' }
+		.targets { 'targets' }
+		.doctor { 'doctor' }
+		.jobs { 'jobs' }
+		.loops { 'loops' }
+		.swarm { 'swarm' }
+		.workspace { 'workspace' }
+		.products { 'products' }
+		.onboarding { 'onboarding' }
+		.insights { 'insights' }
+		else { '' }
 	}
-	if t.contains(q) {
-		return 9000 - t.len
-	}
-	mut qi := 0
-	mut score := 0
-	mut consecutive := 0
-	mut last_match := -1
-	for ti, ch in t {
-		if qi < q.len && ch == q[qi] {
-			score += 10
-			if last_match == ti - 1 {
-				score += 5
-				consecutive++
-			}
-			if ti == 0 || t[ti - 1] == `/` || t[ti - 1] == ` ` || t[ti - 1] == `-` || t[ti - 1] == `_` || t[ti - 1] == `:` {
-				score += 8
-			}
-			last_match = ti
-			qi++
-			if qi == q.len {
-				break
+}
+
+// filtered_palette merges the shared typed registry (navigation + entities,
+// S4A) with the legacy static rows for not-yet-migrated entries. All rows are
+// scored by the palette module's fuzzy scorer — one scoring authority.
+// Empty query keeps the stable build order: navigation, entities, legacy.
+fn filtered_palette(mut app GuiApp) []PaletteRow {
+	q := app.palette_query.trim_space()
+	mut scored := []PaletteRow{}
+	// registry-derived navigation + catalog/config/runtime entities
+	if app.palette_reg != unsafe { nil } {
+		for sa in app.palette_reg.scored_filter(app.palette_query) {
+			a := sa.action
+			scored << PaletteRow{
+				id: a.id
+				label: a.label
+				desc: a.desc
+				keys: a.keys
+				score: sa.score
+				is_entity: true
+				kind: a.kind
+				entity_id: a.entity_id
+				panel: a.panel
+				available: a.available
+				unavailable_reason: a.unavailable_reason
 			}
 		}
 	}
-	if qi != q.len {
-		return -1
-	}
-	score -= t.len / 10
-	score += consecutive * 3
-	return score
-}
-
-fn palette_best_score(query string, item PaletteItem) int {
-	if query == '' {
-		return 1000
-	}
-	mut best := -1
-	for field in [item.label, item.id, item.desc, item.keys] {
-		s := fuzzy_score(query, field)
-		if s > best {
-			best = s
+	// legacy static rows (entries not yet migrated to the registry)
+	for it in palette_items() {
+		mut best := -1
+		if q == '' {
+			best = 1000
+		} else {
+			for field in [it.label, it.id, it.desc, it.keys] {
+				s := palette.fuzzy_score(q, field)
+				if s > best {
+					best = s
+				}
+			}
+		}
+		if best >= 0 {
+			scored << PaletteRow{
+				id: it.id
+				label: it.label
+				desc: it.desc
+				keys: it.keys
+				score: best
+			}
 		}
 	}
-	return best
-}
-
-fn filtered_palette(query string) []PaletteItem {
-	items := palette_items()
-	q := query.trim_space()
 	if q == '' {
-		return items.clone()
-	}
-	struct Scored {
-		item  PaletteItem
-		score int
-	}
-	mut scored := []Scored{}
-	for it in items {
-		s := palette_best_score(q, it)
-		if s >= 0 {
-			scored << Scored{
-				item: it
-				score: s
-			}
-		}
+		return scored
 	}
 	// manual sort to avoid V3 generic monomorphize segfault (see swarm_service fix)
 	for i := 1; i < scored.len; i++ {
 		mut j := i
-		for j > 0 && (scored[j].score > scored[j - 1].score || (scored[j].score == scored[j - 1].score && scored[j].item.label < scored[j - 1].item.label)) {
+		for j > 0 && (scored[j].score > scored[j - 1].score || (scored[j].score == scored[j - 1].score && scored[j].label < scored[j - 1].label)) {
 			tmp := scored[j]
 			scored[j] = scored[j - 1]
 			scored[j - 1] = tmp
 			j--
 		}
 	}
-	mut out := []PaletteItem{}
-	for e in scored {
-		out << e.item
-	}
-	return out
+	return scored
 }
 
 fn desks_for_app(app &GuiApp) []Desk {
@@ -1769,9 +1756,12 @@ fn desks_for_app(app &GuiApp) []Desk {
 				label: labels[r][c]
 				role: roles[r][c]
 				tier: if roles[r][c] == 'holistic' {
-					'holistic'} else if roles[r][c] == 'specialist' {
-					'specialist'} else {
-					'runtime'}
+					'holistic'
+				} else if roles[r][c] == 'specialist' {
+					'specialist'
+				} else {
+					'runtime'
+				}
 				x: 220 + c * 166
 				y: 92 + r * 130
 				// A catalog desk is not a running process. Runtime status is
@@ -1811,15 +1801,11 @@ fn desk_rect(d Desk, idx int, fx int, fy int, fw int, fh int) (int, int, int, in
 // ── Terminal / Activity helpers — workshop palette, English only, gg monospace ──
 const term_bg = ui_cabinet(ui_theme()) // theme: console = surface.cabinet
 
-
 const term_header_bg = ui_cabinet(ui_theme()) // theme: console = surface.cabinet
-
 
 const term_border = ui_line_cabinet(ui_theme()) // theme: quiet cabinet rule
 
-
 const term_cursor = ui_selection(ui_theme()) // theme: signal.selection
-
 
 fn term_level_color(level string) gg.Color {
 	return match level {
@@ -2069,6 +2055,9 @@ fn main() {
 		selected_desk: -1
 		hover_desk: -1
 	}
+	// S4A (#1119): bind the shared typed registry to the boot Engine so the
+	// palette derives navigation + entities from authoritative state.
+	app.palette_reg = d.palette_registry()
 	app.gg = gg.new_context(
 		bg_color: col_ink
 		width: cfg.width
@@ -2895,8 +2884,16 @@ fn draw_office_view_switch(mut app GuiApp, w int) {
 	for i, label_key in ['office.view.overview', 'office.view.floor'] {
 		is_active := (i == 0 && !app.office_map_view) || (i == 1 && app.office_map_view)
 		tx := x + i * (tab_w + gap)
-		app.gg.draw_rect_filled(tx, y, tab_w, tab_h, if is_active { app.pnl_select } else { app.pnl_card })
-		app.gg.draw_rect_empty(tx, y, tab_w, tab_h, if is_active { app.pnl_border_hi } else { app.pnl_border })
+		app.gg.draw_rect_filled(tx, y, tab_w, tab_h, if is_active {
+			app.pnl_select
+		} else {
+			app.pnl_card
+		})
+		app.gg.draw_rect_empty(tx, y, tab_w, tab_h, if is_active {
+			app.pnl_border_hi
+		} else {
+			app.pnl_border
+		})
 		app.gg.draw_text(tx + 8, y + 5, tr(app, label_key), gg.TextCfg{
 			color: if is_active { app.pnl_bg } else { app.pnl_text }
 			size: 10
@@ -3188,8 +3185,10 @@ fn draw_world(mut app GuiApp, w int, h int) {
 						app.gg.draw_rect_empty(dx + 2, strip_y, 136, 10, tint(app.pnl_text, 120))
 						app.gg.draw_text(dx + 4, strip_y + 1, clean2, gg.TextCfg{
 							color: if is_selected {
-								app.pnl_select} else {
-								app.pnl_text_mut}
+								app.pnl_select
+							} else {
+								app.pnl_text_mut
+							}
 							size: 10
 							mono: true
 						})
@@ -3349,8 +3348,10 @@ fn draw_world(mut app GuiApp, w int, h int) {
 			}
 			app.gg.draw_text(ax - 2, ay - 2, glyph, gg.TextCfg{
 				color: if av.carrying == 'paper' {
-					app.pnl_text} else {
-					app.pnl_bg}
+					app.pnl_text
+				} else {
+					app.pnl_bg
+				}
 				size: 10
 				bold: true
 			})
@@ -3999,8 +4000,10 @@ fn draw_mcp(mut app GuiApp, w int, h int) {
 		// provenance + receipt path + toggle action — one-click Engine TX
 		app.gg.draw_text(fx + fw - 90, y + 8, if p.enabled { 'toggle off' } else { 'toggle on' }, gg.TextCfg{
 			color: if p.enabled {
-				app.pnl_text_mut} else {
-				app.pnl_border_hi}
+				app.pnl_text_mut
+			} else {
+				app.pnl_border_hi
+			}
 			size: 12
 			bold: !p.enabled
 		})
@@ -4228,8 +4231,10 @@ fn draw_doctor(mut app GuiApp, w int, h int) {
 		app.gg.draw_rect_empty(cx, cy, tw, 16, bd)
 		app.gg.draw_text(cx + 5, cy + 3, label, gg.TextCfg{
 			color: if active {
-				app.pnl_text} else {
-				app.pnl_text_mut}
+				app.pnl_text
+			} else {
+				app.pnl_text_mut
+			}
 			size: 11
 		})
 		app.doctor_chips << DoctorChip{cat, cx, cy, tw, 16}
@@ -4298,8 +4303,10 @@ fn draw_doctor(mut app GuiApp, w int, h int) {
 	app.gg.draw_text(fx + 20, fy + fh - 20, 'Click fix → for dry-run · chip fixes its category · repairs are real where a repair exists; the rest record audit stamps. All checks are English.', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
 	app.gg.draw_text(fx + fw - 160, fy + fh - 20, '${verify_diags.len} verify warnings', gg.TextCfg{
 		color: if verify_diags.len > 0 {
-			app.pnl_danger} else {
-			app.pnl_success}
+			app.pnl_danger
+		} else {
+			app.pnl_success
+		}
 		size: 11
 	})
 	// dry-run preview card — modal overlay, Confirm applies via Engine TX (#1108)
@@ -5216,8 +5223,10 @@ fn draw_swarm(mut app GuiApp, w int, h int) {
 		}
 		app.gg.draw_text(mx + 10, y + 2, txt, gg.TextCfg{
 			color: if hover_h {
-				app.pnl_text} else {
-				app.pnl_text}
+				app.pnl_text
+			} else {
+				app.pnl_text
+			}
 			size: 11
 			mono: true
 		})
@@ -5530,8 +5539,10 @@ fn draw_editor_panel(mut app GuiApp, x int, y int, w int, h int) {
 		if active { app.gg.draw_rect_filled(tx, y + 6, tw, 2, app.pnl_select) }
 		app.gg.draw_text(tx + 8, y + 10, tab.title, gg.TextCfg{
 			color: if active {
-				app.pnl_text} else {
-				app.pnl_text}
+				app.pnl_text
+			} else {
+				app.pnl_text
+			}
 			size: 12
 			bold: active
 		})
@@ -5668,8 +5679,10 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int) {
 			staged := if c.staged { 'staged' } else { 'unstaged' }
 			app.gg.draw_text(x + w - 50, ry + 5, staged, gg.TextCfg{
 				color: if c.staged {
-					app.pnl_success} else {
-					app.pnl_text_mut}
+					app.pnl_success
+				} else {
+					app.pnl_text_mut
+				}
 				size: 11
 			})
 		}
@@ -5821,8 +5834,10 @@ fn draw_memory_palace_panel(mut app GuiApp, x int, y int, w int, h int) {
 			pct := int(r.score * 100)
 			app.gg.draw_text(x + 14, ry + 2, '${pct}%', gg.TextCfg{
 				color: if pct > 70 {
-					app.pnl_success} else {
-					app.pnl_text_mut}
+					app.pnl_success
+				} else {
+					app.pnl_text_mut
+				}
 				size: 11
 				bold: pct > 70
 			})
@@ -6034,8 +6049,10 @@ fn draw_workspace(mut app GuiApp, w int, h int) {
 	if app.workspace_notice != '' {
 		app.gg.draw_text(l.fx + 24, control_y + 56, app.workspace_notice, gg.TextCfg{
 			color: if app.workspace_notice.contains('error') || app.workspace_notice.contains('Could not') {
-				app.pnl_danger} else {
-				app.pnl_text_mut}
+				app.pnl_danger
+			} else {
+				app.pnl_text_mut
+			}
 			size: 11
 		})
 	}
@@ -6110,8 +6127,10 @@ fn draw_products(mut app GuiApp, w int, h int) {
 		app.gg.draw_rect_empty(fx + fw - 160, y + 26, 56, 16, app.pnl_select)
 		app.gg.draw_text(fx + fw - 152, y + 29, 'Install', gg.TextCfg{
 			color: if hover_install {
-				app.pnl_text} else {
-				app.pnl_card}
+				app.pnl_text
+			} else {
+				app.pnl_card
+			}
 			size: 11
 			bold: hover_install
 		})
@@ -6345,8 +6364,10 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 			app.gg.draw_text(fx + 20, content_y + 74, 'Resolution: AGENT_TOOLKIT_ROOT (override) → XDG → embedded 3a → FHS 3b → checkout — ADR-015/026', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
 			app.gg.draw_text(fx + 20, content_y + 90, '${if status_is_first { '!' } else { '·' }} is_first_run=${status_is_first}   doctor checks via Engine.doctor() typed', gg.TextCfg{
 				color: if status_is_first {
-					app.pnl_danger} else {
-					app.pnl_success}
+					app.pnl_danger
+				} else {
+					app.pnl_success
+				}
 				size: 12
 				mono: true
 			})
@@ -6401,8 +6422,10 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 			app.gg.draw_rect_empty(fx + 20, content_y + 28, fw - 40, 20, app.pnl_text)
 			app.gg.draw_text(fx + 26, content_y + 33, disp_q, gg.TextCfg{
 				color: if q == '' {
-					app.pnl_text_mut} else {
-					app.pnl_text}
+					app.pnl_text_mut
+				} else {
+					app.pnl_text
+				}
 				size: 12
 			})
 			// chips
@@ -6447,8 +6470,10 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 			})
 			app.gg.draw_text(fx + fw - 108, content_y + content_h - 49, 'Install 5', gg.TextCfg{
 				color: if hov {
-					app.pnl_card} else {
-					app.pnl_text}
+					app.pnl_card
+				} else {
+					app.pnl_text
+				}
 				size: 12
 				bold: true
 			})
@@ -6460,7 +6485,8 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 			tgts := if app.desktop != unsafe { nil } {
 				app.desktop.engine_targets().map(it.id)
 			} else {
-				['claude-code', 'cursor', 'opencode', 'copilot-cli', 'pi', 'windsurf', 'codex', 'muse-code']
+				['claude-code', 'cursor', 'opencode', 'copilot-cli', 'pi', 'windsurf', 'codex',
+					'muse-code']
 			}
 			for i, t in tgts {
 				y := content_y + 30 + i * 20
@@ -6551,8 +6577,10 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 			})
 			app.gg.draw_text(fx + 36, content_y + 89, 'Init Workspace', gg.TextCfg{
 				color: if hov_init {
-					app.pnl_card} else {
-					app.pnl_text}
+					app.pnl_card
+				} else {
+					app.pnl_text
+				}
 				size: 13
 				bold: true
 			})
@@ -6577,8 +6605,10 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 				app.gg.draw_text(fx + 26, y + 3, pers, gg.TextCfg{ color: fg4, size: 12, mono: true })
 				app.gg.draw_text(fx + fw - 80, y + 3, if done { 'ready ✓' } else { 'pending' }, gg.TextCfg{
 					color: if done {
-						app.pnl_text} else {
-						app.pnl_text_mut}
+						app.pnl_text
+					} else {
+						app.pnl_text_mut
+					}
 					size: 11
 				})
 			}
@@ -6591,8 +6621,10 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 			})
 			app.gg.draw_text(fx + 32, content_y + 154, 'Bootstrap Personas', gg.TextCfg{
 				color: if hov_boot {
-					app.pnl_card} else {
-					app.pnl_text}
+					app.pnl_card
+				} else {
+					app.pnl_text
+				}
 				size: 12
 				bold: true
 			})
@@ -6643,10 +6675,13 @@ fn draw_onboarding(mut app GuiApp, w int, h int) {
 	})
 	app.gg.draw_text(fx + fw - 284, fy + fh - 27, 'Skip', gg.TextCfg{
 		color: if hov_skip {
-			app.pnl_card} else if app.appearance_dark {
+			app.pnl_card
+		} else if app.appearance_dark {
 			// light button needs ink text in Ink (#1097)
-			app.pnl_bg} else {
-			app.pnl_text_mut}
+			app.pnl_bg
+		} else {
+			app.pnl_text_mut
+		}
 		size: 12
 	})
 	// Back
@@ -7188,8 +7223,10 @@ fn draw_inspector(mut app GuiApp, w int, h int) {
 			}
 			app.gg.draw_text(ix + 22, y, txt, gg.TextCfg{
 				color: if is_hover_i {
-					app.pnl_bg} else {
-					col_text_on_cabinet}
+					app.pnl_bg
+				} else {
+					col_text_on_cabinet
+				}
 				size: 12
 				mono: true
 			})
@@ -7601,7 +7638,7 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 	}
 	qcol := if app.palette_query == '' { app.pnl_text_mut } else { app.pnl_bg }
 	app.gg.draw_text(cx + 20, cy + 42, '› ${q}', gg.TextCfg{ color: qcol, size: scaled_size(14, z) })
-	filtered := filtered_palette(app.palette_query)
+	filtered := filtered_palette(mut app)
 	for i, it in filtered {
 		if i >= 7 {
 			break
@@ -7619,10 +7656,27 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 			// subtle manila tab on unselected
 			app.gg.draw_rect_filled(cx + pw - 52, y + 4, 36, 6, app.pnl_card_sel)
 		}
-		pal_label := tr(app, 'palette.' + it.id)
+		// S4A: registry rows keep their registry labels; navigation rows keep
+		// localized labels via their i18n key.
+		pal_label := if it.is_entity {
+			if it.kind == .navigation {
+				tr(app, 'palette.' + nav_tr_key(it.panel))
+			} else {
+				it.label
+			}
+		} else {
+			tr(app, 'palette.' + it.id)
+		}
+		// S4A entity rows describe truthful state; unavailable rows say why.
 		// R2 product-truth: CLI-action rows render live Engine counts, never
 		// the hardcoded historical numbers in palette_items().
-		pal_desc := if it.id == 'skills_sync' {
+		pal_desc := if it.is_entity {
+			if !it.available {
+				'unavailable — ${it.unavailable_reason}'
+			} else {
+				it.desc
+			}
+		} else if it.id == 'skills_sync' {
 			'Sync and validate ${skills_total(mut app)} skills'
 		} else if it.id == 'mcp_health' {
 			'Health of ${mcp_total(mut app)} providers'
@@ -7645,8 +7699,10 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 		} else if needs_ar(pal_desc) { app.fonts.arabic } else { '' }
 		app.gg.draw_text(cx + 20, y + 18, pal_desc, gg.TextCfg{
 			color: if is_sel {
-				app.pnl_text_mut} else {
-				app.pnl_text_mut}
+				app.pnl_text_mut
+			} else {
+				app.pnl_text_mut
+			}
 			size: scaled_size(11, z)
 			family: pal_dfam
 		})
@@ -7694,7 +7750,7 @@ fn activate_palette_selection(mut app GuiApp) {
 	app.workspace_focus = false
 	app.header_search_focus = false
 	app.ghost_focused = false
-	filtered := filtered_palette(app.palette_query)
+	filtered := filtered_palette(mut app)
 	if filtered.len == 0 {
 		app.palette_open = false
 		app.palette_query = ''
@@ -7709,54 +7765,23 @@ fn activate_palette_selection(mut app GuiApp) {
 		app.palette_selected
 	}
 	sel := filtered[clamped]
-	// navigating anywhere via palette dismisses the onboarding overlay
-	if sel.id in ['world', 'skills', 'agents', 'mcp', 'targets', 'doctor', 'jobs', 'loops', 'swarm',
-		'workspace', 'products', 'onboarding', 'insights'] {
-		app.show_onboarding = sel.id == 'onboarding'
+	// S4A: registry rows navigate to their typed panel destination. Entity
+	// rows open the owning panel; deep-linked contextual actions land in S4B.
+	if sel.is_entity {
+		idx := panel_index_for(sel.panel)
+		if idx >= 0 {
+			app.selected_panel = idx
+			app.show_onboarding = sel.panel == .onboarding
+		}
+		app.palette_open = false
+		app.palette_query = ''
+		app.palette_selected = 0
+		return
 	}
 	match sel.id {
-		'world' {
-			app.selected_panel = 0
-		}
-		'skills' {
-			app.selected_panel = 1
-		}
-		'agents' {
-			app.selected_panel = 2
-		}
-		'mcp' {
-			app.selected_panel = 3
-		}
-		'targets' {
-			app.selected_panel = 4
-		}
-		'doctor' {
-			app.selected_panel = 5
-		}
-		'jobs' {
-			app.selected_panel = 6
-		}
-		'loops' {
-			app.selected_panel = 7
-		}
-		'swarm' {
-			app.selected_panel = 8
-		}
-		'workspace' {
-			app.selected_panel = 9
-		}
 		'workspace_sync' {
 			app.selected_panel = 9
 			app.inspector_msg = 'Workspace — pick or edit the path here; Validate checks it, Switch activates it'
-		}
-		'products' {
-			app.selected_panel = 10
-		}
-		'onboarding' {
-			app.selected_panel = 11
-		}
-		'insights' {
-			app.selected_panel = 12
 		}
 		'serve' {
 			app.inspector_msg = 'Serve: agent-toolkit serve --port 3847'
@@ -7884,7 +7909,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				if app.palette_query.len > 0 {
 					app.palette_query = app.palette_query[..app.palette_query.len - 1]
 					// clamp selection after filtering narrows
-					filtered := filtered_palette(app.palette_query)
+					filtered := filtered_palette(mut app)
 					if app.palette_selected >= filtered.len {
 						app.palette_selected = if filtered.len > 0 { filtered.len - 1 } else { 0 }
 					}
@@ -7892,7 +7917,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 			if e.key_code == .up {
-				filtered := filtered_palette(app.palette_query)
+				filtered := filtered_palette(mut app)
 				if filtered.len > 0 {
 					if app.palette_selected > 0 {
 						app.palette_selected--
@@ -7903,7 +7928,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 			if e.key_code == .down {
-				filtered := filtered_palette(app.palette_query)
+				filtered := filtered_palette(mut app)
 				if filtered.len > 0 {
 					if app.palette_selected + 1 < filtered.len {
 						app.palette_selected++
@@ -7917,7 +7942,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				app.palette_query += rune(e.char_code).str()
 				// keep selection clamped after filter narrows; reset to top for new query
 				app.palette_selected = 0
-				filtered2 := filtered_palette(app.palette_query)
+				filtered2 := filtered_palette(mut app)
 				if app.palette_selected >= filtered2.len && filtered2.len > 0 {
 					app.palette_selected = filtered2.len - 1
 				}
@@ -8902,7 +8927,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			inside_palette := mx >= cx && mx <= cx + pw && my >= cy && my <= cy + ph
 			if inside_palette {
 				// Hit a row? row hit area cy+76 + i*36 size 32
-				filtered := filtered_palette(app.palette_query)
+				filtered := filtered_palette(mut app)
 				for i, _ in filtered {
 					if i >= 7 {
 						break

--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -7770,8 +7770,9 @@ fn activate_palette_selection(mut app GuiApp) {
 	if sel.is_entity {
 		idx := panel_index_for(sel.panel)
 		if idx >= 0 {
-			app.selected_panel = idx
-			app.show_onboarding = sel.panel == .onboarding
+			// shared panel-selection transition (clears desk selection, focus
+			// and onboarding state exactly like dock navigation)
+			select_panel(mut app, idx)
 		}
 		app.palette_open = false
 		app.palette_query = ''

--- a/cmd/agent-toolkit-desktop/palette_rows_test.v
+++ b/cmd/agent-toolkit-desktop/palette_rows_test.v
@@ -1,0 +1,125 @@
+module main
+
+import desktop
+import desktop.nav
+import desktop.palette
+import desktop_engine
+import os
+
+// test_palette_merged_rows_registry_authority verifies the S4A production
+// palette data source: registry navigation rows lead in shell order, legacy
+// static rows remain appended, and queries surface registry entities with
+// preserved canonical identity.
+fn test_palette_merged_rows_registry_authority() {
+	tmp := os.join_path(os.temp_dir(), 'atk-palette-rows-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer {
+		os.rmdir_all(tmp) or {}
+	}
+	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
+		config: desktop.DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	defer {
+		d.shutdown() or {}
+	}
+	mut app := &GuiApp{
+		desktop: d
+		selected_panel: 0
+		hover_panel: -1
+		selected_desk: -1
+		hover_desk: -1
+	}
+	app.palette_reg = d.palette_registry()
+
+	// empty query: navigation rows first, in production shell order
+	rows := filtered_palette(mut app)
+	assert rows.len > 13
+	assert rows[0].id == 'nav:/world'
+	assert rows[1].id == 'nav:/skills'
+	assert rows[0].is_entity
+	assert rows[0].panel == nav.PanelId.world_view
+	// legacy static rows still present (not yet migrated)
+	mut legacy_found := false
+	for r in rows {
+		if !r.is_entity && r.id == 'install_full' {
+			legacy_found = true
+		}
+		// no fabricated rows: every row comes from registry or legacy list
+		assert r.label != ''
+	}
+	assert legacy_found
+	// fresh engine: no fabricated runtime rows
+	for r in rows {
+		assert !(r.is_entity && (r.kind == .job || r.kind == .swarm_run))
+	}
+
+	// query: registry entity identity survives fuzzy matching
+	app.palette_query = 'doctor'
+	qrows := filtered_palette(mut app)
+	assert qrows.len > 0
+	mut nav_doctor := false
+	for r in qrows {
+		if r.is_entity && r.kind == .navigation && r.panel == nav.PanelId.doctor {
+			nav_doctor = true
+		}
+	}
+	assert nav_doctor
+
+	// query with no matches: no fallback rows invented
+	app.palette_query = 'zzz_no_match_42'
+	assert filtered_palette(mut app).len == 0
+}
+
+// test_panel_index_for_matches_production_panels locks the registry → shell
+// panel index mapping.
+fn test_panel_index_for_matches_production_panels() {
+	assert panel_index_for(nav.PanelId.world_view) == 0
+	assert panel_index_for(nav.PanelId.skills) == 1
+	assert panel_index_for(nav.PanelId.agents) == 2
+	assert panel_index_for(nav.PanelId.mcp) == 3
+	assert panel_index_for(nav.PanelId.targets) == 4
+	assert panel_index_for(nav.PanelId.doctor) == 5
+	assert panel_index_for(nav.PanelId.jobs) == 6
+	assert panel_index_for(nav.PanelId.loops) == 7
+	assert panel_index_for(nav.PanelId.swarm) == 8
+	assert panel_index_for(nav.PanelId.workspace) == 9
+	assert panel_index_for(nav.PanelId.products) == 10
+	assert panel_index_for(nav.PanelId.onboarding) == 11
+	assert panel_index_for(nav.PanelId.insights) == 12
+	assert panel_index_for(nav.PanelId.unknown) == -1
+}
+
+// test_nav_tr_key_preserves_localization locks the i18n key suffix mapping.
+fn test_nav_tr_key_preserves_localization() {
+	assert nav_tr_key(nav.PanelId.world_view) == 'world'
+	assert nav_tr_key(nav.PanelId.skills) == 'skills'
+	assert nav_tr_key(nav.PanelId.insights) == 'insights'
+}
+
+// test_desktop_palette_registry_is_stable_binding — one registry per Desktop,
+// rebuilt from the live engine on demand.
+fn test_desktop_palette_registry_is_stable_binding() {
+	tmp := os.join_path(os.temp_dir(), 'atk-palette-reg-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer {
+		os.rmdir_all(tmp) or {}
+	}
+	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
+		config: desktop.DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state2.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	defer {
+		d.shutdown() or {}
+	}
+	r1 := d.palette_registry()
+	r2 := d.palette_registry()
+	assert r1 == r2 // same binding, not a new registry per call
+	_ = desktop_engine.EngineConfig{}
+}

--- a/docs/desktop/S4_HANDOFF.md
+++ b/docs/desktop/S4_HANDOFF.md
@@ -126,11 +126,12 @@ Keep every slice independently shippable with its own green Required CI.
 - **The static list contains entries with no truthful backing** (e.g.
   "Update — agent-toolkit update"): migrate them to honest-unavailable or
   omit them; do not carry them into the registry as fake actions.
-- **CI infrastructure note**: pinned V (master @ 78e581e) cold rebuilds are
+- **CI infrastructure note**: pinned V (master @ c0e47bf) cold rebuilds are
   non-deterministic upstream (vc/tcc moving HEADs); #1154 added a build cache
   + retry to `.github/actions/setup-v`. If a cold rebuild fails persistently,
   bump the pinned commit AND the cache key together (both literals live in
-  the action).
+  the action). Hermetic bootstrap reproducibility is tracked separately in
+  #1158.
 - **Golden fixtures** reflect the current UI; intentional visual changes to
   the palette must include a drift map and recapture (policy in
   `VISUAL_QA.md`), never a silent fixture update.

--- a/modules/desktop/nav/router.v
+++ b/modules/desktop/nav/router.v
@@ -17,6 +17,10 @@ pub enum PanelId {
 	doctor
 	world_view
 	activity
+	targets
+	jobs
+	onboarding
+	insights
 	unknown
 }
 
@@ -35,6 +39,10 @@ pub fn (p PanelId) label() string {
 		.doctor { 'Doctor' }
 		.world_view { 'World View' }
 		.activity { 'Activity' }
+		.targets { 'Targets' }
+		.jobs { 'Jobs' }
+		.onboarding { 'Onboarding' }
+		.insights { 'Insights' }
 		.unknown { 'Unknown' }
 	}
 }
@@ -55,6 +63,10 @@ pub fn panel_id_from_string(s string) PanelId {
 		'doctor' { .doctor }
 		'world_view', 'worldview', 'world-view' { .world_view }
 		'activity' { .activity }
+		'targets' { .targets }
+		'jobs' { .jobs }
+		'onboarding' { .onboarding }
+		'insights' { .insights }
 		else { .unknown }
 	}
 }
@@ -82,6 +94,10 @@ pub fn default_routes() []Route {
 		Route{ panel: .doctor, plane: 'runtime', path: '/doctor' },
 		Route{ panel: .world_view, plane: 'view', path: '/world' },
 		Route{ panel: .activity, plane: 'view', path: '/activity' },
+		Route{ panel: .targets, plane: 'capability', path: '/targets' },
+		Route{ panel: .jobs, plane: 'runtime', path: '/jobs' },
+		Route{ panel: .onboarding, plane: 'capability', path: '/onboarding' },
+		Route{ panel: .insights, plane: 'view', path: '/insights' },
 	]
 }
 

--- a/modules/desktop/palette/palette.v
+++ b/modules/desktop/palette/palette.v
@@ -15,6 +15,14 @@ pub:
 	category string // Skills|Agents|Products|Navigation|Doctor|MCP|Workspace|Loops|Jobs
 	keywords string // extra searchable tokens
 	panel    nav.PanelId
+	// S4A entity identity (#1119) — present on registry-derived actions.
+	desc               string // one-line truthful description (empty = unset)
+	keys               string // shortcut hint (navigation rows)
+	kind               EntityKind
+	entity_id          string // canonical entity id (e.g. core/assistant, claude-code)
+	workspace          string // workspace context when entity is workspace-scoped
+	available          bool // whether the entity's contextual action is currently possible
+	unavailable_reason string // populated when !available
 mut:
 	score int // last fuzzy score (internal)
 }
@@ -162,6 +170,7 @@ mut:
 	engine        &desktop_engine.Engine
 	router        &nav.Router
 	theme         theme.Theme
+	registry      &Registry // S4A: single typed registry source
 	actions       []PaletteAction
 	filtered      []PaletteAction
 	query         string
@@ -199,6 +208,7 @@ pub fn new_palette_viewmodel(mut engine &desktop_engine.Engine, mut router &nav.
 		engine: engine
 		router: router
 		theme: th
+		registry: new_registry(mut engine)
 		debounce_ms: debounce
 		virtualized: new_virtual_palette_list(0, vh)
 		revision: engine.revision()
@@ -208,103 +218,11 @@ pub fn new_palette_viewmodel(mut engine &desktop_engine.Engine, mut router &nav.
 	return vm
 }
 
-// build_actions collects all searchable actions from Engine + nav.
-// Pure derivation, no shell, mirrors skills_viewmodel refresh pattern.
+// build_actions collects all searchable actions through the shared typed
+// registry (S4A #1119) — Engine catalogs, configuration and runtime state.
+// Pure derivation, no shell, no fabricated filler rows.
 fn (mut vm PaletteViewModel) build_actions() []PaletteAction {
-	mut out := []PaletteAction{}
-	// Navigation routes (12)
-	for r in nav.default_routes() {
-		out << PaletteAction{
-			id: 'nav:${r.path}'
-			label: r.panel.label()
-			category: 'Navigation'
-			keywords: '${r.path} ${r.plane} go to open'
-			panel: r.panel
-		}
-	}
-	// Skills (116+)
-	for s in vm.engine.skills_catalog() {
-		out << PaletteAction{
-			id: 'skill:${s.id}'
-			label: s.name
-			category: 'Skills'
-			keywords: '${s.id} ${s.domain} ${s.description}'
-			panel: .skills
-		}
-	}
-	// Agents (18+)
-	for a in vm.engine.agents_catalog() {
-		out << PaletteAction{
-			id: 'agent:${a.id}'
-			label: a.id
-			category: 'Agents'
-			keywords: '${a.id} ${a.role} ${a.tier} ${a.description}'
-			panel: .agents
-		}
-	}
-	// Products/packs (via Engine products)
-	for p in vm.engine.products_catalog() {
-		out << PaletteAction{
-			id: 'product:${p.id}'
-			label: p.name
-			category: 'Products'
-			keywords: '${p.id} ${p.description}'
-			panel: .products
-		}
-	}
-	// Targets
-	for t in vm.engine.targets() {
-		out << PaletteAction{
-			id: 'target:${t.id}'
-			label: t.id
-			category: 'Targets'
-			keywords: '${t.id} ${t.name} ${t.status} ${t.layer}'
-			panel: .world_view
-		}
-	}
-	// Doctor checks
-	for c in vm.engine.doctor() {
-		out << PaletteAction{
-			id: 'doctor:${c.id}'
-			label: c.id
-			category: 'Doctor'
-			keywords: '${c.id} ${c.status} ${c.message} doctor check'
-			panel: .doctor
-		}
-	}
-	// MCP providers
-	for m in vm.engine.mcp_catalog() {
-		out << PaletteAction{
-			id: 'mcp:${m.id}'
-			label: m.id
-			category: 'MCP'
-			keywords: '${m.id} ${m.name} mcp provider ${m.health}'
-			panel: .mcp
-		}
-	}
-	// Loops
-	for l in vm.engine.loops_catalog() {
-		out << PaletteAction{
-			id: 'loop:${l.name}'
-			label: l.name
-			category: 'Loops'
-			keywords: '${l.name} ${l.goal}'
-			panel: .loops
-		}
-	}
-	// If still small (edge CI), ensure at least params for virtualization stress
-	if out.len < 20 {
-		for i in out.len .. 20 {
-			out << PaletteAction{
-				id: 'fallback:${i:04d}'
-				label: 'Fallback Action ${i:04d}'
-				category: 'System'
-				keywords: 'fallback'
-				panel: .skills
-			}
-		}
-	}
-	return out
+	return vm.registry.all_actions()
 }
 
 // refresh rebuilds action list from Engine and reapplies current query.

--- a/modules/desktop/palette/registry.v
+++ b/modules/desktop/palette/registry.v
@@ -1,0 +1,532 @@
+module palette
+
+// S4A (#1119) — shared typed action & entity registry core.
+//
+// One registry supplies palette/search results from authoritative Engine state:
+// catalog truth (skills, agents, targets, providers, products, packs, loops),
+// configuration truth (installed skills, enabled targets/providers), and
+// runtime truth (jobs, swarm runs). It never fabricates rows: a fresh engine
+// yields navigation + catalog entities only, and runtime rows appear only when
+// real records exist. Availability is truthful — an unavailable entry always
+// carries a reason (e.g. "no bundled profile installer for this target").
+//
+// Governing contracts:
+// - docs/desktop/UX_ARCHITECTURE.md §Shared action and entity model
+// - docs/desktop/TRUTH_LEDGER.md (catalog ≠ configuration ≠ runtime ≠ evidence)
+// - AGENTS.md global invariants (no manufactured production state)
+
+import desktop_engine
+import desktop.nav
+
+// EntityKind classifies what a registry entry points at.
+pub enum EntityKind {
+	navigation
+	skill
+	agent
+	target
+	mcp_provider
+	product
+	pack
+	loop_template
+	doctor_check
+	job
+	swarm_run
+}
+
+// RegistryEntry is one typed entity in the registry. `id` is the canonical
+// domain identity (skill `core/assistant`, target `claude-code`, provider
+// `github`, job/swarm run id) — never a CLI flag string.
+pub struct RegistryEntry {
+pub:
+	kind               EntityKind
+	id                 string // canonical id
+	workspace          string // workspace-scoped context ('' = global)
+	label              string
+	category           string
+	keywords           string
+	desc               string
+	keys               string // shortcut hint (navigation rows)
+	available          bool
+	unavailable_reason string
+	panel              nav.PanelId
+}
+
+// action_id returns the stable palette action id for the entry.
+pub fn (e RegistryEntry) action_id() string {
+	return match e.kind {
+		.navigation { 'nav:${e.id}' }
+		.skill { 'skill:${e.id}' }
+		.agent { 'agent:${e.id}' }
+		.target { 'target:${e.id}' }
+		.mcp_provider { 'mcp:${e.id}' }
+		.product { 'product:${e.id}' }
+		.pack { 'pack:${e.id}' }
+		.loop_template { 'loop:${e.id}' }
+		.doctor_check { 'doctor:${e.id}' }
+		.job { 'job:${e.id}' }
+		.swarm_run { 'swarm_run:${e.id}' }
+	}
+}
+
+// is_valid checks required registry fields.
+pub fn (e RegistryEntry) is_valid() bool {
+	return e.id != '' && e.label != '' && e.category != ''
+}
+
+// production_nav_panels is the shell destination order used by the palette
+// (matches the production panel indices in cmd/agent-toolkit-desktop/main.v).
+const production_nav_panels = [
+	nav.PanelId.world_view,
+	nav.PanelId.skills,
+	nav.PanelId.agents,
+	nav.PanelId.mcp,
+	nav.PanelId.targets,
+	nav.PanelId.doctor,
+	nav.PanelId.jobs,
+	nav.PanelId.loops,
+	nav.PanelId.swarm,
+	nav.PanelId.workspace,
+	nav.PanelId.products,
+	nav.PanelId.onboarding,
+	nav.PanelId.insights,
+]
+
+// nav_labels are the product labels for navigation entries (the "Go to …"
+// rows). Navigation destinations are product surfaces, not entities, so the
+// labels live with the registry that owns those rows.
+const nav_labels = {
+	nav.PanelId.world_view: 'Go to World'
+	nav.PanelId.skills:     'Go to Skills'
+	nav.PanelId.agents:     'Go to Agents'
+	nav.PanelId.mcp:        'Go to MCP'
+	nav.PanelId.targets:    'Go to Targets'
+	nav.PanelId.doctor:     'Go to Doctor'
+	nav.PanelId.jobs:       'Go to Jobs'
+	nav.PanelId.loops:      'Go to Loops'
+	nav.PanelId.swarm:      'Go to Swarm'
+	nav.PanelId.workspace:  'Go to Workspace'
+	nav.PanelId.products:   'Go to Products'
+	nav.PanelId.onboarding: 'Go to Onboarding'
+	nav.PanelId.insights:   'Go to Insights'
+}
+
+// nav_descs are the navigation row descriptions.
+const nav_descs = {
+	nav.PanelId.world_view: 'Office floor, desks and handoffs'
+	nav.PanelId.skills:     'Search and install skills'
+	nav.PanelId.agents:     'Browse holistic and specialist'
+	nav.PanelId.mcp:        'Providers and health'
+	nav.PanelId.targets:    'Enable platforms'
+	nav.PanelId.doctor:     'Fix checks'
+	nav.PanelId.jobs:       'Live processes'
+	nav.PanelId.loops:      'Missions and schedules — inner/outer'
+	nav.PanelId.swarm:      'GOD mailbox, Herdr/tmux, pair/team/full, approvals spend/scope/destructive'
+	nav.PanelId.workspace:  'Context and memory'
+	nav.PanelId.products:   'Manage products/packs membership & digest'
+	nav.PanelId.onboarding: 'Super-potent wizard: workspace, personas, capability, target, product'
+	nav.PanelId.insights:   'Telemetry — cost ledger, tool waterfall, OTel spans, budgets spark, CI watcher'
+}
+
+// nav_keys are the global shortcut hints shown on navigation rows.
+const nav_keys = {
+	nav.PanelId.world_view: '1'
+	nav.PanelId.skills:     '2'
+	nav.PanelId.agents:     '3'
+	nav.PanelId.mcp:        '4'
+	nav.PanelId.targets:    '5'
+	nav.PanelId.doctor:     '6'
+	nav.PanelId.jobs:       '7'
+	nav.PanelId.loops:      '8'
+	nav.PanelId.swarm:      '9'
+	nav.PanelId.workspace:  '0'
+	nav.PanelId.products:   'p'
+	nav.PanelId.onboarding: 'o'
+	nav.PanelId.insights:   'i'
+}
+
+// nav_route_path returns the router deep-link path for a panel.
+fn nav_route_path(panel nav.PanelId) string {
+	for r in nav.default_routes() {
+		if r.panel == panel {
+			return r.path
+		}
+	}
+	return '/${panel.str()}'
+}
+
+// trim_desc clamps a description to one palette line.
+fn trim_desc(s string) string {
+	mut out := s.trim_space()
+	if out.len > 120 {
+		out = out[..120] + '…'
+	}
+	return out
+}
+
+// Registry is the shared typed action & entity registry. It caches its
+// derivation per Engine revision: `maybe_refresh` is cheap every frame and
+// rebuilds entries only when the Engine state moved.
+pub struct Registry {
+mut:
+	engine   &desktop_engine.Engine
+	entries  []RegistryEntry
+	actions  []PaletteAction
+	revision u64
+	builds   u64
+}
+
+// new_registry binds a registry to an Engine.
+pub fn new_registry(mut engine &desktop_engine.Engine) &Registry {
+	return &Registry{
+		engine: engine
+	}
+}
+
+// maybe_refresh rebuilds the registry when the Engine revision moved (or on
+// first use). Cheap when unchanged: one revision read.
+pub fn (mut r Registry) maybe_refresh() {
+	rev := r.engine.revision()
+	if r.builds > 0 && rev == r.revision {
+		return
+	}
+	r.entries = r.build_entries()
+	r.actions = entries_to_actions(r.entries)
+	r.revision = rev
+	r.builds++
+}
+
+// all_entries returns the current registry entries (rebuilding if stale).
+pub fn (mut r Registry) all_entries() []RegistryEntry {
+	r.maybe_refresh()
+	return r.entries.clone()
+}
+
+// all_actions returns the current actions (rebuilding if stale).
+pub fn (mut r Registry) all_actions() []PaletteAction {
+	r.maybe_refresh()
+	return r.actions.clone()
+}
+
+// ScoredAction pairs an action with its fuzzy score for cross-source merge.
+pub struct ScoredAction {
+pub:
+	action PaletteAction
+	score  int
+}
+
+// filter returns matching actions ranked by fuzzy score (empty query keeps
+// the stable build order).
+pub fn (mut r Registry) filter(query string) []PaletteAction {
+	return r.scored_filter(query).map(it.action)
+}
+
+// scored_filter returns matching actions with scores so callers can merge
+// with other row sources without re-scoring.
+pub fn (mut r Registry) scored_filter(query string) []ScoredAction {
+	r.maybe_refresh()
+	q := query.trim_space()
+	if q == '' {
+		mut out := []ScoredAction{}
+		for a in r.actions {
+			out << ScoredAction{
+				action: a
+				score: 1000
+			}
+		}
+		return out
+	}
+	mut out := []ScoredAction{}
+	for a in r.actions {
+		s := action_best_score(q, a)
+		if s >= 0 {
+			out << ScoredAction{
+				action: a
+				score: s
+			}
+		}
+	}
+	out.sort_with_compare(fn (a &ScoredAction, b &ScoredAction) int {
+		if a.score > b.score {
+			return -1
+		}
+		if a.score < b.score {
+			return 1
+		}
+		if a.action.label < b.action.label {
+			return -1
+		}
+		if a.action.label > b.action.label {
+			return 1
+		}
+		return 0
+	})
+	return out
+}
+
+// build_entries derives registry entries from authoritative Engine state.
+// Order: navigation, catalog entities (skills, agents, targets, providers,
+// products, packs, loops, doctor), then runtime records (jobs, swarm runs).
+fn (mut r Registry) build_entries() []RegistryEntry {
+	mut out := []RegistryEntry{}
+	mut engine := r.engine
+	out << build_nav_entries()
+	out << build_skill_entries(mut engine)
+	out << build_agent_entries(mut engine)
+	out << build_target_entries(mut engine)
+	out << build_mcp_entries(mut engine)
+	out << build_product_entries(mut engine)
+	out << build_pack_entries(mut engine)
+	out << build_loop_entries(mut engine)
+	out << build_doctor_entries(mut engine)
+	out << build_job_entries(mut engine)
+	out << build_swarm_entries(mut engine)
+	return out
+}
+
+// build_nav_entries derives navigation destinations in shell order.
+fn build_nav_entries() []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for panel in production_nav_panels {
+		path := nav_route_path(panel)
+		out << RegistryEntry{
+			kind: .navigation
+			id: path
+			label: nav_labels[panel]
+			category: 'Navigation'
+			keywords: '${path} ${panel.label()} ${panel.str()} go to open panel'
+			desc: nav_descs[panel]
+			keys: nav_keys[panel]
+			available: true
+			panel: panel
+		}
+	}
+	return out
+}
+
+// build_skill_entries derives catalog skill entities. Availability is always
+// true (a catalog skill is inspectable); install state comes from real
+// configuration and is stated in the description, never invented.
+fn build_skill_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	mut installed := map[string]bool{}
+	for id in engine.skills_installed() {
+		installed[id] = true
+	}
+	for s in engine.skills_catalog() {
+		state := if installed[s.id] { 'installed' } else { 'not installed' }
+		out << RegistryEntry{
+			kind: .skill
+			id: s.id
+			label: if s.name != '' { s.name } else { s.id }
+			category: 'Skills'
+			keywords: '${s.id} ${s.domain} ${s.name} ${s.description} ${s.triggers} skill'
+			desc: '${s.domain} · ${state}'
+			available: true
+			panel: .skills
+		}
+	}
+	return out
+}
+
+// build_agent_entries derives catalog agent personas. A catalog agent is not
+// a running process — descriptions carry tier/role only, never activity.
+fn build_agent_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for a in engine.agents_catalog() {
+		out << RegistryEntry{
+			kind: .agent
+			id: a.id
+			label: a.id
+			category: 'Agents'
+			keywords: '${a.id} ${a.role} ${a.tier} ${a.description} ${a.triggers} agent persona'
+			desc: '${a.tier} · ${a.role}'
+			available: true
+			panel: .agents
+		}
+	}
+	return out
+}
+
+// build_target_entries derives coding-tool target entities. A target is
+// manageable through the registry only when a bundled profile exists; targets
+// without one stay visible but unavailable with that reason.
+fn build_target_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for t in engine.targets() {
+		available := t.path != ''
+		out << RegistryEntry{
+			kind: .target
+			id: t.id
+			label: if t.name != '' { t.name } else { t.id }
+			category: 'Targets'
+			keywords: '${t.id} ${t.name} ${t.status} ${t.layer} target platform'
+			desc: trim_desc('${t.status}${if t.detected { ' · detected' } else { '' }}')
+			available: available
+			unavailable_reason: if available {
+				''
+			} else {
+				'no bundled profile installer for this target'
+			}
+			panel: .targets
+		}
+	}
+	return out
+}
+
+// build_mcp_entries derives MCP provider entities from the bundled provider
+// catalog. Providers without a packaged template are unavailable with reason.
+fn build_mcp_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for m in engine.mcp_catalog() {
+		available := m.template_path != ''
+		state := if m.enabled { 'enabled' } else { m.health }
+		out << RegistryEntry{
+			kind: .mcp_provider
+			id: m.id
+			label: if m.name != '' { m.name } else { m.id }
+			category: 'MCP'
+			keywords: '${m.id} ${m.name} ${m.health} ${m.description} mcp provider'
+			desc: trim_desc(state)
+			available: available
+			unavailable_reason: if available { '' } else { 'no bundled template for this provider' }
+			panel: .mcp
+		}
+	}
+	return out
+}
+
+// build_product_entries derives product entities (catalog truth).
+fn build_product_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for p in engine.products_catalog() {
+		out << RegistryEntry{
+			kind: .product
+			id: p.id
+			label: if p.name != '' { p.name } else { p.id }
+			category: 'Products'
+			keywords: '${p.id} ${p.name} ${p.description} product pack bundle'
+			desc: '${p.skill_ids.len} skills · ${p.pack_ids.len} packs'
+			available: true
+			panel: .products
+		}
+	}
+	return out
+}
+
+// build_pack_entries derives pack entities (catalog truth).
+fn build_pack_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for p in engine.packs_catalog() {
+		out << RegistryEntry{
+			kind: .pack
+			id: p.id
+			label: if p.name != '' { p.name } else { p.id }
+			category: 'Packs'
+			keywords: '${p.id} ${p.name} pack bundle docs'
+			desc: '${p.skill_count} skills${if p.docs_only { ' · docs' } else { '' }}'
+			available: true
+			panel: .products
+		}
+	}
+	return out
+}
+
+// build_loop_entries derives loop template entities (catalog truth, not runs).
+fn build_loop_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for l in engine.loops_catalog() {
+		goal := if l.goal != '' { l.goal } else { l.description }
+		out << RegistryEntry{
+			kind: .loop_template
+			id: l.name
+			label: l.name
+			category: 'Loops'
+			keywords: '${l.name} ${goal} ${l.cadence} ${l.stage} loop mission'
+			desc: trim_desc('${l.cadence} · ${goal}')
+			available: true
+			panel: .loops
+		}
+	}
+	return out
+}
+
+// build_doctor_entries derives doctor checks with their real status. The
+// repair action is available only when the check reports fixable.
+fn build_doctor_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for c in engine.doctor() {
+		out << RegistryEntry{
+			kind: .doctor_check
+			id: c.id
+			label: if c.name != '' { c.name } else { c.id }
+			category: 'Doctor'
+			keywords: '${c.id} ${c.name} ${c.category} ${c.status} ${c.message} doctor check'
+			desc: trim_desc('${c.status} · ${c.message}')
+			available: c.fixable
+			unavailable_reason: if c.fixable { '' } else { 'check is not auto-fixable' }
+			panel: .doctor
+		}
+	}
+	return out
+}
+
+// build_job_entries derives job entities from real runtime records. A fresh
+// engine has no jobs, so this contributes zero rows — honest emptiness.
+fn build_job_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for j in engine.jobs_catalog() {
+		out << RegistryEntry{
+			kind: .job
+			id: j.id
+			workspace: j.work_dir
+			label: if j.cmd != '' { j.cmd } else { j.id }
+			category: 'Jobs'
+			keywords: '${j.id} ${j.cmd} ${j.status} job process'
+			desc: trim_desc('${j.status} · ${j.cmd}')
+			available: true
+			panel: .jobs
+		}
+	}
+	return out
+}
+
+// build_swarm_entries derives swarm run entities from real runtime records.
+fn build_swarm_entries(mut engine &desktop_engine.Engine) []RegistryEntry {
+	mut out := []RegistryEntry{}
+	for s in engine.swarm_list() {
+		out << RegistryEntry{
+			kind: .swarm_run
+			id: s.id
+			workspace: s.worktree
+			label: trim_desc(s.task)
+			category: 'Swarm'
+			keywords: '${s.id} ${s.task} ${s.status} ${s.recipe} swarm run'
+			desc: trim_desc('${s.status} · ${s.task}')
+			available: true
+			panel: .swarm
+		}
+	}
+	return out
+}
+
+// entries_to_actions projects registry entries into palette actions.
+fn entries_to_actions(entries []RegistryEntry) []PaletteAction {
+	mut out := []PaletteAction{}
+	for e in entries {
+		out << PaletteAction{
+			id: e.action_id()
+			label: e.label
+			category: e.category
+			keywords: e.keywords
+			desc: e.desc
+			keys: e.keys
+			panel: e.panel
+			kind: e.kind
+			entity_id: e.id
+			workspace: e.workspace
+			available: e.available
+			unavailable_reason: e.unavailable_reason
+		}
+	}
+	return out
+}

--- a/modules/desktop/palette/registry_test.v
+++ b/modules/desktop/palette/registry_test.v
@@ -1,0 +1,181 @@
+module palette
+
+import os
+import desktop_engine
+import desktop.nav
+
+// fresh_engine builds an Engine over an isolated temp persist path.
+fn fresh_engine(label string) &desktop_engine.Engine {
+	tmp := os.join_path(os.temp_dir(), 'palette-registry-${label}-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	persist := os.join_path(tmp, 'state.json')
+	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
+		persist_path: persist
+	})
+	eng.init() or { panic(err.msg()) }
+	eng.start() or { panic(err.msg()) }
+	return eng
+}
+
+fn find_entry(entries []RegistryEntry, kind EntityKind, id string) ?RegistryEntry {
+	for e in entries {
+		if e.kind == kind && e.id == id {
+			return e
+		}
+	}
+	return none
+}
+
+fn test_fresh_engine_yields_navigation_and_catalog_only() {
+	mut eng := fresh_engine('fresh')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	entries := reg.all_entries()
+	// navigation: the 13 production shell destinations, in shell order
+	navs := entries.filter(it.kind == .navigation)
+	assert navs.len == 13
+	assert navs[0].id == '/world'
+	assert navs[1].id == '/skills'
+	assert navs[0].keys == '1'
+	// runtime truth: a fresh engine has no jobs and no swarm runs — the
+	// registry must not fabricate any
+	assert entries.filter(it.kind == .job).len == 0
+	assert entries.filter(it.kind == .swarm_run).len == 0
+	// no fabricated filler rows: every entry maps to a real catalog record
+	for e in entries {
+		assert e.is_valid()
+		assert e.label != ''
+		assert e.category != ''
+	}
+	// catalog entities mirror the engine catalogs exactly
+	skills := entries.filter(it.kind == .skill)
+	assert skills.len == eng.skills_catalog().len
+	agents := entries.filter(it.kind == .agent)
+	assert agents.len == eng.agents_catalog().len
+	products := entries.filter(it.kind == .product)
+	assert products.len == eng.products_catalog().len
+	// canonical identity survives: skills keep their catalog id
+	if skills.len > 0 {
+		s := eng.skills_catalog()[0]
+		entry := find_entry(entries, .skill, s.id) or { panic('skill ${s.id} missing from registry') }
+		assert entry.action_id() == 'skill:${s.id}'
+	}
+}
+
+fn test_unavailable_entries_carry_reason() {
+	mut eng := fresh_engine('unavail')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	entries := reg.all_entries()
+	// targets without a bundled profile are visible but unavailable, with the
+	// honest reason — never silently dropped, never fake-actionable
+	targets := entries.filter(it.kind == .target)
+	catalog_targets := eng.targets()
+	assert targets.len == catalog_targets.len
+	for t in catalog_targets {
+		entry := find_entry(entries, .target, t.id) or { panic('target ${t.id} missing') }
+		if t.path == '' {
+			assert !entry.available
+			assert entry.unavailable_reason.contains('no bundled profile')
+		} else {
+			assert entry.available
+			assert entry.unavailable_reason == ''
+		}
+	}
+	// doctor checks are repairable only when the engine reports fixable
+	for c in eng.doctor() {
+		entry := find_entry(entries, .doctor_check, c.id) or { panic('doctor check ${c.id} missing') }
+		assert entry.available == c.fixable
+		if !c.fixable {
+			assert entry.unavailable_reason.contains('not auto-fixable')
+		}
+	}
+}
+
+fn test_workspace_scoped_entity_preserves_identity() {
+	mut eng := fresh_engine('workspace')
+	defer {
+		eng.stop() or {}
+	}
+	// a real (trivial) job record gives the registry a runtime row with a
+	// workspace context — spawned via the engine, never fabricated
+	job_id := eng.spawn_job_with_opts('echo', ['registry-workspace-test'], '/tmp/atk-registry-ws') or {
+		panic(err.msg())
+	}
+	eng.job_complete(job_id, 0) or {}
+	mut reg := new_registry(mut eng)
+	entries := reg.all_entries()
+	entry := find_entry(entries, .job, job_id) or { panic('job ${job_id} missing from registry') }
+	assert entry.workspace == '/tmp/atk-registry-ws'
+	assert entry.action_id() == 'job:${job_id}'
+	assert entry.panel == nav.PanelId.jobs
+}
+
+fn test_filter_preserves_canonical_identity() {
+	mut eng := fresh_engine('filter')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	// every query hit keeps its registry identity: category/keyword matches
+	// surface the same actions an empty query would
+	mut hits := reg.filter('skills')
+	assert hits.len > 0
+	for a in hits {
+		assert a.entity_id != '' || a.kind == .navigation
+	}
+	// entity search: match a skill by its canonical id fragment
+	catalog := eng.skills_catalog()
+	if catalog.len > 0 {
+		fragment := catalog[0].id.split('/')[0]
+		hits = reg.filter(fragment)
+		assert hits.len > 0
+		mut found := false
+		for a in hits {
+			if a.kind == .skill && a.entity_id == catalog[0].id {
+				found = true
+			}
+		}
+		assert found
+	}
+	// no match stays empty — no fallback rows invented
+	assert reg.filter('zzz_no_such_query_42').len == 0
+}
+
+fn test_registry_caches_per_revision() {
+	mut eng := fresh_engine('cache')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	_ = reg.all_entries()
+	first_builds := reg.builds
+	assert first_builds == 1
+	// same revision → no rebuild (cheap frame refresh)
+	_ = reg.all_entries()
+	_ = reg.all_actions()
+	assert reg.builds == first_builds
+	// engine mutation bumps revision → registry rebuilds
+	mut repo := eng.state_repo()
+	mut tx := repo.begin('registry-cache-test')
+	tx.set('registry_probe', '1')
+	eng.put_transaction(mut tx) or { panic(err.msg()) }
+	_ = reg.all_entries()
+	assert reg.builds == first_builds + 1
+}
+
+fn test_scored_filter_ranks_exact_match_first() {
+	mut eng := fresh_engine('rank')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	scored := reg.scored_filter('Go to Skills')
+	assert scored.len > 0
+	assert scored[0].action.id == 'nav:/skills'
+	assert scored[0].score > 0
+}

--- a/modules/desktop/window.v
+++ b/modules/desktop/window.v
@@ -4,6 +4,7 @@ import os
 import desktop.theme
 import desktop.shell
 import desktop.nav
+import desktop.palette
 import desktop.state as app_state
 import desktop.backend
 import desktop_engine
@@ -77,6 +78,9 @@ mut:
 	dock      shell.DockLayout
 	router    &nav.Router
 	bus       &eventbus.ToolkitEventBus
+	// S4A (#1119): shared typed action & entity registry, lazily built on the
+	// boot Engine (see palette_registry()).
+	palette_reg &palette.Registry = unsafe { nil }
 }
 
 // DesktopBootArgs allows injecting seams for headless tests.
@@ -141,6 +145,16 @@ pub fn (mut d Desktop) shutdown() ! {
 // is_running reports engine running (window would be open in non-headless).
 pub fn (mut d Desktop) is_running() bool {
 	return d.engine.is_running()
+}
+
+// palette_registry returns the shared typed action & entity registry (S4A,
+// #1119), lazily built on the boot Engine. One registry drives the palette,
+// search and future entity actions; it never shells out to the CLI.
+pub fn (mut d Desktop) palette_registry() &palette.Registry {
+	if d.palette_reg == unsafe { nil } {
+		d.palette_reg = palette.new_registry(mut d.engine)
+	}
+	return d.palette_reg
 }
 
 // app_state_snapshot returns current AppState (derived within one EventBus→frame tick).

--- a/modules/desktop_engine/jobs_service.v
+++ b/modules/desktop_engine/jobs_service.v
@@ -142,6 +142,7 @@ pub fn (mut e Engine) jobs_catalog() []JobRecord {
 		retry_str := snap.data['jobs/${id}/retry'] or { '0' }
 		retry := retry_str.int()
 		canceled := (snap.data['jobs/${id}/canceled'] or { 'false' }) == 'true'
+		work_dir := snap.data['jobs/${id}/work_dir'] or { '' }
 		out << JobRecord{
 			id: id
 			cmd: cmd
@@ -153,6 +154,7 @@ pub fn (mut e Engine) jobs_catalog() []JobRecord {
 			duration_ms: dur
 			canceled: canceled
 			retry_count: retry
+			work_dir: work_dir
 		}
 	}
 	// sort by started_at newest first for easy management
@@ -437,7 +439,6 @@ pub fn (mut e Engine) job_append_log(job_id string, line string) !u64 {
 	})
 	return rev.revision
 }
-
 
 // job_complete records the real runtime outcome of a job. A job run is
 // runtime truth: status, exit code and duration come from the actual run.

--- a/scripts/gui-coverage.py
+++ b/scripts/gui-coverage.py
@@ -70,8 +70,39 @@ def cli_commands() -> dict[str, str]:
 
 
 def palette_ids() -> set[str]:
+    """Palette affordance ids from both sources (S4 #1119).
+
+    S4A moved navigation rows out of the static `palette_items()` list into the
+    typed registry (`modules/desktop/palette/registry.v`); the static list keeps
+    only not-yet-migrated CLI-command rows. Coverage therefore reads both:
+    static rows from main.v and registry navigation panels from the registry
+    module. S4C (#1119) replaces this CLI-row parity with task/workflow
+    coverage of the registry's critical workflows.
+    """
     src = MAIN.read_text()
-    return set(re.findall(r"PaletteItem\{'([a-z_]+)'", src))
+    ids = set(re.findall(r"PaletteItem\{'([a-z_]+)'", src))
+    reg = (ROOT / "modules" / "desktop" / "palette" / "registry.v").read_text()
+    block = re.search(r"production_nav_panels\s*=\s*\[(.*?)\]", reg, re.DOTALL)
+    if block:
+        panels = set(re.findall(r"nav\.PanelId\.([a-z_]+)", block.group(1)))
+        # registry navigation panels map to their CLI-command affordance keys
+        panel_to_cmd = {
+            "world_view": "world",
+            "skills": "skills",
+            "agents": "agents",
+            "mcp": "mcp",
+            "targets": "targets",
+            "doctor": "doctor",
+            "jobs": "jobs",
+            "loops": "loops",
+            "swarm": "swarm",
+            "workspace": "workspace",
+            "products": "products",
+            "onboarding": "onboarding",
+            "insights": "insights",
+        }
+        ids |= {panel_to_cmd[p] for p in panels if p in panel_to_cmd}
+    return ids
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

First slice of S4 (#1119): one typed action & entity registry becomes the production palette's data authority for **navigation and entities**. The static `palette_items()` list remains only for not-yet-migrated CLI-command rows (retired in S4B/S4C).

### What changes

- **`modules/desktop/palette/registry.v` (new)** — `RegistryEntry` with entity kind, canonical id, workspace context, display metadata, and truthful `available` / `unavailable_reason`. Entries derive from Engine catalog truth (skills, agents, targets, MCP providers, products, packs, loops, doctor checks) and runtime truth (jobs, swarm runs). A fresh engine yields navigation + catalog entities **only** — no fabricated rows. The palette module's fabricated `fallback:*` filler rows are removed (also resolves the review finding raised on #1154).
- **`PaletteAction` extended** (entity identity fields) and `PaletteViewModel` now builds through the shared registry — one scoring authority (`fuzzy_score`/`action_best_score`), no new scorer.
- **`cmd/agent-toolkit-desktop/main.v`** — palette reads the registry; navigation rows migrate out of the static list; localized nav labels preserved via `nav_tr_key`; activation maps registry panels to shell panels; the duplicated `fuzzy_score`/`palette_best_score` in main.v are deleted.
- **`nav.PanelId` extended** with `targets`/`jobs`/`onboarding`/`insights` (+ routes/labels/parsing) so the registry can express every production destination; `Desktop.palette_registry()` exposes the seam bound to the boot Engine.
- **`engine.jobs_catalog()`** now surfaces the stored `work_dir`, so job rows carry truthful workspace context (previously silently dropped).
- **`scripts/gui-coverage.py`** reads registry navigation panels in addition to static rows (full task/workflow-coverage evolution is S4C per #1119).
- **`docs/desktop/S4_HANDOFF.md`** — stale V pin corrected (review finding on #1154).

### Truth model

- Catalog ≠ configuration ≠ runtime preserved: skill rows state `installed`/`not installed` from real config; target rows are actionable only when a bundled profile exists (`unavailable — no bundled profile installer for this target` otherwise); doctor checks are repairable only when `fixable`; jobs/swarm rows appear only from real records.
- Fresh engine: navigation + catalog entities only, zero runtime rows.

### User impact

Search / Run and the palette now discover real skills, agents, targets, providers, products, packs, loops, doctor checks and live jobs/swarms — not just fixed navigation rows. Visual interaction (manila folder palette, 7-row viewport, keyboard model) is unchanged; with an empty query the top rows are identical to before.

### Validation

- `modules/desktop/palette` tests including new `registry_test.v` (fresh-engine honesty, unavailable-with-reason, workspace identity, filter identity preservation, revision caching) — pass
- `modules/desktop` (11), `modules/desktop_engine` truth gates (23), `cmd/agent-toolkit-desktop` tests incl. new `palette_rows_test.v` (merged-row authority, panel mapping, i18n keys) — pass
- Production desktop build (`v -o … cmd/agent-toolkit-desktop`) — OK; headless boot smoke — PASS
- `v fmt` clean on all touched files; `gui-coverage.py --check` — pass
- Not verified locally: windowed pixel capture of the palette (no Xvfb/display on this workstation). Empty-query palette content/order for the visible top rows is unchanged; golden CI (paper + ink) guards panel drift. Registry row content is locked by tests.

### Known limitations

- Entity rows open their owning panel; deep-linked selection and contextual typed actions land in S4B.
- Legacy CLI-command rows (install/update/uninstall/memory/…) are untouched and remain static until S4B/S4C.

Refs #1119 · #1118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified the desktop command palette with navigation and available workspace entities, including skills, agents, targets, products, jobs, and more.
  * Added routes and deep links for Targets, Jobs, Onboarding, and Insights panels.
  * Improved fuzzy search with stable entity identity and clearer action details.
  * Entries that cannot currently be used remain visible with an explanation of their unavailable status.
  * Job actions now retain their workspace context when accessed from the palette.

* **Documentation**
  * Updated the desktop CI infrastructure reference and reproducibility tracking note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->