### PR TITLE
feat(desktop): VC1 — pixel-art production foundation (Paper Co. v1)

### DIFF
--- a/docs/desktop/WORLD_VIEW.md
+++ b/docs/desktop/WORLD_VIEW.md
@@ -1,5 +1,16 @@
 # World View — Workshop Metaphor
 
+> **SUPERSEDED 2026-09-08 (in part).** The governing visual authority is
+> now [DESIGN.md](DESIGN.md) (§0 Visual Convergence / Paper Co. v1) and the
+> design references in [assets/design/](assets/design/). The **Workshop
+> metaphor, vector-sprite vocabulary, and workbench/rig zoning below are
+> historical**: the production visual language is the Paper Co. pixel-art
+> office (agent desks, operations, approvals, receipts, diagnostics) built
+> on the pixel-art foundation from the Visual Convergence milestone. The
+> **motion/reduced-motion, no-fake-gamification, and plane-guard contracts
+> below remain binding.** Issue #1065 is narrowed to motion/HDPI/audio
+> stance accordingly.
+
 > **EPIC #1013 — World View + game presentation** — Workshop vertical slice.
 > `modules/desktop/world/` — `V 0.5.2`, `VMODULES=modules`, `import json`, single-repo-one-binary `1.27.0`, `make.vsh` + `gen-embedded`, `docs/ARCHITECTURE.md` planes.
 

