### PR TITLE
ci: drop the runner's third-party apt sources before apt-get update

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -853,6 +853,9 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
+          # The runner image ships third-party apt sources (Chrome, etc.) we do
+          # not use; a stale mirror there (Hash Sum mismatch) must not block us.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/microsoft-*.list
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             xorg-dev libgl1-mesa-dev libegl1-mesa-dev
@@ -882,6 +885,8 @@ jobs:
       - name: Install X11/GL + capture deps
         run: |
           set -euo pipefail
+          # same third-party-source hardening as the shell-tests job
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/microsoft-*.list
           sudo apt-get update -qq
           sudo apt-get install -y -qq --no-install-recommends \
             xorg-dev libgl1-mesa-dev libegl1-mesa-dev \


### PR DESCRIPTION
Since runner image `ubuntu24/20260907.300` the pre-installed Google Chrome apt source returns `E: Failed to fetch … Packages.gz Hash Sum mismatch`, so `apt-get update` fails in *Check V Modules (ubuntu)* and *Golden UI* in ~10s on every PR (seen twice on #1186, run 34382819060 and 34384778596). We do not use those sources; the two install steps now remove their list files first. No product code changes.