### PR TITLE
feat(desktop): S4B — contextual registry actions with typed args, preview and truthful execution (#1119)

### DIFF
--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -906,8 +906,13 @@ mut:
 	// S4A (#1119): shared typed action & entity registry — the palette's data
 	// source. Static rows remain only for entries not yet migrated.
 	palette_reg &palette.Registry = unsafe { nil }
-	mouse_x     int
-	mouse_y     int
+	// S4B contextual action flow state
+	palette_expanded    string // entity row id with expanded actions ('' = collapsed)
+	palette_preview     []string // preview mode lines (len 0 = list mode)
+	palette_preview_for string // action id the open preview belongs to
+	palette_armed       string // action id armed for confirmation ('' = none)
+	mouse_x             int
+	mouse_y             int
 	// dedupe: C backends set char_code on key_down AND send .char — keep one per frame
 	last_keydown_char    u32
 	last_keydown_frame   int
@@ -1623,6 +1628,11 @@ struct PaletteRow {
 	panel              nav.PanelId
 	available          bool
 	unavailable_reason string
+	// S4B contextual action row (derived from a registry action)
+	is_action     bool
+	action_kind   palette.ActionKind
+	needs_preview bool
+	needs_confirm bool
 }
 
 // panel_index_for maps a registry panel destination to the production panel
@@ -1717,7 +1727,7 @@ fn filtered_palette(mut app GuiApp) []PaletteRow {
 		}
 	}
 	if q == '' {
-		return scored
+		return expand_palette_actions(mut app, scored)
 	}
 	// manual sort to avoid V3 generic monomorphize segfault (see swarm_service fix)
 	for i := 1; i < scored.len; i++ {
@@ -1729,7 +1739,55 @@ fn filtered_palette(mut app GuiApp) []PaletteRow {
 			j--
 		}
 	}
-	return scored
+	return expand_palette_actions(mut app, scored)
+}
+
+// expand_palette_actions inserts the contextual actions of the expanded
+// entity row directly beneath it (S4B). Expansion follows the row: when the
+// query filters the entity out, the actions go with it.
+fn expand_palette_actions(mut app GuiApp, rows []PaletteRow) []PaletteRow {
+	if app.palette_expanded == '' || app.palette_reg == unsafe { nil } {
+		return rows
+	}
+	mut out := []PaletteRow{}
+	for row in rows {
+		out << row
+		if row.is_entity && !row.is_action && row.id == app.palette_expanded {
+			for a in app.palette_reg.actions_for(row.kind, row.entity_id) {
+				desc := if a.available {
+					a.desc
+				} else {
+					'unavailable — ${a.unavailable_reason}'
+				}
+				hint := if !a.available {
+					desc
+				} else if a.needs_preview {
+					'${desc} — Enter to preview'
+				} else if a.needs_confirm {
+					'${desc} — Enter twice to confirm'
+				} else {
+					desc
+				}
+				out << PaletteRow{
+					id: a.action_id()
+					label: '  ↳ ${a.label}'
+					desc: hint
+					score: row.score
+					is_entity: true
+					kind: a.entity_kind
+					entity_id: a.entity_id
+					panel: a.panel
+					available: a.available
+					unavailable_reason: a.unavailable_reason
+					is_action: true
+					action_kind: a.kind
+					needs_preview: a.needs_preview
+					needs_confirm: a.needs_confirm
+				}
+			}
+		}
+	}
+	return out
 }
 
 fn desks_for_app(app &GuiApp) []Desk {
@@ -7638,6 +7696,21 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 	}
 	qcol := if app.palette_query == '' { app.pnl_text_mut } else { app.pnl_bg }
 	app.gg.draw_text(cx + 20, cy + 42, '› ${q}', gg.TextCfg{ color: qcol, size: scaled_size(14, z) })
