### PR TITLE
feat(desktop): S4C — retire the static command palette; registry is the sole authority (#1119)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -845,6 +845,18 @@ jobs:
       - name: Setup pinned V
         uses: ./.github/actions/setup-v
 
+      # S4C (#1119): the Desktop shell test suite (incl. the registry
+      # reachability gate) compiles gg/sokol, which needs X11/GL dev headers
+      # on Linux. Mirrors the Golden UI job's dependency list (headers only —
+      # no xdotool/xvfb needed: tests run headless).
+      - name: Install X11/GL dev headers (Desktop shell tests)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            xorg-dev libgl1-mesa-dev libegl1-mesa-dev
+
       - name: vet and test
         env:
           VMODULES: ${{ github.workspace }}/modules

--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -768,13 +768,6 @@ struct DiffHunkRow {
 	kinds []string // context, addition, deletion, header
 }
 
-struct PaletteItem {
-	id    string
-	label string
-	desc  string
-	keys  string
-}
-
 struct TermLine {
 	ts     string
 	level  string
@@ -1089,129 +1082,108 @@ struct I18nRow {
 
 const i18n_table = {
 	// dock — 13 nameplates
-	'panel.world':             I18nRow{'World', 'Mundo', '世界', 'العالم'}
-	'panel.skills':            I18nRow{'Skills', 'Habilidades', '技能', 'المهارات'}
-	'panel.agents':            I18nRow{'Agents', 'Agentes', '代理', 'الوكلاء'}
-	'panel.mcp':               I18nRow{'MCP', 'MCP', '提供方', 'المزودون'}
-	'panel.targets':           I18nRow{'Targets', 'Destinos', '目标', 'الأهداف'}
-	'panel.doctor':            I18nRow{'Doctor', 'Doctor', '诊断', 'الفحص'}
-	'panel.jobs':              I18nRow{'Jobs', 'Trabajos', '作业', 'المهام'}
-	'panel.loops':             I18nRow{'Loops', 'Bucles', '循环', 'الحلقات'}
-	'panel.swarm':             I18nRow{'Swarm', 'Enjambre', '集群', 'السرب'}
-	'panel.workspace':         I18nRow{'Workspace', 'Espacio', '工作区', 'المساحة'}
-	'panel.products':          I18nRow{'Products', 'Productos', '产品', 'المنتجات'}
-	'panel.onboarding':        I18nRow{'Onboarding', 'Inicio', '引导', 'التهيئة'}
-	'panel.insights':          I18nRow{'Insights', 'Métricas', '洞察', 'الرؤى'}
+	'panel.world':          I18nRow{'World', 'Mundo', '世界', 'العالم'}
+	'panel.skills':         I18nRow{'Skills', 'Habilidades', '技能', 'المهارات'}
+	'panel.agents':         I18nRow{'Agents', 'Agentes', '代理', 'الوكلاء'}
+	'panel.mcp':            I18nRow{'MCP', 'MCP', '提供方', 'المزودون'}
+	'panel.targets':        I18nRow{'Targets', 'Destinos', '目标', 'الأهداف'}
+	'panel.doctor':         I18nRow{'Doctor', 'Doctor', '诊断', 'الفحص'}
+	'panel.jobs':           I18nRow{'Jobs', 'Trabajos', '作业', 'المهام'}
+	'panel.loops':          I18nRow{'Loops', 'Bucles', '循环', 'الحلقات'}
+	'panel.swarm':          I18nRow{'Swarm', 'Enjambre', '集群', 'السرب'}
+	'panel.workspace':      I18nRow{'Workspace', 'Espacio', '工作区', 'المساحة'}
+	'panel.products':       I18nRow{'Products', 'Productos', '产品', 'المنتجات'}
+	'panel.onboarding':     I18nRow{'Onboarding', 'Inicio', '引导', 'التهيئة'}
+	'panel.insights':       I18nRow{'Insights', 'Métricas', '洞察', 'الرؤى'}
 	// dock — short descriptors
-	'desc.world':              I18nRow{'Floor — desks, handoffs, live activity', 'Planta — escritorios y actividad', '办公区 · 工位与协作', 'الأرضية — المكاتب والنشاط'}
-	'desc.skills':             I18nRow{'Skills and capabilities', 'Habilidades y capacidades', '技能与能力', 'المهارات والقدرات'}
-	'desc.agents':             I18nRow{'Agents and roles', 'Agentes y roles', '代理与角色', 'الوكلاء والأدوار'}
-	'desc.mcp':                I18nRow{'Providers, health and secrets', 'Proveedores, salud y claves', '提供方、健康与密钥', 'المزودون والصحة والأسرار'}
-	'desc.targets':            I18nRow{'Coding tools and destinations', 'Herramientas y destinos', '编码工具与目标', 'أدوات البرمجة والوجهات'}
-	'desc.doctor':             I18nRow{'Health checks + fix', 'Comprobaciones y reparación', '健康检查与修复', 'فحوصات وإصلاح'}
-	'desc.jobs':               I18nRow{'Jobs & process supervisor', 'Trabajos y supervisor', '作业与进程管理', 'المهام والعمليات'}
-	'desc.loops':              I18nRow{'Loops & missions — inner/outer', 'Bucles y misiones — internos/externos', '循环任务 · 内外环', 'المهام الدورية'}
-	'desc.swarm':              I18nRow{'GOD mailbox, Herdr/tmux, teams', 'Buzón GOD, Herdr/tmux, equipos', 'GOD 信箱 · 集群协作', 'صندوق GOD والفرق'}
-	'desc.workspace':          I18nRow{'IDE — tree, editor, git rails', 'IDE — árbol, editor, git', '工作区 IDE · 编辑器', 'مساحة عمل IDE'}
-	'desc.products':           I18nRow{'Products and packs', 'Productos y paquetes', '产品与包', 'المنتجات والحزم'}
-	'desc.onboarding':         I18nRow{'Wizard — workspace to products', 'Asistente — de workspace a productos', '引导向导 · 一步到位', 'معالج الإعداد'}
-	'desc.insights':           I18nRow{'Cost, waterfall, spans, CI', 'Costos, cascada, spans, CI', '成本 · 瀑布 · CI', 'التكاليف والأداء'}
+	'desc.world':           I18nRow{'Floor — desks, handoffs, live activity', 'Planta — escritorios y actividad', '办公区 · 工位与协作', 'الأرضية — المكاتب والنشاط'}
+	'desc.skills':          I18nRow{'Skills and capabilities', 'Habilidades y capacidades', '技能与能力', 'المهارات والقدرات'}
+	'desc.agents':          I18nRow{'Agents and roles', 'Agentes y roles', '代理与角色', 'الوكلاء والأدوار'}
+	'desc.mcp':             I18nRow{'Providers, health and secrets', 'Proveedores, salud y claves', '提供方、健康与密钥', 'المزودون والصحة والأسرار'}
+	'desc.targets':         I18nRow{'Coding tools and destinations', 'Herramientas y destinos', '编码工具与目标', 'أدوات البرمجة والوجهات'}
+	'desc.doctor':          I18nRow{'Health checks + fix', 'Comprobaciones y reparación', '健康检查与修复', 'فحوصات وإصلاح'}
+	'desc.jobs':            I18nRow{'Jobs & process supervisor', 'Trabajos y supervisor', '作业与进程管理', 'المهام والعمليات'}
+	'desc.loops':           I18nRow{'Loops & missions — inner/outer', 'Bucles y misiones — internos/externos', '循环任务 · 内外环', 'المهام الدورية'}
+	'desc.swarm':           I18nRow{'GOD mailbox, Herdr/tmux, teams', 'Buzón GOD, Herdr/tmux, equipos', 'GOD 信箱 · 集群协作', 'صندوق GOD والفرق'}
+	'desc.workspace':       I18nRow{'IDE — tree, editor, git rails', 'IDE — árbol, editor, git', '工作区 IDE · 编辑器', 'مساحة عمل IDE'}
+	'desc.products':        I18nRow{'Products and packs', 'Productos y paquetes', '产品与包', 'المنتجات والحزم'}
+	'desc.onboarding':      I18nRow{'Wizard — workspace to products', 'Asistente — de workspace a productos', '引导向导 · 一步到位', 'معالج الإعداد'}
+	'desc.insights':        I18nRow{'Cost, waterfall, spans, CI', 'Costos, cascada, spans, CI', '成本 · 瀑布 · CI', 'التكاليف والأداء'}
 	// header
-	'header.tagline':          I18nRow{'Paper Co. Office', 'Oficina Paper Co.', '纸业公司办公室', 'مكتب شركة الورق'}
-	'header.search':           I18nRow{'Search skills, agents, files…', 'Buscar habilidades, agentes, archivos…', '搜索技能、代理和文件…', 'ابحث في المهارات والوكلاء والملفات…'}
-	'header.workspace':        I18nRow{'WORKSPACE', 'ESPACIO', '工作区', 'المساحة'}
-	'header.navigate':         I18nRow{'NAVIGATE', 'NAVEGAR', '导航', 'تنقل'}
-	'header.live':             I18nRow{'live', 'activo', '实时', 'مباشر'}
-	'header.commands':         I18nRow{'commands', 'comandos', '命令', 'أوامر'}
-	'header.lang':             I18nRow{'Language', 'Idioma', '语言', 'اللغة'}
+	'header.tagline':       I18nRow{'Paper Co. Office', 'Oficina Paper Co.', '纸业公司办公室', 'مكتب شركة الورق'}
+	'header.search':        I18nRow{'Search skills, agents, files…', 'Buscar habilidades, agentes, archivos…', '搜索技能、代理和文件…', 'ابحث في المهارات والوكلاء والملفات…'}
+	'header.workspace':     I18nRow{'WORKSPACE', 'ESPACIO', '工作区', 'المساحة'}
+	'header.navigate':      I18nRow{'NAVIGATE', 'NAVEGAR', '导航', 'تنقل'}
+	'header.live':          I18nRow{'live', 'activo', '实时', 'مباشر'}
+	'header.commands':      I18nRow{'commands', 'comandos', '命令', 'أوامر'}
+	'header.lang':          I18nRow{'Language', 'Idioma', '语言', 'اللغة'}
 	// grouped task navigation — six permanent destinations
-	'nav.group.office':        I18nRow{'Office', 'Oficina', '办公', 'المكتب'}
-	'nav.group.library':       I18nRow{'Library', 'Biblioteca', '资源库', 'المكتبة'}
-	'nav.group.operations':    I18nRow{'Operations', 'Operaciones', '运维', 'العمليات'}
-	'nav.group.workspace':     I18nRow{'Workspace', 'Espacio', '工作区', 'المساحة'}
-	'nav.group.insights':      I18nRow{'Insights', 'Métricas', '洞察', 'الرؤى'}
-	'nav.group.settings':      I18nRow{'Settings', 'Ajustes', '设置', 'الإعدادات'}
-	'nav.health':              I18nRow{'Health', 'Salud', '健康', 'الصحة'}
-	'nav.setup':               I18nRow{'Setup', 'Configurar', '设置', 'الإعداد'}
-	'ws.ready':                I18nRow{'ready', 'listo', '就绪', 'جاهز'}
-	'ws.setup_needed':         I18nRow{'setup needed', 'falta configurar', '需要设置', 'يحتاج إعداد'}
+	'nav.group.office':     I18nRow{'Office', 'Oficina', '办公', 'المكتب'}
+	'nav.group.library':    I18nRow{'Library', 'Biblioteca', '资源库', 'المكتبة'}
+	'nav.group.operations': I18nRow{'Operations', 'Operaciones', '运维', 'العمليات'}
+	'nav.group.workspace':  I18nRow{'Workspace', 'Espacio', '工作区', 'المساحة'}
+	'nav.group.insights':   I18nRow{'Insights', 'Métricas', '洞察', 'الرؤى'}
+	'nav.group.settings':   I18nRow{'Settings', 'Ajustes', '设置', 'الإعدادات'}
+	'nav.health':           I18nRow{'Health', 'Salud', '健康', 'الصحة'}
+	'nav.setup':            I18nRow{'Setup', 'Configurar', '设置', 'الإعداد'}
+	'ws.ready':             I18nRow{'ready', 'listo', '就绪', 'جاهز'}
+	'ws.setup_needed':      I18nRow{'setup needed', 'falta configurar', '需要设置', 'يحتاج إعداد'}
 	// status bar
-	'status.palette':          I18nRow{'palette', 'paleta', '命令面板', 'الأوامر'}
-	'status.paperco':          I18nRow{'Paper Co.', 'Paper Co.', '纸业公司', 'شركة الورق'}
-	'status.fps':              I18nRow{'60FPS', '60FPS', '60帧', '٦٠ إطار'}
+	'status.palette':       I18nRow{'palette', 'paleta', '命令面板', 'الأوامر'}
+	'status.paperco':       I18nRow{'Paper Co.', 'Paper Co.', '纸业公司', 'شركة الورق'}
+	'status.fps':           I18nRow{'60FPS', '60FPS', '60帧', '٦٠ إطار'}
 	// world floor
-	'office.view.overview':    I18nRow{'Overview', 'Resumen', '概览', 'ملخص'}
-	'office.view.floor':       I18nRow{'Floor Map', 'Planta', '平面图', 'خريطة الطابق'}
-	'office.catalog':          I18nRow{'Catalog agents', 'Agentes del catálogo', '目录代理', 'وكلاء الدليل'}
-	'world.title':             I18nRow{'Office Floor', 'Planta de oficina', '办公区平面', 'أرضية المكتب'}
-	'world.subtitle':          I18nRow{'desks • envelopes are handoffs • click a desk or use arrow keys', 'escritorios • los sobres son entregas • clica un escritorio o usa flechas', '工位 • 信封即交接 • 点击工位或方向键', 'المكاتب • الأظرف تسليمات • انقر مكتباً أو استخدم الأسهم'}
-	'world.working':           I18nRow{'working', 'trabajando', '工作中', 'يعمل'}
-	'world.idle':              I18nRow{'idle', 'libre', '空闲', 'خامل'}
-	'world.blocked':           I18nRow{'blocked', 'bloqueado', '受阻', 'معطل'}
-	'world.god':               I18nRow{'GOD — in', 'GOD — entra', 'GOD — 收', 'GOD — دخول'}
-	'world.out':               I18nRow{'out', 'sale', '发', 'خروج'}
+	'office.view.overview': I18nRow{'Overview', 'Resumen', '概览', 'ملخص'}
+	'office.view.floor':    I18nRow{'Floor Map', 'Planta', '平面图', 'خريطة الطابق'}
+	'office.catalog':       I18nRow{'Catalog agents', 'Agentes del catálogo', '目录代理', 'وكلاء الدليل'}
+	'world.title':          I18nRow{'Office Floor', 'Planta de oficina', '办公区平面', 'أرضية المكتب'}
+	'world.subtitle':       I18nRow{'desks • envelopes are handoffs • click a desk or use arrow keys', 'escritorios • los sobres son entregas • clica un escritorio o usa flechas', '工位 • 信封即交接 • 点击工位或方向键', 'المكاتب • الأظرف تسليمات • انقر مكتباً أو استخدم الأسهم'}
+	'world.working':        I18nRow{'working', 'trabajando', '工作中', 'يعمل'}
+	'world.idle':           I18nRow{'idle', 'libre', '空闲', 'خامل'}
+	'world.blocked':        I18nRow{'blocked', 'bloqueado', '受阻', 'معطل'}
+	'world.god':            I18nRow{'GOD — in', 'GOD — entra', 'GOD — 收', 'GOD — دخول'}
+	'world.out':            I18nRow{'out', 'sale', '发', 'خروج'}
 	// generic actions
-	'act.open_terminal':       I18nRow{'Open terminal', 'Abrir terminal', '打开终端', 'افتح الطرفية'}
-	'act.route':               I18nRow{'Route handoff', 'Route entrega', '路由交接', 'وجّه التسليم'}
-	'act.run':                 I18nRow{'Run', 'Ejecutar', '运行', 'شغّل'}
-	'act.sched':               I18nRow{'Sched', 'Programar', '计划', 'جدول'}
-	'act.install':             I18nRow{'install', 'instalar', '安装', 'ثبّت'}
-	'act.remove':              I18nRow{'remove', 'quitar', '移除', 'أزل'}
-	'act.cancel':              I18nRow{'Cancel', 'Cancelar', '取消', 'إلغاء'}
-	'act.retry':               I18nRow{'Retry', 'Reintentar', '重试', 'أعد'}
-	'act.fix_all':             I18nRow{'Fix All', 'Reparar todo', '全部修复', 'أصلح الكل'}
-	'act.new_loop':            I18nRow{'+ New Loop', '+ Nuevo bucle', '+ 新循环', '+ حلقة جديدة'}
-	'act.approve':             I18nRow{'Y', 'S', '准', 'نعم'}
-	'act.deny':                I18nRow{'N', 'N', '驳', 'لا'}
+	'act.open_terminal':    I18nRow{'Open terminal', 'Abrir terminal', '打开终端', 'افتح الطرفية'}
+	'act.route':            I18nRow{'Route handoff', 'Route entrega', '路由交接', 'وجّه التسليم'}
+	'act.run':              I18nRow{'Run', 'Ejecutar', '运行', 'شغّل'}
+	'act.sched':            I18nRow{'Sched', 'Programar', '计划', 'جدول'}
+	'act.install':          I18nRow{'install', 'instalar', '安装', 'ثبّت'}
+	'act.remove':           I18nRow{'remove', 'quitar', '移除', 'أزل'}
+	'act.cancel':           I18nRow{'Cancel', 'Cancelar', '取消', 'إلغاء'}
+	'act.retry':            I18nRow{'Retry', 'Reintentar', '重试', 'أعد'}
+	'act.fix_all':          I18nRow{'Fix All', 'Reparar todo', '全部修复', 'أصلح الكل'}
+	'act.new_loop':         I18nRow{'+ New Loop', '+ Nuevo bucle', '+ 新循环', '+ حلقة جديدة'}
+	'act.approve':          I18nRow{'Y', 'S', '准', 'نعم'}
+	'act.deny':             I18nRow{'N', 'N', '驳', 'لا'}
 	// palette — 33 commands, fully translated (ES/中文/عربي)
-	'palette.world':           I18nRow{'Go to World', 'Ir a Mundo', '前往世界', 'اذهب إلى العالم'}
-	'palette.skills':          I18nRow{'Go to Skills', 'Ir a Habilidades', '前往技能', 'اذهب إلى المهارات'}
-	'palette.agents':          I18nRow{'Go to Agents', 'Ir a Agentes', '前往代理', 'اذهب إلى الوكلاء'}
-	'palette.mcp':             I18nRow{'Go to MCP', 'Ir a MCP', '前往提供方', 'اذهب إلى المزودين'}
-	'palette.targets':         I18nRow{'Go to Targets', 'Ir a Destinos', '前往目标', 'اذهب إلى الأهداف'}
-	'palette.doctor':          I18nRow{'Go to Doctor', 'Ir a Doctor', '前往诊断', 'اذهب إلى الفحص'}
-	'palette.jobs':            I18nRow{'Go to Jobs', 'Ir a Trabajos', '前往作业', 'اذهب إلى المهام'}
-	'palette.loops':           I18nRow{'Go to Loops', 'Ir a Bucles', '前往循环', 'اذهب إلى الحلقات'}
-	'palette.swarm':           I18nRow{'Go to Swarm', 'Ir a Enjambre', '前往集群', 'اذهب إلى السرب'}
-	'palette.workspace':       I18nRow{'Go to Workspace', 'Ir a Espacio', '前往工作区', 'اذهب إلى المساحة'}
-	'palette.products':        I18nRow{'Go to Products', 'Ir a Productos', '前往产品', 'اذهب إلى المنتجات'}
-	'palette.onboarding':      I18nRow{'Go to Onboarding', 'Ir a Inicio', '前往引导', 'اذهب إلى التهيئة'}
-	'palette.insights':        I18nRow{'Go to Insights', 'Ir a Métricas', '前往洞察', 'اذهب إلى الرؤى'}
-	'palette.command_palette': I18nRow{'Command palette', 'Paleta de comandos', '命令面板', 'لوحة الأوامر'}
-	'palette.serve':           I18nRow{'Start API server', 'Iniciar servidor API', '启动 API 服务', 'ابدأ خادم API'}
-	'palette.doctor_fix':      I18nRow{'Run doctor --fix', 'Ejecutar doctor --fix', '运行 doctor --fix', 'شغّل doctor --fix'}
-	'palette.install':         I18nRow{'Install profiles', 'Instalar perfiles', '安装配置', 'ثبّت الملفات'}
-	'palette.install_full':    I18nRow{'Install — full', 'Instalar — completo', '安装 — 完整', 'تثبيت — كامل'}
-	'palette.update':          I18nRow{'Update — agent-toolkit update', 'Actualizar — agent-toolkit update', '更新 — agent-toolkit update', 'تحديث — agent-toolkit update'}
-	'palette.uninstall':       I18nRow{'Uninstall', 'Desinstalar', '卸载', 'إزالة التثبيت'}
-	'palette.diff':            I18nRow{'Diff — target/product', 'Diff — destino/producto', '差异 — 目标/产品', 'فرق — هدف/منتج'}
-	'palette.skills_sync':     I18nRow{'Skills — sync/validate', 'Habilidades — sinc/validar', '技能 — 同步/校验', 'المهارات — مزامنة/تحقق'}
-	'palette.mcp_health':      I18nRow{'MCP — health/doctor', 'MCP — salud/doctor', '提供方 — 健康/诊断', 'المزودون — الصحة/الفحص'}
-	'palette.loop_run':        I18nRow{'Loop — run/status/audit/cost', 'Bucle — ejecutar/estado/auditoría/costo', '循环 — 运行/状态/审计/成本', 'حلقة — تشغيل/حالة/تدقيق/تكلفة'}
-	'palette.swarm_start':     I18nRow{'Swarm — start/list/approve', 'Enjambre — iniciar/listar/aprobar', '集群 — 启动/列表/批准', 'سرب — بدء/قائمة/موافقة'}
-	'palette.workspace_sync':  I18nRow{'Workspace — sync/context', 'Espacio — sinc/contexto', '工作区 — 同步/上下文', 'المساحة — مزامنة/سياق'}
-	'palette.memory':          I18nRow{'Memory — add/search/inject/todo', 'Memoria — añadir/buscar/inyectar/todo', '记忆 — 添加/搜索/注入/待办', 'الذاكرة — إضافة/بحث/حقن/مهام'}
-	'palette.project_clone':   I18nRow{'Project — clone/list/scan', 'Proyecto — clonar/listar/escanear', '项目 — 克隆/列表/扫描', 'مشروع — استنساخ/قائمة/فحص'}
-	'palette.devcompanion':    I18nRow{'DevCompanion — queue/status', 'DevCompanion — cola/estado', '开发伴侣 — 队列/状态', 'رفيق التطوير — قائمة/حالة'}
-	'palette.insights_cli':    I18nRow{'Insights — CLI days/output', 'Métricas — días/salida CLI', '洞察 — 天数/输出 CLI', 'الرؤى — أيام/مخرجات CLI'}
-	'palette.build':           I18nRow{'Build — --check', 'Compilar — --check', '构建 — --check', 'بناء — --check'}
-	'palette.inventory':       I18nRow{'Inventory — audit', 'Inventario — auditoría', '清单 — 审计', 'الجرد — تدقيق'}
-	'palette.completion':      I18nRow{'Completion — bash/zsh/fish', 'Autocompletado — bash/zsh/fish', '补全 — bash/zsh/fish', 'الإكمال — bash/zsh/fish'}
-	'palette.cozy':            I18nRow{'Cozy — toggle warm wood', 'Cozy — madera cálida', '温馨 — 暖木切换', 'الدفء — خشب دافئ'}
+	'palette.world':        I18nRow{'Go to World', 'Ir a Mundo', '前往世界', 'اذهب إلى العالم'}
+	'palette.skills':       I18nRow{'Go to Skills', 'Ir a Habilidades', '前往技能', 'اذهب إلى المهارات'}
+	'palette.agents':       I18nRow{'Go to Agents', 'Ir a Agentes', '前往代理', 'اذهب إلى الوكلاء'}
+	'palette.mcp':          I18nRow{'Go to MCP', 'Ir a MCP', '前往提供方', 'اذهب إلى المزودين'}
+	'palette.targets':      I18nRow{'Go to Targets', 'Ir a Destinos', '前往目标', 'اذهب إلى الأهداف'}
+	'palette.doctor':       I18nRow{'Go to Doctor', 'Ir a Doctor', '前往诊断', 'اذهب إلى الفحص'}
+	'palette.jobs':         I18nRow{'Go to Jobs', 'Ir a Trabajos', '前往作业', 'اذهب إلى المهام'}
+	'palette.loops':        I18nRow{'Go to Loops', 'Ir a Bucles', '前往循环', 'اذهب إلى الحلقات'}
+	'palette.swarm':        I18nRow{'Go to Swarm', 'Ir a Enjambre', '前往集群', 'اذهب إلى السرب'}
+	'palette.workspace':    I18nRow{'Go to Workspace', 'Ir a Espacio', '前往工作区', 'اذهب إلى المساحة'}
+	'palette.products':     I18nRow{'Go to Products', 'Ir a Productos', '前往产品', 'اذهب إلى المنتجات'}
+	'palette.onboarding':   I18nRow{'Go to Onboarding', 'Ir a Inicio', '前往引导', 'اذهب إلى التهيئة'}
+	'palette.insights':     I18nRow{'Go to Insights', 'Ir a Métricas', '前往洞察', 'اذهب إلى الرؤى'}
 	// palette — descriptions (nav, short)
-	'pdesc.world':             I18nRow{'Office floor, desks and handoffs', 'Planta, escritorios y entregas', '办公区 · 工位与交接', 'الأرضية والمكاتب والتسليمات'}
-	'pdesc.skills':            I18nRow{'Search and install skills', 'Buscar e instalar habilidades', '搜索并安装技能', 'ابحث وثبّت المهارات'}
-	'pdesc.agents':            I18nRow{'Browse holistic and specialist', 'Explorar globales y especialistas', '浏览全能与专项', 'تصفح الشامل والمتخصص'}
-	'pdesc.mcp':               I18nRow{'Providers and health', 'Proveedores y salud', '提供方与健康', 'المزودون والصحة'}
-	'pdesc.targets':           I18nRow{'Enable platforms', 'Activar plataformas', '启用平台', 'فعّل المنصات'}
-	'pdesc.doctor':            I18nRow{'Fix checks', 'Reparar comprobaciones', '修复检查', 'أصلح الفحوصات'}
-	'pdesc.jobs':              I18nRow{'Live processes', 'Procesos en vivo', '实时进程', 'العمليات المباشرة'}
-	'pdesc.loops':             I18nRow{'Missions and schedules — inner/outer', 'Misiones y agendas — internas/externas', '任务与计划 · 内外环', 'المهام والجداول'}
-	'pdesc.swarm':             I18nRow{'GOD mailbox, Herdr/tmux, pair/team/full', 'Buzón GOD, Herdr/tmux, par/equipo/completo', 'GOD 信箱 · 集群规模', 'صندوق GOD والفرق'}
-	'pdesc.workspace':         I18nRow{'Context and memory', 'Contexto y memoria', '上下文与记忆', 'السياق والذاكرة'}
-	'pdesc.products':          I18nRow{'Manage products/packs membership & digest', 'Gestionar productos/paquetes y resumen', '管理产品/包与摘要', 'أدر المنتجات والحزم'}
-	'pdesc.onboarding':        I18nRow{'Wizard: workspace, personas, capability, target, product', 'Asistente: workspace, personas, capacidad, destino, producto', '向导：工作区到产品', 'معالج: من المساحة إلى المنتج'}
-	'pdesc.insights':          I18nRow{'Cost ledger, waterfall, spans, CI, realtime, gallery', 'Costos, cascada, spans, CI, tiempo real, galería', '成本 · 瀑布 · CI · 实时 · 图库', 'التكاليف والأداء والمعرض'}
+	'pdesc.world':          I18nRow{'Office floor, desks and handoffs', 'Planta, escritorios y entregas', '办公区 · 工位与交接', 'الأرضية والمكاتب والتسليمات'}
+	'pdesc.skills':         I18nRow{'Search and install skills', 'Buscar e instalar habilidades', '搜索并安装技能', 'ابحث وثبّت المهارات'}
+	'pdesc.agents':         I18nRow{'Browse holistic and specialist', 'Explorar globales y especialistas', '浏览全能与专项', 'تصفح الشامل والمتخصص'}
+	'pdesc.mcp':            I18nRow{'Providers and health', 'Proveedores y salud', '提供方与健康', 'المزودون والصحة'}
+	'pdesc.targets':        I18nRow{'Enable platforms', 'Activar plataformas', '启用平台', 'فعّل المنصات'}
+	'pdesc.doctor':         I18nRow{'Fix checks', 'Reparar comprobaciones', '修复检查', 'أصلح الفحوصات'}
+	'pdesc.jobs':           I18nRow{'Live processes', 'Procesos en vivo', '实时进程', 'العمليات المباشرة'}
+	'pdesc.loops':          I18nRow{'Missions and schedules — inner/outer', 'Misiones y agendas — internas/externas', '任务与计划 · 内外环', 'المهام والجداول'}
+	'pdesc.swarm':          I18nRow{'GOD mailbox, Herdr/tmux, pair/team/full', 'Buzón GOD, Herdr/tmux, par/equipo/completo', 'GOD 信箱 · 集群规模', 'صندوق GOD والفرق'}
+	'pdesc.workspace':      I18nRow{'Context and memory', 'Contexto y memoria', '上下文与记忆', 'السياق والذاكرة'}
+	'pdesc.products':       I18nRow{'Manage products/packs membership & digest', 'Gestionar productos/paquetes y resumen', '管理产品/包与摘要', 'أدر المنتجات والحزم'}
+	'pdesc.onboarding':     I18nRow{'Wizard: workspace, personas, capability, target, product', 'Asistente: workspace, personas, capacidad, destino, producto', '向导：工作区到产品', 'معالج: من المساحة إلى المنتج'}
+	'pdesc.insights':       I18nRow{'Cost ledger, waterfall, spans, CI, realtime, gallery', 'Costos, cascada, spans, CI, tiempo real, galería', '成本 · 瀑布 · CI · 实时 · 图库', 'التكاليف والأداء والمعرض'}
 }
 
 // rtl_text — bidi-lite for the fontstash renderer (no shaping, no bidi):
@@ -1578,37 +1550,6 @@ fn panel_desc(i int) string {
 	}
 }
 
-fn palette_items() []PaletteItem {
-	// S4A (#1119): navigation rows migrated to the shared typed registry
-	// (modules/desktop/palette/registry.v). Only entries not yet migrated to
-	// typed registry actions remain here; each is retired in S4B/S4C.
-	return [
-		PaletteItem{'command_palette', 'Command palette', 'Fuzzy search ( / ) — todo administrable', '/'},
-		PaletteItem{'serve', 'Start API server', 'agent-toolkit serve --port 3847', 's'},
-		PaletteItem{'doctor_fix', 'Run doctor --fix', 'Repair missing profiles', 'd'},
-		PaletteItem{'install', 'Install profiles', 'agent-toolkit install --dry-run', 'i'},
-		// —— CLI absoluto — todo administrable desde GUI (palette + terminal) ——
-		PaletteItem{'install_full', 'Install — full', 'agent-toolkit install --tools claude-code,cursor --force', 'install'},
-		PaletteItem{'update', 'Update — agent-toolkit update', 'Update --check --pin', 'update'},
-		PaletteItem{'uninstall', 'Uninstall', 'Uninstall --dry-run --rollback', 'uninstall'},
-		PaletteItem{'diff', 'Diff — target/product', 'Compare configurations', 'diff'},
-		PaletteItem{'skills_sync', 'Skills — sync/validate', 'Sync and validate the catalog', 'skills_sync'},
-		PaletteItem{'mcp_health', 'MCP — health/doctor', 'Health of configured providers', 'mcp_health'},
-		PaletteItem{'loop_run', 'Loop — run/status/audit/cost', 'Missions heartbeat + budgets', 'loop_run'},
-		PaletteItem{'swarm_start', 'Swarm — start/list/approve', 'Launch pair/team/full, approve spend/scope', 'swarm_start'},
-		PaletteItem{'workspace_sync', 'Workspace — sync/context', 'Sync knowledge + context', 'workspace_sync'},
-		PaletteItem{'memory', 'Memory — add/search/inject/todo', 'Palace recall + todos', 'memory'},
-		PaletteItem{'project_clone', 'Project — clone/list/scan', 'Clone and scan repos', 'project_clone'},
-		PaletteItem{'devcompanion', 'DevCompanion — queue/status', 'Background queue + llm-status', 'devcompanion'},
-		PaletteItem{'insights_cli', 'Insights — CLI days/output', 'Telemetry ledger CLI', 'insights_cli'},
-		PaletteItem{'build', 'Build — --check', 'Package plugin and catalogs', 'build'},
-		PaletteItem{'inventory', 'Inventory — audit', 'List tools', 'inventory'},
-		PaletteItem{'completion', 'Completion — bash/zsh/fish', 'Shell completion', 'completion'},
-		PaletteItem{'cozy', 'Cozy — toggle warm wood', 'Cozy mode: warm paper + wood + FPS 62', 'c'},
-		PaletteItem{'theme', 'Theme — cycle Paper/Ink/System', 'Panel appearance, persists', 't'},
-	]
-}
-
 // fuzzy_score and palette_best_score were removed in S4A (#1119): the palette
 // module's scorer (desktop.palette.fuzzy_score / action_best_score) is the
 // single scoring authority shared by registry actions and legacy rows.
@@ -1681,10 +1622,12 @@ fn nav_tr_key(p nav.PanelId) string {
 // S4A) with the legacy static rows for not-yet-migrated entries. All rows are
 // scored by the palette module's fuzzy scorer — one scoring authority.
 // Empty query keeps the stable build order: navigation, entities, legacy.
+// filtered_palette derives every row from the shared typed registry (S4A) —
+// navigation, entities and contextual actions. The static command list and
+// its duplicate scorer were deleted in S4C (#1119); the registry's
+// scored_filter is the single ranking authority.
 fn filtered_palette(mut app GuiApp) []PaletteRow {
-	q := app.palette_query.trim_space()
 	mut scored := []PaletteRow{}
-	// registry-derived navigation + catalog/config/runtime entities
 	if app.palette_reg != unsafe { nil } {
 		for sa in app.palette_reg.scored_filter(app.palette_query) {
 			a := sa.action
@@ -1701,42 +1644,6 @@ fn filtered_palette(mut app GuiApp) []PaletteRow {
 				available: a.available
 				unavailable_reason: a.unavailable_reason
 			}
-		}
-	}
-	// legacy static rows (entries not yet migrated to the registry)
-	for it in palette_items() {
-		mut best := -1
-		if q == '' {
-			best = 1000
-		} else {
-			for field in [it.label, it.id, it.desc, it.keys] {
-				s := palette.fuzzy_score(q, field)
-				if s > best {
-					best = s
-				}
-			}
-		}
-		if best >= 0 {
-			scored << PaletteRow{
-				id: it.id
-				label: it.label
-				desc: it.desc
-				keys: it.keys
-				score: best
-			}
-		}
-	}
-	if q == '' {
-		return expand_palette_actions(mut app, scored)
-	}
-	// manual sort to avoid V3 generic monomorphize segfault (see swarm_service fix)
-	for i := 1; i < scored.len; i++ {
-		mut j := i
-		for j > 0 && (scored[j].score > scored[j - 1].score || (scored[j].score == scored[j - 1].score && scored[j].label < scored[j - 1].label)) {
-			tmp := scored[j]
-			scored[j] = scored[j - 1]
-			scored[j - 1] = tmp
-			j--
 		}
 	}
 	return expand_palette_actions(mut app, scored)
@@ -7729,36 +7636,30 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 			// subtle manila tab on unselected
 			app.gg.draw_rect_filled(cx + pw - 52, y + 4, 36, 6, app.pnl_card_sel)
 		}
-		// S4A: registry rows keep their registry labels; navigation rows keep
-		// localized labels via their i18n key. S4B action rows always render
-		// their own action label (an action on a navigation entity must not
-		// fall into the navigation translation branch).
+		// S4C: every row is registry-derived. Navigation rows keep localized
+		// labels via their i18n key; entities and actions render their own
+		// registry labels.
 		pal_label := if it.is_action {
 			it.label
-		} else if it.is_entity {
-			if it.kind == .navigation {
-				tr(app, 'palette.' + nav_tr_key(it.panel))
-			} else {
-				it.label
-			}
+		} else if it.kind == .navigation {
+			tr(app, 'palette.' + nav_tr_key(it.panel))
 		} else {
-			tr(app, 'palette.' + it.id)
+			it.label
 		}
-		// S4A entity rows describe truthful state; unavailable rows say why.
-		// R2 product-truth: CLI-action rows render live Engine counts, never
-		// the hardcoded historical numbers in palette_items().
-		pal_desc := if it.is_entity {
-			if !it.available {
-				'unavailable — ${it.unavailable_reason}'
+		// S4C: every row is registry-derived. Navigation rows keep localized
+		// labels and descriptions via their i18n keys; entities and actions
+		// render their own registry content; unavailable rows say why.
+		pal_desc := if it.is_action {
+			it.desc
+		} else if !it.available {
+			'unavailable — ${it.unavailable_reason}'
+		} else if it.kind == .navigation {
+			tr_desc := tr(app, 'pdesc.' + nav_tr_key(it.panel))
+			if tr_desc != 'pdesc.' + nav_tr_key(it.panel) {
+				tr_desc
 			} else {
 				it.desc
 			}
-		} else if it.id == 'skills_sync' {
-			'Sync and validate ${skills_total(mut app)} skills'
-		} else if it.id == 'mcp_health' {
-			'Health of ${mcp_total(mut app)} providers'
-		} else if tr(app, 'pdesc.' + it.id) != 'pdesc.' + it.id {
-			tr(app, 'pdesc.' + it.id)
 		} else {
 			it.desc
 		}
@@ -7873,27 +7774,8 @@ fn activate_palette_selection(mut app GuiApp) {
 		app.palette_armed = ''
 		return
 	}
-	match sel.id {
-		'workspace_sync' {
-			app.selected_panel = 9
-			app.inspector_msg = 'Workspace — pick or edit the path here; Validate checks it, Switch activates it'
-		}
-		'serve' {
-			app.inspector_msg = 'Serve: agent-toolkit serve --port 3847'
-		}
-		'theme' {
-			cycle_appearance(mut app)
-		}
-		'doctor_fix' {
-			app.selected_panel = 5
-			app.inspector_msg = 'Doctor fix: running checks…'
-		}
-		'install' {
-			app.selected_panel = 1
-			app.inspector_msg = 'Install: agent-toolkit install --dry-run'
-		}
-		else {}
-	}
+	// S4C: no legacy activation arms remain — every row is a registry entity
+	// or action.
 	app.palette_open = false
 	app.palette_query = ''
 	app.palette_selected = 0
@@ -7910,6 +7792,12 @@ fn run_palette_action(mut app GuiApp, sel PaletteRow) {
 	// unavailable actions never arm and never execute — say why, once
 	if !sel.available {
 		app.inspector_msg = 'Unavailable — ${sel.unavailable_reason}'
+		return
+	}
+	// appearance is a real shell preference: executed directly, no fake
+	// evidence, palette stays open so the user can keep cycling
+	if sel.action_kind == .app_theme_cycle {
+		cycle_appearance(mut app)
 		return
 	}
 	// swarm launch needs a real task-text input (plus recipe/backend choices)

--- a/cmd/agent-toolkit-desktop/palette_rows_test.v
+++ b/cmd/agent-toolkit-desktop/palette_rows_test.v
@@ -42,19 +42,20 @@ fn test_palette_merged_rows_registry_authority() {
 	assert rows[1].id == 'nav:/skills'
 	assert rows[0].is_entity
 	assert rows[0].panel == nav.PanelId.world_view
-	// legacy static rows still present (not yet migrated)
-	mut legacy_found := false
+	// S4C: the static command authority is retired — every row is
+	// registry-shaped (known action-id prefixes), no bare legacy ids
+	known_prefixes := ['nav:', 'app:', 'skill:', 'agent:', 'target:', 'mcp:', 'product:', 'pack:',
+		'loop:', 'doctor:', 'job:', 'swarm_run:', 'action:']
 	for r in rows {
-		if !r.is_entity && r.id == 'install_full' {
-			legacy_found = true
-		}
-		// no fabricated rows: every row comes from registry or legacy list
+		prefixed := known_prefixes.any(r.id.starts_with(it))
+		assert prefixed, 'non-registry row id leaked into the palette: ${r.id}'
+		// no fabricated rows: every row comes from the registry
 		assert r.label != ''
+		assert r.is_entity
 	}
-	assert legacy_found
 	// fresh engine: no fabricated runtime rows
 	for r in rows {
-		assert !(r.is_entity && (r.kind == .job || r.kind == .swarm_run))
+		assert !(r.kind == .job || r.kind == .swarm_run)
 	}
 
 	// query: registry entity identity survives fuzzy matching

--- a/cmd/agent-toolkit-desktop/registry_reachability_test.v
+++ b/cmd/agent-toolkit-desktop/registry_reachability_test.v
@@ -1,0 +1,230 @@
+module main
+
+import desktop
+import desktop.nav
+import desktop.palette
+import desktop_engine
+import os
+import time
+
+// S4C reachability gate (#1119): the canonical set of critical user
+// workflows must be reachable through the typed registry's semantics —
+// not through CLI command parity. This test is the coverage authority;
+// scripts/gui-coverage.py is only a human-readable report.
+
+struct ReachFixture {
+mut:
+	app &GuiApp = unsafe { nil }
+	d   &desktop.Desktop = unsafe { nil }
+	tmp string
+}
+
+fn reach_app(label string) &ReachFixture {
+	tmp := os.join_path(os.temp_dir(), 'atk-s4c-reach-${label}-${os.getpid()}-${time.now().unix_nano()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
+		config: desktop.DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	mut app := &GuiApp{
+		desktop: d
+		selected_panel: 0
+		hover_panel: -1
+		selected_desk: -1
+		hover_desk: -1
+	}
+	app.palette_reg = d.palette_registry()
+	app.palette_open = true
+	return &ReachFixture{
+		app: app
+		d: d
+		tmp: tmp
+	}
+}
+
+fn (mut f ReachFixture) cleanup() {
+	f.d.shutdown() or {}
+	os.rmdir_all(f.tmp) or {}
+	f.tmp = ''
+}
+
+fn has_action(acts []palette.RegistryAction, kind palette.ActionKind) bool {
+	return acts.any(it.kind == kind)
+}
+
+// workflow: discover + inspect + install skill where supported
+fn test_workflow_skill_discovery_install() {
+	mut f := reach_app('skill')
+	defer {
+		f.cleanup()
+	}
+	entries := f.app.palette_reg.all_entries()
+	skills := entries.filter(it.kind == palette.EntityKind.skill)
+	assert skills.len > 0, 'skills must be discoverable'
+	first := skills[0]
+	assert first.panel == nav.PanelId.skills
+	assert first.action_id().starts_with('skill:')
+	// inspect + install: deep-link panel + real install action
+	acts := f.app.palette_reg.actions_for(palette.EntityKind.skill, first.id)
+	assert acts.len > 0
+	install := acts.filter(it.kind == palette.ActionKind.skill_install)
+	assert install.len == 1
+	// a not-installed catalog skill must be installable where supported
+	assert install[0].available
+	assert install[0].entity_id == first.id
+}
+
+// workflow: discover + inspect agent
+fn test_workflow_agent_discovery() {
+	mut f := reach_app('agent')
+	defer {
+		f.cleanup()
+	}
+	entries := f.app.palette_reg.all_entries()
+	agents := entries.filter(it.kind == palette.EntityKind.agent)
+	assert agents.len > 0, 'agents must be discoverable'
+	assert agents[0].panel == nav.PanelId.agents
+	assert agents[0].action_id().starts_with('agent:')
+}
+
+// workflow: discover target; install where supported; enable/disable
+fn test_workflow_target_discovery_install_toggle() {
+	mut f := reach_app('target')
+	defer {
+		f.cleanup()
+	}
+	entries := f.app.palette_reg.all_entries()
+	targets := entries.filter(it.kind == palette.EntityKind.target)
+	assert targets.len > 0, 'targets must be discoverable'
+	first_id := targets[0].id
+	acts := f.app.palette_reg.actions_for(palette.EntityKind.target, first_id)
+	// both directions exist; availability is mutually exclusive config truth
+	enable := acts.filter(it.kind == palette.ActionKind.target_enable)
+	disable := acts.filter(it.kind == palette.ActionKind.target_disable)
+	assert enable.len == 1 && disable.len == 1
+	assert enable[0].available != disable[0].available
+	// install action exists; its availability matches engine execution truth
+	inst := acts.filter(it.kind == palette.ActionKind.target_install)
+	assert inst.len == 1
+	assert inst[0].available == f.d.engine_target_install_supported(first_id)
+	if !inst[0].available {
+		assert inst[0].unavailable_reason.contains('no bundled profile')
+	}
+}
+
+// workflow: discover MCP provider; enable/disable; probe
+fn test_workflow_mcp_discovery_toggle_probe() {
+	mut f := reach_app('mcp')
+	defer {
+		f.cleanup()
+	}
+	entries := f.app.palette_reg.all_entries()
+	providers := entries.filter(it.kind == palette.EntityKind.mcp_provider)
+	assert providers.len > 0, 'MCP providers must be discoverable'
+	first_id := providers[0].id
+	acts := f.app.palette_reg.actions_for(palette.EntityKind.mcp_provider, first_id)
+	assert has_action(acts, palette.ActionKind.mcp_enable)
+	assert has_action(acts, palette.ActionKind.mcp_disable)
+	probe := acts.filter(it.kind == palette.ActionKind.mcp_probe)
+	assert probe.len == 1 && probe[0].available
+}
+
+// workflow: Doctor preview + repair
+fn test_workflow_doctor_preview_repair() {
+	mut f := reach_app('doctor')
+	defer {
+		f.cleanup()
+	}
+	entries := f.app.palette_reg.all_entries()
+	checks := entries.filter(it.kind == palette.EntityKind.doctor_check)
+	assert checks.len > 0, 'doctor checks must be discoverable'
+	mut found_repair := false
+	for c in checks {
+		acts := f.app.palette_reg.actions_for(palette.EntityKind.doctor_check, c.id)
+		repairs := acts.filter(it.kind == palette.ActionKind.doctor_repair)
+		if repairs.len == 1 {
+			found_repair = true
+			assert repairs[0].needs_preview, 'repair must offer a real preview'
+			assert repairs[0].needs_confirm, 'repair is mutating and must confirm'
+			if !c.available {
+				assert !repairs[0].available
+				assert repairs[0].unavailable_reason.contains('not auto-fixable')
+			}
+		}
+	}
+	assert found_repair, 'at least one check must expose the repair action'
+}
+
+// workflow: run a loop
+fn test_workflow_loop_run() {
+	mut f := reach_app('loop')
+	defer {
+		f.cleanup()
+	}
+	entry := desktop_engine.LoopEntry{
+		name: 's4c-reach-loop'
+		goal: 'reachability gate'
+		tier: .l1
+		stage: 'l1'
+		cadence: '1d'
+		schedule: desktop_engine.cadence_to_cron('1d')
+		budget: desktop_engine.LoopBudget{
+			max_tokens: 80000
+			max_runs_per_day: 1
+			max_wall_seconds: 900
+		}
+		budget_total: 80000
+	}
+	f.d.loops_catalog() // warm engine
+	rev := f.d.engine_upsert_loop(entry) or { panic(err.msg()) }
+	assert rev > 0
+	acts := f.app.palette_reg.actions_for(palette.EntityKind.loop_template, 's4c-reach-loop')
+	assert has_action(acts, palette.ActionKind.loop_run)
+	assert has_action(acts, palette.ActionKind.loop_schedule_toggle)
+}
+
+// workflow: swarm launch/request
+fn test_workflow_swarm_launch() {
+	mut f := reach_app('swarm')
+	defer {
+		f.cleanup()
+	}
+	acts := f.app.palette_reg.actions_for(palette.EntityKind.navigation, '/swarm')
+	launch := acts.filter(it.kind == palette.ActionKind.swarm_launch)
+	assert launch.len == 1
+	assert launch[0].available
+}
+
+// application-level actions: theme, honest update unavailability, uninstall
+fn test_workflow_app_level_actions() {
+	mut f := reach_app('app')
+	defer {
+		f.cleanup()
+	}
+	entries := f.app.palette_reg.all_entries()
+	app := entries.filter(it.kind == palette.EntityKind.app)
+	assert app.len == 1
+	assert app[0].id == 'agent-toolkit'
+	acts := f.app.palette_reg.actions_for(palette.EntityKind.app, 'agent-toolkit')
+	// theme: real shell action, no confirmation, no evidence machinery
+	theme := acts.filter(it.kind == palette.ActionKind.app_theme_cycle)
+	assert theme.len == 1 && theme[0].available && !theme[0].needs_confirm
+	// update: honestly unavailable with a reason — never a fake check
+	upd := acts.filter(it.kind == palette.ActionKind.app_update_check)
+	assert upd.len == 1
+	assert !upd[0].available
+	assert upd[0].unavailable_reason.contains('No update feed/updater')
+	// uninstall: destructive — real dry-run preview + explicit confirmation
+	un := acts.filter(it.kind == palette.ActionKind.app_uninstall)
+	assert un.len == 1
+	assert un[0].needs_preview && un[0].needs_confirm
+	if un[0].available {
+		lines := f.app.palette_reg.preview(palette.ActionKind.app_uninstall, 'agent-toolkit') or {
+			panic(err.msg())
+		}
+		assert lines.len > 0
+	}
+}

--- a/docs/desktop/S4_HANDOFF.md
+++ b/docs/desktop/S4_HANDOFF.md
@@ -28,6 +28,17 @@ state before acting; do not trust it blindly.
 
 ## 2. Current palette architecture (what exists today)
 
+> **Updated 2026-09-07 (S4A–S4C):** the two-authority state below is resolved.
+> The typed registry (`modules/desktop/palette/registry.v` + `actions.v`) is
+> the **sole** palette/search authority; `palette_items()`, the duplicate
+> scorer and the legacy activation arms were deleted. Contextual typed
+> actions with preview/confirmation landed in S4B. Application-level actions
+> (appearance, honest-unavailable Update, receipt-based Uninstall) live under
+> one app entity. Critical-workflow reachability is gated by
+> `cmd/agent-toolkit-desktop/registry_reachability_test.v` inside Required
+> CI (`./make.vsh test`). Remaining slices: S4D (truthful undo + recent
+> actions only). The original snapshot is preserved below for history.
+
 Two authorities coexist:
 
 1. **Static production list** — `palette_items()` in

--- a/docs/desktop/WORKFLOW_COVERAGE.md
+++ b/docs/desktop/WORKFLOW_COVERAGE.md
@@ -39,7 +39,7 @@ Source paths below refer to the baseline SHA; line numbers will move as fixes la
 | Fabricated running state and telemetry | `cmd/agent-toolkit-desktop/main.v:1754`, `:1859`, `:4463`, `:5155`, `:5311`, `:5359`, `:5420`, `:6970` | Clean setup remains empty; real events and processes produce matching UI |
 | False process success | `modules/desktop_engine/jobs_service.v:263` | Failed spawn reports failure, no running record |
 | Workspace safety and invented state | `onboarding_service.v:138`, `workspace_service.v:160`, `:271`, `:727` | Containment, no-overwrite, partial failure, actual Git and memory state |
-| Dead/split action discovery | `main.v:7908`; `modules/desktop/palette/palette.v:468` | Typed registry, retained entity identity, functional dispatch/forms/results |
+| Dead/split action discovery | Resolved 2026-09-07 (S4A–S4C, #1159 #1160; static `palette_items()` deleted) | Typed registry is the sole palette/search authority; entity identity + availability reasons + typed actions retained (`modules/desktop/palette/registry.v`, `actions.v`); critical-workflow reachability gated by `cmd/agent-toolkit-desktop/registry_reachability_test.v` in Required CI |
 | Domain duplication | CLI `dispatch.v` imports core; Desktop install services duplicate logic; `loops_service.v:480` invokes own CLI | Shared typed domain execution with GUI/CLI parity tests |
 | Native capability misreporting | `modules/desktop/backend/backend.v:139`, `:164`, `:193` | Actual clipboard/dialog operation or explicit unsupported result |
 | Terminal exit and identity | `modules/pty/pty.v:197`; `modules/ghostty/ghostty.v:5` | Reaped child/closed fd, no unexpected restart, honest VT compatibility |
@@ -65,3 +65,7 @@ Update acceptance must verify the downloaded artifact, checksum/provenance, actu
 installed version and failure recovery. Respect package-manager ownership and
 rollback limits; a state-only version change is not an update. Audit
 `modules/desktop_engine/update_service.v` and channel policy before enabling apply.
+Status 2026-09-07 (S4C): no release-feed reader or updater exists, so Update is an
+honestly unavailable application action (`No update feed/updater is available yet`)
+in the registry — it cannot execute, and it must not be wired until a real feed
+with verified artifacts exists.

--- a/make.vsh
+++ b/make.vsh
@@ -9,6 +9,7 @@
 // Style: bobatea/make.vsh + examples/build_system/build.vsh
 
 import build
+import os
 
 const mods = ['agent_toolkit_core', 'agent_toolkit_cli', 'agent_toolkit_server', 'agent_toolkit_gui', 'desktop_engine', 'desktop']
 
@@ -128,10 +129,17 @@ context.task(name: 'test', help: 'Run unit tests', run: fn [r] (_ build.Task) ! 
 	// S4C (#1119): the production Desktop shell's tests — including the
 	// registry reachability gate for critical workflows — live under
 	// cmd/agent-toolkit-desktop and are part of the Required CI test path.
-	println('==> test cmd/agent-toolkit-desktop')
-	rc := vcmd('test ${join_path(r, 'cmd', 'agent-toolkit-desktop')}')
-	if rc != 0 {
-		exit(rc)
+	// The suite compiles gg/sokol + pty C interop; the pinned master V build
+	// cannot resolve macOS SDK headers on CI runners (the release toolchain
+	// builds the same binary fine from the V 0.5.2 zip), so it runs on Linux
+	// runners. macOS legs keep covering modules. Packaging validation
+	// (#1130) will revisit macOS shell testing.
+	if os.user_os() == 'linux' {
+		println('==> test cmd/agent-toolkit-desktop')
+		rc := vcmd('test ${join_path(r, 'cmd', 'agent-toolkit-desktop')}')
+		if rc != 0 {
+			exit(rc)
+		}
 	}
 })
 

--- a/make.vsh
+++ b/make.vsh
@@ -125,6 +125,14 @@ context.task(name: 'vet', help: 'Vet modules', run: fn [r] (_ build.Task) ! {
 
 context.task(name: 'test', help: 'Run unit tests', run: fn [r] (_ build.Task) ! {
 	each_mod(r, 'test', 'test')
+	// S4C (#1119): the production Desktop shell's tests — including the
+	// registry reachability gate for critical workflows — live under
+	// cmd/agent-toolkit-desktop and are part of the Required CI test path.
+	println('==> test cmd/agent-toolkit-desktop')
+	rc := vcmd('test ${join_path(r, 'cmd', 'agent-toolkit-desktop')}')
+	if rc != 0 {
+		exit(rc)
+	}
 })
 
 context.task(name: 'build', help: 'Compile-smoke each module', run: fn (_ build.Task) ! {

--- a/modules/desktop/palette/actions.v
+++ b/modules/desktop/palette/actions.v
@@ -31,6 +31,9 @@ pub enum ActionKind {
 	loop_run
 	loop_schedule_toggle
 	swarm_launch
+	app_theme_cycle
+	app_update_check
+	app_uninstall
 }
 
 // kind_label returns the human action label used in the palette.
@@ -48,6 +51,9 @@ pub fn kind_label(k ActionKind) string {
 		.loop_run { 'Run now' }
 		.loop_schedule_toggle { 'Toggle schedule' }
 		.swarm_launch { 'Launch' }
+		.app_theme_cycle { 'Change appearance' }
+		.app_update_check { 'Check for updates' }
+		.app_uninstall { 'Uninstall integrations' }
 	}
 }
 
@@ -350,6 +356,54 @@ pub fn (mut r Registry) actions_for(kind EntityKind, entity_id string) []Registr
 				}
 			}
 		}
+		.app {
+			// application-level actions (S4C): one coherent app entity, no
+			// legacy command rows
+			out << RegistryAction{
+				kind: .app_theme_cycle
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.app_theme_cycle)
+				category: entry.category
+				keywords: 'theme appearance cycle paper ink system light dark'
+				desc: 'cycle Paper → Ink → System'
+				needs_confirm: false
+				available: true
+				panel: .onboarding
+			}
+			out << RegistryAction{
+				kind: .app_update_check
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.app_update_check)
+				category: entry.category
+				keywords: 'update upgrade check version feed'
+				desc: 'self-update'
+				needs_confirm: false
+				available: false
+				unavailable_reason: 'No update feed/updater is available yet'
+				panel: .onboarding
+			}
+			candidates := r.engine.uninstall_candidates()
+			out << RegistryAction{
+				kind: .app_uninstall
+				entity_kind: kind
+				entity_id: entity_id
+				label: kind_label(.app_uninstall)
+				category: entry.category
+				keywords: 'uninstall remove integrations profiles receipts'
+				desc: 'remove toolkit-owned files from install receipts (dry-run first)'
+				needs_preview: true
+				needs_confirm: true
+				available: candidates.len > 0
+				unavailable_reason: if candidates.len > 0 {
+					''
+				} else {
+					'no install receipts found — nothing to uninstall'
+				}
+				panel: .onboarding
+			}
+		}
 		else {}
 	}
 	return out
@@ -411,6 +465,21 @@ pub fn (mut r Registry) preview(action ActionKind, entity_id string) ![]string {
 		}
 		.doctor_repair {
 			return r.engine.doctor_fix_preview(entity_id)!
+		}
+		.app_uninstall {
+			// real dry-run preview: the exact files the uninstall would
+			// remove, computed by the core domain operation — nothing written
+			rep := r.engine.uninstall_targets([], true)
+			mut lines := []string{}
+			for line in rep.message.split_into_lines() {
+				if line.trim_space() != '' {
+					lines << line.trim_space()
+				}
+			}
+			if lines.len == 0 {
+				return error('uninstall preview unavailable — no receipts')
+			}
+			return lines
 		}
 		else {
 			return error('preview unavailable for this action')
@@ -742,6 +811,51 @@ fn (mut r Registry) execute_seam(kind EntityKind, entity_id string, action Actio
 				evidence: ActionEvidence{
 					run_id: run_id
 				}
+			}
+		}
+		.app_theme_cycle {
+			// appearance is a real shell preference action; the shell executes
+			// it directly — the registry exposes it but never fakes a domain
+			// result for it
+			return error('appearance is executed by the shell')
+		}
+		.app_update_check {
+			// there is no updater: this stays unreachable (availability is
+			// false) and never fakes a check result
+			return ActionOutcome{
+				status: .unavailable
+				summary: 'No update feed/updater is available yet'
+			}
+		}
+		.app_uninstall {
+			rep := r.engine.uninstall_targets(args.targets, args.dry_run)
+			if args.dry_run {
+				return ActionOutcome{
+					status: .succeeded
+					summary: 'dry-run complete — nothing was deleted'
+				}
+			}
+			summary := 'uninstalled ${rep.files_removed} owned file(s) across ${rep.tools_processed} target(s)${if rep.skipped > 0 {
+				' · ${rep.skipped} skipped (user-owned/merged or absent)'
+			} else {
+				''
+			}}'
+			if rep.ok {
+				return ActionOutcome{
+					status: .succeeded
+					summary: summary
+				}
+			}
+			if rep.files_removed > 0 {
+				// partial: some owned files were removed, some targets failed
+				return ActionOutcome{
+					status: .partial
+					summary: '${summary} — failed: ${rep.failures.join(', ')}'
+				}
+			}
+			return ActionOutcome{
+				status: .failed
+				summary: rep.message
 			}
 		}
 	}

--- a/modules/desktop/palette/actions_test.v
+++ b/modules/desktop/palette/actions_test.v
@@ -428,6 +428,47 @@ fn test_fresh_engine_no_fabricated_runtime_actions() {
 	assert entries.filter(it.kind == .swarm_run).len == 0
 }
 
+// 12. application-level actions are honest (S4C).
+fn test_app_actions_honest() {
+	mut fe := new_s4b_engine('app')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	// update: honestly unavailable — no fake check result, no mutation
+	out := reg.execute(.app, 'agent-toolkit', .app_update_check, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .unavailable
+	assert out.summary.contains('No update feed/updater')
+	// theme: the shell executes appearance changes; the module never fakes a
+	// domain result for it
+	if _ := reg.execute(.app, 'agent-toolkit', .app_theme_cycle, ActionArgs{}) {
+		assert false, 'theme cycle must not execute as a fake domain action'
+	} else {
+		assert err.msg().contains('shell')
+	}
+	// uninstall: preview is a real dry-run (nothing deleted); execution is
+	// only ever attempted with confirm — and tests never run a real uninstall
+	acts := reg.actions_for(.app, 'agent-toolkit')
+	un := find_action(acts, .app_uninstall) or { panic('app_uninstall missing') }
+	assert un.needs_preview && un.needs_confirm
+	if un.available {
+		before := reg.engine.uninstall_candidates().len
+		pv := reg.preview(.app_uninstall, 'agent-toolkit') or { panic(err.msg()) }
+		assert pv.len > 0
+		// dry-run execution (explicitly confirmed) reports success without
+		// deleting anything
+		dr := reg.execute(.app, 'agent-toolkit', .app_uninstall, ActionArgs{
+			confirm: true
+			dry_run: true
+		}) or { panic(err.msg()) }
+		assert dr.status == .succeeded
+		assert dr.summary.contains('nothing was deleted')
+		assert reg.engine.uninstall_candidates().len == before
+	}
+}
+
 // 11. unknown entity → no actions, honest empty (not fabricated defaults).
 fn test_unknown_entity_has_no_actions() {
 	mut fe := new_s4b_engine('unknown')

--- a/modules/desktop/palette/registry.v
+++ b/modules/desktop/palette/registry.v
@@ -21,6 +21,7 @@ import desktop.nav
 // EntityKind classifies what a registry entry points at.
 pub enum EntityKind {
 	navigation
+	app
 	skill
 	agent
 	target
@@ -55,6 +56,7 @@ pub:
 pub fn (e RegistryEntry) action_id() string {
 	return match e.kind {
 		.navigation { 'nav:${e.id}' }
+		.app { 'app:${e.id}' }
 		.skill { 'skill:${e.id}' }
 		.agent { 'agent:${e.id}' }
 		.target { 'target:${e.id}' }
@@ -274,6 +276,7 @@ fn (mut r Registry) build_entries() []RegistryEntry {
 	mut out := []RegistryEntry{}
 	mut engine := r.engine
 	out << build_nav_entries()
+	out << build_app_entries()
 	out << build_skill_entries(mut engine)
 	out << build_agent_entries(mut engine)
 	out << build_target_entries(mut engine)
@@ -285,6 +288,22 @@ fn (mut r Registry) build_entries() []RegistryEntry {
 	out << build_job_entries(mut engine)
 	out << build_swarm_entries(mut engine)
 	return out
+}
+
+// build_app_entries derives the application-level entity (S4C): the app
+// itself — appearance, updates, uninstall. This replaces the legacy static
+// command rows with one coherent, discoverable Setup entity.
+fn build_app_entries() []RegistryEntry {
+	return [RegistryEntry{
+		kind: .app
+		id: 'agent-toolkit'
+		label: 'Agent Toolkit — Setup'
+		category: 'Application'
+		keywords: 'agent toolkit setup application appearance theme update uninstall settings preferences'
+		desc: 'Appearance · updates · integrations — Tab for actions'
+		available: true
+		panel: .onboarding
+	}]
 }
 
 // build_nav_entries derives navigation destinations in shell order.

--- a/modules/desktop/window.v
+++ b/modules/desktop/window.v
@@ -348,6 +348,17 @@ pub fn (mut d Desktop) toggle_loop_cron(name string, enabled bool) !u64 {
 	return d.engine.toggle_loop_cron(name, enabled)
 }
 
+// engine_upsert_loop creates or updates a loop template via the Engine.
+pub fn (mut d Desktop) engine_upsert_loop(entry desktop_engine.LoopEntry) !u64 {
+	return d.engine.upsert_loop(entry)
+}
+
+// engine_target_install_supported reports whether a target can be installed
+// through the Engine install flow (registry availability truth, S4B).
+pub fn (mut d Desktop) engine_target_install_supported(target_id string) bool {
+	return d.engine.target_install_supported(target_id)
+}
+
 // inner_loops_for returns inner loops map snapshot for a swarm run (via State keys).
 pub fn (mut d Desktop) inner_loops_for(run_id string) map[string]string {
 	snap := d.engine.snapshot()

--- a/modules/desktop_engine/uninstall_service.v
+++ b/modules/desktop_engine/uninstall_service.v
@@ -1,0 +1,34 @@
+module desktop_engine
+
+// S4C (#1119) — thin typed Engine adapter over the core receipt-based
+// uninstall domain operation. Desktop actions never shell out to the CLI:
+// core's run_uninstall removes ONLY toolkit-owned (`created`) artifacts
+// recorded in real install receipts, explicitly skips `merged` (user-touched)
+// files with a reason, refuses path escapes, supports a real dry-run, and
+// returns a structured report with partial-failure detail.
+
+import agent_toolkit_core
+
+// uninstall_candidates returns the targets that currently have real install
+// receipts under the default receipt authority. Availability truth for the
+// registry's uninstall action comes from here, not from assumptions.
+pub fn (mut e Engine) uninstall_candidates() []string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	return agent_toolkit_core.discover_uninstall_tools('')
+}
+
+// uninstall_targets runs the core receipt-based uninstall for the given
+// targets (empty = discover all). dry_run produces the real preview without
+// deleting anything. The structured report is passed through unchanged —
+// partial failures are never translated into full success by the Engine.
+pub fn (mut e Engine) uninstall_targets(tools []string, dry_run bool) agent_toolkit_core.UninstallReport {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	return agent_toolkit_core.run_uninstall(agent_toolkit_core.UninstallOptions{
+		tools: tools
+		dry_run: dry_run
+	})
+}

--- a/scripts/gui-coverage.py
+++ b/scripts/gui-coverage.py
@@ -94,18 +94,61 @@ def strip_v_comments(src: str) -> str:
     return "\n".join(line.split("//")[0] for line in src.splitlines())
 
 
+def v_declarations(src: str) -> set[str]:
+    """Collect actual V function declarations, enum members and consts.
+
+    Works on comment-stripped source and matches declarations — not arbitrary
+    substrings — so a commented-out function can never satisfy the report.
+    """
+    out: set[str] = set()
+    for line in strip_v_comments(src).splitlines():
+        s = line.strip()
+        m = re.match(r"(?:pub\s+)?fn\s+(?:\([^)]*\)\s*)?([A-Za-z0-9_]+)\s*\(", s)
+        if m:
+            out.add(m.group(1))
+            continue
+        m2 = re.fullmatch(r"([a-z_0-9]+),?", s)
+        if m2:
+            out.add(m2.group(1))
+            continue
+        m3 = re.match(r"const\s+([a-z_0-9]+)\s*=", s)
+        if m3:
+            out.add(m3.group(1))
+    return out
+
+
+def engine_seam_sources() -> list[Path]:
+    """The typed Engine seams the registry actions invoke (S4B/S4C)."""
+    return sorted((ROOT / "modules" / "desktop_engine").glob("*.v"))
+
+
 def main() -> int:
-    reg, act, gate = read(REG), read(ACT), read(GATE)
+    reg_raw, act_raw, gate_raw = read(REG), read(ACT), read(GATE)
     main_src = strip_v_comments(read(MAIN))
-    if not reg or not act:
+    if not reg_raw or not act_raw:
         print("error: registry/action definitions not found", file=sys.stderr)
         return 2
+    # declarations/members only — commented-out code never counts. The
+    # backing universe includes the typed Engine seams the actions invoke.
+    backing: set[str] = set()
+    calls = ""
+    for p in [REG, ACT, MAIN, *engine_seam_sources()]:
+        src = read(p)
+        backing |= v_declarations(src)
+        calls += strip_v_comments(src) + "\n"
 
     rows: list[tuple[str, str, str]] = []
     missing: list[str] = []
+    gate_fns = v_declarations(gate_raw)
     for wf, (needs, gate_fn) in sorted(WORKFLOWS.items()):
-        unbacked = [n for n in needs if n not in reg and n not in act and n not in main_src]
-        gated = gate_fn in gate
+        unbacked = []
+        for n in needs:
+            if n.endswith("("):
+                if n not in calls:
+                    unbacked.append(n)
+            elif n not in backing:
+                unbacked.append(n)
+        gated = gate_fn in gate_fns
         if unbacked:
             status, via = "MISSING", ",".join(unbacked)
             missing.append(wf)

--- a/scripts/gui-coverage.py
+++ b/scripts/gui-coverage.py
@@ -1,144 +1,142 @@
 #!/usr/bin/env python3
-"""gui-coverage.py — CLI ↔ GUI coverage audit.
+"""gui-coverage.py — critical product workflow coverage report for the Desktop.
 
-Extracts the agent-toolkit CLI command surface from `build/agent-toolkit --help`
-and checks every command has a GUI affordance in the desktop palette
-(cmd/agent-toolkit-desktop/main.v `palette_items()`).
+Since S4 (#1119), the typed registry (modules/desktop/palette/registry.v +
+actions.v) is the sole palette/search authority: the static palette_items()
+command list was deleted. This report therefore no longer asserts CLI→palette
+row parity. It reports how each **critical product workflow** is reachable
+through the registry, by consuming the registry/action definitions themselves.
+
+The authority is the V reachability gate:
+    cmd/agent-toolkit-desktop/registry_reachability_test.v
+run by `./make.vsh test` inside Required CI (Check V Modules). This script is
+an advisory, human-readable view of the same contract — it never gates.
 
 Usage:
   python3 scripts/gui-coverage.py            # print report
-  python3 scripts/gui-coverage.py --check    # exit 1 if coverage < 100%
-
-The desktop GUI also manages commands beyond the palette (panel-scoped forms:
-skills install/toggle, MCP toggle, targets install, doctor fix, loop run/sched,
-swarm launch/approve, workspace IDE, onboarding wizard, insights tabs), so a
-missing palette row is a hint, not always a gap — the report marks those.
+  python3 scripts/gui-coverage.py --check    # exit 1 if a workflow is unbacked
 """
 
 import re
-import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+REG = ROOT / "modules" / "desktop" / "palette" / "registry.v"
+ACT = ROOT / "modules" / "desktop" / "palette" / "actions.v"
 MAIN = ROOT / "cmd" / "agent-toolkit-desktop" / "main.v"
-BIN = ROOT / "build" / "agent-toolkit"
+GATE = ROOT / "cmd" / "agent-toolkit-desktop" / "registry_reachability_test.v"
 
-# CLI command → palette id(s) / panel affordance that manages it
-COVERAGE = {
-    "install": ["install", "install_full"],
-    "update": ["update"],
-    "uninstall": ["uninstall"],
-    "doctor": ["doctor", "doctor_fix", "panel.doctor"],
-    "diff": ["diff"],
-    "skills": ["skills_sync", "panel.skills"],
-    "mcp": ["mcp_health", "panel.mcp"],
-    "plugin": ["build"],
-    "completion": ["completion"],
-    "gui": ["command_palette"],  # `agent-toolkit gui` IS this app
-    "loop": ["loop_run", "panel.loops"],
-    "workspace": ["workspace_sync", "panel.workspace"],
-    "memory": ["memory"],
-    "project": ["project_clone"],
-    "devcompanion": ["devcompanion"],
-    "insights": ["insights_cli", "panel.insights"],
-    "build": ["build"],
-    "inventory": ["inventory"],
-    "swarm": ["swarm_start", "panel.swarm"],
-    "serve": ["serve"],
-    "help": ["command_palette"],  # palette + `h` help overlay
-    "matrix": ["doctor"],  # capability matrix runs as a doctor check
+# Critical product workflow → (registry constructs that must exist, the
+# reachability-gate function that proves it). Tokens are V identifiers as
+# they literally appear in the registry/action definitions.
+WORKFLOWS: dict[str, tuple[set[str], str]] = {
+    "discover skill": (
+        {"build_skill_entries", "skills_catalog"},
+        "test_workflow_skill_discovery_install",
+    ),
+    "inspect skill (deep link)": ({"deep_link_select"}, "test_workflow_skill_discovery_install"),
+    "install skill where supported": ({"skill_install"}, "test_workflow_skill_discovery_install"),
+    "remove skill (config truth)": ({"skill_remove"}, "test_workflow_skill_discovery_install"),
+    "discover agent": ({"build_agent_entries", "agents_catalog"}, "test_workflow_agent_discovery"),
+    "inspect agent": ({"build_agent_entries"}, "test_workflow_agent_discovery"),
+    "discover target": ({"build_target_entries"}, "test_workflow_target_discovery_install_toggle"),
+    "install target where supported": (
+        {"target_install", "target_install_supported"},
+        "test_workflow_target_discovery_install_toggle",
+    ),
+    "enable/disable target": (
+        {"target_enable", "target_disable", "set_target_enabled"},
+        "test_workflow_target_discovery_install_toggle",
+    ),
+    "discover MCP provider": ({"build_mcp_entries"}, "test_workflow_mcp_discovery_toggle_probe"),
+    "enable/disable provider": (
+        {"mcp_enable", "mcp_disable"},
+        "test_workflow_mcp_discovery_toggle_probe",
+    ),
+    "probe provider": ({"mcp_probe"}, "test_workflow_mcp_discovery_toggle_probe"),
+    "Doctor preview repair": ({"doctor_fix_preview"}, "test_workflow_doctor_preview_repair"),
+    "Doctor execute repair": (
+        {"doctor_repair", "doctor_fix("},
+        "test_workflow_doctor_preview_repair",
+    ),
+    "run loop": ({"loop_run", "run_loop("}, "test_workflow_loop_run"),
+    "toggle loop schedule": (
+        {"loop_schedule_toggle", "toggle_loop_cron("},
+        "test_workflow_loop_run",
+    ),
+    "launch/request swarm": ({"swarm_launch("}, "test_workflow_swarm_launch"),
+    "navigate primary surfaces": (
+        {"production_nav_panels", "build_nav_entries"},
+        "test_workflow_skill_discovery_install",
+    ),
+    "application: theme": ({"app_theme_cycle"}, "test_workflow_app_level_actions"),
+    "application: update (honest unavailability)": (
+        {"app_update_check"},
+        "test_workflow_app_level_actions",
+    ),
+    "application: uninstall (preview+confirm)": (
+        {"app_uninstall", "uninstall_targets"},
+        "test_workflow_app_level_actions",
+    ),
 }
 
-# Commands intentionally NOT in the GUI (removed or CI-only per the CLI itself)
-INTENTIONAL_NA = {"tui", "release"}
+# The production shell must consume the registry — no static command authority.
+REMAINING_LEGACY = re.compile(r"palette_items|struct PaletteItem|palette_best_score")
 
 
-def cli_commands() -> dict[str, str]:
-    out = subprocess.run([str(BIN), "--help"], capture_output=True, text=True, timeout=30).stdout
-    cmds: dict[str, str] = {}
-    for line in out.splitlines():
-        m = re.match(r"^  ([a-z][a-z ()a-z-]*?)\s{2,}(.*)$", line)
-        if not m:
-            continue
-        names, desc = m.group(1).strip(), m.group(2).strip()
-        primary = names.split(" ")[0]
-        if primary in ("version",):
-            continue
-        cmds[primary] = desc
-    return cmds
+def read(path: Path) -> str:
+    return path.read_text() if path.exists() else ""
 
 
-def palette_ids() -> set[str]:
-    """Palette affordance ids from both sources (S4 #1119).
-
-    S4A moved navigation rows out of the static `palette_items()` list into the
-    typed registry (`modules/desktop/palette/registry.v`); the static list keeps
-    only not-yet-migrated CLI-command rows. Coverage therefore reads both:
-    static rows from main.v and registry navigation panels from the registry
-    module. S4C (#1119) replaces this CLI-row parity with task/workflow
-    coverage of the registry's critical workflows.
-    """
-    src = MAIN.read_text()
-    ids = set(re.findall(r"PaletteItem\{'([a-z_]+)'", src))
-    reg = (ROOT / "modules" / "desktop" / "palette" / "registry.v").read_text()
-    block = re.search(r"production_nav_panels\s*=\s*\[(.*?)\]", reg, re.DOTALL)
-    if block:
-        panels = set(re.findall(r"nav\.PanelId\.([a-z_]+)", block.group(1)))
-        # registry navigation panels map to their CLI-command affordance keys
-        panel_to_cmd = {
-            "world_view": "world",
-            "skills": "skills",
-            "agents": "agents",
-            "mcp": "mcp",
-            "targets": "targets",
-            "doctor": "doctor",
-            "jobs": "jobs",
-            "loops": "loops",
-            "swarm": "swarm",
-            "workspace": "workspace",
-            "products": "products",
-            "onboarding": "onboarding",
-            "insights": "insights",
-        }
-        ids |= {panel_to_cmd[p] for p in panels if p in panel_to_cmd}
-    return ids
+def strip_v_comments(src: str) -> str:
+    """Remove // line comments so removed-name mentions don't count as code."""
+    return "\n".join(line.split("//")[0] for line in src.splitlines())
 
 
 def main() -> int:
-    if not BIN.exists():
-        print(f"error: {BIN} not found — run make.vsh build-cli first", file=sys.stderr)
+    reg, act, gate = read(REG), read(ACT), read(GATE)
+    main_src = strip_v_comments(read(MAIN))
+    if not reg or not act:
+        print("error: registry/action definitions not found", file=sys.stderr)
         return 2
-    cmds = cli_commands()
-    pal = palette_ids()
-    rows, missing = [], []
-    for cmd, desc in sorted(cmds.items()):
-        want = COVERAGE.get(cmd, [])
-        hit = [p for p in want if p in pal]
-        panel = cmd in pal  # 'Go to <cmd>' palette row ⇒ dedicated panel
-        if hit:
-            rows.append((cmd, desc, "palette", ",".join(hit)))
-        elif panel:
-            rows.append((cmd, desc, "panel", f"panel.{cmd}"))
+
+    rows: list[tuple[str, str, str]] = []
+    missing: list[str] = []
+    for wf, (needs, gate_fn) in sorted(WORKFLOWS.items()):
+        unbacked = [n for n in needs if n not in reg and n not in act and n not in main_src]
+        gated = gate_fn in gate
+        if unbacked:
+            status, via = "MISSING", ",".join(unbacked)
+            missing.append(wf)
+        elif gated:
+            status, via = "covered", "reachability gate"
         else:
-            rows.append((cmd, desc, "MISSING", ""))
-            missing.append(cmd)
-    rows = [r for r in rows if r[0] not in INTENTIONAL_NA]
-    missing = [m for m in missing if m not in INTENTIONAL_NA]
+            status, via = "backed", "registry definitions (gate function missing)"
+            missing.append(wf)
+        rows.append((wf, status, via))
+
     total = len(rows)
     covered = total - len(missing)
-    print(
-        f"# CLI ↔ GUI coverage — {covered}/{total} commands ({100 * covered // max(total, 1)}%)\n"
-    )
-    print("| CLI command | GUI affordance | via |")
+    print(f"# Critical workflow coverage — {covered}/{total} workflows backed\n")
+    print("| Workflow | Status | Via |")
     print("|---|---|---|")
-    for cmd, desc, how, via in rows:
-        mark = "✅" if how != "MISSING" else "⚠️"
-        print(f"| {mark} `{cmd}` | {desc[:60]} | {how} |")
-    if missing:
-        print("\nGaps: " + ", ".join(f"`{m}`" for m in missing))
+    for wf, status, via in rows:
+        mark = "✅" if status != "MISSING" else "⚠️"
+        print(f"| {mark} {wf} | {status} | {via} |")
+
+    legacy = REMAINING_LEGACY.findall(main_src)
+    if legacy:
+        print(
+            "\n⚠️ legacy palette authority still present in production: "
+            + ", ".join(sorted(set(legacy)))
+        )
+        missing.append("legacy authority retirement")
+    else:
+        print("\n✅ static palette authority fully retired from the production shell")
+
     if "--check" in sys.argv and missing:
-        print(f"\nFAIL: {len(missing)} CLI commands without GUI affordance", file=sys.stderr)
+        print(f"\nFAIL: {len(missing)} workflow coverage gap(s)", file=sys.stderr)
         return 1
     return 0
 


### PR DESCRIPTION
## Summary

Third slice of S4 (#1119): **the static command palette authority is retired.** Search / Run no longer knows or cares what the Agent Toolkit CLI command tree looks like — the typed registry is the sole data source for navigation, entities and contextual actions.

### Deleted (no compatibility list kept)

- `palette_items()` — the entire static command list (22 rows)
- the `PaletteItem` struct, the legacy merge branch and its manual sort in `filtered_palette`, the duplicated scorer usage in main.v
- all legacy activation arms (`workspace_sync`, `serve`, `theme`, `doctor_fix`, `install`)
- 21 obsolete i18n rows for command rows (nav-row label + description localization preserved via the existing keys)
- the now-obsolete comment machinery around CLI-shaped rows

### Substantive additions (small; every seam verified against code)

- **`desktop_engine/uninstall_service.v`** — thin typed adapter over core `run_uninstall`: removes only receipt-owned (`created`) artifacts, skips `merged`/user-modified files with reasons, refuses path escapes, real dry-run, structured partial-failure report. Never shells out to the CLI.
- **Application-level entity** `Agent Toolkit — Setup` (`EntityKind.app`) with one coherent action set replacing the legacy rows:
  - *Change appearance* — real shell action (`cycle_appearance`), no confirmation, no manufactured evidence
  - *Check for updates* — **honestly unavailable** (`No update feed/updater is available yet`), execution impossible at both palette and registry layers; verified `UpdateServiceEngine.check_update` returns none and apply/rollback return false
  - *Uninstall integrations* — destructive: real dry-run preview → explicit confirm → Engine adapter → structured result; partial failures never translated to success; availability from real discovered receipts
- **`registry_reachability_test.v`** — the coverage **authority**: 8 workflow tests assert the canonical critical product workflows against `actions_for()` semantics (skill/agent/target/MCP discovery, install/toggle/probe, doctor preview+repair, loop run, swarm request, app-level actions).

### Coverage gate is now actually in Required CI

Investigation found that `cmd/agent-toolkit-desktop/*_test.v` were **not executed by any CI job** (S4A/S4B cmd tests ran locally only). `make.vsh test` now runs the cmd desktop suite, and `Check V Modules` (Required CI) runs `./make.vsh test` — traced: `Required CI → validate.yml → Check V Modules → ./make.vsh test → v test cmd/agent-toolkit-desktop → registry_reachability_test.v`.

### gui-coverage.py rewritten

From CLI-row parity (a mirror of a deleted authority) to a workflow-coverage report that consumes the registry/action definitions themselves and the reachability gate. Advisory only — the V test is authoritative. Current report: **21/21 workflows backed; static authority fully retired.**

### Truth semantics

- Every palette row is registry-shaped (locked by a prefix test in `palette_rows_test.v` — bare legacy ids cannot return)
- Update is unavailable-with-reason per #1119's contract; documented in WORKFLOW_COVERAGE.md (blocker row "Dead/split action discovery" resolved with evidence)
- Uninstall claims exactly what the receipt report proves: owned files removed, skipped-with-reason counts, failed targets listed

### Validation

- Full `./make.vsh test` (all modules + cmd desktop suite, 7 test files) — pass
- Production desktop build + headless boot smoke — pass
- `v fmt` / `vet` / `gui-coverage.py --check` — pass; S7 truth gates green
- Not verified locally: windowed screenshots (no display on this workstation). The empty-query palette's visible top rows are unchanged (13 nav rows in the same order with the same localized labels/descriptions); the removal only affects rows reachable by querying old command names, and goldens guard panel drift.

Refs #1119 · #1118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unified desktop palette search and actions under a single registry for more consistent results.
  - Added application-level actions for cycling themes and managing toolkit uninstall operations.
  - Uninstall now supports previews, confirmations, dry runs, and detailed outcomes.
  - Added availability messaging when update checks cannot be performed.

- **Bug Fixes**
  - Improved palette labels, descriptions, and unavailable-action explanations.

- **Tests**
  - Added coverage for critical desktop workflows, including discovery, installation, configuration, repair, scheduling, and uninstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->