### PR TITLE
fix(terminal,harness): PTY reaping/fd hygiene, rune-safe VT wrap, owned-process harnesses

### DIFF
--- a/modules/ghostty/ghostty.v
+++ b/modules/ghostty/ghostty.v
@@ -1,5 +1,6 @@
 module ghostty
 
+import agent_toolkit_core
 import os
 
 // libghostty-vt — Ghostty VT terminal for Agent Toolkit Desktop — Dunder Mifflin Paper Company edition
@@ -274,13 +275,16 @@ fn (mut t GhosttyTerminal) push_line(s string, color int) {
 		t.lines << ''
 		t.colors << [color]
 	} else {
+		// rune-safe wrap: byte slicing can split a multi-byte UTF-8 rune
+		// (CJK, emoji). Width model is one cell per rune, matching the
+		// repo's utf8_truncate truncation approach.
+		r := s.runes()
 		mut start := 0
-		for start < s.len {
-			end := if start + c < s.len { start + c } else { s.len }
-			chunk := s[start..end]
+		for start < r.len {
+			end := if start + c < r.len { start + c } else { r.len }
+			chunk := r[start..end].string()
 			t.lines << chunk
-			mut ca := []int{len: chunk.len, init: color}
-			t.colors << ca
+			t.colors << []int{len: end - start, init: color}
 			start = end
 		}
 	}
@@ -375,11 +379,6 @@ pub fn (mut t GhosttyTerminal) scroll_by(delta int) {
 	}
 }
 