+	// S4B preview mode: show the real dry-run/diff lines instead of rows.
+	if app.palette_preview.len > 0 {
+		app.gg.draw_text(cx + 20, cy + 62, 'Preview — nothing applied yet', gg.TextCfg{ color: app.pnl_select, size: scaled_size(12, z), bold: true })
+		for pi, line in app.palette_preview {
+			if pi >= 7 {
+				break
+			}
+			app.gg.draw_text(cx + 20, cy + 84 + pi * 18, line, gg.TextCfg{ color: app.pnl_text, size: scaled_size(11, z), mono: true })
+		}
+		if app.palette_preview.len > 7 {
+			app.gg.draw_text(cx + 20, cy + 84 + 7 * 18, '… ${app.palette_preview.len - 7} more lines', gg.TextCfg{ color: app.pnl_text_mut, size: scaled_size(10, z) })
+		}
+		app.gg.draw_text(cx + 16, cy + ph - 16, 'Enter to execute  •  Esc back — the preview is a real dry-run, nothing was written', gg.TextCfg{ color: app.pnl_text_mut, size: scaled_size(11, z) })
+		return
+	}
 	filtered := filtered_palette(mut app)
 	for i, it in filtered {
 		if i >= 7 {
@@ -7715,8 +7788,15 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 	if filtered.len == 0 {
 		app.gg.draw_text(cx + 20, cy + 86, 'No matches — try another query', gg.TextCfg{ color: app.pnl_text_mut, size: scaled_size(13, z) })
 	}
-	// footer hint paper tape
-	app.gg.draw_text(cx + 16, cy + ph - 16, '↑↓ navigate  •  Enter to open  •  Type to filter ${skills_total(mut app)} skills  •  Ctrl± zoom', gg.TextCfg{ color: app.pnl_text_mut, size: scaled_size(11, z) })
+	// footer hint paper tape — reflects the S4B action state honestly
+	footer := if app.palette_armed != '' {
+		'Enter again to confirm  •  Esc to cancel'
+	} else if filtered.any(it.is_entity && !it.is_action) {
+		'↑↓ navigate  •  Enter to open  •  Tab expand actions  •  Type to filter ${skills_total(mut app)} skills  •  Ctrl± zoom'
+	} else {
+		'↑↓ navigate  •  Enter to open  •  Type to filter ${skills_total(mut app)} skills  •  Ctrl± zoom'
+	}
+	app.gg.draw_text(cx + 16, cy + ph - 16, footer, gg.TextCfg{ color: app.pnl_text_mut, size: scaled_size(11, z) })
 }
 
 fn draw_help(mut app GuiApp, w int, h int) {
@@ -7765,18 +7845,28 @@ fn activate_palette_selection(mut app GuiApp) {
 		app.palette_selected
 	}
 	sel := filtered[clamped]
+	// S4B: contextual action rows run through preview → confirm → execute.
+	if sel.is_action {
+		run_palette_action(mut app, sel)
+		return
+	}
 	// S4A: registry rows navigate to their typed panel destination. Entity
-	// rows open the owning panel; deep-linked contextual actions land in S4B.
+	// rows open the owning panel and deep-link the canonical entity (S4B).
 	if sel.is_entity {
 		idx := panel_index_for(sel.panel)
 		if idx >= 0 {
 			// shared panel-selection transition (clears desk selection, focus
 			// and onboarding state exactly like dock navigation)
 			select_panel(mut app, idx)
+			deep_link_select(mut app, sel.kind, sel.entity_id)
 		}
 		app.palette_open = false
 		app.palette_query = ''
 		app.palette_selected = 0
+		app.palette_expanded = ''
+		app.palette_preview = []
+		app.palette_preview_for = ''
+		app.palette_armed = ''
 		return
 	}
 	match sel.id {
@@ -7803,6 +7893,130 @@ fn activate_palette_selection(mut app GuiApp) {
 	app.palette_open = false
 	app.palette_query = ''
 	app.palette_selected = 0
+}
+
+// run_palette_action drives the S4B contextual action flow:
+// preview (real dry-run) → confirmation for mutating actions → execution.
+// Confirmation never comes silently: either the preview was shown or the
+// user pressed Enter twice.
+fn run_palette_action(mut app GuiApp, sel PaletteRow) {
+	if app.palette_reg == unsafe { nil } {
+		return
+	}
+	// unavailable actions never arm and never execute — say why, once
+	if !sel.available {
+		app.inspector_msg = 'Unavailable — ${sel.unavailable_reason}'
+		return
+	}
+	// swarm launch needs a real task-text input (plus recipe/backend choices)
+	// — the palette cannot provide that honestly, so route to the swarm
+	// panel launch form, which executes through the same Engine seam and
+	// records the launch as requested
+	if sel.action_kind == .swarm_launch {
+		select_panel(mut app, 8)
+		reset_palette_action_state(mut app)
+		app.inspector_msg = 'Swarm launch — set task, recipe and backend here; the Engine records the request as requested'
+		return
+	}
+	// an open preview means the user has seen the real effects — Enter now
+	// executes as informed confirmation
+	if app.palette_preview.len > 0 && app.palette_preview_for == sel.id {
+		execute_palette_action(mut app, sel)
+		return
+	}
+	if sel.needs_preview && sel.available {
+		lines := app.palette_reg.preview(sel.action_kind, sel.entity_id) or {
+			app.inspector_msg = 'Preview unavailable: ${err.msg()}'
+			return
+		}
+		app.palette_preview = lines
+		app.palette_preview_for = sel.id
+		return
+	}
+	if sel.needs_confirm {
+		if app.palette_armed == sel.id {
+			execute_palette_action(mut app, sel)
+			return
+		}
+		app.palette_armed = sel.id
+		return
+	}
+	execute_palette_action(mut app, sel)
+}
+
+// execute_palette_action executes through the typed registry (Engine seams)
+// and surfaces the truthful outcome. Failures never render as success.
+fn execute_palette_action(mut app GuiApp, sel PaletteRow) {
+	if app.palette_reg == unsafe { nil } {
+		return
+	}
+	args := palette.ActionArgs{
+		confirm: true
+		task: app.palette_query.trim_space()
+	}
+	out := app.palette_reg.execute(sel.kind, sel.entity_id, sel.action_kind, args) or {
+		app.inspector_msg = 'Failed: ${err.msg()}'
+		reset_palette_action_state(mut app)
+		return
+	}
+	prefix := match out.status {
+		.succeeded { '' }
+		.partial { 'Partial — ' }
+		.failed { 'Failed — ' }
+		.unavailable { 'Unavailable — ' }
+		.not_confirmed { 'Not confirmed — ' }
+	}
+	ev := out.evidence
+	detail := if ev.receipt_path != '' {
+		' · receipt ${ev.receipt_path}'
+	} else if ev.run_id != '' {
+		' · run ${ev.run_id}'
+	} else if ev.job_id != '' {
+		' · job ${ev.job_id}'
+	} else {
+		''
+	}
+	app.inspector_msg = '${prefix}${out.summary}${detail}'
+	reset_palette_action_state(mut app)
+}
+
+// reset_palette_action_state closes the palette and clears the action flow.
+fn reset_palette_action_state(mut app GuiApp) {
+	app.palette_open = false
+	app.palette_query = ''
+	app.palette_selected = 0
+	app.palette_expanded = ''
+	app.palette_preview = []
+	app.palette_preview_for = ''
+	app.palette_armed = ''
+}
+
+// deep_link_select resolves the canonical entity identity in its owning
+// panel: selection is set by identity lookup, never by display strings.
+fn deep_link_select(mut app GuiApp, kind palette.EntityKind, id string) {
+	match kind {
+		.skill {
+			entries := skills_filtered_entries(mut app)
+			for idx, e in entries {
+				if e.id == id {
+					app.skills_selected = idx
+					return
+				}
+			}
+			// narrow the panel to the canonical id so the entity is findable
+			app.skills_query = id
+			app.skills_selected = 0
+		}
+		.agent {
+			// the agents panel shares the search field; filter to the
+			// canonical agent id (Engine search by identity)
+			app.skills_query = id
+		}
+		.target {
+			app.skills_query = id
+		}
+		else {}
+	}
 }
 
 // is_panel_nav_key reports whether c is a documented global panel shortcut
@@ -7897,6 +8111,18 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 		}
 		if app.palette_open {
 			if e.key_code == .escape {
+				// S4B: Esc unwinds the innermost palette context first —
+				// preview mode, then expansion, then the palette itself
+				if app.palette_preview.len > 0 {
+					app.palette_preview = []
+					app.palette_preview_for = ''
+					app.palette_armed = ''
+					return
+				}
+				if app.palette_expanded != '' {
+					app.palette_expanded = ''
+					return
+				}
 				app.palette_open = false
 				app.palette_query = ''
 				app.palette_selected = 0
@@ -7904,6 +8130,25 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			if e.key_code == .enter {
 				activate_palette_selection(mut app)
+				return
+			}
+			if e.key_code == .tab {
+				// S4B: expand/collapse contextual actions of the selected
+				// registry entity row
+				filtered_tab := filtered_palette(mut app)
+				if app.palette_selected >= 0 && app.palette_selected < filtered_tab.len {
+					sel_tab := filtered_tab[app.palette_selected]
+					if sel_tab.is_entity && !sel_tab.is_action {
+						app.palette_expanded = if app.palette_expanded == sel_tab.id {
+							''
+						} else {
+							sel_tab.id
+						}
+						app.palette_preview = []
+						app.palette_preview_for = ''
+						app.palette_armed = ''
+					}
+				}
 				return
 			}
 			if e.key_code == .backspace {
@@ -9966,12 +10211,30 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 						// Run button
 						if mx >= fx + fw - 108 && mx <= fx + fw - 64 && my >= y + 44 && my <= y + 60 {
 							entry := loops[idx]
-							app.inspector_msg = 'Loop run queued: ${entry.name} via Engine.run_loop() → job (legacy budgets tok=${entry.budget.max_tokens} runs=${entry.budget.max_runs_per_day} wall=${entry.budget.max_wall_seconds})'
+							// S4B truth fix: Run executes the real Engine
+							// operation; feedback comes from its actual result
+							// and failures are never rendered as success
+							job_id := app.desktop.loop_run(entry.name) or {
+								app.inspector_msg = 'Loop ${entry.name} failed to start: ${err.msg()}'
+								return
+							}
+							app.inspector_msg = 'Loop run started: ${entry.name} — job ${job_id}'
 							return
 						}
 						if mx >= fx + fw - 58 && mx <= fx + fw - 14 && my >= y + 44 && my <= y + 60 {
 							entry := loops[idx]
-							app.inspector_msg = 'Loop schedule toggled: ${entry.name} cron ${entry.schedule} via Engine.toggle_loop_cron()'
+							// S4B truth fix: the schedule toggle writes real
+							// cron configuration via the Engine
+							next_enabled := !entry.cron_enabled
+							app.desktop.toggle_loop_cron(entry.name, next_enabled) or {
+								app.inspector_msg = 'Loop ${entry.name} schedule failed: ${err.msg()}'
+								return
+							}
+							app.inspector_msg = 'Loop schedule ${if next_enabled {
+								'enabled'
+							} else {
+								'disabled'
+							}}: ${entry.name}'
 							return
 						}
 						app.inspector_msg = 'Loop selected: ${loops[idx].name} • L${loops[idx].tier.str().to_upper()} • ${loops[idx].budget.max_tokens} tok • ${loops[idx].budget.max_runs_per_day}/d • ${loops[idx].budget.max_wall_seconds}s'

--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -7730,8 +7730,12 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 			app.gg.draw_rect_filled(cx + pw - 52, y + 4, 36, 6, app.pnl_card_sel)
 		}
 		// S4A: registry rows keep their registry labels; navigation rows keep
-		// localized labels via their i18n key.
-		pal_label := if it.is_entity {
+		// localized labels via their i18n key. S4B action rows always render
+		// their own action label (an action on a navigation entity must not
+		// fall into the navigation translation branch).
+		pal_label := if it.is_action {
+			it.label
+		} else if it.is_entity {
 			if it.kind == .navigation {
 				tr(app, 'palette.' + nav_tr_key(it.panel))
 			} else {
@@ -8012,10 +8016,11 @@ fn deep_link_select(mut app GuiApp, kind palette.EntityKind, id string) {
 			// canonical agent id (Engine search by identity)
 			app.skills_query = id
 		}
-		.target {
-			app.skills_query = id
+		else {
+			// panels without a selection seam (e.g. targets, whose roster is
+			// rendered directly from the Engine) get navigation only — no
+			// field is written that the panel would ignore
 		}
-		else {}
 	}
 }
 
@@ -8121,6 +8126,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 				if app.palette_expanded != '' {
 					app.palette_expanded = ''
+					app.palette_armed = ''
 					return
 				}
 				app.palette_open = false
@@ -8163,6 +8169,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 			if e.key_code == .up {
+				app.palette_armed = ''
 				filtered := filtered_palette(mut app)
 				if filtered.len > 0 {
 					if app.palette_selected > 0 {
@@ -8174,6 +8181,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 			if e.key_code == .down {
+				app.palette_armed = ''
 				filtered := filtered_palette(mut app)
 				if filtered.len > 0 {
 					if app.palette_selected + 1 < filtered.len {

--- a/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
+++ b/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
@@ -1,0 +1,152 @@
+module main
+
+import desktop
+import desktop.palette
+import os
+
+// S4B production-flow tests: preview → confirm → execute through the real
+// registry, honest unavailability, requested-vs-running, canonical deep-link.
+
+struct S4bFixture {
+mut:
+	app &GuiApp = unsafe { nil }
+	d   &desktop.Desktop = unsafe { nil }
+}
+
+// s4b_app boots a headless Desktop + GuiApp with the registry bound.
+fn s4b_app(label string) &S4bFixture {
+	tmp := os.join_path(os.temp_dir(), 'atk-s4b-flow-${label}-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
+		config: desktop.DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	mut app := &GuiApp{
+		desktop: d
+		selected_panel: 0
+		hover_panel: -1
+		selected_desk: -1
+		hover_desk: -1
+	}
+	app.palette_reg = d.palette_registry()
+	app.palette_open = true
+	return &S4bFixture{
+		app: app
+		d: d
+	}
+}
+
+fn find_row(rows []PaletteRow, pred fn (PaletteRow) bool) ?PaletteRow {
+	for r in rows {
+		if pred(r) {
+			return r
+		}
+	}
+	return none
+}
+
+// preview → informed execution: the real dry-run is shown first and the
+// execution mutates real configuration state.
+fn test_palette_action_flow_preview_then_execute() {
+	mut f := s4b_app('flow')
+	defer {
+		f.d.shutdown() or {}
+	}
+	rows := filtered_palette(mut f.app)
+	skill := find_row(rows, fn (r PaletteRow) bool {
+		return r.is_entity && !r.is_action && r.kind == palette.EntityKind.skill
+	}) or { panic('no skill row in palette') }
+	f.app.palette_expanded = skill.id
+	rows2 := filtered_palette(mut f.app)
+	inst := find_row(rows2, fn (r PaletteRow) bool {
+		return r.is_action && r.action_kind == palette.ActionKind.skill_install
+	}) or { panic('skill_install action row missing after expansion') }
+	assert inst.available
+	// preview step: real diff lines, no mutation
+	run_palette_action(mut f.app, inst)
+	assert f.app.palette_preview.len > 0
+	assert f.app.palette_preview_for == inst.id
+	rev_before := f.d.engine_revision()
+	// Enter again = informed confirmation → real execution
+	run_palette_action(mut f.app, inst)
+	assert f.app.inspector_msg.contains('installed')
+	assert !f.app.inspector_msg.starts_with('Failed')
+	assert f.d.engine_revision() > rev_before
+	// palette flow state reset after execution
+	assert !f.app.palette_open
+	assert f.app.palette_preview.len == 0
+	assert f.app.palette_expanded == ''
+}
+
+// unavailable action rows never fake success.
+fn test_palette_action_unavailable_honest() {
+	mut f := s4b_app('unavail')
+	defer {
+		f.d.shutdown() or {}
+	}
+	rows := filtered_palette(mut f.app)
+	skill := find_row(rows, fn (r PaletteRow) bool {
+		return r.is_entity && !r.is_action && r.kind == palette.EntityKind.skill
+	}) or { panic('no skill row') }
+	f.app.palette_expanded = skill.id
+	rows2 := filtered_palette(mut f.app)
+	rm := find_row(rows2, fn (r PaletteRow) bool {
+		return r.is_action && r.action_kind == palette.ActionKind.skill_remove
+	}) or { panic('skill_remove action row missing') }
+	assert !rm.available
+	rev_before := f.d.engine_revision()
+	run_palette_action(mut f.app, rm)
+	assert f.app.inspector_msg.starts_with('Unavailable —')
+	assert f.app.inspector_msg.contains('not installed')
+	// nothing changed
+	assert f.d.engine_revision() == rev_before
+}
+
+// swarm launch routes to the swarm panel launch form (task text + recipe +
+// backend are real typed inputs the palette cannot provide honestly).
+fn test_palette_swarm_launch_routes_to_panel_form() {
+	mut f := s4b_app('swarm')
+	defer {
+		f.d.shutdown() or {}
+	}
+	rows := filtered_palette(mut f.app)
+	swarm := find_row(rows, fn (r PaletteRow) bool {
+		return r.is_entity && !r.is_action && r.id == 'nav:/swarm'
+	}) or { panic('nav:/swarm row missing') }
+	f.app.palette_expanded = swarm.id
+	rows2 := filtered_palette(mut f.app)
+	launch := find_row(rows2, fn (r PaletteRow) bool {
+		return r.is_action && r.action_kind == palette.ActionKind.swarm_launch
+	}) or { panic('swarm_launch action row missing') }
+	run_palette_action(mut f.app, launch)
+	// routed to the launch form; no run was fabricated by the palette
+	assert f.app.selected_panel == 8
+	assert !f.app.palette_open
+	assert f.d.swarm_list().len == 0
+}
+
+// deep-link preserves canonical entity identity: selection is resolved by id.
+fn test_deep_link_selects_canonical_skill() {
+	mut f := s4b_app('deeplink')
+	defer {
+		f.d.shutdown() or {}
+	}
+	rows := filtered_palette(mut f.app)
+	skill := find_row(rows, fn (r PaletteRow) bool {
+		return r.is_entity && !r.is_action && r.kind == palette.EntityKind.skill
+	}) or { panic('no skill row') }
+	deep_link_select(mut f.app, skill.kind, skill.entity_id)
+	entries := skills_filtered_entries(mut f.app)
+	assert app_selection_matches(mut f.app, entries, skill.entity_id)
+}
+
+// app_selection_matches asserts the panel selection points at the canonical id.
+fn app_selection_matches(mut app GuiApp, entries []SkillEntryProxy, id string) bool {
+	if app.skills_selected < 0 || app.skills_selected >= entries.len {
+		return false
+	}
+	return entries[app.skills_selected].id == id
+}

--- a/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
+++ b/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
@@ -13,9 +13,17 @@ mut:
 	d   &desktop.Desktop = unsafe { nil }
 }
 
-// s4b_app boots a headless Desktop + GuiApp with the registry bound.
+// s4b_app boots a headless Desktop + GuiApp with the registry bound. Stale
+// fixture dirs from previous runs are swept first (engine state persists).
 fn s4b_app(label string) &S4bFixture {
-	tmp := os.join_path(os.temp_dir(), 'atk-s4b-flow-${label}-${os.getpid()}')
+	base := os.temp_dir()
+	entries := os.ls(base) or { []string{} }
+	for e in entries {
+		if e.starts_with('atk-s4b-flow-') {
+			os.rmdir_all(os.join_path(base, e)) or {}
+		}
+	}
+	tmp := os.join_path(base, 'atk-s4b-flow-${label}-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
 		config: desktop.DesktopConfig{

--- a/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
+++ b/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
@@ -3,6 +3,7 @@ module main
 import desktop
 import desktop.palette
 import os
+import time
 
 // S4B production-flow tests: preview → confirm → execute through the real
 // registry, honest unavailability, requested-vs-running, canonical deep-link.
@@ -11,19 +12,13 @@ struct S4bFixture {
 mut:
 	app &GuiApp = unsafe { nil }
 	d   &desktop.Desktop = unsafe { nil }
+	tmp string
 }
 
-// s4b_app boots a headless Desktop + GuiApp with the registry bound. Stale
-// fixture dirs from previous runs are swept first (engine state persists).
+// s4b_app boots a headless Desktop + GuiApp with the registry bound. The
+// fixture owns its exact temp directory and removes it in cleanup().
 fn s4b_app(label string) &S4bFixture {
-	base := os.temp_dir()
-	entries := os.ls(base) or { []string{} }
-	for e in entries {
-		if e.starts_with('atk-s4b-flow-') {
-			os.rmdir_all(os.join_path(base, e)) or {}
-		}
-	}
-	tmp := os.join_path(base, 'atk-s4b-flow-${label}-${os.getpid()}')
+	tmp := os.join_path(os.temp_dir(), 'atk-s4b-flow-${label}-${os.getpid()}-${time.now().unix_nano()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
 		config: desktop.DesktopConfig{
@@ -44,6 +39,16 @@ fn s4b_app(label string) &S4bFixture {
 	return &S4bFixture{
 		app: app
 		d: d
+		tmp: tmp
+	}
+}
+
+// cleanup stops the Desktop and removes this fixture's exact temp path.
+fn (mut f S4bFixture) cleanup() {
+	f.d.shutdown() or {}
+	if f.tmp != '' {
+		os.rmdir_all(f.tmp) or {}
+		f.tmp = ''
 	}
 }
 
@@ -61,7 +66,7 @@ fn find_row(rows []PaletteRow, pred fn (PaletteRow) bool) ?PaletteRow {
 fn test_palette_action_flow_preview_then_execute() {
 	mut f := s4b_app('flow')
 	defer {
-		f.d.shutdown() or {}
+		f.cleanup()
 	}
 	rows := filtered_palette(mut f.app)
 	skill := find_row(rows, fn (r PaletteRow) bool {
@@ -93,7 +98,7 @@ fn test_palette_action_flow_preview_then_execute() {
 fn test_palette_action_unavailable_honest() {
 	mut f := s4b_app('unavail')
 	defer {
-		f.d.shutdown() or {}
+		f.cleanup()
 	}
 	rows := filtered_palette(mut f.app)
 	skill := find_row(rows, fn (r PaletteRow) bool {
@@ -118,7 +123,7 @@ fn test_palette_action_unavailable_honest() {
 fn test_palette_swarm_launch_routes_to_panel_form() {
 	mut f := s4b_app('swarm')
 	defer {
-		f.d.shutdown() or {}
+		f.cleanup()
 	}
 	rows := filtered_palette(mut f.app)
 	swarm := find_row(rows, fn (r PaletteRow) bool {
@@ -140,7 +145,7 @@ fn test_palette_swarm_launch_routes_to_panel_form() {
 fn test_deep_link_selects_canonical_skill() {
 	mut f := s4b_app('deeplink')
 	defer {
-		f.d.shutdown() or {}
+		f.cleanup()
 	}
 	rows := filtered_palette(mut f.app)
 	skill := find_row(rows, fn (r PaletteRow) bool {

--- a/modules/desktop/palette/actions.v
+++ b/modules/desktop/palette/actions.v
@@ -1,0 +1,729 @@
+module palette
+
+// S4B (#1119) — contextual actions with typed arguments, validation, preview
+// and truthful execution. Every action binds a real typed Engine operation;
+// nothing shells out to the CLI. Actions are classified against current code
+// before exposure (READY / READY_WITH_ADAPTER / UNAVAILABLE / OUT_OF_SCOPE):
+// an action without a real backend seam stays out of the registry.
+//
+// Outcome semantics: success / failure / partial / unavailable are distinct.
+// Evidence fields (revision, job id, run id, receipt path) are populated only
+// when the Engine actually produced them — never manufactured.
+//
+// Governing contracts:
+// - docs/desktop/UX_ARCHITECTURE.md §Shared action and entity model
+// - docs/desktop/TRUTH_LEDGER.md (S7 gates must stay green)
+
+import desktop_engine
+import desktop.nav
+
+// ActionKind enumerates registry-backed contextual operations.
+pub enum ActionKind {
+	skill_install
+	skill_remove
+	target_install
+	target_enable
+	target_disable
+	mcp_enable
+	mcp_disable
+	mcp_probe
+	doctor_repair
+	loop_run
+	loop_schedule_toggle
+	swarm_launch
+}
+
+// kind_label returns the human action label used in the palette.
+pub fn kind_label(k ActionKind) string {
+	return match k {
+		.skill_install { 'Install' }
+		.skill_remove { 'Remove' }
+		.target_install { 'Install profile' }
+		.target_enable { 'Enable' }
+		.target_disable { 'Disable' }
+		.mcp_enable { 'Enable from packaged template' }
+		.mcp_disable { 'Disable' }
+		.mcp_probe { 'Probe health' }
+		.doctor_repair { 'Repair' }
+		.loop_run { 'Run now' }
+		.loop_schedule_toggle { 'Toggle schedule' }
+		.swarm_launch { 'Launch' }
+	}
+}
+
+// ActionStatus classifies an outcome truthfully. Partial failure and
+// not-confirmed are distinct from plain success/failure.
+pub enum ActionStatus {
+	succeeded
+	failed
+	partial
+	unavailable
+	not_confirmed
+}
+
+// ActionArgs are the typed arguments an action accepts — product concepts
+// (selection, scope, dry run, confirmation), never CLI flag strings.
+@[params]
+pub struct ActionArgs {
+pub:
+	enabled bool // for enable/disable & schedule toggles
+	dry_run bool // preview-only execution where the Engine supports one
+	confirm bool // explicit confirmation for actions that need one
+	targets []string // multi-subject selection (target install)
+	task    string // swarm launch task text
+	recipe  string // swarm recipe: pair | team | full
+	backend string // swarm backend: auto | herdr | tmux
+}
+
+// validate checks typed argument constraints; returns a reason on failure.
+pub fn (args ActionArgs) validate(kind ActionKind) ?string {
+	return match kind {
+		.swarm_launch {
+			if args.task.trim_space() == '' {
+				'swarm task text is required'
+			} else if args.task.len > 4096 {
+				'swarm task too long (max 4096)'
+			} else if args.recipe != '' && args.recipe !in ['pair', 'team', 'full'] {
+				'unknown swarm recipe: ${args.recipe}'
+			} else if args.backend != '' && args.backend !in ['auto', 'herdr', 'tmux'] {
+				'unknown swarm backend: ${args.backend}'
+			} else {
+				none
+			}
+		}
+		.target_install {
+			if args.targets.len == 0 {
+				'no targets selected'
+			} else {
+				none
+			}
+		}
+		else {
+			none
+		}
+	}
+}
+
+// ActionEvidence carries only evidence that really exists.
+pub struct ActionEvidence {
+pub:
+	revision       u64
+	job_id         string
+	run_id         string
+	receipt_path   string
+	artifact_paths []string
+}
+
+// ActionOutcome is the truthful result envelope.
+pub struct ActionOutcome {
+pub:
+	status   ActionStatus
+	summary  string
+	evidence ActionEvidence
+}
+
+// is_ok reports whether the outcome represents real success (or accepted
+// partial progress — never a fabricated pass).
+pub fn (o ActionOutcome) is_ok() bool {
+	return o.status in [.succeeded, .partial]
+}
+
+// RegistryAction is one contextual action bound to a registry entity.
+pub struct RegistryAction {
+pub:
+	kind        ActionKind
+	entity_kind EntityKind
+	entity_id   string
+	label       string
+	category    string
+	keywords    string
+	desc        string
+	// semantics
+	needs_preview bool // a truthful dry-run/diff exists
+	needs_confirm bool // mutating/destructive: explicit confirmation required
+	// availability
+	available          bool
+	unavailable_reason string
+	panel              nav.PanelId
+}
+
+// action_id is the stable palette id for the action row.
+pub fn (a RegistryAction) action_id() string {
+	return 'action:${a.entity_kind}_${a.entity_id}:${a.kind}'
+}
+
+// is_valid checks required fields.
+pub fn (a RegistryAction) is_valid() bool {
+	return a.entity_id != '' && a.label != ''
+}
+
+// find_entry locates a registry entry by kind + canonical id (fresh state).
+fn (mut r Registry) find_entry(kind EntityKind, id string) ?RegistryEntry {
+	for e in r.all_entries() {
+		if e.kind == kind && e.id == id {
+			return e
+		}
+	}
+	return none
+}
+
+// actions_for derives the contextual actions for one registry entity from its
+// current truthful state. Unavailable actions are listed with their reason.
+pub fn (mut r Registry) actions_for(kind EntityKind, entity_id string) []RegistryAction {
+	entry := r.find_entry(kind, entity_id) or {
+		return []RegistryAction{}
+	}
+	mut out := []RegistryAction{}
+	match kind {
+		.skill {
+			installed := r.engine.skills_installed().contains(entity_id)
+			out << RegistryAction{
+				kind: .skill_install
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.skill_install)
+				category: entry.category
+				keywords: 'install ${entity_id} skill'
+				desc: if installed { 'already installed' } else { 'add to installed selection' }
+				needs_preview: true
+				needs_confirm: false
+				available: !installed
+				unavailable_reason: if installed { 'skill is already installed' } else { '' }
+				panel: .skills
+			}
+			out << RegistryAction{
+				kind: .skill_remove
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.skill_remove)
+				category: entry.category
+				keywords: 'remove uninstall ${entity_id} skill'
+				desc: 'remove from installed selection (configuration only)'
+				needs_preview: true
+				needs_confirm: true
+				available: installed
+				unavailable_reason: if installed { '' } else { 'skill is not installed' }
+				panel: .skills
+			}
+		}
+		.target {
+			installable := r.engine.target_install_supported(entity_id)
+			enabled := r.engine_target_enabled(entity_id)
+			out << RegistryAction{
+				kind: .target_install
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.target_install)
+				category: entry.category
+				keywords: 'install profile ${entity_id} target'
+				desc: 'write bundled profile + real install receipt'
+				needs_preview: true
+				needs_confirm: true
+				available: installable
+				unavailable_reason: if installable {
+					''
+				} else {
+					'no bundled profile installer for this target'
+				}
+				panel: .targets
+			}
+			out << RegistryAction{
+				kind: .target_enable
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.target_enable)
+				category: entry.category
+				keywords: 'enable ${entity_id} target'
+				desc: 'mark target enabled in configuration'
+				needs_confirm: false
+				available: !enabled
+				unavailable_reason: if enabled { 'target is already enabled' } else { '' }
+				panel: .targets
+			}
+			out << RegistryAction{
+				kind: .target_disable
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.target_disable)
+				category: entry.category
+				keywords: 'disable ${entity_id} target'
+				desc: 'mark target disabled in configuration'
+				needs_confirm: false
+				available: enabled
+				unavailable_reason: if enabled { '' } else { 'target is not enabled' }
+				panel: .targets
+			}
+		}
+		.mcp_provider {
+			enabled := r.engine_mcp_enabled(entity_id)
+			out << RegistryAction{
+				kind: .mcp_enable
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.mcp_enable)
+				category: entry.category
+				keywords: 'enable ${entity_id} mcp provider template'
+				desc: 'upsert configuration from the packaged template'
+				needs_preview: true
+				needs_confirm: false
+				available: !enabled
+				unavailable_reason: if enabled { 'provider is already enabled' } else { '' }
+				panel: .mcp
+			}
+			out << RegistryAction{
+				kind: .mcp_disable
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.mcp_disable)
+				category: entry.category
+				keywords: 'disable ${entity_id} mcp provider'
+				desc: 'remove provider configuration (re-enable restores from template)'
+				needs_confirm: true
+				available: enabled
+				unavailable_reason: if enabled { '' } else { 'provider is not enabled' }
+				panel: .mcp
+			}
+			out << RegistryAction{
+				kind: .mcp_probe
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.mcp_probe)
+				category: entry.category
+				keywords: 'probe health ${entity_id} mcp'
+				desc: 'validate template + report live health (read-only)'
+				needs_confirm: false
+				available: true
+				panel: .mcp
+			}
+		}
+		.doctor_check {
+			out << RegistryAction{
+				kind: .doctor_repair
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.doctor_repair)
+				category: entry.category
+				keywords: 'repair fix ${entity_id} doctor check'
+				desc: 'preview the repair, then apply it'
+				needs_preview: true
+				needs_confirm: true
+				available: entry.available
+				unavailable_reason: entry.unavailable_reason
+				panel: .doctor
+			}
+		}
+		.loop_template {
+			out << RegistryAction{
+				kind: .loop_run
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.loop_run)
+				category: entry.category
+				keywords: 'run now ${entity_id} loop'
+				desc: 'start a real supervised run (budget gates apply)'
+				needs_confirm: false
+				available: true
+				panel: .loops
+			}
+			out << RegistryAction{
+				kind: .loop_schedule_toggle
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.loop_schedule_toggle)
+				category: entry.category
+				keywords: 'schedule cron ${entity_id} loop'
+				desc: 'enable or disable the cron schedule in configuration'
+				needs_confirm: false
+				available: true
+				panel: .loops
+			}
+		}
+		.navigation {
+			if entity_id == '/swarm' {
+				out << RegistryAction{
+					kind: .swarm_launch
+					entity_kind: kind
+					entity_id: entity_id
+					label: kind_label(.swarm_launch)
+					category: 'Swarm'
+					keywords: 'launch swarm pair team full request'
+					desc: 'record a swarm launch request (task text required)'
+					needs_confirm: true
+					available: true
+					panel: .swarm
+				}
+			}
+		}
+		else {}
+	}
+	return out
+}
+
+// engine_target_enabled reads the target's real enabled state (configuration
+// truth — never inferred from display strings).
+fn (mut r Registry) engine_target_enabled(target_id string) bool {
+	for t in r.engine.targets() {
+		if t.id == target_id {
+			return t.enabled
+		}
+	}
+	return false
+}
+
+// engine_mcp_enabled reads the provider's real enabled state.
+fn (mut r Registry) engine_mcp_enabled(provider_id string) bool {
+	for p in r.engine.mcp_catalog() {
+		if p.id == provider_id {
+			return p.enabled
+		}
+	}
+	return false
+}
+
+// preview returns truthful expected effects WITHOUT mutating state, using
+// real Engine dry-run/diff operations. Errors are honest (no invented text).
+pub fn (mut r Registry) preview(action ActionKind, entity_id string) ![]string {
+	match action {
+		.skill_install {
+			d := r.engine.install_skill_preview(entity_id)
+			return target_diff_lines(d, 'install')
+		}
+		.skill_remove {
+			d := r.engine.install_skill_preview(entity_id)
+			return target_diff_lines(d, 'remove')
+		}
+		.target_install {
+			d := r.engine.install_preview([entity_id])
+			return target_diff_lines(d, 'install profile')
+		}
+		.mcp_enable {
+			pv := r.engine.mcp_install_preview(entity_id)
+			if pv.will_write.len == 0 && pv.will_update.len == 0 {
+				return error('no packaged template for ${entity_id} — nothing to write')
+			}
+			mut lines := []string{}
+			for p in pv.will_write {
+				lines << 'write: ${p}'
+			}
+			for p in pv.will_update {
+				lines << 'update: ${p}'
+			}
+			if pv.receipt_path != '' {
+				lines << 'receipt: ${pv.receipt_path}'
+			}
+			return lines
+		}
+		.doctor_repair {
+			return r.engine.doctor_fix_preview(entity_id)!
+		}
+		else {
+			return error('preview unavailable for this action')
+		}
+	}
+}
+
+// target_diff_lines renders an Engine TargetDiff as truthful preview lines.
+fn target_diff_lines(d desktop_engine.TargetDiff, verb string) []string {
+	mut lines := []string{}
+	if d.added.len == 0 && d.removed.len == 0 && d.modified.len == 0 {
+		lines << '${verb}: no configuration changes expected'
+		return lines
+	}
+	for a in d.added {
+		lines << '${verb}: add ${a}'
+	}
+	for rm in d.removed {
+		lines << '${verb}: remove ${rm}'
+	}
+	for m in d.modified {
+		if verb == 'remove' {
+			lines << 'remove: ${m} is installed — it will be removed from the selection'
+		} else {
+			lines << '${verb}: ${m} is already present — no change'
+		}
+	}
+	return lines
+}
+
+// execute validates typed args, runs the real Engine operation, and maps the
+// result to a truthful outcome. Failures surface as errors/failures — never
+// as fabricated success.
+pub fn (mut r Registry) execute(kind EntityKind, entity_id string, action ActionKind, args ActionArgs) !ActionOutcome {
+	// typed argument validation first
+	if reason := args.validate(action) {
+		return ActionOutcome{
+			status: .failed
+			summary: reason
+		}
+	}
+	// availability must hold at execution time (state may have moved)
+	acts := r.actions_for(kind, entity_id)
+	mut act := RegistryAction{}
+	mut found := false
+	for a in acts {
+		if a.kind == action {
+			act = a
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ActionOutcome{
+			status: .unavailable
+			summary: 'no such action for this entity'
+		}
+	}
+	if !act.available {
+		return ActionOutcome{
+			status: .unavailable
+			summary: act.unavailable_reason
+		}
+	}
+	if act.needs_confirm && !args.confirm && !args.dry_run {
+		return ActionOutcome{
+			status: .not_confirmed
+			summary: 'confirmation required — review the preview, then confirm'
+		}
+	}
+	return r.execute_seam(kind, entity_id, action, args)
+}
+
+// execute_seam performs the Engine operation for a validated, available,
+// confirmed action.
+fn (mut r Registry) execute_seam(kind EntityKind, entity_id string, action ActionKind, args ActionArgs) !ActionOutcome {
+	match action {
+		.skill_install {
+			rev := r.engine.install_skill(entity_id) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'installed ${entity_id} (configuration selection)'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.skill_remove {
+			rev := r.engine.remove_skill(entity_id) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'removed ${entity_id} from installed selection'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.target_install {
+			opts := desktop_engine.InstallOptionsEngine{
+				targets: if args.targets.len > 0 { args.targets } else { [entity_id] }
+				dry_run: args.dry_run
+				force: false
+				home_dir: r.install_home_dir
+				receipt_dir: r.install_receipt_dir
+			}
+			rev := r.engine.install_with_options(opts) or {
+				// partial install commits configuration but reports remaining
+				// failures — a distinct, honest outcome
+				if err.msg().contains('partial install') {
+					return ActionOutcome{
+						status: .partial
+						summary: err.msg()
+						evidence: ActionEvidence{
+							revision: r.engine.revision()
+						}
+					}
+				}
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			if args.dry_run {
+				return ActionOutcome{
+					status: .succeeded
+					summary: 'dry-run complete — nothing was written'
+					evidence: ActionEvidence{
+						revision: 0
+					}
+				}
+			}
+			// Receipt lookup only when no test injection is active: injected
+			// receipts live outside the real config authority, and state
+			// bookkeeping is never surfaced as a receipt.
+			if r.install_home_dir == '' && r.install_receipt_dir == '' {
+				for rc in r.engine.list_install_receipts() {
+					if rc.target == entity_id {
+						return ActionOutcome{
+							status: .succeeded
+							summary: 'installed ${entity_id} profile'
+							evidence: ActionEvidence{
+								revision: rev
+								receipt_path: rc.receipt_path
+								artifact_paths: rc.artifacts
+							}
+						}
+					}
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'installed ${entity_id} profile (receipt not listed)'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.target_enable {
+			rev := r.engine.set_target_enabled(entity_id, true) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'enabled ${entity_id}'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.target_disable {
+			rev := r.engine.set_target_enabled(entity_id, false) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'disabled ${entity_id}'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.mcp_enable {
+			rev := r.engine.mcp_toggle(entity_id) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'enabled ${entity_id} from packaged template'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.mcp_disable {
+			rev := r.engine.mcp_toggle(entity_id) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'disabled ${entity_id} — configuration removed'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.mcp_probe {
+			res := r.engine.mcp_probe(entity_id) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: res.detail
+				evidence: ActionEvidence{}
+			}
+		}
+		.doctor_repair {
+			rev := r.engine.doctor_fix(entity_id) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'repair applied for ${entity_id}'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.loop_run {
+			job_id := r.engine.run_loop(entity_id) or {
+				// real gate failures (budget exhausted, deleted, not found)
+				// are honest action failures — never fake success
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'run started for ${entity_id}'
+				evidence: ActionEvidence{
+					job_id: job_id
+				}
+			}
+		}
+		.loop_schedule_toggle {
+			rev := r.engine.toggle_loop_cron(entity_id, args.enabled) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'schedule ${if args.enabled { 'enabled' } else { 'disabled' }} for ${entity_id}'
+				evidence: ActionEvidence{
+					revision: rev
+				}
+			}
+		}
+		.swarm_launch {
+			recipe := if args.recipe == '' { 'pair' } else { args.recipe }
+			backend := if args.backend == '' { 'auto' } else { args.backend }
+			run_id := r.engine.swarm_launch(desktop_engine.SwarmLaunchArgs{
+				recipe: desktop_engine.swarm_recipe_from_string(recipe)
+				backend: desktop_engine.swarm_backend_from_string(backend)
+				task: args.task
+			}) or {
+				return ActionOutcome{
+					status: .failed
+					summary: err.msg()
+				}
+			}
+			// The engine records the launch request; workers are not proven
+			// running here — the summary must say exactly that.
+			return ActionOutcome{
+				status: .succeeded
+				summary: 'swarm ${recipe} launch requested (${backend}) — not yet running'
+				evidence: ActionEvidence{
+					run_id: run_id
+				}
+			}
+		}
+	}
+}

--- a/modules/desktop/palette/actions.v
+++ b/modules/desktop/palette/actions.v
@@ -76,6 +76,9 @@ pub:
 }
 
 // validate checks typed argument constraints; returns a reason on failure.
+// Note: single-subject actions fall back to the contextual entity, so an
+// empty selection is only invalid when no subject exists at all (enforced
+// by execute(), which knows the entity).
 pub fn (args ActionArgs) validate(kind ActionKind) ?string {
 	return match kind {
 		.swarm_launch {
@@ -87,13 +90,6 @@ pub fn (args ActionArgs) validate(kind ActionKind) ?string {
 				'unknown swarm recipe: ${args.recipe}'
 			} else if args.backend != '' && args.backend !in ['auto', 'herdr', 'tmux'] {
 				'unknown swarm backend: ${args.backend}'
-			} else {
-				none
-			}
-		}
-		.target_install {
-			if args.targets.len == 0 {
-				'no targets selected'
 			} else {
 				none
 			}
@@ -479,10 +475,24 @@ pub fn (mut r Registry) execute(kind EntityKind, entity_id string, action Action
 			summary: act.unavailable_reason
 		}
 	}
-	if act.needs_confirm && !args.confirm && !args.dry_run {
+	if act.needs_confirm && !args.confirm {
+		// dry_run may bypass confirmation ONLY where a real dry-run seam
+		// exists (target install). Preview methods elsewhere are separate
+		// read-only calls — args.dry_run must never turn a mutating action
+		// into an unconfirmed mutation.
+		dry_ok := action == .target_install && args.dry_run
+		if !dry_ok {
+			return ActionOutcome{
+				status: .not_confirmed
+				summary: 'confirmation required — review the preview, then confirm'
+			}
+		}
+	}
+	// multi-subject install needs at least the contextual entity as subject
+	if action == .target_install && args.targets.len == 0 && entity_id == '' {
 		return ActionOutcome{
-			status: .not_confirmed
-			summary: 'confirmation required — review the preview, then confirm'
+			status: .failed
+			summary: 'no targets selected'
 		}
 	}
 	return r.execute_seam(kind, entity_id, action, args)

--- a/modules/desktop/palette/actions.v
+++ b/modules/desktop/palette/actions.v
@@ -688,7 +688,16 @@ fn (mut r Registry) execute_seam(kind EntityKind, entity_id string, action Actio
 			}
 		}
 		.loop_schedule_toggle {
-			rev := r.engine.toggle_loop_cron(entity_id, args.enabled) or {
+			// one-click schedule toggle: read the real cron state and flip it
+			// (configuration truth), like the other Engine toggles
+			mut target_enabled := true
+			for l in r.engine.loops_catalog() {
+				if l.name == entity_id {
+					target_enabled = !l.cron_enabled
+					break
+				}
+			}
+			rev := r.engine.toggle_loop_cron(entity_id, target_enabled) or {
 				return ActionOutcome{
 					status: .failed
 					summary: err.msg()
@@ -696,7 +705,7 @@ fn (mut r Registry) execute_seam(kind EntityKind, entity_id string, action Actio
 			}
 			return ActionOutcome{
 				status: .succeeded
-				summary: 'schedule ${if args.enabled { 'enabled' } else { 'disabled' }} for ${entity_id}'
+				summary: 'schedule ${if target_enabled { 'enabled' } else { 'disabled' }} for ${entity_id}'
 				evidence: ActionEvidence{
 					revision: rev
 				}

--- a/modules/desktop/palette/actions_test.v
+++ b/modules/desktop/palette/actions_test.v
@@ -1,0 +1,397 @@
+module palette
+
+import os
+import desktop_engine
+
+// s4b_engine builds an Engine over an isolated temp persist path.
+fn s4b_engine(label string) &desktop_engine.Engine {
+	tmp := os.join_path(os.temp_dir(), 'palette-actions-${label}-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	persist := os.join_path(tmp, 'state.json')
+	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
+		persist_path: persist
+	})
+	eng.init() or { panic(err.msg()) }
+	eng.start() or { panic(err.msg()) }
+	return eng
+}
+
+fn first_skill_id(mut eng &desktop_engine.Engine) string {
+	catalog := eng.skills_catalog()
+	if catalog.len == 0 {
+		panic('no catalog skills — test env misconfigured')
+	}
+	return catalog[0].id
+}
+
+// find_action locates an action by kind in a derived action list.
+fn find_action(acts []RegistryAction, kind ActionKind) ?RegistryAction {
+	for a in acts {
+		if a.kind == kind {
+			return a
+		}
+	}
+	return none
+}
+
+// 1. unavailable actions carry a truthful reason.
+fn test_unavailable_action_has_reason() {
+	mut eng := s4b_engine('unavail')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	skill_id := first_skill_id(mut eng)
+
+	// remove on a not-installed skill is unavailable with a reason
+	acts := reg.actions_for(.skill, skill_id)
+	rm := find_action(acts, .skill_remove) or { panic('skill_remove action missing') }
+	assert !rm.available
+	assert rm.unavailable_reason.contains('not installed')
+
+	// disable on a not-enabled target is unavailable with a reason
+	mut target_id := ''
+	for t in eng.targets() {
+		target_id = t.id
+		break
+	}
+	if target_id != '' && !eng.target_enabled(target_id) {
+		dacts := reg.actions_for(.target, target_id)
+		dis := find_action(dacts, .target_disable) or { panic('target_disable action missing') }
+		assert !dis.available
+		assert dis.unavailable_reason.contains('not enabled')
+	}
+
+	// doctor repair on a non-fixable check is unavailable with a reason
+	for c in eng.doctor() {
+		if !c.fixable {
+			cacts := reg.actions_for(.doctor_check, c.id)
+			assert cacts.len == 1
+			assert !cacts[0].available
+			assert cacts[0].unavailable_reason.contains('not auto-fixable')
+			break
+		}
+	}
+}
+
+// 2. typed args are validated before any Engine call.
+fn test_typed_args_are_validated() {
+	mut eng := s4b_engine('args')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	// empty swarm task → failed validation, nothing recorded
+	before := eng.revision()
+	out := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
+		task: '   '
+	}) or { panic(err.msg()) }
+	assert out.status == .failed
+	assert out.summary.contains('task text is required')
+	assert eng.revision() == before
+	// bad recipe → failed validation
+	out2 := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
+		task: 'x'
+		recipe: 'army'
+	}) or { panic(err.msg()) }
+	assert out2.status == .failed
+	assert out2.summary.contains('unknown swarm recipe')
+	// empty target selection → failed validation
+	out3 := reg.execute(.target, 'claude-code', .target_install, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out3.status == .failed
+	assert out3.summary.contains('no targets selected')
+}
+
+// 3. preview calculates real effects without mutating state.
+fn test_preview_does_not_mutate_state() {
+	mut eng := s4b_engine('preview')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	skill_id := first_skill_id(mut eng)
+	before_rev := eng.revision()
+	before_installed := eng.skills_installed().clone()
+
+	lines := reg.preview(.skill_install, skill_id) or { panic(err.msg()) }
+	assert lines.len > 0
+	assert lines[0].contains('add')
+	assert lines[0].contains(skill_id)
+	// nothing mutated: revision and installed selection unchanged
+	assert eng.revision() == before_rev
+	assert eng.skills_installed() == before_installed
+
+	// doctor preview: real dry-run lines, no mutation
+	mut check_id := ''
+	for c in eng.doctor() {
+		if c.fixable {
+			check_id = c.id
+			break
+		}
+	}
+	if check_id != '' {
+		prev := reg.preview(.doctor_repair, check_id) or { panic(err.msg()) }
+		assert prev.len > 0
+		assert eng.revision() == before_rev
+	}
+}
+
+// 4. real execution mutates the expected authoritative state.
+fn test_skill_execution_mutates_config_truth() {
+	mut eng := s4b_engine('exec-skill')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	skill_id := first_skill_id(mut eng)
+	out := reg.execute(.skill, skill_id, .skill_install, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	assert out.evidence.revision > 0
+	assert eng.skills_installed().contains(skill_id)
+	// install of an installed skill is unavailable (not a fake no-op success)
+	out2 := reg.execute(.skill, skill_id, .skill_install, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out2.status == .unavailable
+	// remove needs confirmation; without it the state must be untouched
+	nc := reg.execute(.skill, skill_id, .skill_remove, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert nc.status == .not_confirmed
+	assert eng.skills_installed().contains(skill_id)
+	// confirmed remove really removes
+	rm := reg.execute(.skill, skill_id, .skill_remove, ActionArgs{
+		confirm: true
+	}) or { panic(err.msg()) }
+	assert rm.status == .succeeded
+	assert !eng.skills_installed().contains(skill_id)
+}
+
+// 5. target enable/disable uses actual configuration state.
+fn test_target_enable_disable_uses_config_truth() {
+	mut eng := s4b_engine('exec-target')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	mut target_id := ''
+	for t in eng.targets() {
+		target_id = t.id
+		break
+	}
+	if target_id == '' {
+		panic('no targets in catalog — test env misconfigured')
+	}
+	was_enabled := eng.target_enabled(target_id)
+	if was_enabled {
+		out := reg.execute(.target, target_id, .target_disable, ActionArgs{}) or {
+			panic(err.msg())
+		}
+		assert out.status == .succeeded
+		assert !eng.target_enabled(target_id)
+	} else {
+		out := reg.execute(.target, target_id, .target_enable, ActionArgs{}) or {
+			panic(err.msg())
+		}
+		assert out.status == .succeeded
+		assert eng.target_enabled(target_id)
+	}
+	// the flipped direction now reports unavailability correctly
+	acts := reg.actions_for(.target, target_id)
+	for a in acts {
+		if a.kind == .target_enable {
+			assert a.available == !eng.target_enabled(target_id)
+		}
+		if a.kind == .target_disable {
+			assert a.available == eng.target_enabled(target_id)
+		}
+	}
+}
+
+// 6. MCP actions use the real provider configuration.
+fn test_mcp_actions_use_real_provider_config() {
+	mut eng := s4b_engine('exec-mcp')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	mut provider_id := ''
+	for p in eng.mcp_catalog() {
+		provider_id = p.id
+		break
+	}
+	if provider_id == '' {
+		panic('no mcp providers in catalog — test env misconfigured')
+	}
+	was_enabled := reg.engine_mcp_enabled(provider_id)
+	if was_enabled {
+		// disable requires confirmation
+		nc := reg.execute(.mcp_provider, provider_id, .mcp_disable, ActionArgs{}) or {
+			panic(err.msg())
+		}
+		assert nc.status == .not_confirmed
+		out := reg.execute(.mcp_provider, provider_id, .mcp_disable, ActionArgs{
+			confirm: true
+		}) or { panic(err.msg()) }
+		assert out.status == .succeeded
+		assert !reg.engine_mcp_enabled(provider_id)
+	} else {
+		// preview shows real write targets, mutates nothing
+		before := eng.revision()
+		pv := reg.preview(.mcp_enable, provider_id) or {
+			// providers without a packaged template honestly have no preview
+			assert err.msg().contains('no packaged template')
+			return
+		}
+		assert pv.len > 0
+		assert eng.revision() == before
+		out := reg.execute(.mcp_provider, provider_id, .mcp_enable, ActionArgs{}) or {
+			panic(err.msg())
+		}
+		assert out.status == .succeeded
+		assert reg.engine_mcp_enabled(provider_id)
+	}
+}
+
+// 7. doctor preview → repair is truthful end to end.
+fn test_doctor_preview_repair_truthful() {
+	mut eng := s4b_engine('exec-doctor')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	mut check_id := ''
+	for c in eng.doctor() {
+		if c.fixable {
+			check_id = c.id
+			break
+		}
+	}
+	if check_id == '' {
+		println('no fixable doctor checks — skipping execution leg')
+		return
+	}
+	prev := reg.preview(.doctor_repair, check_id) or {
+		panic(err.msg())
+	}
+	assert prev.len > 0
+	out := reg.execute(.doctor_check, check_id, .doctor_repair, ActionArgs{
+		confirm: true
+	}) or { panic(err.msg()) }
+	assert out.status == .succeeded
+	assert out.evidence.revision > 0
+	// re-execution after a real fix is either an idempotent success (audit
+	// stamp) or an honest unavailability if the check no longer reports
+	// fixable — never a fabricated second repair
+	out2 := reg.execute(.doctor_check, check_id, .doctor_repair, ActionArgs{
+		confirm: true
+	}) or { panic(err.msg()) }
+	assert out2.status in [.succeeded, .unavailable]
+	if out2.status == .succeeded {
+		assert out2.evidence.revision > 0
+	}
+}
+
+// 8. loop run actually invokes the Engine operation (real history + budget).
+fn test_loop_run_invokes_engine() {
+	mut eng := s4b_engine('exec-loop')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	entry := desktop_engine.LoopEntry{
+		name: 's4b-loop'
+		goal: 's4b action test'
+		tier: .l1
+		stage: 'l1'
+		cadence: '1d'
+		schedule: desktop_engine.cadence_to_cron('1d')
+		budget: desktop_engine.LoopBudget{
+			max_tokens: 80000
+			max_runs_per_day: 1
+			max_wall_seconds: 900
+		}
+		budget_total: 80000
+	}
+	eng.upsert_loop(entry) or { panic(err.msg()) }
+	out := reg.execute(.loop_template, 's4b-loop', .loop_run, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	assert out.evidence.job_id.len > 0
+	hist := eng.loops_history('s4b-loop')
+	assert hist.len == 1
+	assert hist[0].status == 'started'
+	// budget gate → real failure, no false success
+	out2 := reg.execute(.loop_template, 's4b-loop', .loop_run, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out2.status == .failed
+	assert out2.summary.contains('budget_exhausted')
+}
+
+// 9. swarm launch preserves requested-vs-running semantics.
+fn test_swarm_launch_preserves_requested_semantics() {
+	mut eng := s4b_engine('exec-swarm')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	// unconfirmed launch must not record anything
+	before := eng.revision()
+	nc := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
+		task: 's4b requested-vs-running check'
+		recipe: 'pair'
+		backend: 'auto'
+	}) or { panic(err.msg()) }
+	assert nc.status == .not_confirmed
+	assert eng.revision() == before
+	out := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
+		task: 's4b requested-vs-running check'
+		recipe: 'pair'
+		backend: 'auto'
+		confirm: true
+	}) or { panic(err.msg()) }
+	assert out.status == .succeeded
+	assert out.evidence.run_id.starts_with('swarm-')
+	assert out.summary.contains('requested')
+	assert !out.summary.to_lower().contains('running workers')
+	// the recorded run is 'requested', never 'running'
+	mut status := ''
+	for s in eng.swarm_list() {
+		if s.id == out.evidence.run_id {
+			status = s.status.str()
+		}
+	}
+	assert status == 'requested'
+}
+
+// 10. fresh engine exposes no fabricated runtime actions.
+fn test_fresh_engine_no_fabricated_runtime_actions() {
+	mut eng := s4b_engine('fresh')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	entries := reg.all_entries()
+	assert entries.filter(it.kind == .job).len == 0
+	assert entries.filter(it.kind == .swarm_run).len == 0
+}
+
+// 11. unknown entity → no actions, honest empty (not fabricated defaults).
+fn test_unknown_entity_has_no_actions() {
+	mut eng := s4b_engine('unknown')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	assert reg.actions_for(.skill, 'does/not-exist').len == 0
+	out := reg.execute(.skill, 'does/not-exist', .skill_install, ActionArgs{}) or {
+		panic('must not error')
+	}
+	assert out.status == .unavailable
+}

--- a/modules/desktop/palette/actions_test.v
+++ b/modules/desktop/palette/actions_test.v
@@ -1,21 +1,21 @@
 module palette
 
 import os
+import time
 import desktop_engine
 
-// s4b_engine builds an Engine over an isolated temp persist path. Before
-// creating a fixture, stale fixture dirs from previous runs with the same
-// prefix are removed (state.json persists; a same-PID rerun could otherwise
-// load stale state).
-fn s4b_engine(label string) &desktop_engine.Engine {
-	base := os.temp_dir()
-	entries := os.ls(base) or { []string{} }
-	for e in entries {
-		if e.starts_with('palette-actions-') {
-			os.rmdir_all(os.join_path(base, e)) or {}
-		}
-	}
-	tmp := os.join_path(base, 'palette-actions-${label}-${os.getpid()}')
+// TestEngine is a test fixture owning its exact temp directory: create the
+// exact path → use the fixture → stop the Engine → remove that exact path.
+// No fixture ever touches another fixture's directory.
+struct TestEngine {
+mut:
+	eng &desktop_engine.Engine = unsafe { nil }
+	tmp string
+}
+
+// new_s4b_engine boots an Engine over a unique isolated temp persist path.
+fn new_s4b_engine(label string) &TestEngine {
+	tmp := os.join_path(os.temp_dir(), 'palette-actions-${label}-${os.getpid()}-${time.now().unix_nano()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	persist := os.join_path(tmp, 'state.json')
 	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
@@ -23,7 +23,19 @@ fn s4b_engine(label string) &desktop_engine.Engine {
 	})
 	eng.init() or { panic(err.msg()) }
 	eng.start() or { panic(err.msg()) }
-	return eng
+	return &TestEngine{
+		eng: eng
+		tmp: tmp
+	}
+}
+
+// cleanup stops the Engine and removes this fixture's exact temp path.
+fn (mut fe TestEngine) cleanup() {
+	fe.eng.stop() or {}
+	if fe.tmp != '' {
+		os.rmdir_all(fe.tmp) or {}
+		fe.tmp = ''
+	}
 }
 
 fn first_skill_id(mut eng &desktop_engine.Engine) string {
@@ -46,12 +58,12 @@ fn find_action(acts []RegistryAction, kind ActionKind) ?RegistryAction {
 
 // 1. unavailable actions carry a truthful reason.
 fn test_unavailable_action_has_reason() {
-	mut eng := s4b_engine('unavail')
+	mut fe := new_s4b_engine('unavail')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
-	skill_id := first_skill_id(mut eng)
+	mut reg := new_registry(mut fe.eng)
+	skill_id := first_skill_id(mut fe.eng)
 
 	// remove on a not-installed skill is unavailable with a reason
 	acts := reg.actions_for(.skill, skill_id)
@@ -61,11 +73,11 @@ fn test_unavailable_action_has_reason() {
 
 	// disable on a not-enabled target is unavailable with a reason
 	mut target_id := ''
-	for t in eng.targets() {
+	for t in fe.eng.targets() {
 		target_id = t.id
 		break
 	}
-	if target_id != '' && !eng.target_enabled(target_id) {
+	if target_id != '' && !fe.eng.target_enabled(target_id) {
 		dacts := reg.actions_for(.target, target_id)
 		dis := find_action(dacts, .target_disable) or { panic('target_disable action missing') }
 		assert !dis.available
@@ -73,7 +85,7 @@ fn test_unavailable_action_has_reason() {
 	}
 
 	// doctor repair on a non-fixable check is unavailable with a reason
-	for c in eng.doctor() {
+	for c in fe.eng.doctor() {
 		if !c.fixable {
 			cacts := reg.actions_for(.doctor_check, c.id)
 			assert cacts.len == 1
@@ -86,19 +98,19 @@ fn test_unavailable_action_has_reason() {
 
 // 2. typed args are validated before any Engine call.
 fn test_typed_args_are_validated() {
-	mut eng := s4b_engine('args')
+	mut fe := new_s4b_engine('args')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	// empty swarm task → failed validation, nothing recorded
-	before := eng.revision()
+	before := fe.eng.revision()
 	out := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
 		task: '   '
 	}) or { panic(err.msg()) }
 	assert out.status == .failed
 	assert out.summary.contains('task text is required')
-	assert eng.revision() == before
+	assert fe.eng.revision() == before
 	// bad recipe → failed validation
 	out2 := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
 		task: 'x'
@@ -118,48 +130,48 @@ fn test_typed_args_are_validated() {
 // dry_run must never bypass confirmation for actions without a real
 // dry-run seam (skill_remove and doctor repair mutate for real).
 fn test_dry_run_does_not_bypass_confirmation() {
-	mut eng := s4b_engine('dryrun')
+	mut fe := new_s4b_engine('dryrun')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
-	skill_id := first_skill_id(mut eng)
+	mut reg := new_registry(mut fe.eng)
+	skill_id := first_skill_id(mut fe.eng)
 	// install the skill so remove is available
 	_ = reg.execute(.skill, skill_id, .skill_install, ActionArgs{}) or {
 		panic(err.msg())
 	}
-	assert eng.skills_installed().contains(skill_id)
-	before := eng.revision()
+	assert fe.eng.skills_installed().contains(skill_id)
+	before := fe.eng.revision()
 	out := reg.execute(.skill, skill_id, .skill_remove, ActionArgs{
 		dry_run: true
 	}) or { panic(err.msg()) }
 	assert out.status == .not_confirmed
-	assert eng.skills_installed().contains(skill_id)
-	assert eng.revision() == before
+	assert fe.eng.skills_installed().contains(skill_id)
+	assert fe.eng.revision() == before
 }
 
 // 3. preview calculates real effects without mutating state.
 fn test_preview_does_not_mutate_state() {
-	mut eng := s4b_engine('preview')
+	mut fe := new_s4b_engine('preview')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
-	skill_id := first_skill_id(mut eng)
-	before_rev := eng.revision()
-	before_installed := eng.skills_installed().clone()
+	mut reg := new_registry(mut fe.eng)
+	skill_id := first_skill_id(mut fe.eng)
+	before_rev := fe.eng.revision()
+	before_installed := fe.eng.skills_installed().clone()
 
 	lines := reg.preview(.skill_install, skill_id) or { panic(err.msg()) }
 	assert lines.len > 0
 	assert lines[0].contains('add')
 	assert lines[0].contains(skill_id)
 	// nothing mutated: revision and installed selection unchanged
-	assert eng.revision() == before_rev
-	assert eng.skills_installed() == before_installed
+	assert fe.eng.revision() == before_rev
+	assert fe.eng.skills_installed() == before_installed
 
 	// doctor preview: real dry-run lines, no mutation
 	mut check_id := ''
-	for c in eng.doctor() {
+	for c in fe.eng.doctor() {
 		if c.fixable {
 			check_id = c.id
 			break
@@ -168,24 +180,24 @@ fn test_preview_does_not_mutate_state() {
 	if check_id != '' {
 		prev := reg.preview(.doctor_repair, check_id) or { panic(err.msg()) }
 		assert prev.len > 0
-		assert eng.revision() == before_rev
+		assert fe.eng.revision() == before_rev
 	}
 }
 
 // 4. real execution mutates the expected authoritative state.
 fn test_skill_execution_mutates_config_truth() {
-	mut eng := s4b_engine('exec-skill')
+	mut fe := new_s4b_engine('exec-skill')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
-	skill_id := first_skill_id(mut eng)
+	mut reg := new_registry(mut fe.eng)
+	skill_id := first_skill_id(mut fe.eng)
 	out := reg.execute(.skill, skill_id, .skill_install, ActionArgs{}) or {
 		panic(err.msg())
 	}
 	assert out.status == .succeeded
 	assert out.evidence.revision > 0
-	assert eng.skills_installed().contains(skill_id)
+	assert fe.eng.skills_installed().contains(skill_id)
 	// install of an installed skill is unavailable (not a fake no-op success)
 	out2 := reg.execute(.skill, skill_id, .skill_install, ActionArgs{}) or {
 		panic(err.msg())
@@ -196,65 +208,65 @@ fn test_skill_execution_mutates_config_truth() {
 		panic(err.msg())
 	}
 	assert nc.status == .not_confirmed
-	assert eng.skills_installed().contains(skill_id)
+	assert fe.eng.skills_installed().contains(skill_id)
 	// confirmed remove really removes
 	rm := reg.execute(.skill, skill_id, .skill_remove, ActionArgs{
 		confirm: true
 	}) or { panic(err.msg()) }
 	assert rm.status == .succeeded
-	assert !eng.skills_installed().contains(skill_id)
+	assert !fe.eng.skills_installed().contains(skill_id)
 }
 
 // 5. target enable/disable uses actual configuration state.
 fn test_target_enable_disable_uses_config_truth() {
-	mut eng := s4b_engine('exec-target')
+	mut fe := new_s4b_engine('exec-target')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	mut target_id := ''
-	for t in eng.targets() {
+	for t in fe.eng.targets() {
 		target_id = t.id
 		break
 	}
 	if target_id == '' {
 		panic('no targets in catalog — test env misconfigured')
 	}
-	was_enabled := eng.target_enabled(target_id)
+	was_enabled := fe.eng.target_enabled(target_id)
 	if was_enabled {
 		out := reg.execute(.target, target_id, .target_disable, ActionArgs{}) or {
 			panic(err.msg())
 		}
 		assert out.status == .succeeded
-		assert !eng.target_enabled(target_id)
+		assert !fe.eng.target_enabled(target_id)
 	} else {
 		out := reg.execute(.target, target_id, .target_enable, ActionArgs{}) or {
 			panic(err.msg())
 		}
 		assert out.status == .succeeded
-		assert eng.target_enabled(target_id)
+		assert fe.eng.target_enabled(target_id)
 	}
 	// the flipped direction now reports unavailability correctly
 	acts := reg.actions_for(.target, target_id)
 	for a in acts {
 		if a.kind == .target_enable {
-			assert a.available == !eng.target_enabled(target_id)
+			assert a.available == !fe.eng.target_enabled(target_id)
 		}
 		if a.kind == .target_disable {
-			assert a.available == eng.target_enabled(target_id)
+			assert a.available == fe.eng.target_enabled(target_id)
 		}
 	}
 }
 
 // 6. MCP actions use the real provider configuration.
 fn test_mcp_actions_use_real_provider_config() {
-	mut eng := s4b_engine('exec-mcp')
+	mut fe := new_s4b_engine('exec-mcp')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	mut provider_id := ''
-	for p in eng.mcp_catalog() {
+	for p in fe.eng.mcp_catalog() {
 		provider_id = p.id
 		break
 	}
@@ -275,14 +287,14 @@ fn test_mcp_actions_use_real_provider_config() {
 		assert !reg.engine_mcp_enabled(provider_id)
 	} else {
 		// preview shows real write targets, mutates nothing
-		before := eng.revision()
+		before := fe.eng.revision()
 		pv := reg.preview(.mcp_enable, provider_id) or {
 			// providers without a packaged template honestly have no preview
 			assert err.msg().contains('no packaged template')
 			return
 		}
 		assert pv.len > 0
-		assert eng.revision() == before
+		assert fe.eng.revision() == before
 		out := reg.execute(.mcp_provider, provider_id, .mcp_enable, ActionArgs{}) or {
 			panic(err.msg())
 		}
@@ -293,13 +305,13 @@ fn test_mcp_actions_use_real_provider_config() {
 
 // 7. doctor preview → repair is truthful end to end.
 fn test_doctor_preview_repair_truthful() {
-	mut eng := s4b_engine('exec-doctor')
+	mut fe := new_s4b_engine('exec-doctor')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	mut check_id := ''
-	for c in eng.doctor() {
+	for c in fe.eng.doctor() {
 		if c.fixable {
 			check_id = c.id
 			break
@@ -332,11 +344,11 @@ fn test_doctor_preview_repair_truthful() {
 
 // 8. loop run actually invokes the Engine operation (real history + budget).
 fn test_loop_run_invokes_engine() {
-	mut eng := s4b_engine('exec-loop')
+	mut fe := new_s4b_engine('exec-loop')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	entry := desktop_engine.LoopEntry{
 		name: 's4b-loop'
 		goal: 's4b action test'
@@ -351,13 +363,13 @@ fn test_loop_run_invokes_engine() {
 		}
 		budget_total: 80000
 	}
-	eng.upsert_loop(entry) or { panic(err.msg()) }
+	fe.eng.upsert_loop(entry) or { panic(err.msg()) }
 	out := reg.execute(.loop_template, 's4b-loop', .loop_run, ActionArgs{}) or {
 		panic(err.msg())
 	}
 	assert out.status == .succeeded
 	assert out.evidence.job_id.len > 0
-	hist := eng.loops_history('s4b-loop')
+	hist := fe.eng.loops_history('s4b-loop')
 	assert hist.len == 1
 	assert hist[0].status == 'started'
 	// budget gate → real failure, no false success
@@ -370,20 +382,20 @@ fn test_loop_run_invokes_engine() {
 
 // 9. swarm launch preserves requested-vs-running semantics.
 fn test_swarm_launch_preserves_requested_semantics() {
-	mut eng := s4b_engine('exec-swarm')
+	mut fe := new_s4b_engine('exec-swarm')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	// unconfirmed launch must not record anything
-	before := eng.revision()
+	before := fe.eng.revision()
 	nc := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
 		task: 's4b requested-vs-running check'
 		recipe: 'pair'
 		backend: 'auto'
 	}) or { panic(err.msg()) }
 	assert nc.status == .not_confirmed
-	assert eng.revision() == before
+	assert fe.eng.revision() == before
 	out := reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
 		task: 's4b requested-vs-running check'
 		recipe: 'pair'
@@ -396,7 +408,7 @@ fn test_swarm_launch_preserves_requested_semantics() {
 	assert !out.summary.to_lower().contains('running workers')
 	// the recorded run is 'requested', never 'running'
 	mut status := ''
-	for s in eng.swarm_list() {
+	for s in fe.eng.swarm_list() {
 		if s.id == out.evidence.run_id {
 			status = s.status.str()
 		}
@@ -406,11 +418,11 @@ fn test_swarm_launch_preserves_requested_semantics() {
 
 // 10. fresh engine exposes no fabricated runtime actions.
 fn test_fresh_engine_no_fabricated_runtime_actions() {
-	mut eng := s4b_engine('fresh')
+	mut fe := new_s4b_engine('fresh')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	entries := reg.all_entries()
 	assert entries.filter(it.kind == .job).len == 0
 	assert entries.filter(it.kind == .swarm_run).len == 0
@@ -418,11 +430,11 @@ fn test_fresh_engine_no_fabricated_runtime_actions() {
 
 // 11. unknown entity → no actions, honest empty (not fabricated defaults).
 fn test_unknown_entity_has_no_actions() {
-	mut eng := s4b_engine('unknown')
+	mut fe := new_s4b_engine('unknown')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	assert reg.actions_for(.skill, 'does/not-exist').len == 0
 	out := reg.execute(.skill, 'does/not-exist', .skill_install, ActionArgs{}) or {
 		panic('must not error')

--- a/modules/desktop/palette/actions_test.v
+++ b/modules/desktop/palette/actions_test.v
@@ -3,9 +3,19 @@ module palette
 import os
 import desktop_engine
 
-// s4b_engine builds an Engine over an isolated temp persist path.
+// s4b_engine builds an Engine over an isolated temp persist path. Before
+// creating a fixture, stale fixture dirs from previous runs with the same
+// prefix are removed (state.json persists; a same-PID rerun could otherwise
+// load stale state).
 fn s4b_engine(label string) &desktop_engine.Engine {
-	tmp := os.join_path(os.temp_dir(), 'palette-actions-${label}-${os.getpid()}')
+	base := os.temp_dir()
+	entries := os.ls(base) or { []string{} }
+	for e in entries {
+		if e.starts_with('palette-actions-') {
+			os.rmdir_all(os.join_path(base, e)) or {}
+		}
+	}
+	tmp := os.join_path(base, 'palette-actions-${label}-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	persist := os.join_path(tmp, 'state.json')
 	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
@@ -96,12 +106,36 @@ fn test_typed_args_are_validated() {
 	}) or { panic(err.msg()) }
 	assert out2.status == .failed
 	assert out2.summary.contains('unknown swarm recipe')
-	// empty target selection → failed validation
-	out3 := reg.execute(.target, 'claude-code', .target_install, ActionArgs{}) or {
+	// single-subject target install defaults to the contextual entity: an
+	// empty selection with no entity is the only invalid case
+	out3 := reg.execute(.target, '', .target_install, ActionArgs{}) or {
 		panic(err.msg())
 	}
-	assert out3.status == .failed
-	assert out3.summary.contains('no targets selected')
+	assert out3.status == .unavailable
+	// no default subject is invented when the entity is unknown
+}
+
+// dry_run must never bypass confirmation for actions without a real
+// dry-run seam (skill_remove and doctor repair mutate for real).
+fn test_dry_run_does_not_bypass_confirmation() {
+	mut eng := s4b_engine('dryrun')
+	defer {
+		eng.stop() or {}
+	}
+	mut reg := new_registry(mut eng)
+	skill_id := first_skill_id(mut eng)
+	// install the skill so remove is available
+	_ = reg.execute(.skill, skill_id, .skill_install, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert eng.skills_installed().contains(skill_id)
+	before := eng.revision()
+	out := reg.execute(.skill, skill_id, .skill_remove, ActionArgs{
+		dry_run: true
+	}) or { panic(err.msg()) }
+	assert out.status == .not_confirmed
+	assert eng.skills_installed().contains(skill_id)
+	assert eng.revision() == before
 }
 
 // 3. preview calculates real effects without mutating state.

--- a/modules/desktop/palette/registry.v
+++ b/modules/desktop/palette/registry.v
@@ -173,6 +173,10 @@ mut:
 	actions  []PaletteAction
 	revision u64
 	builds   u64
+	// Install injection seams for tests ('' = real user home / config
+	// authority), mirroring InstallOptionsEngine's own injection design.
+	install_home_dir    string
+	install_receipt_dir string
 }
 
 // new_registry binds a registry to an Engine.

--- a/modules/desktop/palette/registry_test.v
+++ b/modules/desktop/palette/registry_test.v
@@ -5,8 +5,18 @@ import desktop_engine
 import desktop.nav
 
 // fresh_engine builds an Engine over an isolated temp persist path.
+// Before creating a fixture, stale fixture dirs from previous runs with the
+// same prefix are removed (state.json persists; a same-PID rerun could
+// otherwise load stale state).
 fn fresh_engine(label string) &desktop_engine.Engine {
-	tmp := os.join_path(os.temp_dir(), 'palette-registry-${label}-${os.getpid()}')
+	base := os.temp_dir()
+	entries := os.ls(base) or { []string{} }
+	for e in entries {
+		if e.starts_with('palette-registry-') {
+			os.rmdir_all(os.join_path(base, e)) or {}
+		}
+	}
+	tmp := os.join_path(base, 'palette-registry-${label}-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	persist := os.join_path(tmp, 'state.json')
 	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{

--- a/modules/desktop/palette/registry_test.v
+++ b/modules/desktop/palette/registry_test.v
@@ -1,22 +1,21 @@
 module palette
 
 import os
+import time
 import desktop_engine
 import desktop.nav
 
-// fresh_engine builds an Engine over an isolated temp persist path.
-// Before creating a fixture, stale fixture dirs from previous runs with the
-// same prefix are removed (state.json persists; a same-PID rerun could
-// otherwise load stale state).
-fn fresh_engine(label string) &desktop_engine.Engine {
-	base := os.temp_dir()
-	entries := os.ls(base) or { []string{} }
-	for e in entries {
-		if e.starts_with('palette-registry-') {
-			os.rmdir_all(os.join_path(base, e)) or {}
-		}
-	}
-	tmp := os.join_path(base, 'palette-registry-${label}-${os.getpid()}')
+// TestEngine is a test fixture owning its exact temp directory: create the
+// exact path → use the fixture → stop the Engine → remove that exact path.
+struct TestEngine {
+mut:
+	eng &desktop_engine.Engine = unsafe { nil }
+	tmp string
+}
+
+// fresh_engine boots an Engine over a unique isolated temp persist path.
+fn fresh_engine(label string) &TestEngine {
+	tmp := os.join_path(os.temp_dir(), 'palette-registry-${label}-${os.getpid()}-${time.now().unix_nano()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
 	persist := os.join_path(tmp, 'state.json')
 	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
@@ -24,7 +23,19 @@ fn fresh_engine(label string) &desktop_engine.Engine {
 	})
 	eng.init() or { panic(err.msg()) }
 	eng.start() or { panic(err.msg()) }
-	return eng
+	return &TestEngine{
+		eng: eng
+		tmp: tmp
+	}
+}
+
+// cleanup stops the Engine and removes this fixture's exact temp path.
+fn (mut fe TestEngine) cleanup() {
+	fe.eng.stop() or {}
+	if fe.tmp != '' {
+		os.rmdir_all(fe.tmp) or {}
+		fe.tmp = ''
+	}
 }
 
 fn find_entry(entries []RegistryEntry, kind EntityKind, id string) ?RegistryEntry {
@@ -37,11 +48,11 @@ fn find_entry(entries []RegistryEntry, kind EntityKind, id string) ?RegistryEntr
 }
 
 fn test_fresh_engine_yields_navigation_and_catalog_only() {
-	mut eng := fresh_engine('fresh')
+	mut fe := fresh_engine('fresh')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	entries := reg.all_entries()
 	// navigation: the 13 production shell destinations, in shell order
 	navs := entries.filter(it.kind == .navigation)
@@ -61,30 +72,30 @@ fn test_fresh_engine_yields_navigation_and_catalog_only() {
 	}
 	// catalog entities mirror the engine catalogs exactly
 	skills := entries.filter(it.kind == .skill)
-	assert skills.len == eng.skills_catalog().len
+	assert skills.len == fe.eng.skills_catalog().len
 	agents := entries.filter(it.kind == .agent)
-	assert agents.len == eng.agents_catalog().len
+	assert agents.len == fe.eng.agents_catalog().len
 	products := entries.filter(it.kind == .product)
-	assert products.len == eng.products_catalog().len
+	assert products.len == fe.eng.products_catalog().len
 	// canonical identity survives: skills keep their catalog id
 	if skills.len > 0 {
-		s := eng.skills_catalog()[0]
+		s := fe.eng.skills_catalog()[0]
 		entry := find_entry(entries, .skill, s.id) or { panic('skill ${s.id} missing from registry') }
 		assert entry.action_id() == 'skill:${s.id}'
 	}
 }
 
 fn test_unavailable_entries_carry_reason() {
-	mut eng := fresh_engine('unavail')
+	mut fe := fresh_engine('unavail')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	entries := reg.all_entries()
 	// targets without a bundled profile are visible but unavailable, with the
 	// honest reason — never silently dropped, never fake-actionable
 	targets := entries.filter(it.kind == .target)
-	catalog_targets := eng.targets()
+	catalog_targets := fe.eng.targets()
 	assert targets.len == catalog_targets.len
 	for t in catalog_targets {
 		entry := find_entry(entries, .target, t.id) or { panic('target ${t.id} missing') }
@@ -97,7 +108,7 @@ fn test_unavailable_entries_carry_reason() {
 		}
 	}
 	// doctor checks are repairable only when the engine reports fixable
-	for c in eng.doctor() {
+	for c in fe.eng.doctor() {
 		entry := find_entry(entries, .doctor_check, c.id) or { panic('doctor check ${c.id} missing') }
 		assert entry.available == c.fixable
 		if !c.fixable {
@@ -107,17 +118,17 @@ fn test_unavailable_entries_carry_reason() {
 }
 
 fn test_workspace_scoped_entity_preserves_identity() {
-	mut eng := fresh_engine('workspace')
+	mut fe := fresh_engine('workspace')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
 	// a real (trivial) job record gives the registry a runtime row with a
 	// workspace context — spawned via the engine, never fabricated
-	job_id := eng.spawn_job_with_opts('echo', ['registry-workspace-test'], '/tmp/atk-registry-ws') or {
+	job_id := fe.eng.spawn_job_with_opts('echo', ['registry-workspace-test'], '/tmp/atk-registry-ws') or {
 		panic(err.msg())
 	}
-	eng.job_complete(job_id, 0) or {}
-	mut reg := new_registry(mut eng)
+	fe.eng.job_complete(job_id, 0) or {}
+	mut reg := new_registry(mut fe.eng)
 	entries := reg.all_entries()
 	entry := find_entry(entries, .job, job_id) or { panic('job ${job_id} missing from registry') }
 	assert entry.workspace == '/tmp/atk-registry-ws'
@@ -126,11 +137,11 @@ fn test_workspace_scoped_entity_preserves_identity() {
 }
 
 fn test_filter_preserves_canonical_identity() {
-	mut eng := fresh_engine('filter')
+	mut fe := fresh_engine('filter')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	// every query hit keeps its registry identity: category/keyword matches
 	// surface the same actions an empty query would
 	mut hits := reg.filter('skills')
@@ -139,7 +150,7 @@ fn test_filter_preserves_canonical_identity() {
 		assert a.entity_id != '' || a.kind == .navigation
 	}
 	// entity search: match a skill by its canonical id fragment
-	catalog := eng.skills_catalog()
+	catalog := fe.eng.skills_catalog()
 	if catalog.len > 0 {
 		fragment := catalog[0].id.split('/')[0]
 		hits = reg.filter(fragment)
@@ -157,11 +168,11 @@ fn test_filter_preserves_canonical_identity() {
 }
 
 fn test_registry_caches_per_revision() {
-	mut eng := fresh_engine('cache')
+	mut fe := fresh_engine('cache')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	_ = reg.all_entries()
 	first_builds := reg.builds
 	assert first_builds == 1
@@ -170,20 +181,20 @@ fn test_registry_caches_per_revision() {
 	_ = reg.all_actions()
 	assert reg.builds == first_builds
 	// engine mutation bumps revision → registry rebuilds
-	mut repo := eng.state_repo()
+	mut repo := fe.eng.state_repo()
 	mut tx := repo.begin('registry-cache-test')
 	tx.set('registry_probe', '1')
-	eng.put_transaction(mut tx) or { panic(err.msg()) }
+	fe.eng.put_transaction(mut tx) or { panic(err.msg()) }
 	_ = reg.all_entries()
 	assert reg.builds == first_builds + 1
 }
 
 fn test_scored_filter_ranks_exact_match_first() {
-	mut eng := fresh_engine('rank')
+	mut fe := fresh_engine('rank')
 	defer {
-		eng.stop() or {}
+		fe.cleanup()
 	}
-	mut reg := new_registry(mut eng)
+	mut reg := new_registry(mut fe.eng)
 	scored := reg.scored_filter('Go to Skills')
 	assert scored.len > 0
 	assert scored[0].action.id == 'nav:/skills'

--- a/modules/desktop/window.v
+++ b/modules/desktop/window.v
@@ -337,6 +337,17 @@ pub fn (mut d Desktop) loops_catalog() []desktop_engine.LoopEntry {
 	return d.engine.loops_catalog()
 }
 
+// loop_run starts a real supervised loop run via Engine (job + history +
+// budget gates). The returned job id is the run's runtime handle.
+pub fn (mut d Desktop) loop_run(name string) !string {
+	return d.engine.run_loop(name)
+}
+
+// toggle_loop_cron enables/disables the loop schedule in configuration.
+pub fn (mut d Desktop) toggle_loop_cron(name string, enabled bool) !u64 {
+	return d.engine.toggle_loop_cron(name, enabled)
+}
+
 // inner_loops_for returns inner loops map snapshot for a swarm run (via State keys).
 pub fn (mut d Desktop) inner_loops_for(run_id string) map[string]string {
 	snap := d.engine.snapshot()

--- a/modules/desktop_engine/swarm_service.v
+++ b/modules/desktop_engine/swarm_service.v
@@ -24,6 +24,7 @@ pub enum SwarmRecipeKind {
 
 // SwarmRunStatus is runtime status for swarm runs.
 pub enum SwarmRunStatus {
+	requested
 	pending
 	running
 	awaiting_approval
@@ -488,6 +489,9 @@ pub fn (mut e Engine) swarm_list() []SwarmRun {
 			backend: swarm_backend_from_string(backend_str)
 			task: task
 			status: match status_str {
+				// 'requested' is the honest launch state: the engine recorded
+				// the request but no backend worker is proven running yet
+				'requested' { SwarmRunStatus.requested }
 				'running' { SwarmRunStatus.running }
 				'awaiting_approval' { SwarmRunStatus.awaiting_approval }
 				'completed' { SwarmRunStatus.completed }

--- a/modules/desktop_engine/targets_service.v
+++ b/modules/desktop_engine/targets_service.v
@@ -182,7 +182,9 @@ pub fn (mut e Engine) targets() []TargetEntry {
 		if rr := agent_toolkit_core.load_install_receipt(install_tool_name(r.id), agent_toolkit_core.profiles_product, '') {
 			receipt = os.join_path(agent_toolkit_core.default_receipt_dir(), agent_toolkit_core.receipt_filename(rr.target, rr.product))
 		}
-		status := if enabled { 'enabled' } else if detected { 'detected' } else { 'available' }
+		status := if enabled {
+			'enabled'
+		} else if detected { 'detected' } else { 'available' }
 		out << TargetEntry{
 			id: r.id
 			name: if r.display_name != '' { r.display_name } else { r.id }
@@ -224,6 +226,29 @@ pub fn (mut e Engine) toggle_target(target_id string) !u64 {
 		}
 	}
 	return error('target not found: ${target_id}')
+}
+
+// target_enabled reads the target's real enabled state (configuration truth).
+pub fn (mut e Engine) target_enabled(target_id string) bool {
+	for t in e.targets() {
+		if t.id == target_id {
+			return t.enabled
+		}
+	}
+	return false
+}
+
+// target_install_supported reports whether a target can be installed through
+// the Engine install flow: a bundled profile must exist and the tool must be
+// supported by the core installer. This mirrors the install_with_options
+// guard so registry availability truth matches execution truth (S4B #1119).
+pub fn (mut e Engine) target_install_supported(target_id string) bool {
+	for t in e.targets() {
+		if t.id == target_id {
+			return t.path != '' && install_tool_name(t.id) in agent_toolkit_core.install_valid_tools
+		}
+	}
+	return false
 }
 
 pub fn (mut e Engine) diff(before []string, after []string) TargetDiff {
@@ -522,8 +547,10 @@ pub fn (mut e Engine) doctor_fix_preview(check_id string) ![]string {
 		if c.id == check_id {
 			known = true
 			if c.status == 'pass' {
-				return ['note: check already passes — fix records an audit stamp only',
-					'set doctor:fix:${check_id} = fixed']
+				return [
+					'note: check already passes — fix records an audit stamp only',
+					'set doctor:fix:${check_id} = fixed',
+				]
 			}
 			break
 		}
@@ -533,8 +560,7 @@ pub fn (mut e Engine) doctor_fix_preview(check_id string) ![]string {
 	}
 	if check_id.starts_with('profile:') {
 		tid := check_id.all_after('profile:')
-		return ['set target:${tid}:enabled = true',
-			'set doctor:fix:profile:${tid} = fixed']
+		return ['set target:${tid}:enabled = true', 'set doctor:fix:profile:${tid} = fixed']
 	}
 	if check_id.starts_with('mcp:') && check_id != 'mcp:docker' {
 		mid := check_id.all_after('mcp:')


### PR DESCRIPTION
## Summary

Second slice of S4 (#1119): registry entities expose **meaningful typed actions** with validation, real previews, confirmation and truthful execution through the Engine — plus one S7 truth regression found and fixed along the way.

### Action classification (verified against code before exposure)

| Action | Class | Seam |
|---|---|---|
| skill install / remove | READY | `install_skill` / `remove_skill` (config-truth transactions; no files written by skill install, so removal has no file-ownership ambiguity) |
| target install | READY | `install_with_options` (real dry-run, real receipts, real partial-failure) + new `target_install_supported` so availability == execution truth |
| target enable / disable | READY | `set_target_enabled` (configuration truth, distinct from installed receipts) |
| MCP enable / disable | READY | `mcp_toggle` (disabled → upsert from packaged template; enabled → remove) |
| MCP probe | READY | `mcp_probe` (read-only typed result; never implies health from config alone) |
| doctor preview / repair | READY | `doctor_fix_preview` / `doctor_fix` — the reference implementation for the availability → preview → confirm → execute → outcome pattern |
| loop run / schedule toggle | READY | `run_loop` (real supervised job + history + budget gates) / `toggle_loop_cron` |
| swarm launch | READY | `swarm_launch` records **requested** — never claims running |
| agent/skill inspect | READY_WITH_ADAPTER | typed deep-link into owning panel |
| agent open session | OUT_OF_SCOPE | PTY terminal subsystem, not a registry action |

### Truth fixes

- **Swarm `requested` status**: the engine records launch requests as `requested`, but `swarm_list()` had no such enum member and silently coerced them to `pending`. `SwarmRunStatus.requested` added and parsed; outcome copy says "requested — not yet running" and tests lock it.
- **Loops panel Run/Schedule buttons** only emitted toasts *claiming* `Engine.run_loop()`/`toggle_loop_cron()` without executing. They now perform the real operations and render feedback from the actual result; failures never render as success.

### UX (interaction-phase, no redesign)

- **Tab** expands a registry entity row into its contextual actions, each showing truthful availability or its reason.
- **Preview mode** shows the real Engine dry-run/diff lines (install diff, MCP write targets, doctor repair preview) with "nothing applied yet"; Enter executes as informed confirmation.
- **Confirmation**: previewless mutating actions arm on first Enter, execute on second; unavailable actions refuse immediately with their reason and never arm.
- Outcomes surface as toasts with real evidence only (receipt path / run id / job id).
- **Swarm launch** routes to the swarm panel launch form — task text + recipe/backend are real typed inputs the palette cannot provide honestly.
- **Deep links** select the canonical entity by identity lookup (`skills_selected` by id), never display strings.
- Esc unwinds the innermost palette context (preview → expansion → palette).

### Tests (behavior, not struct construction)

- Module: unavailable-with-reason, typed-args validation without mutation, preview non-mutation (revision unchanged), config/runtime mutation truth, doctor preview→repair end-to-end, loop run with real budget-gate failure, swarm requested-vs-running, fresh-engine honesty, unknown-entity honesty.
- Shell: preview→execute flow through the real palette, honest unavailability through the UI path, swarm routing to the panel form, canonical deep-link selection.
- All existing suites green: palette (3), desktop (12), desktop_engine truth gates (23), cmd (6); production build + headless smoke; `v fmt`/`vet`; `gui-coverage.py --check`.

### Not in this slice

- MCP *configure* (arbitrary config JSON editing) stays in the MCP drawer (#1106 machinery); the palette covers enable/probe from packaged templates.
- `Update` and remaining static CLI rows are S4C.
- Undo/recent actions are S4D.

Refs #1119 · #1118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added contextual actions to the command palette, including previews, confirmations, and availability guidance.
  - Palette actions now deep-link to relevant panels and support swarm task configuration.
  - Action results now show clear outcomes, including successes, failures, partial results, and evidence.
  - Loop Run and scheduling controls now perform real operations and display actual errors.

- **Bug Fixes**
  - Improved handling of unavailable actions and persisted swarm request statuses.
  - Prevented actions from reporting success when no operation was performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->