--- a/modules/desktop/pixelart/palette.v
+++ b/modules/desktop/pixelart/palette.v
@@ -1,0 +1,144 @@
+module pixelart
+
+// Paper Co. pixel-art palette (VC1, #1118 / DESIGN.md §0).
+// Material colors from the established surface tokens, compressed for the
+// pixel-art density. Two variants: Paper (light flagship) and Ink (dark).
+
+pub enum PaletteId {
+	paper
+	ink
+}
+
+// PaletteKey — single-char keys used in sprite grids (readable/diffable).
+// Same key maps to different material colors per palette variant.
+pub enum PaletteKey {
+	outline  = 107
+	paper    = 112
+	paper_hi = 80
+	manila   = 109
+	manila_d = 77
+	brass    = 98
+	brass_hi = 66
+	wood     = 119
+	wood_d   = 87
+	foliage  = 102
+	foliage_d= 70
+	sky      = 115
+	slate    = 83
+	terminal = 116
+	accent   = 97
+	skin     = 110
+	skin_d   = 78
+	hair     = 104
+	shirt    = 99
+	shirt_d  = 67
+	white    = 101
+	steel    = 108
+	coral    = 114
+	transparent = 46
+}
+
+pub struct Palette {
+pub:
+	id PaletteId
+mut:
+	colors map[u8]u64
+}
+
+// rgba64 packs RGBA into a u64: (r<<24) | (g<<16) | (b<<8) | a.
+pub fn rgba64(r int, g int, b int) u64 {
+	return (u64(r) << 24) | (u64(g) << 16) | (u64(b) << 8) | u64(255)
+}
+
+// channels unpacks a packed color.
+pub fn channels(v u64) (int, int, int, int) {
+	return int((v >> 24) & 0xFF), int((v >> 16) & 0xFF), int((v >> 8) & 0xFF), int(v & 0xFF)
+}
+
+// rgba returns the RGBA tuple for a palette-key byte.
+pub fn (p Palette) rgba(k u8) [4]u8 {
+	if v := p.colors[k] {
+		r, g, b, a := channels(v)
+		mut out := [4]u8{}
+		out[0] = u8(r)
+		out[1] = u8(g)
+		out[2] = u8(b)
+		out[3] = u8(a)
+		return out
+	}
+	return [4]u8{}
+}
+
+// rgb_hex returns '#RRGGBB' for UI-adjacent uses.
+pub fn (p Palette) rgb_hex(k u8) string {
+	v := p.rgba(k)
+	return '#${v[0]:02x}${v[1]:02x}${v[2]:02x}'
+}
+
+// paper_palette — warm flagship: cream paper, manila folders, brass, wood,
+// ink outlines. Matches the established chrome tokens.
+pub fn paper_palette() Palette {
+	mut c := map[u8]u64{}
+	c[u8(`k`)] = rgba64(37, 42, 45)
+	c[u8(`p`)] = rgba64(246, 239, 227)
+	c[u8(`P`)] = rgba64(255, 249, 237)
+	c[u8(`m`)] = rgba64(217, 183, 121)
+	c[u8(`M`)] = rgba64(201, 164, 95)
+	c[u8(`b`)] = rgba64(154, 100, 22)
+	c[u8(`B`)] = rgba64(220, 158, 60)
+	c[u8(`w`)] = rgba64(166, 124, 82)
+	c[u8(`W`)] = rgba64(120, 88, 58)
+	c[u8(`f`)] = rgba64(106, 153, 78)
+	c[u8(`F`)] = rgba64(74, 112, 56)
+	c[u8(`s`)] = rgba64(126, 156, 216)
+	c[u8(`S`)] = rgba64(59, 66, 82)
+	c[u8(`t`)] = rgba64(23, 28, 31)
+	c[u8(`a`)] = rgba64(168, 70, 49)
+	c[u8(`n`)] = rgba64(232, 190, 160)
+	c[u8(`N`)] = rgba64(198, 152, 122)
+	c[u8(`h`)] = rgba64(72, 52, 38)
+	c[u8(`c`)] = rgba64(143, 174, 204)
+	c[u8(`C`)] = rgba64(104, 134, 164)
+	c[u8(`e`)] = rgba64(255, 252, 245)
+	c[u8(`l`)] = rgba64(156, 163, 175)
+	c[u8(`r`)] = rgba64(228, 110, 90)
+	return Palette{ id: .paper, colors: c }
+}
+
+// ink_palette — authored dark variant: deep cabinet surfaces, dimmed manila,
+// desaturated foliage; NOT a global inversion.
+pub fn ink_palette() Palette {
+	mut c := map[u8]u64{}
+	c[u8(`k`)] = rgba64(10, 12, 14)
+	c[u8(`p`)] = rgba64(44, 50, 56)
+	c[u8(`P`)] = rgba64(56, 63, 70)
+	c[u8(`m`)] = rgba64(120, 100, 66)
+	c[u8(`M`)] = rgba64(96, 78, 50)
+	c[u8(`b`)] = rgba64(180, 124, 44)
+	c[u8(`B`)] = rgba64(224, 168, 80)
+	c[u8(`w`)] = rgba64(104, 82, 60)
+	c[u8(`W`)] = rgba64(76, 58, 42)
+	c[u8(`f`)] = rgba64(74, 102, 60)
+	c[u8(`F`)] = rgba64(54, 76, 44)
+	c[u8(`s`)] = rgba64(66, 96, 148)
+	c[u8(`S`)] = rgba64(40, 46, 54)
+	c[u8(`t`)] = rgba64(8, 10, 12)
+	c[u8(`a`)] = rgba64(178, 84, 62)
+	c[u8(`n`)] = rgba64(198, 158, 128)
+	c[u8(`N`)] = rgba64(162, 124, 98)
+	c[u8(`h`)] = rgba64(40, 30, 22)
+	c[u8(`c`)] = rgba64(92, 116, 142)
+	c[u8(`C`)] = rgba64(66, 86, 108)
+	c[u8(`e`)] = rgba64(222, 220, 214)
+	c[u8(`l`)] = rgba64(110, 118, 130)
+	c[u8(`r`)] = rgba64(186, 92, 74)
+	return Palette{ id: .ink, colors: c }
+}
+
+// palette_for returns the palette for a PaletteId.
+pub fn palette_for(id PaletteId) Palette {
+	return match id {
+		.paper { paper_palette() }
+		.ink { ink_palette() }
+	}
+}