-// scroll_to_top scrolls to the top of scrollback.
-pub fn (mut t GhosttyTerminal) scroll_to_top() {
-	t.scroll = if t.lines.len < t.rows { t.lines.len } else { t.rows }
-}
-
 // scroll_to_bottom scrolls to the bottom (pinned).
 pub fn (mut t GhosttyTerminal) scroll_to_bottom() {
 	t.scroll = t.lines.len
@@ -395,33 +394,9 @@ pub fn (mut t GhosttyTerminal) page_down() {
 	t.scroll_down(t.rows)
 }
 
-// copy_all copies all scrollback lines.
-pub fn (t GhosttyTerminal) copy_all() string {
-	return t.lines.join('\n')
-}
-
 // copy_visible copies the currently visible lines.
 pub fn (t GhosttyTerminal) copy_visible() string {
 	return t.visible_lines().join('\n')
-}
-
-// copy_last copies the last n lines.
-pub fn (t GhosttyTerminal) copy_last(n int) string {
-	if n <= 0 || t.lines.len == 0 {
-		return ''
-	}
-	start := if t.lines.len - n < 0 { 0 } else { t.lines.len - n }
-	return t.lines[start..].join('\n')
-}
-
-// line_count returns the number of lines in scrollback.
-pub fn (t GhosttyTerminal) line_count() int {
-	return t.lines.len
-}
-
-// is_at_bottom returns true if the view is pinned to the bottom.
-pub fn (t GhosttyTerminal) is_at_bottom() bool {
-	return t.scroll >= t.lines.len
 }
 
 // scroll_offset returns how many lines we are scrolled from the bottom.
@@ -477,7 +452,7 @@ fn (mut t GhosttyTerminal) exec_line(line string) string {
 			return 'MCP: github healthy, slack idle, linear idle, notion idle …'
 		}
 		'version' {
-			return 'Agent Toolkit Desktop 1.28.0 (V master, build ${os.getenv('ATK_VER')})'
+			return 'Agent Toolkit Desktop ${agent_toolkit_core.resolve_toolkit_version()} (libghostty-vt ${lib_version})'
 		}
 		'echo' {
 			if parts.len > 1 {
@@ -741,15 +716,15 @@ pub fn (m GhosttyMultiplexer) copy_desk_all(idx int) string {
 	if idx < 0 || idx >= m.desks.len {
 		return ''
 	}
-	return m.desks[idx].copy_all()
+	return m.desks[idx].lines.join('\n')
 }
 
 // total_lines returns the sum of scrollback across all VTs — bounded at
 // desks×1000 + 1000, proving 60 FPS culling is honest.
 pub fn (m GhosttyMultiplexer) total_lines() int {
-	mut n := m.global.line_count()
+	mut n := m.global.lines.len
 	for d in m.desks {
-		n += d.line_count()
+		n += d.lines.len
 	}
 	return n
 }

--- a/modules/ghostty/ghostty_test.v
+++ b/modules/ghostty/ghostty_test.v
@@ -1,0 +1,153 @@
+module ghostty
+
+import agent_toolkit_core
+import os
+
+// hermetic Ghostty VT tests: pure computation, no I/O, no sleeps, no network.
+// os is used for the TMPDIR-honoring temp-dir lifecycle proof (cleanup via defer).
+
+fn clean_term(cols int, rows int) GhosttyTerminal {
+	mut t := new_terminal(cols, rows)
+	t.clear()
+	return t
+}
+
+fn test_sgr_basic_colors_30_37() {
+	mut t := clean_term(80, 18)
+	// note: feed flushes the pending line at each SGR boundary, so no
+	// trailing newline here — it would append one extra empty line.
+	t.feed('\x1b[31merr\x1b[0m')
+	assert t.lines == ['err']
+	assert t.colors.last() == [2, 2, 2]
+}
+
+fn test_sgr_full_low_palette() {
+	codes := ['30', '31', '32', '33', '34', '35', '36', '37']
+	wants := [4, 2, 3, 1, 6, 5, 6, 0]
+	for i, code in codes {
+		mut t := clean_term(80, 18)
+		t.feed('\x1b[${code}mx\x1b[0m')
+		assert t.lines == ['x'], 'SGR ${code} line'
+		assert t.colors.last() == [wants[i]], 'SGR ${code} color'
+	}
+}
+
+fn test_sgr_bright_palette_90_97() {
+	codes := ['90', '91', '92', '93', '94', '95', '96', '97']
+	wants := [4, 2, 3, 1, 6, 5, 6, 0]
+	for i, code in codes {
+		mut t := clean_term(80, 18)
+		t.feed('\x1b[${code}mx\x1b[0m')
+		assert t.lines == ['x'], 'SGR ${code} line'
+		assert t.colors.last() == [wants[i]], 'SGR ${code} color'
+	}
+}
+
+fn test_ed_2j_clears_scrollback() {
+	mut t := clean_term(80, 18)
+	t.feed('one\ntwo\n')
+	assert t.lines.len == 2
+	t.feed('\x1b[2J')
+	assert t.lines.len == 0
+	assert t.colors.len == 0
+}
+
+fn test_scrollback_caps_at_1000_lines() {
+	mut t := clean_term(80, 18)
+	for i in 0 .. 1010 {
+		t.feed('line ${i}\n')
+	}
+	assert t.lines.len == 1000
+	assert t.colors.len == 1000
+	// trim drops the oldest: first visible line is line 10
+	assert t.lines[0] == 'line 10'
+	assert t.lines.last() == 'line 1009'
+}
+
+fn test_resize_keeps_scroll_pinned_at_bottom() {
+	mut t := clean_term(80, 5)
+	for i in 0 .. 20 {
+		t.feed('line ${i}\n')
+	}
+	t.scroll_to_bottom()
+	assert t.scroll == t.lines.len
+	t.resize(100, 10)
+	assert t.scroll == t.lines.len
+}
+
+fn test_push_line_wrap_is_rune_safe() {
+	mut t := clean_term(4, 18)
+	t.feed('abcdefghij\n')
+	assert t.lines == ['abcd', 'efgh', 'ij']
+}
+
+fn test_push_line_cjk_wrap_never_splits_rune() {
+	// regression seed shared with the palette utf8_truncate test (#1168):
+	// CJK runes are 3 bytes each; byte-slicing cols=4 would split mid-rune.
+	cjk := '工作区设置向导'
+	assert cjk.len == 21 // 7 runes x 3 bytes
+	mut t := clean_term(4, 18)
+	t.feed(cjk + '\n')
+	assert t.lines.len == 2
+	assert t.lines[0] == '工作区设'
+	assert t.lines[1] == '置向导'
+	assert t.lines.join('') == cjk
+	// every wrapped chunk is valid UTF-8 with matching color cells
+	for i, ln in t.lines {
+		assert ln.runes().len <= 4
+		assert t.colors[i].len == ln.runes().len
+	}
+}
+
+fn test_push_line_emoji_wrap_never_splits_rune() {
+	// emoji are 4-byte runes: cols=2 must not split them
+	mut t := clean_term(2, 18)
+	t.feed('a👍b\n')
+	assert t.lines == ['a👍', 'b']
+	for i, ln in t.lines {
+		assert t.colors[i].len == ln.runes().len
+	}
+}
+
+fn test_scroll_to_bottom_semantics() {
+	mut t := clean_term(80, 5)
+	for i in 0 .. 20 {
+		t.feed('line ${i}\n')
+	}
+	assert t.scroll == t.lines.len
+	t.scroll_up(10)
+	assert t.scroll < t.lines.len
+	t.scroll_to_bottom()
+	assert t.scroll == t.lines.len
+	// visible window shows the last `rows` lines when pinned
+	vis := t.visible_lines()
+	assert vis.len == 5
+	assert vis.last() == 'line 19'
+	assert t.copy_visible() == vis.join('\n')
+}
+
+fn test_version_reports_core_version() {
+	mut t := clean_term(80, 18)
+	t.submit_input_void_helper('version')
+	want := 'Agent Toolkit Desktop ${agent_toolkit_core.resolve_toolkit_version()}'
+	assert t.lines.last().starts_with(want), 'got: ${t.lines.last()}'
+}
+
+// submit_input_void_helper drives the version branch without touching history
+// semantics under test elsewhere.
+fn (mut t GhosttyTerminal) submit_input_void_helper(line string) {
+	t.input = line
+	t.cursor = line.len
+	t.submit_input()
+}
+
+fn test_tmpdir_honored_for_temp_paths() {
+	base := os.temp_dir()
+	assert base.len > 0
+	dir := os.join_path(base, 'atk-ghostty-${os.getpid()}')
+	os.mkdir_all(dir) or { panic(err.msg()) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	assert os.is_dir(dir)
+}

--- a/modules/pty/pty.v
+++ b/modules/pty/pty.v
@@ -21,6 +21,8 @@ import os
 
 #include <sys/ioctl.h>
 
+#include <sys/wait.h>
+
 pub struct Winsize {
 pub:
 	ws_row    u16
@@ -50,6 +52,42 @@ fn C.read(fd int, buf voidptr, count usize) isize
 fn C.close(fd int) int
 
 fn C.kill(pid int, sig int) int
+
+fn C.waitpid(pid int, status &int, options int) int
+
+fn C.usleep(usec u32) int
+
+const sig_term = 15
+const sig_kill = 9
+// wnohang is WNOHANG: waitpid in the reap path never blocks.
+const wnohang = 1
+// kill_grace_polls × kill_grace_us bounds the SIGTERM grace period before
+// SIGKILL escalation (10 × 20ms = 200ms).
+const kill_grace_polls = 10
+const kill_grace_us = u32(20000)
+
+// child_exited — non-blocking reap check via waitpid(WNOHANG). Returns true
+// once the child is gone: reaped by this very call (zombie → reaped, never
+// reported alive) or already reaped earlier (ECHILD). Returns false while it
+// is still running. Never blocks. A pid <= 0 (zero-value Session) counts as
+// gone so kill(0, ·) process-group semantics are never reached.
+fn child_exited(pid int) bool {
+	if pid <= 0 {
+		return true
+	}
+	mut status := 0
+	res := C.waitpid(pid, &status, wnohang)
+	if res == pid {
+		return true
+	}
+	if res == 0 {
+		return false
+	}
+	// res < 0: ECHILD (already reaped) or a transient error. Confirm with
+	// kill 0 so a transient failure on a live child is not misread as dead
+	// (a zombie still owns its pid entry, so kill 0 succeeds on zombies).
+	return C.kill(pid, 0) != 0
+}
 
 fn C.ioctl(fd i32, request u64, args ...voidptr) i32
 
@@ -153,7 +191,13 @@ pub fn spawn(agent string, binary string, args []string, cols int, rows int) !Se
 
 // drain — reads all currently pending output (non-blocking), returns it as
 // a string for GhosttyTerminal.feed(). Empty string = nothing pending.
+// Reaps an exited child first (never blocks) and is a safe no-op once the
+// fd is closed (fd parked at -1 by kill).
 pub fn (mut s Session) drain() string {
+	if s.fd < 0 {
+		return ''
+	}
+	child_exited(s.pid)
 	mut out := []u8{}
 	mut buf := [8192]u8{}
 	for {
@@ -173,7 +217,8 @@ pub fn (mut s Session) drain() string {
 	return out.bytestr()
 }
 
-// write — send input bytes to the agent (keyboard path).
+// write — send input bytes to the agent (keyboard path). Documented no-op
+// on a closed (or never-opened) fd and on empty input — never crashes.
 pub fn (mut s Session) write(data string) {
 	if s.fd <= 0 || data.len == 0 {
 		return
@@ -181,8 +226,12 @@ pub fn (mut s Session) write(data string) {
 	C.write(s.fd, data.str, data.len)
 }
 
-// resize — TIOCSWINSZ on the master fd.
+// resize — TIOCSWINSZ on the master fd. Documented no-op once the fd is
+// closed (fd parked at -1 by kill) — never crashes.
 pub fn (mut s Session) resize(cols int, rows int) {
+	if s.fd < 0 {
+		return
+	}
 	ws := Winsize{
 		ws_row: u16(rows)
 		ws_col: u16(cols)
@@ -191,13 +240,43 @@ pub fn (mut s Session) resize(cols int, rows int) {
 	C.ioctl(s.fd, 0x5414, &ws)
 }
 
-// alive — false when the child exited (poll via kill 0).
+// alive — false once the child exited. waitpid(WNOHANG)-based: unlike the
+// old kill(pid, 0) probe this reaps zombies instead of reporting them
+// alive. Never blocks. A zero-value Session (pid <= 0) is never alive.
 pub fn (s Session) alive() bool {
-	return C.kill(s.pid, 0) == 0
+	return !child_exited(s.pid)
 }
 
-// kill — SIGTERM the child; caller closes fd afterwards.
+// close_fd closes the master fd exactly once and parks it at -1, so a
+// second kill can neither double-close nor close a recycled fd.
+fn (mut s Session) close_fd() {
+	if s.fd >= 0 {
+		C.close(s.fd)
+		s.fd = -1
+	}
+}
+
+// kill — SIGTERM the child, escalate to SIGKILL after a short grace
+// (kill_grace_polls × kill_grace_us), reap without blocking, then close the
+// master fd exactly once (fd parked at -1, close semantics kept). Safe to
+// call twice and safe on an already-closed or zero-value session: signals
+// are only sent to a child that waitpid still reports running, so an
+// already-reaped (possibly recycled) pid is never signalled.
 pub fn (mut s Session) kill() {
-	C.kill(s.pid, 15)
-	C.close(s.fd)
+	if s.pid > 0 && !child_exited(s.pid) {
+		C.kill(s.pid, sig_term)
+		for _ in 0 .. kill_grace_polls {
+			C.usleep(kill_grace_us)
+			if child_exited(s.pid) {
+				break
+			}
+		}
+		if !child_exited(s.pid) {
+			C.kill(s.pid, sig_kill)
+		}
+		// final non-blocking reap attempt; a slow-dying child is reaped
+		// by the next alive()/drain() poll instead
+		child_exited(s.pid)
+	}
+	s.close_fd()
 }

--- a/modules/pty/pty_test.v
+++ b/modules/pty/pty_test.v
@@ -1,0 +1,95 @@
+module pty
+
+import time
+
+// Hermetic PTY lifecycle tests: only /bin/true and /bin/sleep (absolute
+// paths, no PATH dependence), no network, no fixed ports, no temp files
+// ($TMPDIR honored vacuously — nothing is written to disk). Every spawned
+// session is reaped via cleanup with defer.
+
+// waitpid mirror for the no-zombie proofs below. pty.v declares the same
+// prototype for the reap path; the duplicate identical prototype is legal C.
+fn C.waitpid(pid int, status &int, options int) int
+
+// wnohang_test is WNOHANG (Linux value 1): never block in waitpid.
+const wnohang_test = 1
+
+fn poll_exit(mut s Session, tries int) bool {
+	for _ in 0 .. tries {
+		if !s.alive() {
+			return true
+		}
+		time.sleep(20 * time.millisecond)
+	}
+	return false
+}
+
+fn test_true_exit_detected_and_reaped() {
+	mut s := spawn('test', '/bin/true', [], 80, 24) or { panic(err.msg()) }
+	defer {
+		s.kill()
+	}
+	pid := s.pid
+	assert pid > 0
+	assert poll_exit(mut s, 100), '/bin/true exit not detected promptly'
+	// no zombie left: the aliveness path reaps via waitpid(WNOHANG), so a
+	// further waitpid must report ECHILD (-1) — never the pid again.
+	mut st := 0
+	mut gone := false
+	for _ in 0 .. 50 {
+		if C.waitpid(pid, &st, wnohang_test) == -1 {
+			gone = true
+			break
+		}
+		time.sleep(20 * time.millisecond)
+	}
+	assert gone, 'zombie left behind for pid ${pid}'
+}
+
+fn test_sleep_kill_escalation_reaps() {
+	mut s := spawn('test', '/bin/sleep', ['30'], 80, 24) or { panic(err.msg()) }
+	defer {
+		s.kill()
+	}
+	assert s.alive(), '/bin/sleep should be running'
+	s.kill()
+	assert poll_exit(mut s, 100), 'SIGTERM-then-SIGKILL did not stop /bin/sleep'
+	mut st := 0
+	assert C.waitpid(s.pid, &st, wnohang_test) == -1, 'zombie left behind after kill'
+}
+
+fn test_double_kill_is_safe() {
+	mut s := spawn('test', '/bin/sleep', ['30'], 80, 24) or { panic(err.msg()) }
+	defer {
+		s.kill()
+	}
+	s.kill()
+	first_fd := s.fd
+	s.kill() // must not crash and must not double-close
+	assert first_fd == -1, 'kill must park the fd at -1'
+	assert s.fd == -1
+	assert !s.alive()
+	// drain after close is a safe no-op, not a crash
+	assert s.drain() == ''
+}
+
+fn test_drain_after_exit_and_closed_fd_ops_safe() {
+	mut s := spawn('test', '/bin/true', [], 80, 24) or { panic(err.msg()) }
+	defer {
+		s.kill()
+	}
+	assert poll_exit(mut s, 100), '/bin/true exit not detected promptly'
+	s.kill()
+	// drain-after-exit and drain-after-close: safe, repeatable
+	_ = s.drain()
+	assert s.drain() == ''
+	// write/resize on the closed fd: documented no-ops, never a crash
+	s.write('echo hi\n')
+	s.resize(80, 24)
+	assert s.fd == -1
+}
+
+fn test_zero_session_is_not_alive() {
+	s := Session{}
+	assert !s.alive(), 'zero-value Session must never report alive'
+}

--- a/scripts/clean-machine-acceptance.sh
+++ b/scripts/clean-machine-acceptance.sh
@@ -42,7 +42,21 @@ COMMIT="$(git -c safe.directory='*' -C "$(dirname "$0")/.." rev-parse --short HE
 echo "provenance: artifact=$ART_NAME sha256=$ART_SHA size=$ART_SIZE version=$VERSION commit=$COMMIT"
 
 # ── neutral prefix: the ONLY place the artifact lives for validation ──────
-PREFIX="$(mktemp -d /tmp/atk-clean-XXXXXX)"
+PREFIX="$(mktemp -d "${TMPDIR:-/tmp}/atk-clean-XXXXXX")"
+# trap cleanup (first-run pattern): prefix/Xvfb/app are always released,
+# even on an early fail — evidence copies to EVIDENCE_DIR happen mid-run.
+APP_PID=0
+XVFB_PID=0
+cleanup_acceptance() {
+  for p in "$APP_PID" "$XVFB_PID"; do
+    if [ "$p" != 0 ]; then kill "$p" 2>/dev/null || true; fi
+  done
+  for p in "$APP_PID" "$XVFB_PID"; do
+    if [ "$p" != 0 ]; then wait "$p" 2>/dev/null || true; fi
+  done
+  rm -rf "$PREFIX"
+}
+trap cleanup_acceptance EXIT
 # EVIDENCE_DIR: when set (CI), durable copies of captures/evidence land here
 # BEFORE the prefix trap cleans up (#1130 harness contract).
 EVIDENCE_DIR="${EVIDENCE_DIR:-}"
@@ -137,8 +151,15 @@ if command -v Xvfb >/dev/null 2>&1 && command -v import >/dev/null 2>&1; then
   # fixed display: xvfb-run -a would pick one our capture cannot know
   Xvfb :98 -screen 0 1280x800x24 &
   XVFB_PID=$!
-  sleep 2
-  env DISPLAY=:98 PATH=/usr/bin:/bin HOME="$CLEAN_HOME" \
+  # Xvfb readiness probe (poll the X socket like the other harnesses probe
+  # the server — never a bare sleep before launching the app)
+  xready=0
+  for _ in $(seq 1 20); do
+    if [ -S /tmp/.X11-unix/X98 ]; then xready=1; break; fi
+    sleep 0.5
+  done
+  [ "$xready" = 1 ] || fail "Xvfb :98 did not become ready"
+  env DISPLAY=:98 PATH=/usr/bin:/bin HOME="$CLEAN_HOME" LANG=C.UTF-8 \
     XDG_DATA_HOME="$CLEAN_DATA" XDG_CONFIG_HOME="$CLEAN_CONFIG" \
     "$INSTALLED_BIN" &
   APP_PID=$!

--- a/scripts/first-run-acceptance.sh
+++ b/scripts/first-run-acceptance.sh
@@ -14,6 +14,9 @@
 #
 # States are explicit per check (PASS/FAIL/NOT_PROVEN/MANUAL); captures
 # are staged into EVIDENCE_DIR for human inspection — never hash-approved.
+#
+# Display: fixed (default :99, ATK_FIRST_RUN_DISPLAY to override) guarded by
+# a shared lock file, so local parallel runs fail loudly instead of colliding.
 set -euo pipefail
 
 ARCHIVE="${1:?usage: first-run-acceptance.sh <desktop-archive.tar.gz>}"
@@ -31,10 +34,27 @@ ART_SHA="$(sha256sum "$ARCHIVE" | cut -d' ' -f1)"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 echo "provenance: artifact=$ART_NAME sha256=$ART_SHA"
 
-PREFIX="$(mktemp -d /tmp/atk-firstrun-XXXXXX)"
+PREFIX="$(mktemp -d "${TMPDIR:-/tmp}/atk-firstrun-XXXXXX")"
 EVIDENCE="${EVIDENCE_DIR:-$PREFIX/evidence}"
 mkdir -p "$EVIDENCE"
-trap 'rm -rf "$PREFIX"' EXIT
+# shared display lock: parallel local runs must fail loudly, never collide
+DISP="${ATK_FIRST_RUN_DISPLAY:-:99}"
+DISPNUM="${DISP#:}"
+LOCK=""
+trap 'rm -rf "$PREFIX"; if [ -n "$LOCK" ]; then rm -rf "$LOCK"; fi' EXIT
+LOCK_CANDIDATE="${TMPDIR:-/tmp}/atk-acceptance-X${DISPNUM}.lock"
+if ! mkdir "$LOCK_CANDIDATE" 2>/dev/null; then
+  lock_owner="$(cat "$LOCK_CANDIDATE/pid" 2>/dev/null || echo unknown)"
+  if [ "$lock_owner" != unknown ] && ! kill -0 "$lock_owner" 2>/dev/null; then
+    echo "warning: stealing stale acceptance lock $LOCK_CANDIDATE (owner $lock_owner dead)" >&2
+    rm -rf "$LOCK_CANDIDATE"
+    mkdir "$LOCK_CANDIDATE" || fail "cannot take display lock $LOCK_CANDIDATE"
+  else
+    fail "display $DISP is locked by another acceptance run (owner pid $lock_owner)"
+  fi
+fi
+LOCK="$LOCK_CANDIDATE"
+echo "$$" >"$LOCK/pid"
 
 # ── install via the real bundle script (#1130 chain) ───────────────────────
 STAGE="$PREFIX/stage"
@@ -51,18 +71,18 @@ record "artifact-install" "PASS" "receipt-backed install from $ART_NAME"
 
 launch() { # $1 home  $2 extra PATH prefix (fixture)  → sets APP_PID, WIN_ID
   local home="$1" pathfix="${2:-}"
-  Xvfb :99 -screen 0 1280x800x24 &
+  Xvfb "$DISP" -screen 0 1280x800x24 &
   XVFB_PID=$!
   sleep 1
   # a bare Xvfb has no WM → no window ever has input focus → XTEST keys
   # would go nowhere. openbox gives the journey real focus semantics.
-  DISPLAY=:99 openbox &
+  DISPLAY="$DISP" openbox &
   OB_PID=$!
   sleep 1
   # env -i: NO CI environment leakage — the app sees exactly the clean
   # launcher-like environment (a leaked XDG_CACHE_HOME would send engine
   # state outside the clean HOME and silently break the acceptance)
-  env -i DISPLAY=:99 PATH="${pathfix:+$pathfix:}/usr/bin:/bin" \
+  env -i DISPLAY="$DISP" PATH="${pathfix:+$pathfix:}/usr/bin:/bin" \
     HOME="$home" LANG=C.UTF-8 \
     XDG_DATA_HOME="$home/.local/share" XDG_CONFIG_HOME="$home/.config" \
     XDG_CACHE_HOME="$home/.cache" \
@@ -70,18 +90,18 @@ launch() { # $1 home  $2 extra PATH prefix (fixture)  → sets APP_PID, WIN_ID
   APP_PID=$!
   for _ in $(seq 1 30); do
     sleep 1
-    WIN_ID="$(DISPLAY=:99 xdotool search --onlyvisible --name 'Agent Toolkit' 2>/dev/null | head -1 || true)"
+    WIN_ID="$(DISPLAY="$DISP" xdotool search --onlyvisible --name 'Agent Toolkit' 2>/dev/null | head -1 || true)"
     [ -n "$WIN_ID" ] && break
   done
   [ -n "$WIN_ID" ] || fail "app window never appeared"
-  DISPLAY=:99 xdotool windowactivate --sync "$WIN_ID" 2>/dev/null || true
-  DISPLAY=:99 xdotool windowfocus "$WIN_ID" 2>/dev/null || true
+  DISPLAY="$DISP" xdotool windowactivate --sync "$WIN_ID" 2>/dev/null || true
+  DISPLAY="$DISP" xdotool windowfocus "$WIN_ID" 2>/dev/null || true
   sleep 1
   local focused
-  focused="$(DISPLAY=:99 xdotool getwindowfocus 2>/dev/null || true)"
+  focused="$(DISPLAY="$DISP" xdotool getwindowfocus 2>/dev/null || true)"
   if [ "$focused" != "$WIN_ID" ]; then
     echo "focus probe: focused=$focused want=$WIN_ID — retrying windowfocus" >&2
-    DISPLAY=:99 xdotool windowfocus "$WIN_ID" || true
+    DISPLAY="$DISP" xdotool windowfocus "$WIN_ID" || true
     sleep 1
   fi
 }
@@ -94,13 +114,15 @@ kill_session() {
   wait $XVFB_PID 2>/dev/null || true
 }
 
-journey_key() { DISPLAY=:99 xdotool key --window "$WIN_ID" "$1" 2>/dev/null || DISPLAY=:99 xdotool key "$1"; sleep 1; }
+journey_key() { DISPLAY="$DISP" xdotool key --window "$WIN_ID" "$1" 2>/dev/null || DISPLAY="$DISP" xdotool key "$1"; sleep 1; }
 # Enter actions are retried once: every step action is idempotent (bulk
 # installs are set-semantics, personas skip existing, workspace mkdir_all,
 # targets set-true), and a Return swallowed while a transaction commits
 # would otherwise leave the journey silently incomplete.
 journey_enter() { journey_key Return; sleep 0.8; journey_key Return; sleep 1; }
-shot() { DISPLAY=:99 import -window root "$EVIDENCE/$1" 2>/dev/null || true; }
+# shot captures NAMED evidence: a failed capture fails the run loudly
+# (missing evidence must never pass silently as an empty check).
+shot() { DISPLAY="$DISP" import -window root "$EVIDENCE/$1" 2>/dev/null || fail "evidence capture failed: $1"; }
 
 assert_state() { # $1 python-expr over the engine state json  $2 label
   python3 -c "
@@ -155,7 +177,7 @@ shot journey-final.png
 echo "journey diagnostics:" >&2
 find "$HOME_FRESH" -name '*.json' | head -5 >&2 || true
 find "$HOME_FRESH/knowledge" 2>/dev/null | head -3 >&2 || true
-DISPLAY=:99 xdotool getactivewindowname 2>/dev/null >&2 || true
+DISPLAY="$DISP" xdotool getactivewindowname 2>/dev/null >&2 || true
 
 STATE_FILE="$HOME_FRESH/.cache/agent-toolkit/desktop/engine_state.json"
 sleep 1
@@ -191,7 +213,6 @@ print('recent_workspace:', repr(r.get('recent_workspace')))
 " >&2 || true
   fail "personas not bootstrapped under ~/.ai-workspace"
 fi
-record "personas" "PASS" "personas bootstrapped under ~/.ai-workspace"
 record "personas" "PASS" "personas bootstrapped under ~/.ai-workspace"
 
 # restart — hard gate: wizard must NOT reappear, state preserved

--- a/scripts/golden.sh
+++ b/scripts/golden.sh
@@ -16,6 +16,13 @@
 #   ATK_GOLDEN_THEME=ink ./scripts/golden.sh capture|compare  # Ink fixtures
 # Requires: Xvfb/xdotool (see scripts/ui-smoke.sh), ImageMagick, built binary.
 #
+# Display constraint: captures run on a FIXED display (default :77,
+# GOLDEN_DISPLAY to override) because the window id is captured per run.
+# A lock file guards it so two local runs fail loudly instead of colliding.
+# The app runs under a temp HOME/XDG — real ~/.cache prefs are never read
+# or written. Temp paths honor $TMPDIR. System Xvfb/xdotool are preferred;
+# /tmp/opencode/xtools fallbacks stay (CI may rely on them).
+#
 # Fixture update policy (#1111): intentional visual changes re-capture with
 # capture (both themes) and include the RMSE summary in the PR description.
 # Never hand-edit a fixture; compare passing on the old set is the no-drift
@@ -44,39 +51,75 @@ if ! command -v "$XVFB" >/dev/null 2>&1 && [ -x /tmp/opencode/xtools/usr/bin/Xvf
 fi
 # timeout guards: a degraded Xvfb hangs xdotool/import forever — fail fast
 # instead (#1111; observed on a long-lived :77 server)
-xdt() { DISPLAY="${GOLDEN_DISPLAY:-:77}" LD_LIBRARY_PATH="$XLIB" timeout 30 "$XD" "$@"; }
-shot() { sleep 1.2; DISPLAY="${GOLDEN_DISPLAY:-:77}" timeout 60 import -window "$WID" "$1"; }
+EFFDIS="${GOLDEN_DISPLAY:-:77}"
+EFFNUM="${EFFDIS#:}"
+xdt() { DISPLAY="$EFFDIS" LD_LIBRARY_PATH="$XLIB" timeout 30 "$XD" "$@"; }
+shot() { sleep 1.2; DISPLAY="$EFFDIS" timeout 60 import -window "$WID" "$1"; }
 
 [ -x "$BIN" ] || { echo "error: build the desktop binary first" >&2; exit 2; }
 mkdir -p "$GOLD"
 
-# virtual display + app (Wayland forced off — sokol prefers it when present)
-pkill -f 'agent-toolkit-desktop-native' 2>/dev/null || true
+# fixed-display lock: only processes owned by this run are ever signalled
+LOCK="${TMPDIR:-/tmp}/atk-golden-X${EFFNUM}.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+	owner="$(cat "$LOCK/pid" 2>/dev/null || echo unknown)"
+	if [ "$owner" != unknown ] && ! kill -0 "$owner" 2>/dev/null; then
+		echo "warning: stealing stale golden lock $LOCK (owner $owner dead)" >&2
+		rm -rf "$LOCK"
+		mkdir "$LOCK" || { echo "error: cannot take golden lock $LOCK" >&2; exit 2; }
+	else
+		echo "error: display $EFFDIS is locked by another golden run (owner pid $owner)" >&2
+		exit 2
+	fi
+fi
+echo "$$" >"$LOCK/pid"
+
+# temp HOME/XDG: the app must never read or write real user prefs
+GOLDEN_HOME="$(mktemp -d "${TMPDIR:-/tmp}/atk-golden-home-XXXXXX")"
+export HOME="$GOLDEN_HOME"
+export XDG_CACHE_HOME="$GOLDEN_HOME/.cache"
+export XDG_CONFIG_HOME="$GOLDEN_HOME/.config"
+export XDG_DATA_HOME="$GOLDEN_HOME/.local/share"
+
+XVFB_PID=0
+APP_PID=0
+cleanup_golden() {
+	if [ "$APP_PID" != 0 ]; then kill "$APP_PID" 2>/dev/null || true; fi
+	if [ "$XVFB_PID" != 0 ]; then kill "$XVFB_PID" 2>/dev/null || true; fi
+	if [ "$APP_PID" != 0 ]; then wait "$APP_PID" 2>/dev/null || true; fi
+	if [ "$XVFB_PID" != 0 ]; then wait "$XVFB_PID" 2>/dev/null || true; fi
+	rm -rf "$GOLDEN_HOME" "$LOCK"
+}
+trap cleanup_golden EXIT
+
+# virtual display + app (Wayland forced off — sokol prefers it when present).
 # Xvfb servers degrade after many client cycles — always start a fresh one
-pkill -x Xvfb 2>/dev/null || true
+# owned by this run (PID-scoped kills only, never pkill).
 sleep 0.5
-rm -f /tmp/.X11-unix/X77
-/usr/bin/env "$XVFB" :77 -screen 0 1280x800x24 -nolisten tcp >/tmp/atk-golden-xvfb.log 2>&1 &
+rm -f "/tmp/.X11-unix/X${EFFNUM}"
+/usr/bin/env "$XVFB" "$EFFDIS" -screen 0 1280x800x24 -nolisten tcp >"${TMPDIR:-/tmp}/atk-golden-xvfb.log" 2>&1 &
+XVFB_PID=$!
 sleep 1.5
 xprobe_ok=0
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-	if timeout 5 env DISPLAY=:77 LD_LIBRARY_PATH="$XLIB" "$XD" getdisplaygeometry >/dev/null 2>&1; then
+	if timeout 5 env DISPLAY="$EFFDIS" LD_LIBRARY_PATH="$XLIB" "$XD" getdisplaygeometry >/dev/null 2>&1; then
 		xprobe_ok=1
 		break
 	fi
 	sleep 1
 done
 [ "$xprobe_ok" = "1" ] || {
-	echo "error: Xvfb :77 not responding" >&2
+	echo "error: Xvfb $EFFDIS not responding" >&2
 	exit 2
 }
-rm -f "$HOME/.cache/agent-toolkit/desktop/ui_state.env"
+# Paper determinism: temp HOME starts clean, so no ui_state.env exists yet.
 if [ "${ATK_GOLDEN_THEME:-paper}" = "ink" ]; then
-	# seed Ink appearance (deleted above for Paper determinism)
+	# seed Ink appearance under the TEMP home only
 	mkdir -p "$HOME/.cache/agent-toolkit/desktop"
 	printf 'appearance=ink\n' >"$HOME/.cache/agent-toolkit/desktop/ui_state.env"
 fi
-(env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET ATK_GUI_FREEZE=1 ATK_GOLDEN_TERMINAL=1 DISPLAY=:77 "$BIN" >"$ROOT/tests/golden-app.log" 2>&1 &)
+env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET ATK_GUI_FREEZE=1 ATK_GOLDEN_TERMINAL=1 DISPLAY="$EFFDIS" "$BIN" >"$ROOT/tests/golden-app.log" 2>&1 &
+APP_PID=$!
 # software GL (llvmpipe) needs longer than 3s for the first frame — poll
 WID=""
 for _ in $(seq 1 45); do
@@ -133,7 +176,7 @@ for k in 1 2 3 4 5 6 7 8 9 0 p i o; do
 	fi
 done
 
-pkill -f 'agent-toolkit-desktop-native' 2>/dev/null || true
+# owned processes die via the EXIT trap (PID-scoped, never pkill)
 if [ "$MODE" = "compare" ]; then
 	[ "$fail" = "0" ] && echo "GOLDEN PASS" || { echo "GOLDEN FAIL"; exit 1; }
 else

--- a/scripts/ui-smoke.sh
+++ b/scripts/ui-smoke.sh
@@ -10,11 +10,18 @@
 #
 # Requirements: Xvfb + xdotool + ImageMagick `import` (paths auto-probed).
 # Usage: ./scripts/ui-smoke.sh  [SMOKE_BIN=...] [SMOKE_OUT=/tmp/...]
+#
+# Display constraint: the smoke runs on a FIXED display (default :99,
+# SMOKE_DISPLAY to override) because tour coordinates are display-bound.
+# A lock file guards it so two local runs fail loudly instead of colliding.
+# The app runs under a temp HOME/XDG — real ~/.cache prefs are never read
+# or written. Temp paths honor $TMPDIR. System Xvfb/xdotool are preferred;
+# /tmp/opencode/xtools fallbacks stay (CI may rely on them).
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="${SMOKE_BIN:-$ROOT/build/agent-toolkit-desktop-native}"
-OUT="${SMOKE_OUT:-/tmp/atk-ui-smoke}"
+OUT="${SMOKE_OUT:-${TMPDIR:-/tmp}/atk-ui-smoke}"
 XD="${XDOTOOL:-xdotool}"
 # preserve a caller-provided LD_LIBRARY_PATH (user-space Xvfb/xdotool installs
 # whose libs are not on the system loader path); default empty as before
@@ -23,20 +30,60 @@ if ! command -v "$XD" >/dev/null && [ -x /tmp/opencode/xtools/usr/bin/xdotool ];
 	XD=/tmp/opencode/xtools/usr/bin/xdotool
 	XLIB=/tmp/opencode/xtools/usr/lib
 fi
-xdt() { LD_LIBRARY_PATH="$XLIB" "$XD" "$@" 2>/dev/null || true; }
+# system Xvfb first, user-space fallback second (never drop the fallback)
+XVFB="${XVFB:-Xvfb}"
+if ! command -v "$XVFB" >/dev/null 2>&1 && [ -x /tmp/opencode/xtools/usr/bin/Xvfb ]; then
+	XVFB=/tmp/opencode/xtools/usr/bin/Xvfb
+fi
+EFFDIS="${SMOKE_DISPLAY:-:99}"
+EFFNUM="${EFFDIS#:}"
+xdt() { DISPLAY="$EFFDIS" LD_LIBRARY_PATH="$XLIB" "$XD" "$@" 2>/dev/null || true; }
 key() { xdt key "$@"; }
 clk() { xdt mousemove "$1" "$2" click 1; }
 
 mkdir -p "$OUT"
 
-# fresh Xvfb every run (servers degrade after many client cycles)
-pkill -f agent-toolkit-desktop-native 2>/dev/null || true
-pkill -x Xvfb 2>/dev/null || true
+# fixed-display lock: only processes owned by this run are ever signalled
+LOCK="${TMPDIR:-/tmp}/atk-uismoke-X${EFFNUM}.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+	owner="$(cat "$LOCK/pid" 2>/dev/null || echo unknown)"
+	if [ "$owner" != unknown ] && ! kill -0 "$owner" 2>/dev/null; then
+		echo "warning: stealing stale ui-smoke lock $LOCK (owner $owner dead)" >&2
+		rm -rf "$LOCK"
+		mkdir "$LOCK" || { echo "error: cannot take ui-smoke lock $LOCK" >&2; exit 2; }
+	else
+		echo "error: display $EFFDIS is locked by another ui-smoke run (owner pid $owner)" >&2
+		exit 2
+	fi
+fi
+echo "$$" >"$LOCK/pid"
+
+# temp HOME/XDG: the app must never read or write real user prefs
+SMOKE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/atk-uismoke-home-XXXXXX")"
+export HOME="$SMOKE_HOME"
+export XDG_CACHE_HOME="$SMOKE_HOME/.cache"
+export XDG_CONFIG_HOME="$SMOKE_HOME/.config"
+export XDG_DATA_HOME="$SMOKE_HOME/.local/share"
+
+XVFB_PID=0
+APP_PID=0
+cleanup_uismoke() {
+	if [ "$APP_PID" != 0 ]; then kill "$APP_PID" 2>/dev/null || true; fi
+	if [ "$XVFB_PID" != 0 ]; then kill "$XVFB_PID" 2>/dev/null || true; fi
+	if [ "$APP_PID" != 0 ]; then wait "$APP_PID" 2>/dev/null || true; fi
+	if [ "$XVFB_PID" != 0 ]; then wait "$XVFB_PID" 2>/dev/null || true; fi
+	rm -rf "$SMOKE_HOME" "$LOCK"
+}
+trap cleanup_uismoke EXIT
+
+# fresh Xvfb every run (servers degrade after many client cycles),
+# owned by this run (PID-scoped kills only, never pkill)
 sleep 0.5
-rm -f /tmp/.X11-unix/X99 "$HOME/.cache/agent-toolkit/desktop/ui_state.env"
-/tmp/opencode/xtools/usr/bin/Xvfb :99 -screen 0 1280x800x24 -nolisten tcp >/tmp/atk-xvfb.log 2>&1 &
+rm -f "/tmp/.X11-unix/X${EFFNUM}"
+/usr/bin/env "$XVFB" "$EFFDIS" -screen 0 1280x800x24 -nolisten tcp >"${TMPDIR:-/tmp}/atk-xvfb.log" 2>&1 &
+XVFB_PID=$!
 sleep 2
-export DISPLAY="${SMOKE_DISPLAY:-:99}"
+export DISPLAY="$EFFDIS"
 up=0
 for _ in 1 2 3 4 5 6 7 8 9 10; do
 	if xdt getdisplaygeometry >/dev/null 2>&1; then
@@ -47,8 +94,10 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
 done
 [ "$up" = "1" ] || { echo "SMOKE FAIL: Xvfb not responding"; exit 1; }
 
-# boot the app — Wayland forced off (sokol prefers it when present)
-(env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET DISPLAY="$DISPLAY" "$BIN" >"$OUT/app.log" 2>&1 &)
+# boot the app — Wayland forced off (sokol prefers it when present).
+# Direct background (no subshell) so APP_PID is the owned app process.
+env -u WAYLAND_DISPLAY -u WAYLAND_SOCKET DISPLAY="$DISPLAY" "$BIN" >"$OUT/app.log" 2>&1 &
+APP_PID=$!
 # software GL (llvmpipe) needs longer than 3s for the first frame — poll
 WID=""
 for _ in $(seq 1 45); do
@@ -71,7 +120,8 @@ shot() {
 	exit 1
 }
 alive() {
-	pgrep -f 'agent-toolkit-desktop-native' >/dev/null 2>&1
+	# PID-scoped: only the app process owned by this run counts
+	[ "$APP_PID" != 0 ] && kill -0 "$APP_PID" 2>/dev/null
 }
 
 # panel tour — numeric shortcuts cover every panel; onboarding via o

--- a/scripts/workspace-lifecycle-acceptance.sh
+++ b/scripts/workspace-lifecycle-acceptance.sh
@@ -16,6 +16,10 @@
 #
 # Provenance gate inherited: the app runs from the installed path under a
 # clean HOME/XDG with no repo in PATH.
+#
+# Display: fixed (default :99, ATK_WSLC_DISPLAY to override) guarded by the
+# shared acceptance lock file, so local parallel runs fail loudly instead
+# of colliding (see scripts/first-run-acceptance.sh).
 set -euo pipefail
 
 ARCHIVE="${1:?usage: workspace-lifecycle-acceptance.sh <desktop-archive.tar.gz>}"
@@ -29,10 +33,27 @@ ART_NAME="$(basename "$ARCHIVE")"
 ART_SHA="$(sha256sum "$ARCHIVE" | cut -d' ' -f1)"
 echo "provenance: artifact=$ART_NAME sha256=$ART_SHA"
 
-PREFIX="$(mktemp -d /tmp/atk-wslc-XXXXXX)"
+PREFIX="$(mktemp -d "${TMPDIR:-/tmp}/atk-wslc-XXXXXX")"
 EVIDENCE="${EVIDENCE_DIR:-$PREFIX/evidence}"
 mkdir -p "$EVIDENCE"
-trap 'rm -rf "$PREFIX"' EXIT
+# shared display lock: parallel local runs must fail loudly, never collide
+DISP="${ATK_WSLC_DISPLAY:-:99}"
+DISPNUM="${DISP#:}"
+LOCK=""
+trap 'rm -rf "$PREFIX"; if [ -n "$LOCK" ]; then rm -rf "$LOCK"; fi' EXIT
+LOCK_CANDIDATE="${TMPDIR:-/tmp}/atk-acceptance-X${DISPNUM}.lock"
+if ! mkdir "$LOCK_CANDIDATE" 2>/dev/null; then
+  lock_owner="$(cat "$LOCK_CANDIDATE/pid" 2>/dev/null || echo unknown)"
+  if [ "$lock_owner" != unknown ] && ! kill -0 "$lock_owner" 2>/dev/null; then
+    echo "warning: stealing stale acceptance lock $LOCK_CANDIDATE (owner $lock_owner dead)" >&2
+    rm -rf "$LOCK_CANDIDATE"
+    mkdir "$LOCK_CANDIDATE" || fail "cannot take display lock $LOCK_CANDIDATE"
+  else
+    fail "display $DISP is locked by another acceptance run (owner pid $lock_owner)"
+  fi
+fi
+LOCK="$LOCK_CANDIDATE"
+echo "$$" >"$LOCK/pid"
 
 STAGE="$PREFIX/stage"
 mkdir -p "$STAGE"
@@ -62,13 +83,13 @@ VALIDATE_X=$((SWITCH_X - 6 - 68))
 
 launch() { # $1 home  $2 extra PATH prefix
   local home="$1" pathfix="${2:-}"
-  Xvfb :99 -screen 0 1280x800x24 &
+  Xvfb "$DISP" -screen 0 1280x800x24 &
   XVFB_PID=$!
   sleep 1
-  DISPLAY=:99 openbox &
+  DISPLAY="$DISP" openbox &
   OB_PID=$!
   sleep 1
-  env -i DISPLAY=:99 PATH="${pathfix:+$pathfix:}/usr/bin:/bin" \
+  env -i DISPLAY="$DISP" PATH="${pathfix:+$pathfix:}/usr/bin:/bin" \
     HOME="$home" LANG=C.UTF-8 \
     XDG_DATA_HOME="$home/.local/share" XDG_CONFIG_HOME="$home/.config" \
     XDG_CACHE_HOME="$home/.cache" \
@@ -76,12 +97,12 @@ launch() { # $1 home  $2 extra PATH prefix
   APP_PID=$!
   for _ in $(seq 1 30); do
     sleep 1
-    WIN_ID="$(DISPLAY=:99 xdotool search --onlyvisible --name 'Agent Toolkit' 2>/dev/null | head -1 || true)"
+    WIN_ID="$(DISPLAY="$DISP" xdotool search --onlyvisible --name 'Agent Toolkit' 2>/dev/null | head -1 || true)"
     [ -n "$WIN_ID" ] && break
   done
   [ -n "$WIN_ID" ] || fail "app window never appeared"
-  DISPLAY=:99 xdotool windowactivate --sync "$WIN_ID" 2>/dev/null || true
-  DISPLAY=:99 xdotool windowfocus "$WIN_ID" 2>/dev/null || true
+  DISPLAY="$DISP" xdotool windowactivate --sync "$WIN_ID" 2>/dev/null || true
+  DISPLAY="$DISP" xdotool windowfocus "$WIN_ID" 2>/dev/null || true
   sleep 1
 }
 
@@ -94,27 +115,29 @@ kill_session() {
   wait $XVFB_PID 2>/dev/null || true
 }
 
-shot() { DISPLAY=:99 import -window root "$EVIDENCE/$1" 2>/dev/null || true; }
+# shot captures NAMED evidence: a failed capture fails the run loudly
+# (missing evidence must never pass silently as an empty check).
+shot() { DISPLAY="$DISP" import -window root "$EVIDENCE/$1" 2>/dev/null || fail "evidence capture failed: $1"; }
 # click uses WINDOW-RELATIVE coords: openbox frames/places the window, so
 # screen-absolute mousemove would miss. Geometry is probed per click.
 click() { # $1 window-x  $2 window-y
   # --window: xdotool resolves the position against the app window itself,
   # immune to WM frame/placement offsets
-  DISPLAY=:99 xdotool mousemove --window "$WIN_ID" --sync "$1" "$2"
-  DISPLAY=:99 xdotool click 1
+  DISPLAY="$DISP" xdotool mousemove --window "$WIN_ID" --sync "$1" "$2"
+  DISPLAY="$DISP" xdotool click 1
   sleep 0.6
 }
 
 click() { # $1 window-x  $2 window-y
   # --window: xdotool resolves the position against the app window itself,
   # immune to WM frame/placement offsets
-  DISPLAY=:99 xdotool mousemove --window "$WIN_ID" --sync "$1" "$2"
-  DISPLAY=:99 xdotool click 1
+  DISPLAY="$DISP" xdotool mousemove --window "$WIN_ID" --sync "$1" "$2"
+  DISPLAY="$DISP" xdotool click 1
   sleep 0.6
 }
 
-key() { DISPLAY=:99 xdotool key "$1"; sleep 0.3; }
-type_text() { DISPLAY=:99 xdotool type --delay 40 "$1"; sleep 0.4; }
+key() { DISPLAY="$DISP" xdotool key "$1"; sleep 0.3; }
+type_text() { DISPLAY="$DISP" xdotool type --delay 40 "$1"; sleep 0.4; }
 clear_field() { for _ in $(seq 1 80); do key BackSpace; done; }
 
 state_data() {


### PR DESCRIPTION
## Summary

Terminal release hardening + test-harness hygiene. No visual changes.

**User impact**: embedded terminal no longer misreports exited sessions as alive (zombie reap via `waitpid(WNOHANG)`); kill escalates SIGTERM->SIGKILL with grace; double-kill/restart-adjacent paths can't double-close fds; CJK/emoji VT output wraps on rune boundaries instead of splitting mid-rune; `:version` reports the real binary version (was stale `1.28.0` + writer-less env var).

**Architecture/truth**: forkpty+execvp + non-blocking-drain design kept; `alive()` semantics now truthful (zombie != alive). Deleted dead Ghostty API (`copy_all/copy_last/line_count/is_at_bottom/scroll_to_top`, zero callers). Harnesses now own their Xvfb/processes (PID-scoped kills, no `pkill`), run golden/ui-smoke under temp HOME/XDG (real prefs untouched), trap cleanup in clean-machine, loud `shot()` failures on named captures.

## Validation

- New `modules/pty/pty_test.v` (written first, failed pre-fix: zombie-alive, fd stuck, zero-Session alive) — green post-fix
- New `modules/ghostty/ghostty_test.v` (first for module: SGR, ESC[2J, scrollback cap, resize pinning, UTF-8/CJK/emoji wrap, version) — green post-fix
- `v test modules/pty/ modules/ghostty/` 2 passed; `./make.vsh vet` exit 0; `bash -n` clean on all 5 scripts
- Desktop caller compile-compatible (`v vet cmd/agent-toolkit-desktop/` exit 0)

## Known limitations / follow-ups

- `main.v` restart path still overwrites `s.sess` without closing/reaping the old session (one-line fix flagged for the cmd/ owner — belongs to the naming branch follow-up or Phase 2)
- No Xvfb/xdotool on this dev machine; GUI-capture behavior of edited scripts re-verified via CI