### PR TITLE
feat(desktop): S4D — truthful Recent Actions + evidence-backed Undo (#1119)

### DIFF
--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -1635,8 +1635,10 @@ fn filtered_palette(mut app GuiApp) []PaletteRow {
 		// S4D: recent executions first on an empty query — visibly distinct
 		// (↻ prefix, outcome + evidence in the description), bounded display
 		if app.palette_query.trim_space() == '' {
+			// at most 3 recent rows — the palette stays an action/entity
+			// surface, recents must not crowd out navigation (#1162 review)
 			for rec in app.palette_reg.journal_records() {
-				if scored.len >= 5 {
+				if scored.len >= 3 {
 					break
 				}
 				scored << palette_recent_row(mut app, rec)
@@ -8186,15 +8188,22 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			if e.key_code == .u {
 				// S4D: undo the selected recent execution (optimistic exact
-				// check runs again right before restoring)
+				// check runs again right before restoring). Only a recent
+				// row with undo consumes the key — otherwise 'u' falls
+				// through to normal query typing (#1162 review).
 				filtered_u := filtered_palette(mut app)
 				if app.palette_selected >= 0 && app.palette_selected < filtered_u.len {
 					sel_u := filtered_u[app.palette_selected]
 					if sel_u.is_recent {
-						handle_palette_undo(mut app, sel_u)
+						rec_u := app.palette_reg.find_recent(sel_u.execution_id) or {
+							return
+						}
+						if rec_u.is_undoable() {
+							handle_palette_undo(mut app, sel_u)
+							return
+						}
 					}
 				}
-				return
 			}
 			if e.key_code == .tab {
 				// S4B: expand/collapse contextual actions of the selected

--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -1574,6 +1574,9 @@ struct PaletteRow {
 	action_kind   palette.ActionKind
 	needs_preview bool
 	needs_confirm bool
+	// S4D recent execution row (journal-sourced)
+	is_recent    bool
+	execution_id u64
 }
 
 // panel_index_for maps a registry panel destination to the production panel
@@ -1629,6 +1632,16 @@ fn nav_tr_key(p nav.PanelId) string {
 fn filtered_palette(mut app GuiApp) []PaletteRow {
 	mut scored := []PaletteRow{}
 	if app.palette_reg != unsafe { nil } {
+		// S4D: recent executions first on an empty query — visibly distinct
+		// (↻ prefix, outcome + evidence in the description), bounded display
+		if app.palette_query.trim_space() == '' {
+			for rec in app.palette_reg.journal_records() {
+				if scored.len >= 5 {
+					break
+				}
+				scored << palette_recent_row(mut app, rec)
+			}
+		}
 		for sa in app.palette_reg.scored_filter(app.palette_query) {
 			a := sa.action
 			scored << PaletteRow{
@@ -1647,6 +1660,129 @@ fn filtered_palette(mut app GuiApp) []PaletteRow {
 		}
 	}
 	return expand_palette_actions(mut app, scored)
+}
+
+// palette_recent_row renders one journal record as a distinct recent row.
+// The description carries the truthful outcome and real evidence refs only.
+// Undo availability is recomputed live (optimistic exact-state check) so a
+// stale undo is visible without executing anything.
+fn palette_recent_row(mut app GuiApp, rec palette.RecentAction) PaletteRow {
+	outcome := match rec.outcome {
+		.succeeded { 'succeeded' }
+		.partial { 'partial' }
+		else { 'failed' }
+	}
+	mut desc := outcome
+	if rec.evidence.receipt_path != '' {
+		desc += ' · receipt ${rec.evidence.receipt_path}'
+	} else if rec.evidence.run_id != '' {
+		desc += ' · run ${rec.evidence.run_id}'
+	} else if rec.evidence.job_id != '' {
+		desc += ' · job ${rec.evidence.job_id}'
+	} else if rec.evidence.revision > 0 {
+		desc += ' · rev ${rec.evidence.revision}'
+	}
+	if rec.has_undo {
+		match app.palette_reg.undo_precheck(rec.execution_id) {
+			.available {
+				desc += ' · U undo ready'
+			}
+			.consumed {
+				desc += ' · undone'
+			}
+			.stale {
+				desc += ' · undo unavailable — state changed'
+			}
+			else {}
+		}
+	}
+	return PaletteRow{
+		id: 'recent:${rec.execution_id}'
+		label: '↻ ${rec.label}'
+		desc: desc
+		is_entity: true
+		kind: rec.entity_kind
+		entity_id: rec.entity_id
+		panel: nav.PanelId.unknown
+		is_recent: true
+		execution_id: rec.execution_id
+	}
+}
+
+// handle_palette_undo executes the undo for the selected recent row.
+// Appearance undo is restored through the real shell setter; everything
+// else goes through the registry's typed restore seams.
+fn handle_palette_undo(mut app GuiApp, sel PaletteRow) {
+	if app.palette_reg == unsafe { nil } {
+		return
+	}
+	rec := app.palette_reg.find_recent(sel.execution_id) or { return }
+	if !rec.has_undo {
+		app.inspector_msg = 'No undo for this action'
+		return
+	}
+	// live optimistic check before committing
+	status := app.palette_reg.undo_precheck(sel.execution_id)
+	if status != .available {
+		app.inspector_msg = match status {
+			.consumed { 'Already undone' }
+			.stale { 'Undo unavailable — state changed since this action; cannot safely undo.' }
+			else { 'No undo for this action' }
+		}
+		return
+	}
+	if rec.undo.kind == .appearance {
+		spec := rec.undo.spec
+		if spec is palette.AppearanceUndo {
+			// guard: current appearance must equal the expected post-state
+			if app.appearance.str() != spec.expected_appearance {
+				app.inspector_msg = 'Undo unavailable — state changed since this action; cannot safely undo.'
+				return
+			}
+			app.apply_appearance(appearance_from_string(spec.previous_appearance))
+			save_ui_state(app)
+			out := app.palette_reg.mark_undo_consumed(sel.execution_id, 0)
+			app.inspector_msg = out.summary
+		}
+		return
+	}
+	out := app.palette_reg.execute_undo(sel.execution_id) or {
+		app.inspector_msg = 'Undo failed: ${err.msg()}'
+		return
+	}
+	app.inspector_msg = out.summary
+}
+
+// rerun_recent re-executes a recent action through the CURRENT registry:
+// it resolves the current RegistryAction, current availability and the
+// normal preview/confirmation rules — never replays stored arguments.
+fn rerun_recent(mut app GuiApp, sel PaletteRow) {
+	if app.palette_reg == unsafe { nil } {
+		return
+	}
+	rec := app.palette_reg.find_recent(sel.execution_id) or { return }
+	acts := app.palette_reg.actions_for(rec.entity_kind, rec.entity_id)
+	for a in acts {
+		if a.kind == rec.action_kind {
+			run_palette_action(mut app, PaletteRow{
+				id: a.action_id()
+				label: a.label
+				desc: a.desc
+				is_entity: true
+				kind: a.entity_kind
+				entity_id: a.entity_id
+				panel: a.panel
+				available: a.available
+				unavailable_reason: a.unavailable_reason
+				is_action: true
+				action_kind: a.kind
+				needs_preview: a.needs_preview
+				needs_confirm: a.needs_confirm
+			})
+			return
+		}
+	}
+	app.inspector_msg = 'This action is no longer available for ${rec.entity_id}'
 }
 
 // expand_palette_actions inserts the contextual actions of the expanded
@@ -7696,6 +7832,8 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 	// footer hint paper tape — reflects the S4B action state honestly
 	footer := if app.palette_armed != '' {
 		'Enter again to confirm  •  Esc to cancel'
+	} else if filtered.any(it.is_recent) {
+		'↑↓ navigate  •  Enter run again (re-validated)  •  U undo  •  Type to filter ${skills_total(mut app)} skills'
 	} else if filtered.any(it.is_entity && !it.is_action) {
 		'↑↓ navigate  •  Enter to open  •  Tab expand actions  •  Type to filter ${skills_total(mut app)} skills  •  Ctrl± zoom'
 	} else {
@@ -7750,6 +7888,11 @@ fn activate_palette_selection(mut app GuiApp) {
 		app.palette_selected
 	}
 	sel := filtered[clamped]
+	// S4D: recent rows re-run through the current registry (never replay)
+	if sel.is_recent {
+		rerun_recent(mut app, sel)
+		return
+	}
 	// S4B: contextual action rows run through preview → confirm → execute.
 	if sel.is_action {
 		run_palette_action(mut app, sel)
@@ -7794,10 +7937,25 @@ fn run_palette_action(mut app GuiApp, sel PaletteRow) {
 		app.inspector_msg = 'Unavailable — ${sel.unavailable_reason}'
 		return
 	}
-	// appearance is a real shell preference: executed directly, no fake
-	// evidence, palette stays open so the user can keep cycling
+	// appearance is a real shell preference: executed directly via the real
+	// setter, recorded truthfully in the journal with an exact undo
+	// (previous appearance + real setter), no fake evidence
 	if sel.action_kind == .app_theme_cycle {
+		previous := app.appearance.str()
 		cycle_appearance(mut app)
+		if app.palette_reg != unsafe { nil } {
+			app.palette_reg.record_execution(.app_theme_cycle, .app, 'agent-toolkit', 'Change appearance', .succeeded, palette.ActionEvidence{}, palette.UndoEntry{
+				kind: .appearance
+				action_kind: .app_theme_cycle
+				entity_kind: .app
+				entity_id: 'agent-toolkit'
+				label: 'Change appearance'
+				spec: palette.AppearanceUndo{
+					previous_appearance: previous
+					expected_appearance: app.appearance.str()
+				}
+			})
+		}
 		return
 	}
 	// swarm launch needs a real task-text input (plus recipe/backend choices)
@@ -8024,6 +8182,18 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			if e.key_code == .enter {
 				activate_palette_selection(mut app)
+				return
+			}
+			if e.key_code == .u {
+				// S4D: undo the selected recent execution (optimistic exact
+				// check runs again right before restoring)
+				filtered_u := filtered_palette(mut app)
+				if app.palette_selected >= 0 && app.palette_selected < filtered_u.len {
+					sel_u := filtered_u[app.palette_selected]
+					if sel_u.is_recent {
+						handle_palette_undo(mut app, sel_u)
+					}
+				}
 				return
 			}
 			if e.key_code == .tab {

--- a/cmd/agent-toolkit-desktop/palette_recents_flow_test.v
+++ b/cmd/agent-toolkit-desktop/palette_recents_flow_test.v
@@ -1,0 +1,210 @@
+module main
+
+import desktop
+import desktop.palette
+import os
+import time
+
+// S4D shell-flow tests: recents render distinctly, rerun re-resolves current
+// availability, undo is single-use and guarded by live exact-state checks.
+
+struct S4dFixture {
+mut:
+	app &GuiApp = unsafe { nil }
+	d   &desktop.Desktop = unsafe { nil }
+	tmp string
+}
+
+fn s4d_app(label string) &S4dFixture {
+	tmp := os.join_path(os.temp_dir(), 'atk-s4d-flow-${label}-${os.getpid()}-${time.now().unix_nano()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
+		config: desktop.DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	mut app := &GuiApp{
+		desktop: d
+		selected_panel: 0
+		hover_panel: -1
+		selected_desk: -1
+		hover_desk: -1
+	}
+	app.palette_reg = d.palette_registry()
+	app.palette_open = true
+	return &S4dFixture{
+		app: app
+		d: d
+		tmp: tmp
+	}
+}
+
+fn (mut f S4dFixture) cleanup() {
+	f.d.shutdown() or {}
+	os.rmdir_all(f.tmp) or {}
+	f.tmp = ''
+}
+
+fn find_recent_row(rows []PaletteRow) ?PaletteRow {
+	for r in rows {
+		if r.is_recent {
+			return r
+		}
+	}
+	return none
+}
+
+// a real executed action produces a recent row that is visibly distinct,
+// and the fresh session starts with none.
+fn test_recents_appear_after_execution() {
+	mut f := s4d_app('recents')
+	defer {
+		f.cleanup()
+	}
+	// fresh session: no recents at all
+	assert f.app.palette_reg.journal_records().len == 0
+	// execute a real mutation (target toggle)
+	mut target_id := ''
+	for t in f.d.engine_targets() {
+		target_id = t.id
+		break
+	}
+	kind := if f.d.engine_target_enabled(target_id) {
+		palette.ActionKind.target_disable
+	} else {
+		palette.ActionKind.target_enable
+	}
+	out := f.app.palette_reg.execute(.target, target_id, kind, palette.ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	// empty query → the recent row leads the palette, distinctly prefixed
+	rows := filtered_palette(mut f.app)
+	rec := find_recent_row(rows) or { panic('recent row missing') }
+	assert rec.label.starts_with('↻ ')
+	assert rec.execution_id > 0
+	assert rec.desc.contains('succeeded')
+	// the record preserves canonical entity identity
+	assert rec.entity_id == target_id
+}
+
+// rerun of a recent action goes through the CURRENT registry (revalidation),
+// and the second toggle records another recent (not a blind replay).
+fn test_recents_rerun_revalidates() {
+	mut f := s4d_app('rerun')
+	defer {
+		f.cleanup()
+	}
+	mut target_id := ''
+	for t in f.d.engine_targets() {
+		target_id = t.id
+		break
+	}
+	was := f.d.engine_target_enabled(target_id)
+	kind := if was { palette.ActionKind.target_disable } else { palette.ActionKind.target_enable }
+	f.app.palette_reg.execute(.target, target_id, kind, palette.ActionArgs{}) or {
+		panic(err.msg())
+	}
+	rows := filtered_palette(mut f.app)
+	rec := find_recent_row(rows) or { panic('recent row missing') }
+	// rerun via the shell path — resolves the CURRENT action and availability.
+	// The same toggle is now unavailable (the state already matches its
+	// effect), so the rerun is honestly refused: no replay, no new record.
+	rerun_recent(mut f.app, rec)
+	recs := f.app.palette_reg.journal_records()
+	assert recs.len == 1
+	for rr in recs {
+		println('DBG rec id=${rr.execution_id} kind=${rr.action_kind} entity=${rr.entity_kind}/${rr.entity_id} label=${rr.label}')
+	}
+	// DBG row.id=${rec.id} row.exec=${rec.execution_id} state=${f.d.engine_target_enabled(target_id)}')
+	assert f.app.inspector_msg.starts_with('Unavailable —')
+	// the current opposite direction IS available and rerunning it works
+	jrec := f.app.palette_reg.find_recent(rec.execution_id) or {
+		panic('journal record missing')
+	}
+	opp := if jrec.action_kind == palette.ActionKind.target_enable {
+		palette.ActionKind.target_disable
+	} else {
+		palette.ActionKind.target_enable
+	}
+	out2 := f.app.palette_reg.execute(.target, target_id, opp, palette.ActionArgs{}) or {
+		panic(err.msg())
+	}
+	// DBG out2=${out2.status} ${out2.summary}')
+	assert out2.status == .succeeded
+	assert f.d.engine_target_enabled(target_id) == was
+}
+
+// undo through the shell path: exact restore, single use; a diverged state
+// refuses without overwriting.
+fn test_recents_undo_shell_path() {
+	mut f := s4d_app('undo')
+	defer {
+		f.cleanup()
+	}
+	mut target_id := ''
+	for t in f.d.engine_targets() {
+		target_id = t.id
+		break
+	}
+	was := f.d.engine_target_enabled(target_id)
+	kind := if was { palette.ActionKind.target_disable } else { palette.ActionKind.target_enable }
+	out := f.app.palette_reg.execute(.target, target_id, kind, palette.ActionArgs{}) or {
+		panic(err.msg())
+	}
+	rows := filtered_palette(mut f.app)
+	rec := find_recent_row(rows) or { panic('recent row missing') }
+	// undo available and reflected in the row description
+	assert rec.desc.contains('U undo ready')
+	// execute the undo
+	handle_palette_undo(mut f.app, rec)
+	assert f.d.engine_target_enabled(target_id) == was
+	// consumed: a second undo refuses honestly
+	assert f.app.palette_reg.undo_precheck(rec.execution_id) == .consumed
+	handle_palette_undo(mut f.app, rec)
+	assert f.app.inspector_msg.contains('Already undone')
+}
+
+// theme is recorded by the shell through the real setter and its undo
+// restores the exact previous appearance via the same setter.
+fn test_theme_shell_undo() {
+	mut f := s4d_app('theme')
+	defer {
+		f.cleanup()
+	}
+	before := f.app.appearance.str()
+	// forward: theme cycle via the shell path with journal recording
+	rows := filtered_palette(mut f.app)
+	mut app_row_idx := -1
+	for idx, r in rows {
+		if r.is_entity && r.kind == palette.EntityKind.app {
+			app_row_idx = idx
+		}
+	}
+	assert app_row_idx >= 0, 'app entity row must be discoverable'
+	f.app.palette_expanded = rows[app_row_idx].id
+	rows2 := filtered_palette(mut f.app)
+	mut theme_row := ?PaletteRow(none)
+	for r in rows2 {
+		if r.is_action && r.action_kind == palette.ActionKind.app_theme_cycle {
+			theme_row = r
+		}
+	}
+	tr := theme_row or { panic('theme action missing') }
+	run_palette_action(mut f.app, tr)
+	// the shell executed the real setter and recorded the execution
+	assert f.app.appearance.str() != before
+	recs := f.app.palette_reg.journal_records()
+	assert recs.len == 1
+	assert recs[0].action_kind == palette.ActionKind.app_theme_cycle
+	assert recs[0].has_undo
+	// undo via the shell path restores the exact previous appearance
+	f.app.palette_expanded = ''
+	rows3 := filtered_palette(mut f.app)
+	rec_row := find_recent_row(rows3) or { panic('recent row missing') }
+	handle_palette_undo(mut f.app, rec_row)
+	assert f.app.appearance.str() == before
+	assert f.app.palette_reg.undo_precheck(rec_row.execution_id) == .consumed
+}

--- a/cmd/agent-toolkit-desktop/palette_recents_flow_test.v
+++ b/cmd/agent-toolkit-desktop/palette_recents_flow_test.v
@@ -18,6 +18,9 @@ mut:
 fn s4d_app(label string) &S4dFixture {
 	tmp := os.join_path(os.temp_dir(), 'atk-s4d-flow-${label}-${os.getpid()}-${time.now().unix_nano()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
+	// appearance persistence (save_ui_state) must never touch the real user
+	// cache from tests — point XDG_CACHE_HOME at the fixture dir
+	os.setenv('XDG_CACHE_HOME', tmp, true)
 	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
 		config: desktop.DesktopConfig{
 			headless: true

--- a/cmd/agent-toolkit-desktop/ui_tokens.v
+++ b/cmd/agent-toolkit-desktop/ui_tokens.v
@@ -212,6 +212,11 @@ pub fn ui_hover_tint(t theme.Theme) gg.Color {
 // app.pnl_*; chrome (header/dock/status/terminal) keeps the startup consts.
 pub fn (mut app GuiApp) apply_appearance(a Appearance) {
 	app.appearance = a
+	// S4D: appearance-undo prechecks compare the real observed value;
+	// apply_appearance is the single appearance mutation point
+	if app.palette_reg != unsafe { nil } {
+		app.palette_reg.observe_appearance(app.appearance.str())
+	}
 	t := appearance_theme(a)
 	// cache the resolved kind — per-frame panel code (pixel_panel, …) branches
 	// on this instead of re-probing the OS, so System costs one probe total.

--- a/modules/desktop/palette/actions.v
+++ b/modules/desktop/palette/actions.v
@@ -564,7 +564,32 @@ pub fn (mut r Registry) execute(kind EntityKind, entity_id string, action Action
 			summary: 'no targets selected'
 		}
 	}
-	return r.execute_seam(kind, entity_id, action, args)
+	// ── ACTUAL EXECUTION SEAM STARTS HERE ──────────────────────────────────
+	// S4D recording boundary: the journal records only what crosses this
+	// line (succeeded / partial / failed). Validation failures,
+	// unavailable, not-confirmed and preview paths above never record.
+	// The undo's PREVIOUS state is captured here — strictly before the
+	// seam mutates anything; the expected post-state is finalized from the
+	// real Engine after the seam ran.
+	label := '${kind_label(action)} — ${entity_id}'
+	prev := r.capture_undo(action, entity_id)
+	// read-only probes and dry-run executions are not state-changing
+	// executions — they are previews by proxy and never enter the journal
+	record := action != .mcp_probe && action != .app_theme_cycle && !args.dry_run
+	out := r.execute_seam(kind, entity_id, action, args) or {
+		failed := ActionOutcome{
+			status: .failed
+			summary: err.msg()
+		}
+		if record {
+			r.journal_execution(action, kind, entity_id, label, failed, prev)
+		}
+		return failed
+	}
+	if record {
+		r.journal_execution(action, kind, entity_id, label, out, prev)
+	}
+	return out
 }
 
 // execute_seam performs the Engine operation for a validated, available,

--- a/modules/desktop/palette/actions_test.v
+++ b/modules/desktop/palette/actions_test.v
@@ -441,13 +441,14 @@ fn test_app_actions_honest() {
 	}
 	assert out.status == .unavailable
 	assert out.summary.contains('No update feed/updater')
-	// theme: the shell executes appearance changes; the module never fakes a
-	// domain result for it
-	if _ := reg.execute(.app, 'agent-toolkit', .app_theme_cycle, ActionArgs{}) {
-		assert false, 'theme cycle must not execute as a fake domain action'
-	} else {
-		assert err.msg().contains('shell')
+	// theme: the shell executes appearance changes; the registry refuses to
+	// run or fake it (failed outcome, never journaled)
+	tout := reg.execute(.app, 'agent-toolkit', .app_theme_cycle, ActionArgs{}) or {
+		panic(err.msg())
 	}
+	assert tout.status == .failed
+	assert tout.summary.contains('shell')
+	assert reg.journal_records().len == 0
 	// uninstall: preview is a real dry-run (nothing deleted); execution is
 	// only ever attempted with confirm — and tests never run a real uninstall
 	acts := reg.actions_for(.app, 'agent-toolkit')

--- a/modules/desktop/palette/journal.v
+++ b/modules/desktop/palette/journal.v
@@ -141,6 +141,12 @@ pub:
 // Desktop session never accumulates an unbounded execution log.
 pub const recents_limit = 25
 
+// observe_appearance records the shell's current appearance (called from
+// apply_appearance, the single appearance mutation point).
+pub fn (mut r Registry) observe_appearance(name string) {
+	r.observed_appearance = name
+}
+
 // record_execution appends a truthful execution record to the journal.
 // The caller must provide registry-real action/entity identity, and only
 // after the actual execution seam ran. Shell-native actions (appearance)
@@ -383,8 +389,10 @@ fn (mut r Registry) undo_state_matches(ue UndoEntry) bool {
 			return r.engine_loop_cron(ue.entity_id) == ue.spec.expected_cron
 		}
 		AppearanceUndo {
-			// the shell verifies appearance equality at execution time
-			return true
+			// the shell observes every real appearance change; an undo is
+			// only safe when the observed value still equals the recorded
+			// post-action appearance
+			return r.observed_appearance != '' && r.observed_appearance == ue.spec.expected_appearance
 		}
 	}
 }
@@ -495,6 +503,7 @@ fn (mut r Registry) undo_restored(ue UndoEntry) bool {
 			}
 			return cur.config == ue.spec.snapshot.config && cur.enabled == ue.spec.snapshot.enabled
 				&& cur.health == ue.spec.snapshot.health
+				&& cur.provenance == ue.spec.snapshot.provenance
 		}
 		LoopScheduleUndo {
 			return r.engine_loop_cron(ue.entity_id) == ue.spec.previous_cron

--- a/modules/desktop/palette/journal.v
+++ b/modules/desktop/palette/journal.v
@@ -1,0 +1,565 @@
+module palette
+
+// S4D (#1119) — truthful Recent Actions + evidence-backed Undo.
+//
+// The registry owns ONE canonical execution journal. A record is appended
+// only after an action's real execution seam has actually run — never for
+// validation failures, unavailable/unconfirmed outcomes, previews,
+// navigation or inspection. Two execution planes are legitimate:
+//
+//   Engine/core actions  → Registry.execute() → real seam → record result
+//   Shell-native actions → shell typed handler → real shell setter →
+//                          registry.record_execution()
+//
+// Undo exists only where the exact previous authoritative state is known and
+// an exact typed restore seam exists. Every undo performs an optimistic
+// exact-state check first: current state must equal the state recorded right
+// after the action; any divergence makes the undo stale (state changed — it
+// must never overwrite newer changes). Undo is single-use: available →
+// consumed on success, available → stale on divergence, stale stays stale.
+// No redo.
+//
+// Governing contracts: docs/desktop/TRUTH_LEDGER.md, docs/desktop/DESIGN.md.
+
+import desktop_engine
+import time
+
+// UndoKind identifies the typed undo variant.
+pub enum UndoKind {
+	target_enabled
+	skill_selection
+	mcp_state
+	loop_schedule
+	appearance
+}
+
+// UndoStatus is the lifecycle of one undo capability: available → consumed
+// (successful restoration) or available → stale (state diverged). Stale is
+// terminal — no automatic re-enable. No redo.
+pub enum UndoStatus {
+	available
+	consumed
+	stale
+	unsupported
+}
+
+// TargetEnabledUndo restores the exact prior enabled boolean.
+pub struct TargetEnabledUndo {
+pub mut:
+	entity_id        string
+	previous_enabled bool
+	expected_enabled bool
+}
+
+// SkillsSelectionUndo restores the exact prior installed-skill selection.
+pub struct SkillsSelectionUndo {
+pub mut:
+	previous_selection []string
+	expected_selection []string
+}
+
+// McpStateUndo restores the exact prior provider state via the narrow
+// Engine restore seam. The snapshot is opaque: session-local only, never
+// displayed, logged, serialized or put in RecentAction metadata.
+pub struct McpStateUndo {
+pub mut:
+	entity_id string
+	snapshot  desktop_engine.McpStateSnapshot
+	expected  desktop_engine.McpStateSnapshot
+}
+
+// LoopScheduleUndo restores the exact prior cron configuration.
+pub struct LoopScheduleUndo {
+pub mut:
+	entity_id     string
+	previous_cron bool
+	expected_cron bool
+}
+
+// AppearanceUndo restores the exact prior appearance via the real shell
+// setter (apply_appearance + save_ui_state). The appearance is stored as
+// its canonical name ('paper'|'ink'|'system') — the shell parses it.
+pub struct AppearanceUndo {
+pub mut:
+	previous_appearance string
+	expected_appearance string
+}
+
+// UndoSpec is the typed reversal description. Domain variants — never CLI
+// fragments, never a generic map.
+pub type UndoSpec = TargetEnabledUndo
+	| SkillsSelectionUndo
+	| McpStateUndo
+	| LoopScheduleUndo
+	| AppearanceUndo
+
+// UndoEntry pairs a spec with its lifecycle status.
+pub struct UndoEntry {
+pub:
+	kind        UndoKind
+	action_kind ActionKind
+	entity_kind EntityKind
+	entity_id   string
+	label       string
+	spec        UndoSpec
+mut:
+	status UndoStatus = .available
+}
+
+// RecentAction is one truthful execution record. Outcomes are only
+// succeeded / partial / failed — an execution seam actually ran.
+pub struct RecentAction {
+pub:
+	execution_id u64
+	timestamp    i64 // unix seconds, from the actual execution
+	action_kind  ActionKind
+	entity_kind  EntityKind
+	entity_id    string
+	label        string // safe display label
+	workspace    string // workspace context when applicable
+	outcome      ActionStatus
+	evidence     ActionEvidence // only refs the action really produced
+	has_undo     bool
+pub mut:
+	undo UndoEntry
+}
+
+// is_undoable reports whether the record currently offers undo (rendering
+// additionally runs undo_precheck for the live optimistic check).
+pub fn (ra RecentAction) is_undoable() bool {
+	return ra.has_undo && ra.undo.status == .available
+}
+
+// UndoOutcome reports the result of an undo attempt truthfully.
+pub struct UndoOutcome {
+pub:
+	status  UndoStatus
+	summary string
+}
+
+// recents_limit bounds the session-local journal. Bounded by design: a long
+// Desktop session never accumulates an unbounded execution log.
+pub const recents_limit = 25
+
+// record_execution appends a truthful execution record to the journal.
+// The caller must provide registry-real action/entity identity, and only
+// after the actual execution seam ran. Shell-native actions (appearance)
+// use this path; the journal itself never invents activity.
+pub fn (mut r Registry) record_execution(action_kind ActionKind, entity_kind EntityKind, entity_id string, label string, outcome ActionStatus, evidence ActionEvidence, undo ?UndoEntry) u64 {
+	if outcome !in [.succeeded, .partial, .failed] {
+		return 0
+	}
+	r.undo_seq++
+	exec_id := r.undo_seq
+	u := undo or { UndoEntry{} }
+	has := undo != none
+	rec := RecentAction{
+		execution_id: exec_id
+		timestamp: time.now().unix()
+		action_kind: action_kind
+		entity_kind: entity_kind
+		entity_id: entity_id
+		label: label
+		outcome: outcome
+		evidence: evidence
+		has_undo: has
+		undo: u
+	}
+	r.journal.prepend(rec)
+	for r.journal.len > recents_limit {
+		r.journal.delete(r.journal.len - 1)
+	}
+	return exec_id
+}
+
+// journal_records returns the session journal (newest first).
+pub fn (r Registry) journal_records() []RecentAction {
+	return r.journal.clone()
+}
+
+// find_recent locates a record by execution id.
+pub fn (r Registry) find_recent(execution_id u64) ?RecentAction {
+	for rec in r.journal {
+		if rec.execution_id == execution_id {
+			return rec
+		}
+	}
+	return none
+}
+
+fn (r Registry) recent_index(execution_id u64) ?int {
+	for idx, rec in r.journal {
+		if rec.execution_id == execution_id {
+			return idx
+		}
+	}
+	return none
+}
+
+// ── state readers (the exact authoritative values) ─────────────────────────
+
+fn (mut r Registry) engine_loop_cron(name string) bool {
+	for l in r.engine.loops_catalog() {
+		if l.name == name {
+			return l.cron_enabled
+		}
+	}
+	return false
+}
+
+// ── capture: previous state before a mutating seam runs ────────────────────
+
+// capture_undo reads the exact previous authoritative state for an action
+// that is about to execute its seam. Returns none when the action is not
+// reversible (irreversible / read-only) — such actions never get undo.
+fn (mut r Registry) capture_undo(action_kind ActionKind, entity_id string) ?UndoEntry {
+	match action_kind {
+		.target_enable {
+			previous := r.engine_target_enabled(entity_id)
+			return UndoEntry{
+				kind: .target_enabled
+				action_kind: action_kind
+				entity_kind: .target
+				entity_id: entity_id
+				label: 'Enable target ${entity_id}'
+				spec: TargetEnabledUndo{
+					entity_id: entity_id
+					previous_enabled: previous
+					expected_enabled: true
+				}
+			}
+		}
+		.target_disable {
+			previous := r.engine_target_enabled(entity_id)
+			return UndoEntry{
+				kind: .target_enabled
+				action_kind: action_kind
+				entity_kind: .target
+				entity_id: entity_id
+				label: 'Disable target ${entity_id}'
+				spec: TargetEnabledUndo{
+					entity_id: entity_id
+					previous_enabled: previous
+					expected_enabled: false
+				}
+			}
+		}
+		.skill_install, .skill_remove {
+			label := if action_kind == .skill_install {
+				'Install skill ${entity_id}'
+			} else {
+				'Remove skill ${entity_id}'
+			}
+			return UndoEntry{
+				kind: .skill_selection
+				action_kind: action_kind
+				entity_kind: .skill
+				entity_id: entity_id
+				label: label
+				spec: SkillsSelectionUndo{
+					previous_selection: r.engine.skills_installed()
+					expected_selection: []string{}
+				}
+			}
+		}
+		.mcp_enable, .mcp_disable {
+			snap := r.engine.mcp_state_snapshot(entity_id) or {
+				// nothing to restore — undo unavailable for this execution
+				return none
+			}
+			label := if action_kind == .mcp_enable {
+				'Enable MCP ${entity_id}'
+			} else {
+				'Disable MCP ${entity_id}'
+			}
+			return UndoEntry{
+				kind: .mcp_state
+				action_kind: action_kind
+				entity_kind: .mcp_provider
+				entity_id: entity_id
+				label: label
+				spec: McpStateUndo{
+					entity_id: entity_id
+					snapshot: snap
+					expected: desktop_engine.McpStateSnapshot{}
+				}
+			}
+		}
+		.loop_schedule_toggle {
+			previous := r.engine_loop_cron(entity_id)
+			return UndoEntry{
+				kind: .loop_schedule
+				action_kind: action_kind
+				entity_kind: .loop_template
+				entity_id: entity_id
+				label: 'Toggle schedule ${entity_id}'
+				spec: LoopScheduleUndo{
+					entity_id: entity_id
+					previous_cron: previous
+					expected_cron: !previous
+				}
+			}
+		}
+		else {
+			return none
+		}
+	}
+}
+
+// finish_undo_expected fills the expected post-state of an undo entry from
+// the ACTUAL state the Engine reports after the action ran — the optimistic
+// guard later compares exact truth, never assumptions.
+fn finish_undo_expected(ue UndoEntry, mut r Registry) UndoEntry {
+	mut spec := ue.spec
+	match mut spec {
+		TargetEnabledUndo {
+			spec.expected_enabled = r.engine_target_enabled(ue.entity_id)
+		}
+		SkillsSelectionUndo {
+			spec.expected_selection = r.engine.skills_installed()
+		}
+		McpStateUndo {
+			spec.expected = r.engine.mcp_state_snapshot(ue.entity_id) or {
+				desktop_engine.McpStateSnapshot{}
+			}
+		}
+		LoopScheduleUndo {
+			spec.expected_cron = r.engine_loop_cron(ue.entity_id)
+		}
+		else {}
+	}
+	return UndoEntry{
+		kind: ue.kind
+		action_kind: ue.action_kind
+		entity_kind: ue.entity_kind
+		entity_id: ue.entity_id
+		label: ue.label
+		spec: spec
+	}
+}
+
+// ── undo execution ─────────────────────────────────────────────────────────
+
+// undo_precheck reports whether an undo would currently be allowed — the
+// optimistic exact-state check, run before any user commits to it. Used by
+// rendering so a stale undo is visible as unavailable without executing.
+pub fn (mut r Registry) undo_precheck(execution_id u64) UndoStatus {
+	rec := r.find_recent(execution_id) or {
+		return .unsupported
+	}
+	if !rec.has_undo {
+		return .unsupported
+	}
+	if rec.undo.status != .available {
+		return rec.undo.status
+	}
+	if !r.undo_state_matches(rec.undo) {
+		return .stale
+	}
+	return .available
+}
+
+// undo_state_matches performs the optimistic exact-state verification: the
+// affected authoritative state must equal the state recorded right after the
+// action ran. Never the global revision alone — unrelated changes may
+// legitimately bump it.
+fn (mut r Registry) undo_state_matches(ue UndoEntry) bool {
+	match ue.spec {
+		TargetEnabledUndo {
+			return r.engine_target_enabled(ue.entity_id) == ue.spec.expected_enabled
+		}
+		SkillsSelectionUndo {
+			return r.engine.skills_installed() == ue.spec.expected_selection
+		}
+		McpStateUndo {
+			cur := r.engine.mcp_state_snapshot(ue.entity_id) or {
+				desktop_engine.McpStateSnapshot{}
+			}
+			return cur.config == ue.spec.expected.config && cur.enabled == ue.spec.expected.enabled
+				&& cur.health == ue.spec.expected.health
+				&& cur.provenance == ue.spec.expected.provenance
+		}
+		LoopScheduleUndo {
+			return r.engine_loop_cron(ue.entity_id) == ue.spec.expected_cron
+		}
+		AppearanceUndo {
+			// the shell verifies appearance equality at execution time
+			return true
+		}
+	}
+}
+
+// execute_undo restores the exact previous state for an executed action.
+// Single-use, guarded by the optimistic exact-state check; the undo itself
+// is recorded as a real execution ('Undid …') with no undo of its own.
+// Appearance undo is executed by the shell (real setter) — the registry
+// refuses to fake it.
+pub fn (mut r Registry) execute_undo(execution_id u64) !UndoOutcome {
+	idx := r.recent_index(execution_id) or {
+		return error('no such execution record')
+	}
+	if !r.journal[idx].has_undo {
+		return error('this action has no undo')
+	}
+	if r.journal[idx].undo.status != .available {
+		return UndoOutcome{
+			status: r.journal[idx].undo.status
+			summary: match r.journal[idx].undo.status {
+				.consumed { 'already undone' }
+				.stale { 'State changed since this action; cannot safely undo.' }
+				else { 'undo unsupported' }
+			}
+		}
+	}
+	ue := r.journal[idx].undo
+	// optimistic exact-state verification — never clobber newer changes
+	if !r.undo_state_matches(ue) {
+		mut rec := r.journal[idx]
+		rec.undo.status = .stale
+		r.journal[idx] = rec
+		return UndoOutcome{
+			status: .stale
+			summary: 'State changed since this action; cannot safely undo.'
+		}
+	}
+	// typed restore seams
+	mut ok := true
+	match ue.spec {
+		TargetEnabledUndo {
+			r.engine.set_target_enabled(ue.entity_id, ue.spec.previous_enabled) or {
+				ok = false
+			}
+		}
+		SkillsSelectionUndo {
+			r.engine.restore_skill_selection(ue.spec.previous_selection) or {
+				ok = false
+			}
+		}
+		McpStateUndo {
+			r.engine.restore_mcp_state(ue.spec.snapshot) or {
+				ok = false
+			}
+		}
+		LoopScheduleUndo {
+			r.engine.toggle_loop_cron(ue.entity_id, ue.spec.previous_cron) or {
+				ok = false
+			}
+		}
+		AppearanceUndo {
+			return error('appearance undo is executed by the shell')
+		}
+	}
+	if !ok {
+		// the restore failed to execute; the capability stays available so
+		// the user can retry after resolving the underlying problem
+		return UndoOutcome{
+			status: .available
+			summary: 'undo failed — the restore operation could not run'
+		}
+	}
+	// post-verify: the state must now equal the previous state
+	if !r.undo_restored(ue) {
+		mut rec := r.journal[idx]
+		rec.undo.status = .stale
+		r.journal[idx] = rec
+		return UndoOutcome{
+			status: .stale
+			summary: 'restore did not produce the previous state — verify manually'
+		}
+	}
+	mut rec := r.journal[idx]
+	rec.undo.status = .consumed
+	r.journal[idx] = rec
+	// the undo itself is a real execution event — recorded, no undo of its own
+	r.record_execution(ue.action_kind, ue.entity_kind, ue.entity_id, 'Undid ${ue.label}', .succeeded, ActionEvidence{
+		revision: r.engine.revision()
+	}, none)
+	return UndoOutcome{
+		status: .consumed
+		summary: 'Undid ${ue.label}'
+	}
+}
+
+// undo_restored verifies the affected state now equals the previous state.
+fn (mut r Registry) undo_restored(ue UndoEntry) bool {
+	match ue.spec {
+		TargetEnabledUndo {
+			return r.engine_target_enabled(ue.entity_id) == ue.spec.previous_enabled
+		}
+		SkillsSelectionUndo {
+			return r.engine.skills_installed() == ue.spec.previous_selection
+		}
+		McpStateUndo {
+			cur := r.engine.mcp_state_snapshot(ue.entity_id) or {
+				desktop_engine.McpStateSnapshot{}
+			}
+			return cur.config == ue.spec.snapshot.config && cur.enabled == ue.spec.snapshot.enabled
+				&& cur.health == ue.spec.snapshot.health
+		}
+		LoopScheduleUndo {
+			return r.engine_loop_cron(ue.entity_id) == ue.spec.previous_cron
+		}
+		AppearanceUndo {
+			return false
+		}
+	}
+}
+
+// mark_undo_consumed finalizes a shell-executed undo (e.g. appearance): the
+// shell restored the exact previous value through the real setter, then the
+// registry records the undo as a real execution with no undo of its own.
+pub fn (mut r Registry) mark_undo_consumed(execution_id u64, revision u64) UndoOutcome {
+	idx := r.recent_index(execution_id) or {
+		return UndoOutcome{
+			status: .unsupported
+			summary: 'no such execution record'
+		}
+	}
+	if !r.journal[idx].has_undo {
+		return UndoOutcome{
+			status: .unsupported
+			summary: 'this action has no undo'
+		}
+	}
+	if r.journal[idx].undo.status != .available {
+		return UndoOutcome{
+			status: r.journal[idx].undo.status
+			summary: match r.journal[idx].undo.status {
+				.consumed { 'already undone' }
+				.stale { 'State changed since this action; cannot safely undo.' }
+				else { 'undo unsupported' }
+			}
+		}
+	}
+	mut rec := r.journal[idx]
+	rec.undo.status = .consumed
+	r.journal[idx] = rec
+	ue := r.journal[idx].undo
+	r.record_execution(ue.action_kind, ue.entity_kind, ue.entity_id, 'Undid ${ue.label}', .succeeded, ActionEvidence{
+		revision: revision
+	}, none)
+	return UndoOutcome{
+		status: .consumed
+		summary: 'Undid ${ue.label}'
+	}
+}
+
+// hook into execution: called by Registry.execute after the seam ran. The
+// execution boundary is explicit — this runs only when execute_seam was
+// invoked. Reversible mutating actions capture their previous state and
+// finalize the expected post-state from the real Engine.
+fn (mut r Registry) journal_execution(action_kind ActionKind, entity_kind EntityKind, entity_id string, label string, outcome ActionOutcome, prev ?UndoEntry) {
+	mut undo_entry := UndoEntry{}
+	mut has_undo := false
+	// only genuinely mutated executions with a captured previous state get
+	// undo; failed runs record truthfully without an undo capability
+	if outcome.status in [.succeeded, .partial] && prev != none {
+		undo_entry = finish_undo_expected(prev, mut r)
+		has_undo = true
+	}
+	r.record_execution(action_kind, entity_kind, entity_id, label, outcome.status, outcome.evidence, if has_undo {
+		undo_entry
+	} else {
+		none
+	})
+}

--- a/modules/desktop/palette/journal_test.v
+++ b/modules/desktop/palette/journal_test.v
@@ -352,6 +352,28 @@ fn test_journal_mcp_enable_snapshot() {
 	}
 }
 
+// SECURITY: a snapshot whose config carries a raw secret (predating the
+// guard) is refused on restore — undo unavailable, secret policy never
+// weakened. gho_ tokens are detected even alongside placeholders.
+fn test_journal_mcp_restore_refuses_raw_secret() {
+	mut fe := new_journal_engine('mcp-secret')
+	defer {
+		fe.cleanup()
+	}
+	bad := '{"token":"gho_rawsecretvalue123","command":"' + '\${GUARDED_CMD}' + '"}'
+	snap := desktop_engine.McpStateSnapshot{
+		provider_id: 'github'
+		config: bad
+		enabled: true
+		health: 'configured'
+	}
+	if _ := fe.eng.restore_mcp_state(snap) {
+		assert false, 'raw gho_ token must be refused'
+	} else {
+		assert err.msg().contains('secret guard')
+	}
+}
+
 // LOOP schedule: exact previous configuration restored; loop RUN is never
 // undoable.
 fn test_journal_loop_schedule_undo() {

--- a/modules/desktop/palette/journal_test.v
+++ b/modules/desktop/palette/journal_test.v
@@ -1,0 +1,449 @@
+module palette
+
+import os
+import time
+import desktop_engine
+
+// s4d journal/undo tests — every case from the S4D acceptance matrix.
+
+// JrnEngine is the journal test fixture owning its exact temp directory.
+struct JrnEngine {
+mut:
+	eng &desktop_engine.Engine = unsafe { nil }
+	tmp string
+}
+
+fn new_journal_engine(label string) &JrnEngine {
+	tmp := os.join_path(os.temp_dir(), 'palette-journal-${label}-${os.getpid()}-${time.now().unix_nano()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	persist := os.join_path(tmp, 'state.json')
+	mut eng := desktop_engine.new_engine(desktop_engine.EngineConfig{
+		persist_path: persist
+	})
+	eng.init() or { panic(err.msg()) }
+	eng.start() or { panic(err.msg()) }
+	return &JrnEngine{
+		eng: eng
+		tmp: tmp
+	}
+}
+
+fn (mut fe JrnEngine) cleanup() {
+	fe.eng.stop() or {}
+	if fe.tmp != '' {
+		os.rmdir_all(fe.tmp) or {}
+		fe.tmp = ''
+	}
+}
+
+fn journal_skill_id(mut eng &desktop_engine.Engine) string {
+	catalog := eng.skills_catalog()
+	if catalog.len == 0 {
+		panic('no catalog skills')
+	}
+	return catalog[0].id
+}
+
+fn has_action(acts []RegistryAction, kind ActionKind) bool {
+	return acts.any(it.kind == kind)
+}
+
+// fresh session → empty journal, no fabricated recent actions
+fn test_journal_fresh_session_is_empty() {
+	mut fe := new_journal_engine('fresh')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	assert reg.journal_records().len == 0
+}
+
+// TARGET: enable → recent + undo → exact restore → consumed; second undo
+// reports already-undone; undo record itself has no undo.
+fn test_journal_target_undo_exact() {
+	mut fe := new_journal_engine('target')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	mut target_id := ''
+	for t in fe.eng.targets() {
+		target_id = t.id
+		break
+	}
+	if target_id == '' {
+		panic('no targets')
+	}
+	was_enabled := fe.eng.target_enabled(target_id)
+	kind := if was_enabled { ActionKind.target_disable } else { ActionKind.target_enable }
+	out := reg.execute(.target, target_id, kind, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	recs := reg.journal_records()
+	assert recs.len == 1
+	rec := recs[0]
+	assert rec.outcome == .succeeded
+	assert rec.entity_id == target_id
+	assert rec.has_undo
+	assert rec.undo.status == .available
+	assert rec.undo.spec !is AppearanceUndo
+	// the undo record must carry no fabricated evidence: revision matches
+	// the real post-execution state
+	// undo restores the exact previous value
+	uout := reg.execute_undo(rec.execution_id) or {
+		panic(err.msg())
+	}
+	assert uout.status == .consumed
+	assert uout.summary.contains('Undid')
+	assert fe.eng.target_enabled(target_id) == was_enabled
+	// single use
+	uout2 := reg.execute_undo(rec.execution_id) or {
+		panic(err.msg())
+	}
+	assert uout2.status == .consumed
+	assert uout2.summary.contains('already undone')
+	// the undo itself is a recorded execution with no undo
+	recs2 := reg.journal_records()
+	assert recs2.len == 2
+	assert recs2[0].label.starts_with('Undid')
+	assert !recs2[0].has_undo
+}
+
+// TARGET divergence: a later unrelated change makes undo stale and it must
+// not overwrite the newer state; stale stays stale.
+fn test_journal_target_undo_stale() {
+	mut fe := new_journal_engine('target-stale')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	mut target_id := ''
+	for t in fe.eng.targets() {
+		target_id = t.id
+		break
+	}
+	was := fe.eng.target_enabled(target_id)
+	kind := if was { ActionKind.target_disable } else { ActionKind.target_enable }
+	out := reg.execute(.target, target_id, kind, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	// an unrelated later change flips the target back
+	fe.eng.set_target_enabled(target_id, was) or { panic(err.msg()) }
+	// optimistic precheck sees the divergence
+	assert reg.undo_precheck(out_status_id(reg)) == .stale
+	uout := reg.execute_undo(out_status_id(reg)) or {
+		panic(err.msg())
+	}
+	assert uout.status == .stale
+	assert uout.summary.contains('State changed')
+	// no overwrite: the newer state survives
+	assert fe.eng.target_enabled(target_id) == was
+	// stale stays stale
+	assert reg.undo_precheck(out_status_id(reg)) == .stale
+}
+
+// helper: first recent execution id
+fn out_status_id(reg &Registry) u64 {
+	recs := reg.journal_records()
+	if recs.len == 0 {
+		panic('no journal records')
+	}
+	return recs[0].execution_id
+}
+
+// SKILL: full-selection snapshot; unrelated later install makes undo stale
+// and preserves the unrelated change.
+fn test_journal_skill_selection_guard() {
+	mut fe := new_journal_engine('skill-guard')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	s1 := journal_skill_id(mut fe.eng)
+	catalog := fe.eng.skills_catalog()
+	if catalog.len < 2 {
+		panic('need two catalog skills')
+	}
+	s2 := catalog[1].id
+	out := reg.execute(.skill, s1, .skill_install, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	assert fe.eng.skills_installed().contains(s1)
+	// unrelated later change: install s2
+	fe.eng.install_skill(s2) or { panic(err.msg()) }
+	// undo must be stale — restoring would destroy the s2 change
+	assert reg.undo_precheck(out_status_id(reg)) == .stale
+	uout := reg.execute_undo(out_status_id(reg)) or {
+		panic(err.msg())
+	}
+	assert uout.status == .stale
+	// unrelated state preserved
+	inst := fe.eng.skills_installed()
+	assert inst.contains(s1) && inst.contains(s2)
+}
+
+// SKILL: exact restore when nothing diverged.
+fn test_journal_skill_undo_exact() {
+	mut fe := new_journal_engine('skill-exact')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	s1 := journal_skill_id(mut fe.eng)
+	before := fe.eng.skills_installed().clone()
+	out := reg.execute(.skill, s1, .skill_install, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert fe.eng.skills_installed() != before || before.contains(s1)
+	uout := reg.execute_undo(out_status_id(reg)) or {
+		panic(err.msg())
+	}
+	assert uout.status == .consumed
+	after := fe.eng.skills_installed()
+	assert after == before
+}
+
+// EXECUTION HISTORY boundary: validation failure, unavailable and
+// not-confirmed never record; seam failure records failed truthfully.
+fn test_journal_recording_boundary() {
+	mut fe := new_journal_engine('boundary')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	s1 := journal_skill_id(mut fe.eng)
+	// validation failure (empty swarm task) → no recent
+	_ = reg.execute(.navigation, '/swarm', .swarm_launch, ActionArgs{
+		task: ' '
+	}) or { panic('must not error') }
+	assert reg.journal_records().len == 0
+	// unavailable (remove a not-installed skill) → no recent
+	_ = reg.execute(.skill, s1, .skill_remove, ActionArgs{
+		confirm: true
+	}) or { panic('must not error') }
+	assert reg.journal_records().len == 0
+	// not confirmed (install first, then unconfirmed remove) → no recent
+	_ = reg.execute(.skill, s1, .skill_install, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	inst_recs := reg.journal_records()
+	assert inst_recs.len == 1 && inst_recs[0].outcome == .succeeded
+	_ = reg.execute(.skill, s1, .skill_remove, ActionArgs{}) or {
+		panic('must not error')
+	}
+	assert reg.journal_records().len == 1
+	// seam failure records failed truthfully (budget-gated loop run)
+	entry := desktop_engine.LoopEntry{
+		name: 'journal-loop'
+		goal: 'boundary'
+		tier: .l1
+		stage: 'l1'
+		cadence: '1d'
+		schedule: desktop_engine.cadence_to_cron('1d')
+		budget: desktop_engine.LoopBudget{
+			max_tokens: 80000
+			max_runs_per_day: 1
+			max_wall_seconds: 900
+		}
+		budget_total: 80000
+	}
+	fe.eng.upsert_loop(entry) or { panic(err.msg()) }
+	_ = reg.execute(.loop_template, 'journal-loop', .loop_run, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	_ = reg.execute(.loop_template, 'journal-loop', .loop_run, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	// second run fails at the budget gate — a real seam failure
+	recs := reg.journal_records()
+	assert recs[0].outcome == .failed
+	assert recs[0].label.contains('Run now')
+	// failed records carry no undo
+	assert !recs[0].has_undo
+}
+
+// MCP disable: config survives in place; undo restores the exact captured
+// state (config + enabled + health) via the typed restore seam.
+fn test_journal_mcp_disable_undo() {
+	mut fe := new_journal_engine('mcp')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	mut pid := ''
+	for p in fe.eng.mcp_catalog() {
+		pid = p.id
+		break
+	}
+	if pid == '' {
+		panic('no providers')
+	}
+	// start from a known enabled state
+	_ = reg.execute(.mcp_provider, pid, .mcp_enable, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	before := fe.eng.mcp_state_snapshot(pid) or { panic('snapshot missing') }
+	out := reg.execute(.mcp_provider, pid, .mcp_disable, ActionArgs{
+		confirm: true
+	}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	after_disable := fe.eng.mcp_state_snapshot(pid) or { panic('missing') }
+	// disable keeps the config bytes in place
+	assert after_disable.config == before.config
+	assert !after_disable.enabled
+	// undo restores the exact captured state
+	uout := reg.execute_undo(out_status_id_for(reg, out)) or {
+		panic(err.msg())
+	}
+	_ = uout
+	restored := fe.eng.mcp_state_snapshot(pid) or { panic('missing') }
+	assert restored.config == before.config
+	assert restored.enabled == before.enabled
+	assert restored.health == before.health
+}
+
+// helper: execution id of the most recent record
+fn out_status_id_for(reg &Registry, _ ActionOutcome) u64 {
+	return out_status_id(reg)
+}
+
+// MCP enable: prior config is overwritten by the template — undo must
+// restore the exact prior state from the snapshot; the snapshot never
+// appears in journal metadata.
+fn test_journal_mcp_enable_snapshot() {
+	mut fe := new_journal_engine('mcp-enable')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	mut pid := ''
+	for p in fe.eng.mcp_catalog() {
+		pid = p.id
+		break
+	}
+	// a pre-existing (custom) configuration the user had before
+	custom := '{"command":"custom-guarded","args":["' + '\${CUSTOM_TOKEN}' + '"]}'
+	fe.eng.upsert_mcp_provider(pid, custom) or { panic(err.msg()) }
+	fe.eng.mcp_toggle(pid) or { panic(err.msg()) } // disable — config preserved
+	// enable overwrites the custom config with the packaged template
+	out := reg.execute(.mcp_provider, pid, .mcp_enable, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	after_enable := fe.eng.mcp_state_snapshot(pid) or { panic('missing') }
+	assert after_enable.config != custom
+	// undo restores the exact prior (custom, disabled) state
+	uout := reg.execute_undo(out_status_id_for(reg, out)) or {
+		panic(err.msg())
+	}
+	assert uout.status == .consumed
+	restored := fe.eng.mcp_state_snapshot(pid) or { panic('missing') }
+	assert restored.config == custom
+	assert !restored.enabled
+	// no config blob ever leaks into journal metadata
+	for rec in reg.journal_records() {
+		assert !rec.label.contains('custom-guarded')
+		assert !rec.label.contains('CUSTOM_TOKEN')
+	}
+}
+
+// LOOP schedule: exact previous configuration restored; loop RUN is never
+// undoable.
+fn test_journal_loop_schedule_undo() {
+	mut fe := new_journal_engine('loop-cron')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	entry := desktop_engine.LoopEntry{
+		name: 'journal-cron-loop'
+		goal: 'undo schedule'
+		tier: .l1
+		stage: 'l1'
+		cadence: '1d'
+		schedule: desktop_engine.cadence_to_cron('1d')
+		budget: desktop_engine.LoopBudget{
+			max_tokens: 80000
+			max_runs_per_day: 1
+			max_wall_seconds: 900
+		}
+		budget_total: 80000
+	}
+	fe.eng.upsert_loop(entry) or { panic(err.msg()) }
+	out := reg.execute(.loop_template, 'journal-cron-loop', .loop_schedule_toggle, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert out.status == .succeeded
+	assert fe.eng.loops_catalog().filter(it.name == 'journal-cron-loop')[0].cron_enabled
+	uout := reg.execute_undo(out_status_id(reg)) or {
+		panic(err.msg())
+	}
+	assert uout.status == .consumed
+	assert !fe.eng.loops_catalog().filter(it.name == 'journal-cron-loop')[0].cron_enabled
+	// loop RUN has no undo
+	run_out := reg.execute(.loop_template, 'journal-cron-loop', .loop_run, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert run_out.status == .succeeded
+	run_rec := reg.journal_records()[0]
+	assert !run_rec.has_undo
+}
+
+// PROBE and dry-run executions are not recorded (read-only / preview-like).
+fn test_journal_probe_and_dry_run_not_recorded() {
+	mut fe := new_journal_engine('probe')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	mut pid := ''
+	for p in fe.eng.mcp_catalog() {
+		pid = p.id
+		break
+	}
+	_ = reg.execute(.mcp_provider, pid, .mcp_probe, ActionArgs{}) or {
+		panic(err.msg())
+	}
+	assert reg.journal_records().len == 0
+	// target install dry-run crosses the seam but writes nothing — it is a
+	// preview, not an execution
+	mut tid := ''
+	for t in fe.eng.targets() {
+		if fe.eng.target_install_supported(t.id) {
+			tid = t.id
+			break
+		}
+	}
+	if tid != '' {
+		_ = reg.execute(.target, tid, .target_install, ActionArgs{
+			dry_run: true
+			confirm: true
+		}) or { panic(err.msg()) }
+		assert reg.journal_records().len == 0
+	}
+}
+
+// SESSION bound: the journal stays capped.
+fn test_journal_bounded() {
+	mut fe := new_journal_engine('bounded')
+	defer {
+		fe.cleanup()
+	}
+	mut reg := new_registry(mut fe.eng)
+	s1 := journal_skill_id(mut fe.eng)
+	for i in 0 .. 40 {
+		kind := if i % 2 == 0 { ActionKind.skill_install } else { ActionKind.skill_remove }
+		_ = reg.execute(.skill, s1, kind, ActionArgs{
+			confirm: true
+		}) or { panic(err.msg()) }
+	}
+	assert reg.journal_records().len == recents_limit
+	// newest first with stable ids
+	recs := reg.journal_records()
+	assert recs[0].execution_id > recs[recs.len - 1].execution_id
+}

--- a/modules/desktop/palette/registry.v
+++ b/modules/desktop/palette/registry.v
@@ -179,6 +179,10 @@ mut:
 	// authority), mirroring InstallOptionsEngine's own injection design.
 	install_home_dir    string
 	install_receipt_dir string
+	// S4D (#1119): session-local execution journal (newest first, bounded)
+	// + undo sequence. Fresh session ⇒ empty journal. Never persisted.
+	journal  []RecentAction
+	undo_seq u64
 }
 
 // new_registry binds a registry to an Engine.

--- a/modules/desktop/palette/registry.v
+++ b/modules/desktop/palette/registry.v
@@ -179,6 +179,10 @@ mut:
 	// authority), mirroring InstallOptionsEngine's own injection design.
 	install_home_dir    string
 	install_receipt_dir string
+	// S4D: the shell reports the current appearance through
+	// observe_appearance (apply_appearance is the only mutation point), so
+	// appearance-undo prechecks compare real values instead of assuming.
+	observed_appearance string
 	// S4D (#1119): session-local execution journal (newest first, bounded)
 	// + undo sequence. Fresh session ⇒ empty journal. Never persisted.
 	journal  []RecentAction

--- a/modules/desktop/window.v
+++ b/modules/desktop/window.v
@@ -359,6 +359,11 @@ pub fn (mut d Desktop) engine_target_install_supported(target_id string) bool {
 	return d.engine.target_install_supported(target_id)
 }
 
+// engine_target_enabled reads the target's real enabled state (S4D tests).
+pub fn (mut d Desktop) engine_target_enabled(target_id string) bool {
+	return d.engine.target_enabled(target_id)
+}
+
 // inner_loops_for returns inner loops map snapshot for a swarm run (via State keys).
 pub fn (mut d Desktop) inner_loops_for(run_id string) map[string]string {
 	snap := d.engine.snapshot()

--- a/modules/desktop_engine/mcp_service.v
+++ b/modules/desktop_engine/mcp_service.v
@@ -439,6 +439,75 @@ pub fn (mut e Engine) mcp_toggle(provider_id string) !u64 {
 	return error('mcp provider not found: ${provider_id}')
 }
 
+// McpStateSnapshot captures the complete authoritative state of one MCP
+// provider (S4D undo): exactly the state keys the Engine writes for it.
+// Snapshots are session-local, opaque and never rendered — stored configs
+// cannot contain raw secrets (the secret guard rejects them at write time),
+// but old migrated state is not assumed safe, so snapshots stay private.
+pub struct McpStateSnapshot {
+pub:
+	provider_id string
+	config      string
+	enabled     bool
+	health      string
+	provenance  string
+}
+
+// mcp_state_snapshot reads the provider's current authoritative state.
+// Returns none when the provider has no recorded state at all.
+pub fn (mut e Engine) mcp_state_snapshot(provider_id string) ?McpStateSnapshot {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	config := snap.data['mcp:${provider_id}:config'] or { '' }
+	enabled := (snap.data['mcp:${provider_id}:enabled'] or { 'false' }) == 'true'
+	health := snap.data['mcp:${provider_id}:health'] or { '' }
+	provenance := snap.data['provenance:mcp:${provider_id}:source'] or { '' }
+	if config == '' && !enabled && health == '' && provenance == '' {
+		return none
+	}
+	return McpStateSnapshot{
+		provider_id: provider_id
+		config: config
+		enabled: enabled
+		health: health
+		provenance: provenance
+	}
+}
+
+// restore_mcp_state restores an exact previously captured provider state in
+// one transaction (S4D undo, Option B). It writes only the four keys the
+// Engine itself owns for a provider — no generic state-map restoration. The
+// secret guard still applies to the restored config; a snapshot that
+// predates the guard and carries a raw secret is refused, and the caller
+// treats that undo as unavailable.
+pub fn (mut e Engine) restore_mcp_state(s McpStateSnapshot) !u64 {
+	if s.provider_id == '' {
+		return error('provider id empty')
+	}
+	if has_raw_secret(s.config) {
+		return error('secret guard: snapshot config carries a raw token — undo unavailable')
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('restore-mcp-state')
+	if s.config != '' {
+		tx.set('mcp:${s.provider_id}:config', s.config)
+	}
+	tx.set('mcp:${s.provider_id}:enabled', if s.enabled { 'true' } else { 'false' })
+	if s.health != '' {
+		tx.set('mcp:${s.provider_id}:health', s.health)
+	}
+	if s.provenance != '' {
+		tx.set('provenance:mcp:${s.provider_id}:source', s.provenance)
+	}
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
 // verify_mcp_receipts checks that every enabled MCP provider has a recorded
 // configuration (real config-truth drift check). Enabled without config is a
 // genuine defect; no receipt is fabricated to satisfy this.

--- a/modules/desktop_engine/mcp_service.v
+++ b/modules/desktop_engine/mcp_service.v
@@ -353,7 +353,9 @@ pub fn mask_mcp_secrets(text string) string {
 pub fn has_raw_secret(text string) bool {
 	if text.contains('ghp_') || text.contains('gho_') || text.contains('sk-') || text.contains('xoxb-') {
 		if text.contains('\${') {
-			for pat in ['ghp_', 'sk-', 'xoxb-'] {
+			// scan EVERY known prefix: a raw token is one whose occurrence is
+			// not a \${ENV_VAR} placeholder — gho_ was missing (#1162 review)
+			for pat in ['ghp_', 'gho_', 'sk-', 'xoxb-'] {
 				idx := text.index(pat) or { continue }
 				before := if idx > 2 { text[idx - 2..idx] } else { '' }
 				if before != '\${' {
@@ -494,16 +496,13 @@ pub fn (mut e Engine) restore_mcp_state(s McpStateSnapshot) !u64 {
 	e.mu.unlock()
 	mut repo := e.repo
 	mut tx := repo.begin('restore-mcp-state')
-	if s.config != '' {
-		tx.set('mcp:${s.provider_id}:config', s.config)
-	}
+	// write ALL four keys unconditionally: an empty captured field means the
+	// previous state had no value — restore must clear it, never retain a
+	// newer value (#1162 review)
+	tx.set('mcp:${s.provider_id}:config', s.config)
 	tx.set('mcp:${s.provider_id}:enabled', if s.enabled { 'true' } else { 'false' })
-	if s.health != '' {
-		tx.set('mcp:${s.provider_id}:health', s.health)
-	}
-	if s.provenance != '' {
-		tx.set('provenance:mcp:${s.provider_id}:source', s.provenance)
-	}
+	tx.set('mcp:${s.provider_id}:health', s.health)
+	tx.set('provenance:mcp:${s.provider_id}:source', s.provenance)
 	rev := e.put_transaction(mut tx)!
 	return rev.revision
 }

--- a/modules/desktop_engine/skills_service.v
+++ b/modules/desktop_engine/skills_service.v
@@ -418,6 +418,26 @@ pub fn (mut e Engine) install_skill_preview(id string) TargetDiff {
 	}
 }
 
+// restore_skill_selection restores an exact previously captured installed
+// selection (S4D undo). Every id must still resolve in the catalog — the
+// restore never invents membership for deleted skills.
+pub fn (mut e Engine) restore_skill_selection(ids []string) !u64 {
+	for id in ids {
+		_ := e.skill_detail(id) or {
+			return error('cannot restore selection: skill not in catalog: ${id}')
+		}
+	}
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	mut repo := e.repo
+	mut tx := repo.begin('restore-skill-selection')
+	tx.set('installed_skills', ids.join(','))
+	tx.set('skills_count', ids.len.str())
+	rev := e.put_transaction(mut tx)!
+	return rev.revision
+}
+
 // toggle_skill installs if not installed else removes — one-click management.
 pub fn (mut e Engine) toggle_skill(id string) !u64 {
 	if id in e.skills_installed() {
@@ -470,8 +490,7 @@ pub fn (mut e Engine) skill_receipt(id string) ?SkillReceiptInfo {
 					version: r.version
 					product: r.product
 					digest: a.digest
-					receipt_path: os.join_path(agent_toolkit_core.default_receipt_dir(),
-						agent_toolkit_core.receipt_filename(r.target, r.product))
+					receipt_path: os.join_path(agent_toolkit_core.default_receipt_dir(), agent_toolkit_core.receipt_filename(r.target, r.product))
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fourth and final slice of S4 (#1119): **truthful Recent Actions + evidence-backed Undo.** Recents are a consequence of actions actually executed; Undo exists only where the exact previous authoritative state is known and restorable through a typed seam without guessing or overwriting newer changes.

### Execution journal (one canonical source, two planes)

- Records are appended **only after the real execution seam ran** — the boundary is explicit in `Registry.execute()`. Validation failures, unavailable, not-confirmed, previews, probes, dry-runs and navigation never record.
- Shell-native actions (appearance) record via typed `record_execution` after the real shell setter ran — no second journal, no fake Engine ownership.
- Session-local, bounded (25, newest-first, stable ids); fresh session ⇒ empty journal; no persistence invented, no domain revisions polluted.

### Reversibility matrix (verified against code — not inferred from symmetrical names)

| Class | Actions |
|---|---|
| REVERSIBLE_EXACT | target enable/disable (single config key), skill install/remove (full-selection restore), loop schedule toggle, theme (real `apply_appearance` setter + persisted ui state) |
| REVERSIBLE_WITH_SNAPSHOT | MCP enable/disable — new narrow typed Engine seam `mcp_state_snapshot`/`restore_mcp_state` restoring exactly the four authoritative keys (config, enabled, health, provenance) |
| IRREVERSIBLE (preview/confirm only) | target install, app uninstall, doctor repair, loop run, swarm launch |
| NOT_MEANINGFUL | probe, inspect, navigation, update-unavailable |

### Undo semantics (all locked by tests)

- Typed `UndoSpec` variants — no CLI fragments, no maps.
- **Optimistic exact-state checks**: undo runs only if the current affected state equals the state recorded right after the action (full `installed_skills` selection guard for skills, complete MCP state guard, appearance equality guard). Divergence ⇒ stale, never an overwrite of newer changes.
- **Single-use**: available → consumed | stale; stale is terminal; no redo.
- Post-restore verification: the state must equal the previous state or the undo reports it honestly.
- The undo itself records a real execution (`Undid …`) with no undo of its own.
- MCP snapshots are session-local, opaque, never displayed/logged/serialized; a snapshot carrying a raw secret (predating the guard) is refused — undo unavailable, secret policy never weakened.

### UX (smallest useful affordance)

Recents lead the empty-query palette — visually distinct (`↻` prefix, truthful outcome + real evidence refs: receipt/run id/job id/revision), `U` executes undo with a live precheck shown in the description (`undo ready` / `undone` / `undo unavailable — state changed`). Rerun (Enter) re-resolves the **current** `RegistryAction`, availability and confirmation rules — never replays stored arguments; unavailable reruns are refused honestly. Empty journal ⇒ no Recent section at all.

### Tests

- `journal_test.v` — 11 behaviors: fresh-session emptiness, exact target/skill/loop/MCP restores, full-selection divergence guard (unrelated later install survives, undo stale), recording boundary (validation/unavailable/not-confirmed never record; seam failure records `failed` truthfully), MCP snapshot restore + no-config-leak-into-metadata, loop-run-never-undoable, probe/dry-run never recorded, boundedness.
- `palette_recents_flow_test.v` — shell flow: recents render distinctly with canonical identity, rerun revalidation refuses stale toggles, shell undo path (exact restore, single use, `Already undone`), theme record + exact undo via the real setter.
- All S7 truth gates, S4C reachability gate, full `./make.vsh test`, production build, headless smoke, `gui-coverage.py --check` (21/21) green.

### Visual evidence limitation

No display/Xvfb on this workstation: windowed pixel inspection of the new Recent rows was not possible locally. The Recent section only appears after real executions (fresh sessions render exactly as S4C left the palette — golden-covered). Row content, ordering and undo-state text are locked by the flow tests. CI goldens guard panel drift.

Refs #1119 · #1118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recent executions to the command palette, with up to five recent actions shown when no search query is entered.
  - Re-run recent actions directly from the palette.
  - Added undo support for eligible actions, including exact-state checks and single-use protection.
  - Recent entries now display execution outcomes and evidence, including partial and failed results.
  - Theme changes can now be undone to the exact previous appearance.

- **Bug Fixes**
  - Actions that cannot be re-run or undone now report their status honestly instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->