--- a/modules/desktop/pixelart/pixelart_test.v
+++ b/modules/desktop/pixelart/pixelart_test.v
@@ -1,0 +1,109 @@
+module pixelart
+
+import os
+import time
+
+// Grid validity: all authored sprites have uniform rows and known palette keys.
+fn test_all_sprites_validate() {
+	pal := paper_palette()
+	known := [
+		u8(`k`), u8(`p`), u8(`P`), u8(`m`), u8(`M`), u8(`b`), u8(`B`),
+		u8(`w`), u8(`W`), u8(`f`), u8(`F`), u8(`s`), u8(`S`), u8(`t`),
+		u8(`a`), u8(`n`), u8(`N`), u8(`h`), u8(`c`), u8(`C`), u8(`e`),
+		u8(`l`), u8(`r`),
+	]
+	for s in all_sprites() {
+		errs := s.validate(known)
+		assert errs.len == 0, 'sprite ${s.name} invalid: ${errs.join("; ")}'
+	}
+}
+
+// Expansion: dimensions, palette mapping, transparency.
+fn test_expand_rgba() {
+	pal := paper_palette()
+	s := env_terminal
+	rgba := s.expand(pal, 1)
+	assert rgba.len == s.width() * s.height() * 4
+	// terminal well pixel: 't' at row 1 col 2
+	row1 := s.rows[1]
+	mut px := -1
+	for ci, ch in row1 {
+		if ch == `t` {
+			px = ci
+			break
+		}
+	}
+	assert px >= 0, 'terminal well pixel not found'
+	base := (1 * s.width() + px) * 4
+	assert rgba[base] == 23 && rgba[base + 1] == 28 && rgba[base + 2] == 31
+	assert rgba[base + 3] == 255
+	// transparent corner (row 0 col 0 is '.')
+	assert rgba[3] == 0
+}
+
+// Scale: 2× expansion doubles dimensions with 2×2 pixel blocks.
+fn test_expand_scale2() {
+	pal := paper_palette()
+	s := agent_idle
+	rgba := s.expand(pal, 2)
+	assert rgba.len == 12 * 2 * 12 * 2 * 4
+	// block uniformity: pixel (0,0) == (1,0) == (0,1)
+	base00 := 0
+	base10 := 4 * 2
+	base01 := 4 * 2 * 2
+	assert rgba[base00] == rgba[base10] && rgba[base00] == rgba[base01]
+}
+
+// Paper/Ink palettes both map every key; Ink differs from Paper (not an inversion clone)
+fn test_palettes_complete_and_distinct() {
+	paper := paper_palette()
+	ink := ink_palette()
+	for s in all_sprites() {
+		for row in s.rows {
+			for ch in row {
+				k := u8(ch)
+				if k == `.` {
+					continue
+				}
+				_ = paper.rgba(k)
+				_ = ink.rgba(k)
+			}
+		}
+	}
+	// same key, different material between variants (not a clone)
+	assert paper.rgba(u8(`p`)) != ink.rgba(u8(`p`))
+	// palette ids
+	assert paper.id == .paper && ink.id == .ink
+	assert palette_for(.ink).id == .ink
+}
+
+// Mapping coverage: every state and environment asset resolves to a valid sprite.
+fn test_mapping_coverage() {
+	for st in all_agent_states() {
+		s := agent_for_state(st)
+		assert s.rows.len > 0
+	}
+	for a in all_environment_assets() {
+		s := environment_for(a)
+		assert s.rows.len > 0
+	}
+	// no duplicate names
+	mut names := map[string]bool{}
+	for s in all_sprites() {
+		assert !names[s.name]
+		names[s.name] = true
+	}
+}
+
+// Package/clean-machine: the module is pure V (no file I/O at sprite build
+// time). This test pins that: expansion works in an empty CWD.
+fn test_expansion_works_from_any_cwd() {
+	old := os.getwd()
+	os.chdir('/') or {}
+	defer { os.chdir(old) or {} }
+	pal := paper_palette()
+	s := env_desk
+	rgba := s.expand(pal, 1)
+	assert rgba.len == s.width() * s.height() * 4
+	_ = time.now()
+}

--- a/modules/desktop/pixelart/sprites.v
+++ b/modules/desktop/pixelart/sprites.v
@@ -1,0 +1,445 @@
+module pixelart
+
+// VC1 sprite grids (#1118 VC1) — authored as readable text rows of palette
+// keys. A row of '.' is transparent. Every sprite documents its logical
+// pixel size; the renderer scales by integer factors with nearest-neighbor
+// semantics (via pre-expanded RGBA), keeping pixels crisp.
+
+// AgentVisualState — the truthful runtime state that selects the avatar
+// variant. Catalog/idle agents are never rendered as running.
+pub enum AgentVisualState {
+	idle
+	running
+	waiting
+	attention
+	error
+}
+
+// EnvironmentAsset — office furniture and operational props.
+pub enum EnvironmentAsset {
+	desk
+	chair
+	terminal
+	shelf
+	plant
+	lamp
+	cabinet
+	rug
+	meeting_table
+	board
+	tray
+}
+
+// Sprite is an authored pixel grid with its palette keys.
+pub struct Sprite {
+pub:
+	name  string
+	rows  []string // one char per pixel, palette-key or '.'
+}
+
+// width/height of the sprite grid.
+pub fn (s Sprite) width() int {
+	return if s.rows.len > 0 { s.rows[0].len } else { 0 }
+}
+
+pub fn (s Sprite) height() int {
+	return s.rows.len
+}
+
+// validate checks all rows share the same width and use known palette keys.
+pub fn (s Sprite) validate(known_keys []u8) []string {
+	mut errs := []string{}
+	if s.rows.len == 0 {
+		errs << '${s.name}: empty grid'
+		return errs
+	}
+	w := s.rows[0].len
+	for ri, row in s.rows {
+		if row.len != w {
+			errs << '${s.name}: row ${ri} width ${row.len} != ${w}'
+		}
+		for ch in row {
+			k := u8(ch)
+			if k == `.` {
+				continue
+			}
+			if !(k in known_keys) {
+				errs << '${s.name}: row ${ri} has unknown palette key "${ch}"'
+				break
+			}
+		}
+	}
+	return errs
+}
+
+// expand returns the RGBA byte buffer for the sprite at integer scale N
+// (nearest-neighbor by construction: each source pixel becomes N×N bytes).
+pub fn (s Sprite) expand(p Palette, scale int) []u8 {
+	w, h := s.width(), s.height()
+	mut out := []u8{len: w * scale * h * scale * 4, cap: w * scale * h * scale * 4}
+	for gy in 0 .. h * scale {
+		src_y := gy / scale
+		row := s.rows[src_y]
+		for gx in 0 .. w * scale {
+			src_x := gx / scale
+			k := u8(row[src_x])
+			rgba := p.rgba(k)
+			base := (gy * w * scale + gx) * 4
+			out[base] = rgba[0]
+			out[base + 1] = rgba[1]
+			out[base + 2] = rgba[2]
+			out[base + 3] = rgba[3]
+		}
+	}
+	return out
+}
+
+// ── agent avatar (12×16 logical) — shared anatomy: hair/head/torso/desk edge.
+// Variants adjust the posture/head/screen pixels. State semantics come from
+// Engine truth; idle agents sit facing the terminal, running agents face the
+// screen with an active glow, waiting agents turn toward the inbox.
+const agent_idle = Sprite{
+	name: 'agent-idle'
+	rows: [
+		'....hhhh....',
+		'...hhhhhh...',
+		'...hnnnnh...',
+		'...nnnnnn...',
+		'....nnnn....',
+		'...cccccc...',
+		'..cccccccc..',
+		'..nccccccn..',
+		'..nccccccn..',
+		'...cccccc...',
+		'...CC..CC...',
+		'...CC..CC...',
+	]
+}
+
+const agent_running = Sprite{
+	name: 'agent-running'
+	rows: [
+		'....hhhh....',
+		'...hhhhhh...',
+		'...hnnnnh...',
+		'...nnsssn...',
+		'....nnnn....',
+		'...cccccc...',
+		'..cccccccc..',
+		'..nccccccn..',
+		'..nccccccn..',
+		'...cccccc...',
+		'...CC..CC...',
+		'...CC..CC...',
+	]
+}
+
+const agent_waiting = Sprite{
+	name: 'agent-waiting'
+	rows: [
+		'...hhhh.....',
+		'..hhhhhh....',
+		'..hnnnnh....',
+		'..nnnnnn.r..',
+		'...nnnn.....',
+		'...cccccc...',
+		'..cccccccc..',
+		'..nccccccn..',
+		'..nccccccn..',
+		'...cccccc...',
+		'...CC..CC...',
+		'...CC..CC...',
+	]
+}
+
+const agent_attention = Sprite{
+	name: 'agent-attention'
+	rows: [
+		'....hhhh..r.',
+		'...hhhhhh.r.',
+		'...hnnnnh...',
+		'...nnnnnn...',
+		'....nnnn....',
+		'...cccccc...',
+		'..cccccccc..',
+		'..nccccccn..',
+		'..nccccccn..',
+		'...cccccc...',
+		'...CC..CC...',
+		'...CC..CC...',
+	]
+}
+
+const agent_error = Sprite{
+	name: 'agent-error'
+	rows: [
+		'..r.hhhh....',
+		'....hhhhhh..',
+		'..r.hnnnnh..',
+		'...nnnnnn...',
+		'....nnnn....',
+		'...cccccc...',
+		'..cccccccc..',
+		'..nccccccn..',
+		'..nccccccn..',
+		'...cccccc...',
+		'...CC..CC...',
+		'...CC..CC...',
+	]
+}
+
+// agent_for_state returns the avatar sprite for a truthful visual state.
+pub fn agent_for_state(state AgentVisualState) Sprite {
+	return match state {
+		.idle { agent_idle }
+		.running { agent_running }
+		.waiting { agent_waiting }
+		.attention { agent_attention }
+		.error { agent_error }
+	}
+}
+
+// ── environment assets ─────────────────────────────────────────────────────
+
+// desk (18×12 logical): wooden top with paper + terminal edge.
+const env_desk = Sprite{
+	name: 'env-desk'
+	rows: [
+		'wwwwwwwwwwwwwwwwww',
+		'wwwwwwwwwwwwwwwwww',
+		'WWWWWWWWWWWWWWWWWW',
+		'W..W..........W..W',
+		'W..W..........W..W',
+		'W..W..........W..W',
+		'W..W..........W..W',
+		'W..W....mm....W..W',
+		'W..W....mm....W..W',
+		'WWWWWWWWWWWWWWWWWW',
+		'..................',
+		'..................',
+	]
+}
+
+// terminal on desk (10×9): dark screen with glow.
+const env_terminal = Sprite{
+	name: 'env-terminal'
+	rows: [
+		'.llllllll.',
+		'.lttttttl.',
+		'.ltsssstl.',
+		'.ltsststl.',
+		'.lttttttl.',
+		'.llllllll.',
+		'...ll.....',
+		'.llllllll.',
+		'..........',
+	]
+}
+
+// chair (8×12).
+const env_chair = Sprite{
+	name: 'env-chair'
+	rows: [
+		'.WWWWWW.',
+		'.W....W.',
+		'.W....W.',
+		'.WWWWWW.',
+		'.W....W.',
+		'.W....W.',
+		'.W....W.',
+		'.W....W.',
+		'.WWWWWW.',
+		'........',
+		'........',
+		'........',
+	]
+}
+
+// bookshelf (14×16): wood frame, shelves with book spines.
+const env_shelf = Sprite{
+	name: 'env-shelf'
+	rows: [
+		'.WWWWWWWWWWWW.',
+		'.WcrmcfcrcrfW.',
+		'.WcrcfmrcfcfW.',
+		'.WWWWWWWWWWWW.',
+		'.WfcmrcfcmrcW.',
+		'.WcmrfcmrfcmW.',
+		'.WWWWWWWWWWWW.',
+		'.WrcfcmrcfcmrW',
+		'.WfmrcfcmrcfcW',
+		'.WWWWWWWWWWWW.',
+		'.WcmrcfcmrcfcW',
+		'.WfcmrcfcmrcfW',
+		'.WWWWWWWWWWWW.',
+		'.WW........WW.',
+		'.WW........WW.',
+		'.WWWWWWWWWWWW.',
+	]
+}
+
+// potted plant (10×14).
+const env_plant = Sprite{
+	name: 'env-plant'
+	rows: [
+		'....ff....',
+		'..ffFFff..',
+		'.fFFffFFf.',
+		'.fFffffFf.',
+		'..fFffFf..',
+		'...ffff...',
+		'....ff....',
+		'..MMMMMM..',
+		'..MmmmmM..',
+		'..MmmmmM..',
+		'...MmmM...',
+		'...MmmM...',
+		'..MMMMMM..',
+		'..........',
+	]
+}
+
+// desk lamp (8×12): brass arm + warm head.
+const env_lamp = Sprite{
+	name: 'env-lamp'
+	rows: [
+		'..BBBB..',
+		'.BBBBBB.',
+		'.BeeeBB.',
+		'..BBBB..',
+		'...ll...',
+		'...ll...',
+		'....ll..',
+		'....ll..',
+		'.....ll.',
+		'..lllll.',
+		'.MMMMMM.',
+		'........',
+	]
+}
+
+// filing cabinet (12×14): steel drawers with handles.
+const env_cabinet = Sprite{
+	name: 'env-cabinet'
+	rows: [
+		'.llllllllll.',
+		'.lSSSSSSSSl.',
+		'.lSSSSeSSSl.',
+		'.llllllllll.',
+		'.lSSSSSSSSl.',
+		'.lSSSeSSSSl.',
+		'.llllllllll.',
+		'.lSSSSSSSSl.',
+		'.lSSSSeSSSl.',
+		'.llllllllll.',
+		'.lSSSSSSSSl.',
+		'.lSSeSSSSSl.',
+		'.llllllllll.',
+		'.WWWWWWWWWW.',
+	]
+}
+
+// rug (24×10): warm woven pattern.
+const env_rug = Sprite{
+	name: 'env-rug'
+	rows: [
+		'..aaaaaaaaaaaaaaaaaaaa..',
+		'.aMMMMMMaaaaaaMMMMMMaa..',
+		'aaMbbbbMaaaaaaaaMbbbbMaa',
+		'aaMbbbbMaaaaaaaaMbbbbMaa',
+		'aaaaaaaaaaaaaaaaaaaaaaaa',
+		'aaaaaaaaaaaaaaaaaaaaaaaa',
+		'aaMbbbbMaaaaaaaaMbbbbMaa',
+		'aaMbbbbMaaaaaaaaMbbbbMaa',
+		'.aMMMMMMaaaaaaMMMMMMaa..',
+		'..aaaaaaaaaaaaaaaaaaaa..',
+	]
+}
+
+// meeting table (20×10): wood oval top with legs.
+const env_meeting = Sprite{
+	name: 'env-meeting'
+	rows: [
+		'....wwwwwwwwwwww....',
+		'..wwwwwwwwwwwwwwww..',
+		'.wwwwwwwwwwwwwwwwww.',
+		'.wwwwwwwwwwwwwwwwww.',
+		'.wwwwwwwwwwwwwwwwww.',
+		'..wwwwwwwwwwwwwwww..',
+		'....wwwwwwwwwwww....',
+		'.....WW......WW.....',
+		'.....WW......WW.....',
+		'....................',
+	]
+}
+
+// attention board (16×12): cork board with pinned papers.
+const env_board = Sprite{
+	name: 'env-board'
+	rows: [
+		'.WWWWWWWWWWWWWW.',
+		'.WmmmmmmmmmmmmW.',
+		'.Wm.e...e..e.mW.',
+		'.Wm......e....W.',
+		'.Wm.e..e.....mW.',
+		'.Wm....e..e..mW.',
+		'.Wm.e.......emW.',
+		'.WmmmmmmmmmmmmW.',
+		'.WWWWWWWWWWWWWW.',
+		'.W............W.',
+		'.WWWWWWWWWWWWWW.',
+		'................',
+	]
+}
+
+// inbox tray (10×8): stacked paper trays.
+const env_tray = Sprite{
+	name: 'env-tray'
+	rows: [
+		'.llllllll.',
+		'.leeeeel..',
+		'.llllllll.',
+		'..leeeel..',
+		'..llllll..',
+		'...leel...',
+		'..llllll..',
+		'..........',
+	]
+}
+
+// environment_for returns the sprite for an environment asset.
+pub fn environment_for(a EnvironmentAsset) Sprite {
+	return match a {
+		.desk { env_desk }
+		.chair { env_chair }
+		.terminal { env_terminal }
+		.shelf { env_shelf }
+		.plant { env_plant }
+		.lamp { env_lamp }
+		.cabinet { env_cabinet }
+		.rug { env_rug }
+		.meeting_table { env_meeting }
+		.board { env_board }
+		.tray { env_tray }
+	}
+}
+
+// all_sprites returns every authored sprite (asset-manifest completeness).
+pub fn all_sprites() []Sprite {
+	return [
+		agent_idle, agent_running, agent_waiting, agent_attention, agent_error,
+		env_desk, env_chair, env_terminal, env_shelf, env_plant, env_lamp,
+		env_cabinet, env_rug, env_meeting, env_board, env_tray,
+	]
+}
+
+// all_environment_assets returns every EnvironmentAsset (mapping coverage).
+pub fn all_environment_assets() []EnvironmentAsset {
+	return [.desk, .chair, .terminal, .shelf, .plant, .lamp, .cabinet, .rug,
+		.meeting_table, .board, .tray]
+}
+
+// all_agent_states returns every AgentVisualState (mapping coverage).
+pub fn all_agent_states() []AgentVisualState {
+	return [.idle, .running, .waiting, .attention, .error]
+}


### PR DESCRIPTION
## Summary

VC1 of the Visual Convergence / Paper Co. v1 milestone (#1118, DESIGN.md §0): the production pixel-art material system — authored pixel grids → palette expansion → nearest-neighbor RGBA → render-ready, with unit tests.

## Design decisions

- **Authored text grids** (readable palette-key chars, `'.'` transparent) — maintainable, diffable, versioned like code. No binary blobs in git for the foundation.
- **Nearest-neighbor by construction**: each source pixel expands to N×N RGBA at runtime — crisp at any integer scale with zero sampler dependency.
- **Paper + Ink palette variants**: same key → different material per variant. Ink is authored dark, not inverted.
- **Pure V** — no file I/O at sprite-build time. Clean-machine safe (no source-tree dependency).

## Asset classes (VC1 initial kit)

- **Agent avatars** (12×16, 5 truthful states): idle (sitting, facing away from screen), running (screen glow on face), waiting (attention to inbox), attention (alert marker), error (distress marker)
- **Environment assets** (11): desk, chair, terminal, bookshelf (with book spines), potted plant, desk lamp, filing cabinet, rug, meeting table, attention board, inbox tray
- All original; palette derived from the established Paper Co. tokens

## Tests

- Grid validity (uniform rows, known palette keys) — all_sprites()
- Expansion: dimensions, palette mapping, transparency, 2× block uniformity
- Paper ≠ Ink; both palettes complete for all used keys
- Mapping coverage: every AgentVisualState and EnvironmentAsset resolves
- No duplicate sprite names
- CWD-independence (expansion from `/` works)

## Non-goals (per VC1 issue #1171)

- No destination redesigns (Office = VC3)
- No animation (#1065)
- No third-party assets

Refs #1171 · #1118 · DESIGN.md §0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Paper Co. pixel-art visual assets, including agent states and office environment elements.
  * Added Paper and Ink color palettes for consistent desktop visuals.
  * Added support for scaling pixel-art graphics while preserving crisp, block-based rendering.

* **Documentation**
  * Updated desktop visual guidelines to establish Paper Co. pixel art as the production visual language.
  * Clarified that motion, reduced-motion, no-fake-gamification, and plane-guard requirements remain in effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->