### PR TITLE
refactor(desktop): domain-language naming cleanup, unified shared helpers

### DIFF
--- a/cmd/agent-toolkit-desktop/insights_view.v
+++ b/cmd/agent-toolkit-desktop/insights_view.v
@@ -5,13 +5,13 @@ import time
 import desktop.pixelart
 import desktop_engine
 
-// VC7 (#1173) — Insights destination, visual convergence pass.
+// Insights destination: Engine-backed metric tabs in one paper-sheet composition.
 //
 // Reference grammar: operations.jpg (metric row + dense table + right-hand
 // details), library.jpg (tab strip with a sage underline), concept-board.jpg
 // (materials). The seven real tabs stay — cost | waterfall | spans | budgets
 // | ci | realtime | gallery — each backed by the same Engine calls as before.
-// What changes is the composition: editorial header, four metric cards that
+// The composition: editorial header, four metric cards that
 // only show recorded values, pixel-marked tabs, one paper sheet per tab with
 // the operations table styling, selectable rows, and a "Report details"
 // column on the right that replaces the generic inspector.
@@ -111,9 +111,9 @@ fn insights_rows_visible(l InsightsLayout) int {
 
 // ── row model ───────────────────────────────────────────────────────────────
 
-// InsRow is one selectable record: table cells + the label/value pairs the
+// InsightsRow is one selectable record: table cells + the label/value pairs the
 // details column shows. tone marks the status cell (ok / warn / bad / '').
-struct InsRow {
+struct InsightsRow {
 	kind   string
 	id     string
 	tone   string
@@ -121,30 +121,30 @@ struct InsRow {
 	fields [][]string
 }
 
-struct InsTable {
+struct InsightsTable {
 	title string
 	sub   string
 	cols  []string
 	col_x []int // offsets from inner_x
-	rows  []InsRow
+	rows  []InsightsRow
 	empty string // one honest sentence when rows.len == 0
 	scene int // empty-state scene variant
 	hint  string // second muted line: where the real affordance lives
 	note  string // truthful caveat rendered under the rows (may be '')
 }
 
-fn ins_time(ts i64) string {
+fn insights_time(ts i64) string {
 	if ts <= 0 {
 		return '—'
 	}
 	return time.unix(ts).format()
 }
 
-fn ins_or_dash(s string) string {
+fn insights_or_dash(s string) string {
 	return if s.trim_space() == '' { '—' } else { s }
 }
 
-fn ins_status_tone(s string) string {
+fn insights_status_tone(s string) string {
 	low := s.to_lower()
 	if low.contains('fail') || low.contains('error') || low.contains('cancel') {
 		return 'bad'
@@ -162,20 +162,20 @@ fn ins_status_tone(s string) string {
 // width: drawing, metrics, click and details all read the SAME table in a
 // frame (collect_engine_logs scans state.data — building it four times a
 // frame is wasteful) and the next frame rebuilds so Engine updates show.
-fn insights_table(mut app GuiApp, tab string, inner_w int) InsTable {
+fn insights_table(mut app GuiApp, tab string, inner_w int) InsightsTable {
 	key := '${tab}:${inner_w}'
-	if app.ins_cache_frame == app.frame && app.ins_cache_key == key {
-		return app.ins_cache
+	if app.insights_cache_frame == app.frame && app.insights_cache_key == key {
+		return app.insights_cache
 	}
 	t := insights_table_build(mut app, tab, inner_w)
-	app.ins_cache = t
-	app.ins_cache_key = key
-	app.ins_cache_frame = app.frame
+	app.insights_cache = t
+	app.insights_cache_key = key
+	app.insights_cache_frame = app.frame
 	return t
 }
 
 // insights_table_build assembles the current tab's rows from the Engine.
-fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
+fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsightsTable {
 	has_engine := app.desktop != unsafe { nil }
 	match tab {
 		'cost' {
@@ -189,38 +189,38 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
 			} else {
 				[]desktop_engine.JobRecord{}
 			}
-			mut rows := []InsRow{}
+			mut rows := []InsightsRow{}
 			for r in swarms {
-				rows << InsRow{
+				rows << InsightsRow{
 					kind: 'Swarm run'
 					id: r.id
-					tone: ins_status_tone(r.status.str())
+					tone: insights_status_tone(r.status.str())
 					cells: [r.id, '${r.recipe.str()} · ${r.status.str()}',
-						'${r.budget_spent} / ${r.budget_total}', ins_time(r.created_at)]
+						'${r.budget_spent} / ${r.budget_total}', insights_time(r.created_at)]
 					fields: [['Kind', 'Swarm run'], ['Recipe', r.recipe.str()],
 						['Backend', r.backend.str()], ['Status', r.status.str()],
 						['Budget spent', '${r.budget_spent}'],
 						['Budget total', '${r.budget_total} (as reported)'],
-						['Created', ins_time(r.created_at)], ['Task', ins_or_dash(r.task)],
-						['Worktree', ins_or_dash(r.worktree)], ['Trace', ins_or_dash(r.trace_id)]]
+						['Created', insights_time(r.created_at)], ['Task', insights_or_dash(r.task)],
+						['Worktree', insights_or_dash(r.worktree)], ['Trace', insights_or_dash(r.trace_id)]]
 				}
 			}
 			for j in jobs {
 				// every recorded job is a row — ids are Engine-issued, never filtered
-				rows << InsRow{
+				rows << InsightsRow{
 					kind: 'Job'
 					id: j.id
-					tone: ins_status_tone(j.status.str())
+					tone: insights_status_tone(j.status.str())
 					cells: [j.id, 'job · ${j.status.str()}', 'exit ${j.exit_code}',
-						ins_time(j.started_at)]
+						insights_time(j.started_at)]
 					fields: [['Kind', 'Job'], ['Status', j.status.str()],
 						['Exit code', '${j.exit_code}'], ['Duration', '${j.duration_ms} ms'],
-						['Started', ins_time(j.started_at)], ['Finished', ins_time(j.finished_at)],
-						['Command', ins_or_dash((j.cmd + ' ' + j.args.join(' ')).trim_space())],
-						['Work dir', ins_or_dash(j.work_dir)], ['Retries', '${j.retry_count}']]
+						['Started', insights_time(j.started_at)], ['Finished', insights_time(j.finished_at)],
+						['Command', insights_or_dash((j.cmd + ' ' + j.args.join(' ')).trim_space())],
+						['Work dir', insights_or_dash(j.work_dir)], ['Retries', '${j.retry_count}']]
 				}
 			}
-			return InsTable{
+			return InsightsTable{
 				title: 'Cost ledger'
 				sub: 'Swarm runs and jobs recorded by the Engine ledger. Budget units as reported — no currency is assumed.'
 				cols: ['Run / job', 'Kind · status', 'Budget spent / total', 'Started']
@@ -237,18 +237,18 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
 			} else {
 				[]desktop_engine.AgentEntry{}
 			}
-			mut rows := []InsRow{}
+			mut rows := []InsightsRow{}
 			for a in agents {
-				rows << InsRow{
+				rows << InsightsRow{
 					kind: 'Agent'
 					id: a.id
 					cells: [a.id, a.tier, a.role, '—']
-					fields: [['Kind', 'Catalog agent'], ['Tier', ins_or_dash(a.tier)],
-						['Role', ins_or_dash(a.role)], ['Description', ins_or_dash(a.description)],
+					fields: [['Kind', 'Catalog agent'], ['Tier', insights_or_dash(a.tier)],
+						['Role', insights_or_dash(a.role)], ['Description', insights_or_dash(a.description)],
 						['Measured spans', 'none — no tool call has been observed']]
 				}
 			}
-			return InsTable{
+			return InsightsTable{
 				title: 'Tool waterfall'
 				sub: 'Per-agent tool spans. Agent identity alone is never evidence that a tool call happened.'
 				cols: ['Agent', 'Tier', 'Role', 'Measured spans']
@@ -267,7 +267,7 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
 				pids, drops := app.desktop.engine_process_supervisor_stats()
 				sub = 'Jobs: pids=${pids} drops=${drops} total=${st.total} running=${st.running} failed=${st.failed}'
 			}
-			return InsTable{
+			return InsightsTable{
 				title: 'OTel spans'
 				sub: sub
 				empty: 'No measured spans yet. They appear once a job, loop or swarm emits telemetry.'
@@ -287,23 +287,23 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
 				[]desktop_engine.LoopHistory{}
 			}
 			with_budget := loops.filter(it.budget.max_tokens > 0 || it.budget.max_wall_seconds > 0).len
-			mut rows := []InsRow{}
+			mut rows := []InsightsRow{}
 			for hrow in hist {
-				rows << InsRow{
+				rows << InsightsRow{
 					kind: 'Loop run'
 					id: hrow.run_id
-					tone: ins_status_tone(hrow.status)
+					tone: insights_status_tone(hrow.status)
 					cells: [hrow.run_id, hrow.loop_name, '${hrow.status} · ${hrow.exit_condition}',
 						'${hrow.budget_spent} tok', '${hrow.duration_ms} ms']
 					fields: [['Kind', 'Loop run'], ['Loop', hrow.loop_name],
-						['Status', ins_or_dash(hrow.status)],
-						['Exit condition', ins_or_dash(hrow.exit_condition)],
+						['Status', insights_or_dash(hrow.status)],
+						['Exit condition', insights_or_dash(hrow.exit_condition)],
 						['Budget spent', '${hrow.budget_spent} tokens'],
 						['Duration', '${hrow.duration_ms} ms'],
-						['Started', ins_time(hrow.started_at)]]
+						['Started', insights_time(hrow.started_at)]]
 				}
 			}
-			return InsTable{
+			return InsightsTable{
 				title: 'Budgets'
 				sub: '${with_budget} of ${loops.len} loop templates declare a budget · run history from the ledger'
 				cols: ['Run', 'Loop', 'Status · exit', 'Spent', 'Duration']
@@ -316,7 +316,7 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
 			}
 		}
 		'ci' {
-			return InsTable{
+			return InsightsTable{
 				title: 'CI observations'
 				sub: 'No CI provider is connected in this build.'
 				empty: 'Nothing observed. Workflow names are not results — checks appear here only when a provider reports them.'
@@ -326,22 +326,22 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
 		}
 		'realtime' {
 			logs := if has_engine { collect_engine_logs(app) } else { []TermLine{} }
-			mut rows := []InsRow{cap: logs.len}
+			mut rows := []InsightsRow{cap: logs.len}
 			// reversed snapshot order; the Engine records no per-event timestamps,
 			// so this is NOT chronological — the column is the ledger revision
 			for i := logs.len - 1; i >= 0; i-- {
 				l := logs[i]
-				rows << InsRow{
+				rows << InsightsRow{
 					kind: 'Event'
 					id: l.ts
-					tone: ins_status_tone(l.level)
+					tone: insights_status_tone(l.level)
 					cells: [l.ts, l.level, l.source, l.msg]
 					fields: [['Kind', 'Engine event'], ['Revision', l.ts],
-						['Level', ins_or_dash(l.level)], ['Source', ins_or_dash(l.source)],
-						['Message', ins_or_dash(l.msg)], ['Raw', ins_or_dash(l.raw)]]
+						['Level', insights_or_dash(l.level)], ['Source', insights_or_dash(l.source)],
+						['Message', insights_or_dash(l.msg)], ['Raw', insights_or_dash(l.raw)]]
 				}
 			}
-			return InsTable{
+			return InsightsTable{
 				title: 'Realtime feed'
 				sub: 'GOD envelopes ${app.god_inbox} in · ${app.god_outbox} out · rev ${app.engine_rev} · api ${app.api_calls} — EventBus, one tick, no polling'
 				cols: ['Revision', 'Level', 'Source', 'Message']
@@ -353,7 +353,7 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsTable {
 			}
 		}
 		else {
-			return InsTable{
+			return InsightsTable{
 				title: 'Gallery'
 			}
 		}
@@ -368,24 +368,24 @@ fn draw_insights(mut app GuiApp, w int, h int) {
 	app.gg.draw_rect_filled(l.fx, l.fy, l.fw, l.fh, app.pnl_bg)
 	destination_header(mut app, l.fx, l.fy, l.fw, l.head_h, pixelart.environment_for(.ledger), tr(app, 'panel.insights'), 'Metrics, traces and reports — every number comes from the Engine ledger')
 	if l.metric_h > 0 {
-		draw_ins_metrics(mut app, l)
+		draw_insights_metrics(mut app, l)
 	}
 	if l.tab_h == 0 || l.content_h < 40 {
 		return
 	}
-	draw_ins_tabs(mut app, l)
-	paper_sheet(mut app, l.fx + 12, l.content_y, l.fw - 24, l.content_h)
+	draw_insights_tabs(mut app, l)
+	draw_paper_sheet(mut app, l.fx + 12, l.content_y, l.fw - 24, l.content_h)
 	if app.insights_tab == 'gallery' {
 		draw_insights_gallery(mut app, l)
 		return
 	}
 	t := insights_table(mut app, app.insights_tab, l.inner_w)
-	draw_ins_table(mut app, l, t)
+	draw_insights_table(mut app, l, t)
 }
 
-// draw_ins_metrics — four recorded values, never estimates. Zero is a valid
+// draw_insights_metrics — four recorded values, never estimates. Zero is a valid
 // state and is written as 0 with a truthful sub-line.
-fn draw_ins_metrics(mut app GuiApp, l InsightsLayout) {
+fn draw_insights_metrics(mut app GuiApp, l InsightsLayout) {
 	has_engine := app.desktop != unsafe { nil }
 	swarms := if has_engine { app.desktop.swarm_list() } else { []desktop_engine.SwarmRun{} }
 	jobs := if has_engine {
@@ -437,7 +437,7 @@ fn draw_ins_metrics(mut app GuiApp, l InsightsLayout) {
 		row := i / cols
 		x := l.fx + 12 + col * (cw + gap)
 		y := l.metric_y + row * (ch + gap)
-		paper_sheet(mut app, x, y, cw, ch)
+		draw_paper_sheet(mut app, x, y, cw, ch)
 		m := marks[i]
 		ms := if !l.compact && cw >= 230 { 3 } else { 2 }
 		sc.draw(m, pid, x + 10, y + (ch - m.height() * ms) / 2, ms)
@@ -455,7 +455,7 @@ fn draw_ins_metrics(mut app GuiApp, l InsightsLayout) {
 			size: if l.compact { 11 } else { 13 }
 			bold: true
 		})
-		// 11px Plex averages ~5.6px/char; onb_fit's 7px would clip real fits
+		// 11px Plex averages ~5.6px/char; text_fit_chars's 7px would clip real fits
 		if !l.compact {
 			app.gg.draw_text(tx, y + 56, utf8_truncate(c[2], (cw - (tx - x) - 8) / 6), gg.TextCfg{
 				color: app.pnl_text_mut
@@ -465,9 +465,9 @@ fn draw_ins_metrics(mut app GuiApp, l InsightsLayout) {
 	}
 }
 
-// draw_ins_tabs — pixel-marked tabs; the active one merges into the sheet
+// draw_insights_tabs — pixel-marked tabs; the active one merges into the sheet
 // below it and carries the sage underline (library.jpg grammar).
-fn draw_ins_tabs(mut app GuiApp, l InsightsLayout) {
+fn draw_insights_tabs(mut app GuiApp, l InsightsLayout) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	marks := [pixelart.environment_for(.ledger), pixelart.environment_for(.chart_mark),
@@ -502,7 +502,7 @@ fn draw_ins_tabs(mut app GuiApp, l InsightsLayout) {
 	}
 }
 
-fn ins_tone_color(app &GuiApp, tone string) gg.Color {
+fn insights_tone_color(app &GuiApp, tone string) gg.Color {
 	return match tone {
 		'ok' { app.pnl_success }
 		'warn' { app.pnl_select }
@@ -511,19 +511,19 @@ fn ins_tone_color(app &GuiApp, tone string) gg.Color {
 	}
 }
 
-// draw_ins_table renders one tab sheet: title, sub-line, column header,
+// draw_insights_table renders one tab sheet: title, sub-line, column header,
 // alternating rows with selection + hover, footer counter. Empty tables
 // render a small scene and one honest sentence instead of a blank grid.
-fn draw_ins_table(mut app GuiApp, l InsightsLayout, t InsTable) {
+fn draw_insights_table(mut app GuiApp, l InsightsLayout, t InsightsTable) {
 	app.gg.draw_text(l.inner_x, l.inner_y, t.title, gg.TextCfg{
 		color: app.pnl_text
 		size: 17
 		family: app.fonts.display
 	})
-	draw_onb_wrapped(mut app, l.inner_x, l.inner_y + 22, l.inner_w, t.sub, 2)
+	draw_wrapped_text(mut app, l.inner_x, l.inner_y + 22, l.inner_w, t.sub, 2)
 	bottom := l.content_y + l.content_h
 	if t.rows.len == 0 {
-		draw_ins_empty(mut app, l.inner_x, l.inner_y + 44, l.inner_w, bottom - (l.inner_y + 44) - 12, t.scene, t.empty, t.hint)
+		draw_insights_empty(mut app, l.inner_x, l.inner_y + 44, l.inner_w, bottom - (l.inner_y + 44) - 12, t.scene, t.empty, t.hint)
 		return
 	}
 	// column header
@@ -548,7 +548,7 @@ fn draw_ins_table(mut app GuiApp, l InsightsLayout, t InsTable) {
 		row := idx - start
 		ry := l.rows_y + row * l.row_h
 		selected := idx == app.insights_sel
-		hover := onb_hit(app.mouse_x, app.mouse_y, l.inner_x, ry, l.inner_w, l.row_h)
+		hover := rect_contains(app.mouse_x, app.mouse_y, l.inner_x, ry, l.inner_w, l.row_h)
 		if selected {
 			app.gg.draw_rect_filled(l.inner_x, ry, l.inner_w, l.row_h, tint(app.pnl_success, 70))
 			app.gg.draw_rect_filled(l.inner_x, ry, 3, l.row_h, app.pnl_success)
@@ -570,10 +570,10 @@ fn draw_ins_table(mut app GuiApp, l InsightsLayout, t InsTable) {
 			mut tx := cx
 			if ci == 1 && r.tone != '' {
 				// status cell: tone dot + text, never color alone
-				app.gg.draw_rect_filled(cx, ry + 7, 6, 6, ins_tone_color(app, r.tone))
+				app.gg.draw_rect_filled(cx, ry + 7, 6, 6, insights_tone_color(app, r.tone))
 				tx += 10
 			}
-			app.gg.draw_text(tx, ry + 4, utf8_truncate(cell, onb_fit(next - tx - 6, 11)), gg.TextCfg{
+			app.gg.draw_text(tx, ry + 4, utf8_truncate(cell, text_fit_chars(next - tx - 6, 11)), gg.TextCfg{
 				color: if ci == 0 || ci == r.cells.len - 1 {
 					app.pnl_text
 				} else {
@@ -597,9 +597,9 @@ fn draw_ins_table(mut app GuiApp, l InsightsLayout, t InsTable) {
 	})
 }
 
-// ins_center_lines draws text centered on cx, wrapping to at most max_lines
+// draw_centered_lines draws text centered on cx, wrapping to at most max_lines
 // of ~per characters; returns the y after the last line.
-fn ins_center_lines(mut app GuiApp, cx int, y int, per int, text string, size int, col gg.Color, max_lines int) int {
+fn draw_centered_lines(mut app GuiApp, cx int, y int, per int, text string, size int, col gg.Color, max_lines int) int {
 	mut lines := []string{}
 	mut line := ''
 	for word in text.split(' ') {
@@ -629,13 +629,13 @@ fn ins_center_lines(mut app GuiApp, cx int, y int, per int, text string, size in
 	return yy
 }
 
-// draw_ins_empty is the empty state: scene + sentence + affordance hint as
+// draw_insights_empty is the empty state: scene + sentence + affordance hint as
 // ONE centered group anchored in the upper-middle of the sheet (scene centre
 // at ~30% height), never a lone sprite floating mid-void.
-fn draw_ins_empty(mut app GuiApp, x int, y int, w int, h int, scene int, sentence string, hint string) {
+fn draw_insights_empty(mut app GuiApp, x int, y int, w int, h int, scene int, sentence string, hint string) {
 	cx := x + w / 2
 	if h < 90 {
-		ins_center_lines(mut app, cx, y + 8, onb_fit(w, 12), sentence, 12, app.pnl_text_mut, 2)
+		draw_centered_lines(mut app, cx, y + 8, text_fit_chars(w, 12), sentence, 12, app.pnl_text_mut, 2)
 		return
 	}
 	mut sc := app.pixel_cache
@@ -698,9 +698,9 @@ fn draw_ins_empty(mut app GuiApp, x int, y int, w int, h int, scene int, sentenc
 		sc.draw(picture, pid, cx - picture.width(), ay + 12, 2)
 	}
 	app.gg.draw_rect_empty(ax, ay, art_w, art_h, tint(pc(app, `W`), 100))
-	ty := ins_center_lines(mut app, cx, base + 18, onb_fit(w - 40, 12), sentence, 12, app.pnl_text, 2)
+	ty := draw_centered_lines(mut app, cx, base + 18, text_fit_chars(w - 40, 12), sentence, 12, app.pnl_text, 2)
 	if hint != '' {
-		ins_center_lines(mut app, cx, ty + 4, onb_fit(w - 40, 11), hint, 11, app.pnl_text_mut, 1)
+		draw_centered_lines(mut app, cx, ty + 4, text_fit_chars(w - 40, 11), hint, 11, app.pnl_text_mut, 1)
 	}
 }
 
@@ -831,7 +831,7 @@ fn draw_insights_detail(mut app GuiApp, w int, h int) {
 	if app.insights_sel >= 0 && app.insights_sel < t.rows.len {
 		r := t.rows[app.insights_sel]
 		paper_pill(mut app, ix + 16, y, r.kind, app.pnl_select)
-		app.gg.draw_text(ix + 16, y + 22, utf8_truncate(r.id, onb_fit(iw - 32, 13)), gg.TextCfg{
+		app.gg.draw_text(ix + 16, y + 22, utf8_truncate(r.id, text_fit_chars(iw - 32, 13)), gg.TextCfg{
 			color: app.pnl_text
 			size: 13
 			bold: true
@@ -840,7 +840,7 @@ fn draw_insights_detail(mut app GuiApp, w int, h int) {
 		y += 48
 		app.gg.draw_rect_filled(ix + 16, y - 6, iw - 32, 1, tint(pc(app, `W`), 90))
 		for f in r.fields {
-			long := f[1].len > onb_fit(iw - 32, 12)
+			long := f[1].len > text_fit_chars(iw - 32, 12)
 			need := if long { 46 } else { 32 }
 			if y + need > quote_y - 8 {
 				app.gg.draw_text(ix + 16, y, '… more fields than fit', gg.TextCfg{
@@ -854,7 +854,7 @@ fn draw_insights_detail(mut app GuiApp, w int, h int) {
 				size: 10
 			})
 			if long {
-				draw_onb_wrapped(mut app, ix + 16, y + 13, iw - 32, f[1], 2)
+				draw_wrapped_text(mut app, ix + 16, y + 13, iw - 32, f[1], 2)
 			} else {
 				app.gg.draw_text(ix + 16, y + 13, f[1], gg.TextCfg{
 					color: app.pnl_text
@@ -866,7 +866,7 @@ fn draw_insights_detail(mut app GuiApp, w int, h int) {
 	} else {
 		// truthful empty card — nothing selected, or nothing selectable
 		card_h := 132
-		paper_sheet(mut app, ix + 8, y, iw - 16, card_h)
+		draw_paper_sheet(mut app, ix + 8, y, iw - 16, card_h)
 		sc.draw(pixelart.environment_for(.ledger), pid, ix + 24, y + 18, 3)
 		app.gg.draw_text(ix + 76, y + 18, 'Nothing selected', gg.TextCfg{
 			color: app.pnl_text
@@ -878,9 +878,9 @@ fn draw_insights_detail(mut app GuiApp, w int, h int) {
 		} else {
 			'The ${tab_label} tab has no rows to select.'
 		}
-		draw_onb_wrapped(mut app, ix + 76, y + 40, iw - 92, sentence, 3)
+		draw_wrapped_text(mut app, ix + 76, y + 40, iw - 92, sentence, 3)
 		y += card_h + 16
-		ws_section_label(mut app, ix + 16, y, 'SOURCES')
+		workspace_section_label(mut app, ix + 16, y, 'SOURCES')
 		app.gg.draw_text(ix + 16, y + 20, 'Engine state · swarm and job ledger', gg.TextCfg{
 			color: app.pnl_text
 			size: 11
@@ -911,14 +911,14 @@ fn insights_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 	if l.tab_h == 0 || l.content_h < 40 {
 		ix := inspector_x(app, w)
 		iy := panel_top(app)
-		if onb_hit(mx, my, ix, iy, inspector_w, content_bottom(app, h) - iy) {
+		if rect_contains(mx, my, ix, iy, inspector_w, content_bottom(app, h) - iy) {
 			return true
 		}
 		return false
 	}
 	for i, t in insights_tabs {
 		x, y, tw, th := insights_tab_rect(l, i)
-		if onb_hit(mx, my, x, y, tw, th) {
+		if rect_contains(mx, my, x, y, tw, th) {
 			if app.insights_tab != t {
 				app.insights_tab = t
 				app.insights_sel = -1
@@ -933,7 +933,7 @@ fn insights_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 		if tbl.rows.len > 0 {
 			visible := insights_rows_visible(l)
 			start := clamp_scroll(app.insights_scroll, tbl.rows.len, visible)
-			if onb_hit(mx, my, l.inner_x, l.rows_y, l.inner_w, visible * l.row_h) {
+			if rect_contains(mx, my, l.inner_x, l.rows_y, l.inner_w, visible * l.row_h) {
 				idx := start + (my - l.rows_y) / l.row_h
 				if idx >= 0 && idx < tbl.rows.len {
 					app.insights_sel = if app.insights_sel == idx { -1 } else { idx }
@@ -946,7 +946,7 @@ fn insights_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 	// generic inspector geometry never reacts underneath it
 	ix := inspector_x(app, w)
 	iy := panel_top(app)
-	if onb_hit(mx, my, ix, iy, inspector_w, content_bottom(app, h) - iy) {
+	if rect_contains(mx, my, ix, iy, inspector_w, content_bottom(app, h) - iy) {
 		return true
 	}
 	return false
@@ -958,7 +958,7 @@ fn insights_hover_at(mut app GuiApp, mx int, my int, w int, h int) {
 	l := insights_layout(app, w, h)
 	for i in 0 .. insights_tabs.len {
 		x, y, tw, th := insights_tab_rect(l, i)
-		if onb_hit(mx, my, x, y, tw, th) {
+		if rect_contains(mx, my, x, y, tw, th) {
 			app.insights_hover = i
 			return
 		}
@@ -971,7 +971,7 @@ fn insights_scroll_by(mut app GuiApp, delta int, w int, h int) bool {
 		return false
 	}
 	l := insights_layout(app, w, h)
-	if !onb_hit(app.mouse_x, app.mouse_y, l.fx + 12, l.content_y, l.fw - 24, l.content_h) {
+	if !rect_contains(app.mouse_x, app.mouse_y, l.fx + 12, l.content_y, l.fw - 24, l.content_h) {
 		return false
 	}
 	tbl := insights_table(mut app, app.insights_tab, l.inner_w)

--- a/cmd/agent-toolkit-desktop/library_view.v
+++ b/cmd/agent-toolkit-desktop/library_view.v
@@ -4,7 +4,7 @@ import gg
 import desktop.pixelart
 import desktop_engine
 
-// VC5 (#1173) — the Library as an illustrated collection.
+// The Library as an illustrated collection.
 //
 // Canonical visual reference: docs/desktop/assets/design/library.jpg with
 // concept-board.jpg as the shell/material authority. One composition serves
@@ -22,28 +22,28 @@ import desktop_engine
 // Illustration (marks, banner) is catalog identity and environment only; it
 // never encodes runtime activity or popularity.
 //
-// Geometry: lib_layout() is computed once per frame and shared by drawing,
+// Geometry: library_layout() is computed once per frame and shared by drawing,
 // hover, click and wheel handling (single source of geometry).
 
 // tab order in the tab bar → panel id
-const lib_tab_panels = [1, 2, 10, 3]
+const library_tab_panels = [1, 2, 10, 3]
 
-// hovered chrome element codes (lib_hover_ui)
-const lib_ui_tab0 = 10 // 10..13 tabs
-const lib_ui_search = 20
-const lib_ui_chip0 = 30 // 30..59 chips
-const lib_ui_primary = 60
-const lib_ui_second = 61
-const lib_ui_third = 62
+// hovered chrome element codes (library_hover_ui)
+const library_ui_tab0 = 10 // 10..13 tabs
+const library_ui_search = 20
+const library_ui_chip0 = 30 // 30..59 chips
+const library_ui_primary = 60
+const library_ui_second = 61
+const library_ui_third = 62
 
-// lib_is_panel reports whether a panel id is served by the Library composition.
-fn lib_is_panel(p int) bool {
-	return p in lib_tab_panels
+// library_is_panel reports whether a panel id is served by the Library composition.
+fn library_is_panel(p int) bool {
+	return p in library_tab_panels
 }
 
-// lib_tab_for_panel maps a panel id to its tab index (-1 when not a Library panel).
-fn lib_tab_for_panel(p int) int {
-	for i, tp in lib_tab_panels {
+// library_tab_for_panel maps a panel id to its tab index (-1 when not a Library panel).
+fn library_tab_for_panel(p int) int {
+	for i, tp in library_tab_panels {
 		if tp == p {
 			return i
 		}
@@ -51,8 +51,8 @@ fn lib_tab_for_panel(p int) int {
 	return -1
 }
 
-// LibLayout is the per-frame geometry shared by draw and hit-testing.
-struct LibLayout {
+// LibraryLayout is the per-frame geometry shared by draw and hit-testing.
+struct LibraryLayout {
 	fx       int
 	fy       int
 	fw       int
@@ -81,15 +81,15 @@ struct LibLayout {
 	tab      int
 }
 
-// lib_side_w is the detail column width: wider than the Office inspector at
+// library_side_w is the detail column width: wider than the Office inspector at
 // desktop widths so the detail pane can carry actions + facts without
 // shrinking type.
-fn lib_side_w(w int) int {
+fn library_side_w(w int) int {
 	return if w >= 1180 { 340 } else { inspector_w }
 }
 
-fn lib_layout(mut app GuiApp, w int, h int) LibLayout {
-	side_w := lib_side_w(w)
+fn library_layout(mut app GuiApp, w int, h int) LibraryLayout {
+	side_w := library_side_w(w)
 	rtl := app.lang.is_rtl()
 	fx := if rtl { side_w + 8 } else { dock_w + 8 }
 	fw := w - dock_w - 8 - side_w
@@ -103,7 +103,7 @@ fn lib_layout(mut app GuiApp, w int, h int) LibLayout {
 	search_y := tabs_y + tabs_h + 6
 	search_h := 32
 	chips_y := search_y + search_h + 6
-	chip_rows := lib_chip_rows(mut app, fx, fw)
+	chip_rows := library_chip_rows(mut app, fx, fw)
 	chips_h := chip_rows * 24 + (chip_rows - 1) * 4
 	grid_y := chips_y + chips_h + 8
 	grid_bottom := fy + fh - 20
@@ -123,7 +123,7 @@ fn lib_layout(mut app GuiApp, w int, h int) LibLayout {
 	mut rows := (grid_h + gap) / (card_h + gap)
 	if rows < 2 && (grid_h - gap) / 2 >= 86 {
 		// short windows: two slightly shorter rows beat one row over dead
-		// space (cards below 100px drop the footer line, see draw_lib_grid)
+		// space (cards below 100px drop the footer line, see draw_library_grid)
 		rows = 2
 		card_h = (grid_h - gap) / 2
 	}
@@ -142,7 +142,7 @@ fn lib_layout(mut app GuiApp, w int, h int) LibLayout {
 	// detail column alike — exactly like the reference's header band; the
 	// title/subtitle keep the room their text needs and the banner takes
 	// the rest. Hidden when that rest is too narrow to read as a scene.
-	sub_px := tr(app, 'lib.subtitle').runes().len * 7 + 20
+	sub_px := tr(app, 'library.subtitle').runes().len * 7 + 20
 	shelf_px := 14 + 14 * 3 + 14
 	title_need := shelf_px + sub_px // room the header text block needs
 	mut banner_x := 0
@@ -166,7 +166,7 @@ fn lib_layout(mut app GuiApp, w int, h int) LibLayout {
 		banner_w = 0
 		banner_x = if rtl { fx } else { fx + fw }
 	}
-	return LibLayout{
+	return LibraryLayout{
 		fx: fx
 		fy: fy
 		fw: fw
@@ -192,40 +192,40 @@ fn lib_layout(mut app GuiApp, w int, h int) LibLayout {
 		card_h: card_h
 		gap: gap
 		compact: compact
-		tab: lib_tab_for_panel(app.selected_panel)
+		tab: library_tab_for_panel(app.selected_panel)
 	}
 }
 
 // ── shared rects ────────────────────────────────────────────────────────────
 
-fn lib_tab_rect(l LibLayout, i int) (int, int, int, int) {
+fn library_tab_rect(l LibraryLayout, i int) (int, int, int, int) {
 	tw := if l.fw >= 640 { 118 } else { (l.fw - 24 - 3 * 6) / 4 }
 	return l.fx + 12 + i * (tw + 6), l.tabs_y, tw, l.tabs_h
 }
 
-fn lib_search_rect(l LibLayout) (int, int, int, int) {
+fn library_search_rect(l LibraryLayout) (int, int, int, int) {
 	// the count badge on the right needs ~110px; the field takes the rest
 	return l.fx + 12, l.search_y, l.fw - 24 - 116, l.search_h
 }
 
-fn lib_chip_w(label string) int {
+fn library_chip_w(label string) int {
 	return label.len * 6 + 20
 }
 
-// lib_chip_rows measures how many chip rows the current tab's labels need.
+// library_chip_rows measures how many chip rows the current tab's labels need.
 // Rows grow with the catalog (no cap): every chip is drawn and hit-testable,
 // and the grid below recomputes from chips_h. The chip list is catalog-
 // driven (Skills domains), so a silently dropped chip would be a filter the
 // user can never reach.
-fn lib_chip_rows(mut app GuiApp, fx int, fw int) int {
-	return lib_chip_rows_for(lib_chips(mut app), fx, fw)
+fn library_chip_rows(mut app GuiApp, fx int, fw int) int {
+	return library_chip_rows_for(library_chips(mut app), fx, fw)
 }
 
-fn lib_chip_rows_for(labels []string, fx int, fw int) int {
+fn library_chip_rows_for(labels []string, fx int, fw int) int {
 	mut x := fx + 12
 	mut rows := 1
 	for lb in labels {
-		cw := lib_chip_w(lb)
+		cw := library_chip_w(lb)
 		if x + cw > fx + fw - 12 && x > fx + 12 {
 			rows++
 			x = fx + 12
@@ -235,14 +235,14 @@ fn lib_chip_rows_for(labels []string, fx int, fw int) int {
 	return rows
 }
 
-// lib_chip_rect returns the rect for chip i of labels — the same wrapping
-// walk as lib_chip_rows, so drawing and hit-testing never disagree. w == 0
+// library_chip_rect returns the rect for chip i of labels — the same wrapping
+// walk as library_chip_rows, so drawing and hit-testing never disagree. w == 0
 // only for an out-of-range index.
-fn lib_chip_rect(l LibLayout, labels []string, i int) (int, int, int, int) {
+fn library_chip_rect(l LibraryLayout, labels []string, i int) (int, int, int, int) {
 	mut x := l.fx + 12
 	mut row := 0
 	for j, lb in labels {
-		cw := lib_chip_w(lb)
+		cw := library_chip_w(lb)
 		if x + cw > l.fx + l.fw - 12 && x > l.fx + 12 {
 			row++
 			x = l.fx + 12
@@ -255,8 +255,8 @@ fn lib_chip_rect(l LibLayout, labels []string, i int) (int, int, int, int) {
 	return 0, 0, 0, 0
 }
 
-// lib_card_rect returns the rect of the visible card slot v (row-major).
-fn lib_card_rect(l LibLayout, v int) (int, int, int, int) {
+// library_card_rect returns the rect of the visible card slot v (row-major).
+fn library_card_rect(l LibraryLayout, v int) (int, int, int, int) {
 	if l.cols == 0 {
 		return 0, 0, 0, 0
 	}
@@ -266,10 +266,10 @@ fn lib_card_rect(l LibLayout, v int) (int, int, int, int) {
 }
 
 // detail-pane action buttons: primary + up to two secondary
-fn lib_btn_rect(l LibLayout, which int) (int, int, int, int) {
+fn library_btn_rect(l LibraryLayout, which int) (int, int, int, int) {
 	x := l.side_x + 16
 	inner := l.side_w - 32
-	y := lib_detail_actions_y(l)
+	y := library_detail_actions_y(l)
 	pw := if inner >= 300 { 132 } else { 112 }
 	sw := (inner - pw - 16) / 2
 	return match which {
@@ -279,13 +279,13 @@ fn lib_btn_rect(l LibLayout, which int) (int, int, int, int) {
 	}
 }
 
-fn lib_detail_actions_y(l LibLayout) int {
+fn library_detail_actions_y(l LibraryLayout) int {
 	return l.side_y + 176
 }
 
 // ── items (Engine truth → one card model) ───────────────────────────────────
 
-struct LibItem {
+struct LibraryItem {
 	id    string
 	name  string
 	desc  string
@@ -296,10 +296,10 @@ struct LibItem {
 	on    bool // installed / enabled — configuration truth only
 }
 
-// lib_chips returns the category chips for the active tab. Skills: catalog
+// library_chips returns the category chips for the active tab. Skills: catalog
 // domains. Agents: tiers. Products: kind. MCP: configuration facets.
-fn lib_chips(mut app GuiApp) []string {
-	match lib_tab_for_panel(app.selected_panel) {
+fn library_chips(mut app GuiApp) []string {
+	match library_tab_for_panel(app.selected_panel) {
 		0 {
 			mut out := ['All']
 			if app.desktop != unsafe { nil } {
@@ -322,54 +322,54 @@ fn lib_chips(mut app GuiApp) []string {
 	}
 }
 
-fn lib_chip_active(app &GuiApp, label string) bool {
-	if lib_tab_for_panel(app.selected_panel) == 0 {
+fn library_chip_active(app &GuiApp, label string) bool {
+	if library_tab_for_panel(app.selected_panel) == 0 {
 		return (label == 'All' && app.skills_domain == '') || app.skills_domain == label
 	}
-	return (label == 'All' && app.lib_filter == '') || app.lib_filter == label
+	return (label == 'All' && app.library_filter == '') || app.library_filter == label
 }
 
-fn lib_set_chip(mut app GuiApp, label string) {
+fn library_set_chip(mut app GuiApp, label string) {
 	v := if label == 'All' { '' } else { label }
-	if lib_tab_for_panel(app.selected_panel) == 0 {
+	if library_tab_for_panel(app.selected_panel) == 0 {
 		app.skills_domain = v
 		app.skills_scroll = 0
 		app.skills_selected = 0
 	} else {
-		app.lib_filter = v
-		app.lib_scroll = 0
-		app.lib_sel = 0
+		app.library_filter = v
+		app.library_scroll = 0
+		app.library_sel = 0
 	}
 	app.inspector_msg = if v == '' { 'Filter: all' } else { 'Filter: ${v}' }
 }
 
-// lib_items returns the card models for the active tab. The result is cached
+// library_items returns the card models for the active tab. The result is cached
 // per frame + filter key: draw, detail, hover and click all read the same
 // list, and the products/packs catalogs are parsed at most once per frame.
-// Actions bust the cache (lib_invalidate) so the next read sees Engine state.
-fn lib_items(mut app GuiApp) []LibItem {
-	key := '${app.selected_panel}|${app.skills_query}|${app.skills_domain}|${app.lib_filter}'
-	if app.lib_cache_frame == app.frame && app.lib_cache_key == key {
-		return app.lib_cache
+// Actions bust the cache (library_invalidate) so the next read sees Engine state.
+fn library_items(mut app GuiApp) []LibraryItem {
+	key := '${app.selected_panel}|${app.skills_query}|${app.skills_domain}|${app.library_filter}'
+	if app.library_cache_frame == app.frame && app.library_cache_key == key {
+		return app.library_cache
 	}
-	out := lib_items_uncached(mut app)
-	app.lib_cache = out
-	app.lib_cache_key = key
-	app.lib_cache_frame = app.frame
+	out := library_items_uncached(mut app)
+	app.library_cache = out
+	app.library_cache_key = key
+	app.library_cache_frame = app.frame
 	return out
 }
 
-fn lib_invalidate(mut app GuiApp) {
-	app.lib_cache_frame = -1
+fn library_invalidate(mut app GuiApp) {
+	app.library_cache_frame = -1
 }
 
-fn lib_items_uncached(mut app GuiApp) []LibItem {
-	mut out := []LibItem{}
+fn library_items_uncached(mut app GuiApp) []LibraryItem {
+	mut out := []LibraryItem{}
 	if app.desktop == unsafe { nil } {
 		return out
 	}
 	q := app.skills_query
-	match lib_tab_for_panel(app.selected_panel) {
+	match library_tab_for_panel(app.selected_panel) {
 		0 {
 			installed := app.desktop.engine_skills_installed()
 			for s in app.desktop.engine_skills_search(q, app.skills_domain) {
@@ -381,7 +381,7 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 				if s.kind != '' && s.kind != 'skill' {
 					tags << s.kind
 				}
-				out << LibItem{
+				out << LibraryItem{
 					id: s.id
 					name: if s.name != '' { s.name } else { s.id }
 					desc: s.description
@@ -393,12 +393,12 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 			}
 		}
 		1 {
-			tier := if app.lib_filter == 'archived' { '' } else { app.lib_filter }
+			tier := if app.library_filter == 'archived' { '' } else { app.library_filter }
 			for i, a in app.desktop.engine_agents_search(q, tier) {
-				if app.lib_filter == 'archived' && !a.archived {
+				if app.library_filter == 'archived' && !a.archived {
 					continue
 				}
-				if app.lib_filter != 'archived' && a.archived {
+				if app.library_filter != 'archived' && a.archived {
 					continue
 				}
 				mut tags := [a.tier]
@@ -418,7 +418,7 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 				} else {
 					''
 				}
-				out << LibItem{
+				out << LibraryItem{
 					id: a.id
 					name: a.id
 					desc: if a.description != '' { a.description } else { a.role }
@@ -430,7 +430,7 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 			}
 		}
 		2 {
-			if app.lib_filter != 'packs' {
+			if app.library_filter != 'packs' {
 				prods := if q != '' {
 					app.desktop.engine_products_search(q)
 				} else {
@@ -440,7 +440,7 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 					// products.yaml is the only truthful source here: the Engine's
 					// skill_ids/version/receipt_path fields are placeholders, not
 					// catalog facts, so they are deliberately not shown
-					out << LibItem{
+					out << LibraryItem{
 						id: p.id
 						name: if p.name != '' { p.name } else { p.id }
 						desc: p.description.trim("'")
@@ -450,7 +450,7 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 					}
 				}
 			}
-			if app.lib_filter != 'products' {
+			if app.library_filter != 'products' {
 				packs := if q != '' {
 					app.desktop.engine_packs_search(q)
 				} else {
@@ -462,7 +462,7 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 						tags << 'docs-only'
 					}
 					tags << '${pk.skill_count} skills'
-					out << LibItem{
+					out << LibraryItem{
 						id: pk.id
 						name: if pk.name != '' { pk.name } else { pk.id }
 						desc: if pk.docs_only {
@@ -485,10 +485,10 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 				app.desktop.engine_mcp_catalog()
 			}
 			for i, p in provs {
-				if app.lib_filter == 'enabled' && !p.enabled {
+				if app.library_filter == 'enabled' && !p.enabled {
 					continue
 				}
-				if app.lib_filter == 'docker' && !p.requires_docker {
+				if app.library_filter == 'docker' && !p.requires_docker {
 					continue
 				}
 				// deterministic node colour per provider — identity, not health
@@ -506,7 +506,7 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 				if p.requires_docker {
 					tags << 'docker'
 				}
-				out << LibItem{
+				out << LibraryItem{
 					id: p.id
 					name: if p.name != '' { p.name } else { p.id }
 					desc: if p.description != '' {
@@ -527,49 +527,49 @@ fn lib_items_uncached(mut app GuiApp) []LibItem {
 	return out
 }
 
-// lib_scroll_row / lib_selected read the per-tab state (Skills keeps its
+// library_scroll_row / library_selected read the per-tab state (Skills keeps its
 // pre-existing fields so shortcuts and tests stay valid).
-fn lib_scroll_row(app &GuiApp) int {
-	return if lib_tab_for_panel(app.selected_panel) == 0 {
+fn library_scroll_row(app &GuiApp) int {
+	return if library_tab_for_panel(app.selected_panel) == 0 {
 		app.skills_scroll
 	} else {
-		app.lib_scroll
+		app.library_scroll
 	}
 }
 
-fn lib_set_scroll_row(mut app GuiApp, v int) {
-	if lib_tab_for_panel(app.selected_panel) == 0 {
+fn library_set_scroll_row(mut app GuiApp, v int) {
+	if library_tab_for_panel(app.selected_panel) == 0 {
 		app.skills_scroll = v
 	} else {
-		app.lib_scroll = v
+		app.library_scroll = v
 	}
 }
 
-fn lib_selected(app &GuiApp) int {
-	return if lib_tab_for_panel(app.selected_panel) == 0 {
+fn library_selected(app &GuiApp) int {
+	return if library_tab_for_panel(app.selected_panel) == 0 {
 		app.skills_selected
 	} else {
-		app.lib_sel
+		app.library_sel
 	}
 }
 
-fn lib_set_selected(mut app GuiApp, v int) {
-	if lib_tab_for_panel(app.selected_panel) == 0 {
+fn library_set_selected(mut app GuiApp, v int) {
+	if library_tab_for_panel(app.selected_panel) == 0 {
 		app.skills_selected = v
 	} else {
-		app.lib_sel = v
+		app.library_sel = v
 	}
 }
 
-// lib_visible_range clamps the scroll row and returns [start, end) item
+// library_visible_range clamps the scroll row and returns [start, end) item
 // indexes for the visible grid (selection is revalidated by callers).
-fn lib_visible_range(mut app GuiApp, l LibLayout, total int) (int, int) {
+fn library_visible_range(mut app GuiApp, l LibraryLayout, total int) (int, int) {
 	if l.cols == 0 || l.rows == 0 {
 		return 0, 0
 	}
 	total_rows := (total + l.cols - 1) / l.cols
-	row := clamp_scroll(lib_scroll_row(app), total_rows, l.rows)
-	lib_set_scroll_row(mut app, row)
+	row := clamp_scroll(library_scroll_row(app), total_rows, l.rows)
+	library_set_scroll_row(mut app, row)
 	start := row * l.cols
 	mut end := start + l.rows * l.cols
 	if end > total {
@@ -580,9 +580,9 @@ fn lib_visible_range(mut app GuiApp, l LibLayout, total int) (int, int) {
 
 // ── text helpers ────────────────────────────────────────────────────────────
 
-// lib_wrap splits s into at most max_lines lines of about per characters,
+// wrap_text_lines splits s into at most max_lines lines of about per characters,
 // marking overflow with an ellipsis on the last line.
-fn lib_wrap(s string, per int, max_lines int) []string {
+fn wrap_text_lines(s string, per int, max_lines int) []string {
 	mut lines := []string{}
 	if max_lines <= 0 || per <= 0 {
 		return lines
@@ -623,15 +623,15 @@ fn lib_wrap(s string, per int, max_lines int) []string {
 	return lines
 }
 
-// lib_clip truncates to n runes and marks the cut with an ellipsis.
-fn lib_clip(s string, n int) string {
+// truncate_with_ellipsis truncates to n runes and marks the cut with an ellipsis.
+fn truncate_with_ellipsis(s string, n int) string {
 	if n <= 1 || s.runes().len <= n {
 		return s
 	}
 	return utf8_truncate(s, n - 1) + '…'
 }
 
-fn lib_text(mut app GuiApp, x int, y int, s string, size int, c gg.Color, bold bool) {
+fn library_text(mut app GuiApp, x int, y int, s string, size int, c gg.Color, bold bool) {
 	app.gg.draw_text(x, y, s, gg.TextCfg{
 		color: c
 		size: size
@@ -639,22 +639,8 @@ fn lib_text(mut app GuiApp, x int, y int, s string, size int, c gg.Color, bold b
 	})
 }
 
-// lib_check draws a check glyph from pixel runs (the bundled fonts have no
-// dependable ✓ glyph).
-fn lib_check(mut app GuiApp, x int, y int, c gg.Color) {
-	onb_check(mut app, x, y, c)
-}
-
-// lib_sheet is the soft paper surface every card and the detail column sit
-// on: a quiet edge, a faint drop, no wireframe double borders.
-fn lib_sheet(mut app GuiApp, x int, y int, w int, h int) {
-	app.gg.draw_rect_filled(x + 2, y + 2, w, h, tint(col_ink, 12))
-	app.gg.draw_rounded_rect_filled(x, y, w, h, 4, pc(app, `P`))
-	app.gg.draw_rounded_rect_empty(x, y, w, h, 4, tint(pc(app, `W`), 60))
-}
-
-// lib_pill draws a chip; filled sage when active.
-fn lib_pill(mut app GuiApp, x int, y int, w int, h int, label string, active bool, hover bool) {
+// library_pill draws a chip; filled sage when active.
+fn library_pill(mut app GuiApp, x int, y int, w int, h int, label string, active bool, hover bool) {
 	sage := app.pnl_success
 	if active {
 		app.gg.draw_rounded_rect_filled(x, y, w, h, h / 2, sage)
@@ -665,22 +651,22 @@ fn lib_pill(mut app GuiApp, x int, y int, w int, h int, label string, active boo
 			tint(pc(app, `m`), 90)
 		})
 	}
-	lib_text(mut app, x + 10, y + (h - 14) / 2, label, 11, if active {
+	library_text(mut app, x + 10, y + (h - 14) / 2, label, 11, if active {
 		app.pnl_bg
 	} else {
 		app.pnl_text
 	}, active)
 }
 
-// lib_tag is the small manila fact chip on cards and in the detail pane.
-fn lib_tag(mut app GuiApp, x int, y int, label string, accent bool) int {
+// library_tag is the small manila fact chip on cards and in the detail pane.
+fn library_tag(mut app GuiApp, x int, y int, label string, accent bool) int {
 	w := label.len * 6 + 14
 	app.gg.draw_rounded_rect_filled(x, y, w, 18, 4, if accent {
 		tint(app.pnl_success, 70)
 	} else {
 		tint(pc(app, `m`), 110)
 	})
-	lib_text(mut app, x + 7, y + 2, label, 11, if accent { app.pnl_success } else { app.pnl_text }, false)
+	library_text(mut app, x + 7, y + 2, label, 11, if accent { app.pnl_success } else { app.pnl_text }, false)
 	return w
 }
 
@@ -689,7 +675,7 @@ fn lib_tag(mut app GuiApp, x int, y int, label string, accent bool) int {
 // draw_library is the panel body for panels 1/2/10/3.
 fn draw_library(mut app GuiApp, w int, h int) {
 	ensure_pixel_cache(mut app)
-	l := lib_layout(mut app, w, h)
+	l := library_layout(mut app, w, h)
 	pid := office_palette_id(app)
 	app.gg.draw_rect_filled(l.fx, l.fy, l.fw, l.fh, app.pnl_bg)
 	if l.banner_w > 0 {
@@ -697,15 +683,15 @@ fn draw_library(mut app GuiApp, w int, h int) {
 		app.gg.draw_rect_filled(l.side_x, l.fy, l.side_w, l.side_y - l.fy, app.pnl_bg)
 	}
 
-	draw_lib_header(mut app, l, pid)
-	draw_lib_tabs(mut app, l, pid)
-	items := lib_items(mut app)
-	draw_lib_search(mut app, l, items.len)
-	draw_lib_chips(mut app, l)
-	draw_lib_grid(mut app, l, pid, items)
+	draw_library_header(mut app, l, pid)
+	draw_library_tabs(mut app, l, pid)
+	items := library_items(mut app)
+	draw_library_search(mut app, l, items.len)
+	draw_library_chips(mut app, l)
+	draw_library_grid(mut app, l, pid, items)
 }
 
-fn draw_lib_header(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
+fn draw_library_header(mut app GuiApp, l LibraryLayout, pid pixelart.PaletteId) {
 	mut sc := app.pixel_cache
 	rtl := app.lang.is_rtl()
 	y := l.head_y
@@ -727,7 +713,7 @@ fn draw_lib_header(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
 		size: if l.compact { 22 } else { 28 }
 		family: app.fonts.display
 	})
-	sub := tr(app, 'lib.subtitle')
+	sub := tr(app, 'library.subtitle')
 	max_px := if rtl {
 		x - tx - 12
 	} else if l.banner_w > 0 {
@@ -735,16 +721,16 @@ fn draw_lib_header(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
 	} else {
 		l.fw - (tx - l.fx) - 20
 	}
-	app.gg.draw_text(tx, y + (if l.compact { 30 } else { 46 }), utf8_truncate(sub, onb_fit(max_px, 13)), gg.TextCfg{
+	app.gg.draw_text(tx, y + (if l.compact { 30 } else { 46 }), utf8_truncate(sub, text_fit_chars(max_px, 13)), gg.TextCfg{
 		color: app.pnl_text_mut
 		size: 13
 	})
 	if l.banner_w > 0 {
-		draw_lib_banner(mut app, l.banner_x, y, l.banner_w, l.head_h, pid)
+		draw_library_banner(mut app, l.banner_x, y, l.banner_w, l.head_h, pid)
 	}
 }
 
-// draw_lib_banner composes the header illustration as a floor-to-ceiling
+// draw_library_banner composes the header illustration as a floor-to-ceiling
 // reading room, layered back to front: dark wood back wall with a crown band,
 // plank floor (same rhythm as the Office room), one continuous wall of tall
 // shelves (butted, alternating book materials) broken only by a reading nook
@@ -752,7 +738,7 @@ fn draw_lib_header(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
 // builder, a side table with a globe — then a ladder, plants of two sizes and
 // book piles on the floor. Deterministic and static; environmental only —
 // nothing here encodes catalog counts or runtime activity.
-fn draw_lib_banner(mut app GuiApp, x int, y int, w int, h int, pid pixelart.PaletteId) {
+fn draw_library_banner(mut app GuiApp, x int, y int, w int, h int, pid pixelart.PaletteId) {
 	mut sc := app.pixel_cache
 	ink := app.appearance_dark
 	// ── surfaces: back wall, crown, floor planks ─────────────────────────
@@ -823,7 +809,7 @@ fn draw_lib_banner(mut app GuiApp, x int, y int, w int, h int, pid pixelart.Pale
 		name: 'env-lamp-pendant'
 		rows: lamp.rows[0..4]
 	}
-	s := onb_art_scale(shelf_a.width(), shelf_a.height(), w, h - floor_h - crown_h)
+	s := onboarding_art_scale(shelf_a.width(), shelf_a.height(), w, h - floor_h - crown_h)
 	sw := shelf_a.width() * s
 	shelf_top := base - shelf_a.height() * s
 
@@ -914,7 +900,7 @@ fn draw_lib_banner(mut app GuiApp, x int, y int, w int, h int, pid pixelart.Pale
 	}
 }
 
-fn draw_lib_tabs(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
+fn draw_library_tabs(mut app GuiApp, l LibraryLayout, pid pixelart.PaletteId) {
 	mut sc := app.pixel_cache
 	labels := [tr(app, 'panel.skills'), tr(app, 'panel.agents'), tr(app, 'panel.products'),
 		tr(app, 'panel.mcp')]
@@ -930,9 +916,9 @@ fn draw_lib_tabs(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
 	// one hairline under the whole tab row; the active tab carries a sage bar
 	app.gg.draw_rect_filled(l.fx + 12, l.tabs_y + l.tabs_h - 1, l.fw - 24, 1, tint(pc(app, `W`), 70))
 	for i, lb in labels {
-		tx, ty, tw, th := lib_tab_rect(l, i)
+		tx, ty, tw, th := library_tab_rect(l, i)
 		active := i == l.tab
-		hover := app.lib_hover_ui == lib_ui_tab0 + i
+		hover := app.library_hover_ui == library_ui_tab0 + i
 		if hover && !active {
 			app.gg.draw_rect_filled(tx, ty, tw, th - 2, tint(pc(app, `m`), 60))
 		}
@@ -940,7 +926,7 @@ fn draw_lib_tabs(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
 		ms := 1
 		my := ty + (th - m.height() * ms) / 2 - 1
 		sc.draw(m, pid, tx + 8, my, ms)
-		lib_text(mut app, tx + 8 + m.width() * ms + 8, ty + 7, utf8_truncate(lb, onb_fit(tw - 40, 14)), 14, if active {
+		library_text(mut app, tx + 8 + m.width() * ms + 8, ty + 7, utf8_truncate(lb, text_fit_chars(tw - 40, 14)), 14, if active {
 			app.pnl_text
 		} else {
 			app.pnl_text_mut
@@ -951,9 +937,9 @@ fn draw_lib_tabs(mut app GuiApp, l LibLayout, pid pixelart.PaletteId) {
 	}
 }
 
-fn draw_lib_search(mut app GuiApp, l LibLayout, count int) {
-	sx, sy, sw, sh := lib_search_rect(l)
-	focus := app.lib_hover_ui == lib_ui_search
+fn draw_library_search(mut app GuiApp, l LibraryLayout, count int) {
+	sx, sy, sw, sh := library_search_rect(l)
+	focus := app.library_hover_ui == library_ui_search
 	app.gg.draw_rounded_rect_filled(sx, sy, sw, sh, 6, pc(app, `P`))
 	app.gg.draw_rounded_rect_empty(sx, sy, sw, sh, 6, if focus {
 		app.pnl_success
@@ -974,7 +960,7 @@ fn draw_lib_search(mut app GuiApp, l LibLayout, count int) {
 		else { 'Search MCP providers, e.g. "github", "slack"…' }
 	}
 	shown := if q == '' { hint } else { q }
-	lib_text(mut app, sx + 30, sy + 8, utf8_truncate(shown, onb_fit(sw - 44, 13)), 13, if q == '' {
+	library_text(mut app, sx + 30, sy + 8, utf8_truncate(shown, text_fit_chars(sw - 44, 13)), 13, if q == '' {
 		app.pnl_text_mut
 	} else {
 		app.pnl_text
@@ -985,7 +971,7 @@ fn draw_lib_search(mut app GuiApp, l LibLayout, count int) {
 	}
 	// honest result count on the right instead of a Filters/Sort control we
 	// do not have
-	total := lib_total(mut app)
+	total := library_total(mut app)
 	label := if count == total { '${total}' } else { '${count} of ${total}' }
 	kind := match l.tab {
 		0 { 'skills' }
@@ -993,15 +979,15 @@ fn draw_lib_search(mut app GuiApp, l LibLayout, count int) {
 		2 { 'items' }
 		else { 'providers' }
 	}
-	lib_text(mut app, sx + sw + 12, sy + 9, '${label} ${kind}', 12, app.pnl_text_mut, false)
+	library_text(mut app, sx + sw + 12, sy + 9, '${label} ${kind}', 12, app.pnl_text_mut, false)
 }
 
-// lib_total is the unfiltered catalog size for the active tab.
-fn lib_total(mut app GuiApp) int {
+// library_total is the unfiltered catalog size for the active tab.
+fn library_total(mut app GuiApp) int {
 	if app.desktop == unsafe { nil } {
 		return 0
 	}
-	return match lib_tab_for_panel(app.selected_panel) {
+	return match library_tab_for_panel(app.selected_panel) {
 		0 { app.desktop.engine_skills_stats().total }
 		1 { agents_active_total(mut app) }
 		2 { app.desktop.engine_products_catalog().len + app.desktop.engine_packs_catalog().len }
@@ -1009,42 +995,42 @@ fn lib_total(mut app GuiApp) int {
 	}
 }
 
-fn draw_lib_chips(mut app GuiApp, l LibLayout) {
-	labels := lib_chips(mut app)
+fn draw_library_chips(mut app GuiApp, l LibraryLayout) {
+	labels := library_chips(mut app)
 	for i, lb in labels {
-		cx, cy, cw, ch := lib_chip_rect(l, labels, i)
+		cx, cy, cw, ch := library_chip_rect(l, labels, i)
 		if cw == 0 {
 			continue
 		}
-		lib_pill(mut app, cx, cy, cw, ch, lb, lib_chip_active(app, lb), app.lib_hover_ui == lib_ui_chip0 + i)
+		library_pill(mut app, cx, cy, cw, ch, lb, library_chip_active(app, lb), app.library_hover_ui == library_ui_chip0 + i)
 	}
 }
 
-fn draw_lib_grid(mut app GuiApp, l LibLayout, pid pixelart.PaletteId, items []LibItem) {
+fn draw_library_grid(mut app GuiApp, l LibraryLayout, pid pixelart.PaletteId, items []LibraryItem) {
 	mut sc := app.pixel_cache
 	if items.len == 0 {
 		msg := if app.desktop == unsafe { nil } {
 			'Catalog unavailable — Engine not booted.'
-		} else if app.skills_query != '' || app.skills_domain != '' || app.lib_filter != '' {
+		} else if app.skills_query != '' || app.skills_domain != '' || app.library_filter != '' {
 			'Nothing matches — clear the search or filter (Esc).'
 		} else {
 			'This catalog is empty in the resolved toolkit root.'
 		}
-		lib_text(mut app, l.fx + 16, l.grid_y + 12, msg, 13, app.pnl_text_mut, false)
+		library_text(mut app, l.fx + 16, l.grid_y + 12, msg, 13, app.pnl_text_mut, false)
 		return
 	}
-	start, end := lib_visible_range(mut app, l, items.len)
-	mut sel := lib_selected(app)
+	start, end := library_visible_range(mut app, l, items.len)
+	mut sel := library_selected(app)
 	if sel >= items.len || sel < 0 {
 		sel = 0
-		lib_set_selected(mut app, 0)
+		library_set_selected(mut app, 0)
 	}
 	for idx in start .. end {
 		item := items[idx]
-		cx, cy, cw, ch := lib_card_rect(l, idx - start)
+		cx, cy, cw, ch := library_card_rect(l, idx - start)
 		is_sel := idx == sel
-		is_hover := idx == app.lib_hover
-		lib_sheet(mut app, cx, cy, cw, ch)
+		is_hover := idx == app.library_hover
+		draw_paper_sheet(mut app, cx, cy, cw, ch)
 		if is_sel {
 			app.gg.draw_rounded_rect_filled(cx, cy, cw, ch, 4, tint(app.pnl_success, 28))
 			app.gg.draw_rounded_rect_empty(cx, cy, cw, ch, 4, app.pnl_success)
@@ -1060,48 +1046,48 @@ fn draw_lib_grid(mut app GuiApp, l LibLayout, pid pixelart.PaletteId, items []Li
 		sc.draw(item.mark, pid, mx + (48 - item.mark.width() * ms) / 2, my + (48 - item.mark.height() * ms) / 2, ms)
 		tx := cx + 70
 		tw := cw - 70 - 10
-		lib_text(mut app, tx, cy + 9, lib_clip(item.name, onb_fit(tw, 14)), 14, app.pnl_text, true)
+		library_text(mut app, tx, cy + 9, truncate_with_ellipsis(item.name, text_fit_chars(tw, 14)), 14, app.pnl_text, true)
 		desc_lines := if ch >= 120 { 3 } else { 2 }
-		for li, ln in lib_wrap(item.desc, onb_fit(tw, 12), desc_lines) {
-			lib_text(mut app, tx, cy + 28 + li * 14, ln, 12, app.pnl_text_mut, false)
+		for li, ln in wrap_text_lines(item.desc, text_fit_chars(tw, 12), desc_lines) {
+			library_text(mut app, tx, cy + 28 + li * 14, ln, 12, app.pnl_text_mut, false)
 		}
 		// tags row; short cards fold the configuration fact into an accent tag
 		short := ch < 100
 		mut tgx := cx + 10
 		tgy := if short { cy + ch - 26 } else { cy + ch - 40 }
 		if short && item.on {
-			tgx += lib_tag(mut app, tgx, tgy, item.foot, true) + 5
+			tgx += library_tag(mut app, tgx, tgy, item.foot, true) + 5
 		}
 		for t in item.tags {
 			tw2 := t.len * 6 + 14
 			if tgx + tw2 > cx + cw - 8 {
 				break
 			}
-			tgx += lib_tag(mut app, tgx, tgy, t, false) + 5
+			tgx += library_tag(mut app, tgx, tgy, t, false) + 5
 		}
 		if !short {
 			// footer facts: configuration truth left, catalog truth right
 			fy2 := cy + ch - 16
-			lib_text(mut app, cx + 10, fy2, item.foot, 11, if item.on {
+			library_text(mut app, cx + 10, fy2, item.foot, 11, if item.on {
 				app.pnl_success
 			} else {
 				app.pnl_text_mut
 			}, item.on)
 			if item.foot2 != '' && cw > 180 {
 				fw2 := item.foot2.len * 6
-				lib_text(mut app, cx + cw - 10 - fw2, fy2, item.foot2, 11, app.pnl_text_mut, false)
+				library_text(mut app, cx + cw - 10 - fw2, fy2, item.foot2, 11, app.pnl_text_mut, false)
 			}
 		}
 	}
 	// scroll indicator + honest count under the grid
 	total_rows := (items.len + l.cols - 1) / l.cols
-	row := lib_scroll_row(app)
+	row := library_scroll_row(app)
 	foot := if items.len > end - start {
 		'${start + 1}–${end} of ${items.len} · wheel or ↑↓ to scroll · Enter toggles the selected card'
 	} else {
 		'${items.len} shown · Enter toggles the selected card'
 	}
-	lib_text(mut app, l.fx + 14, l.fy + l.fh - 16, utf8_truncate(foot, onb_fit(l.fw - 40, 11)), 11, app.pnl_text_mut, false)
+	library_text(mut app, l.fx + 14, l.fy + l.fh - 16, utf8_truncate(foot, text_fit_chars(l.fw - 40, 11)), 11, app.pnl_text_mut, false)
 	if total_rows > l.rows && l.rows > 0 {
 		track_x := l.fx + l.fw - 8
 		bar_h := if l.grid_h * l.rows / total_rows < 16 {
@@ -1117,14 +1103,14 @@ fn draw_lib_grid(mut app GuiApp, l LibLayout, pid pixelart.PaletteId, items []Li
 
 // ── detail column (replaces the Office inspector for Library panels) ─────────
 
-struct LibFact {
+struct LibraryFact {
 	label string
 	value string
 	ok    bool // draws a check instead of a dash when true
 	mono  bool
 }
 
-struct LibDetail {
+struct LibraryDetail {
 	title     string
 	sub       string
 	desc      string
@@ -1135,8 +1121,8 @@ struct LibDetail {
 	quiet     bool // primary is a non-mutating helper (copy), drawn as a plain button
 	second    string
 	third     string
-	compat    []LibFact
-	prov      []LibFact
+	compatibility    []LibraryFact
+	prov      []LibraryFact
 	inc_title string
 	included  []string
 	inc_mono  bool // included lines are code (masked template), not a checklist
@@ -1144,9 +1130,9 @@ struct LibDetail {
 	quote_by  string
 }
 
-// lib_targets_fact summarizes the targets registry: enabled targets are the
+// library_targets_fact summarizes the targets registry: enabled targets are the
 // real destinations a capability deploys to.
-fn lib_targets_fact(mut app GuiApp) (string, bool) {
+fn library_targets_fact(mut app GuiApp) (string, bool) {
 	tg := app.desktop.engine_targets()
 	en := tg.filter(it.enabled).map(it.id)
 	if en.len == 0 {
@@ -1159,37 +1145,37 @@ fn lib_targets_fact(mut app GuiApp) (string, bool) {
 	return s, true
 }
 
-fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
+fn library_detail(mut app GuiApp, items []LibraryItem) ?LibraryDetail {
 	if app.desktop == unsafe { nil } || items.len == 0 {
 		return none
 	}
-	sel := lib_selected(app)
+	sel := library_selected(app)
 	if sel < 0 || sel >= items.len {
 		return none
 	}
 	item := items[sel]
-	tfact, tok := lib_targets_fact(mut app)
+	tfact, tok := library_targets_fact(mut app)
 	found := app.desktop.engine_tool_discovery_catalog_cached()
 	nfound := found.filter(it.found).len
-	match lib_tab_for_panel(app.selected_panel) {
+	match library_tab_for_panel(app.selected_panel) {
 		0 {
 			s := app.desktop.engine_skill_detail(item.id) or { return none }
 			installed := s.id in app.desktop.engine_skills_installed()
 			mut prov := [
-				LibFact{'Source', 'skills/${s.id}/SKILL.md', false, true},
-				LibFact{'Stability', if s.stability != '' { s.stability } else { 'unknown' }, s.stability == 'stable', false},
+				LibraryFact{'Source', 'skills/${s.id}/SKILL.md', false, true},
+				LibraryFact{'Stability', if s.stability != '' { s.stability } else { 'unknown' }, s.stability == 'stable', false},
 			]
 			if r := app.desktop.engine_skill_receipt(s.id) {
-				prov << LibFact{'Receipt', '${r.installed_at} · v${r.version}', true, true}
-				prov << LibFact{'Digest', utf8_truncate(r.digest, 16), false, true}
+				prov << LibraryFact{'Receipt', '${r.installed_at} · v${r.version}', true, true}
+				prov << LibraryFact{'Digest', utf8_truncate(r.digest, 16), false, true}
 			} else {
-				prov << LibFact{'Receipt', 'none — not deployed yet', false, false}
+				prov << LibraryFact{'Receipt', 'none — not deployed yet', false, false}
 			}
 			mut inc := ['SKILL.md — definition and instructions']
 			if s.triggers != '' {
 				inc << 'Triggers: ${utf8_truncate(s.triggers, 40)}'
 			}
-			return LibDetail{
+			return LibraryDetail{
 				title: item.name
 				sub: s.id
 				desc: s.description
@@ -1199,10 +1185,10 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 				on: installed
 				second: 'Copy id'
 				third: ''
-				compat: [
-					LibFact{'Targets', tfact, tok, false},
-					LibFact{'Tools found', '${nfound} of ${found.len} on this computer', nfound > 0, false},
-					LibFact{'Selected', if installed { 'yes — in this workspace' } else { 'no' }, installed, false},
+				compatibility: [
+					LibraryFact{'Targets', tfact, tok, false},
+					LibraryFact{'Tools found', '${nfound} of ${found.len} on this computer', nfound > 0, false},
+					LibraryFact{'Selected', if installed { 'yes — in this workspace' } else { 'no' }, installed, false},
 				]
 				prov: prov
 				inc_title: "What's included"
@@ -1220,19 +1206,19 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 				}
 			}
 			mut prov := [
-				LibFact{'Source', if ag.source_file != '' {
+				LibraryFact{'Source', if ag.source_file != '' {
 					ag.source_file
 				} else {
 					'agents/${ag.id}/AGENT.md'
 				}, false, true},
 			]
 			if ag.provenance != '' {
-				prov << LibFact{'Provenance', utf8_truncate(ag.provenance, 28), false, true}
+				prov << LibraryFact{'Provenance', utf8_truncate(ag.provenance, 28), false, true}
 			}
 			if r := app.desktop.engine_agent_receipt(ag.id) {
-				prov << LibFact{'Receipt', r.installed_at, true, true}
+				prov << LibraryFact{'Receipt', r.installed_at, true, true}
 			} else {
-				prov << LibFact{'Receipt', 'none — not deployed yet', false, false}
+				prov << LibraryFact{'Receipt', 'none — not deployed yet', false, false}
 			}
 			mut inc := ['AGENT.md — persona contract']
 			for d in ag.delegates_to {
@@ -1241,7 +1227,7 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 			for c in ag.collaborates_with {
 				inc << 'Collaborates with ${c}'
 			}
-			return LibDetail{
+			return LibraryDetail{
 				title: ag.id
 				sub: 'agents/${ag.id}'
 				desc: if ag.description != '' { ag.description } else { ag.role }
@@ -1250,14 +1236,14 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 				primary: 'Copy id'
 				quiet: true
 				second: ''
-				compat: [
-					LibFact{'Targets', tfact, tok, false},
-					LibFact{'Holistic owner', if ag.holistic_owner != '' {
+				compatibility: [
+					LibraryFact{'Targets', tfact, tok, false},
+					LibraryFact{'Holistic owner', if ag.holistic_owner != '' {
 						ag.holistic_owner
 					} else {
 						'—'
 					}, ag.holistic_owner != '', false},
-					LibFact{'Archived', if ag.archived { 'yes' } else { 'no' }, !ag.archived, false},
+					LibraryFact{'Archived', if ag.archived { 'yes' } else { 'no' }, !ag.archived, false},
 				]
 				prov: prov
 				inc_title: 'Relationships'
@@ -1275,7 +1261,7 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 						break
 					}
 				}
-				return LibDetail{
+				return LibraryDetail{
 					title: item.name
 					sub: 'packs/${pk.id}'
 					desc: item.desc
@@ -1284,13 +1270,13 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 					primary: if pk.enabled { 'Disable' } else { 'Enable' }
 					on: pk.enabled
 					second: 'Copy id'
-					compat: [
-						LibFact{'Targets', tfact, tok, false},
-						LibFact{'Docs-only', if pk.docs_only { 'yes (ADR-006)' } else { 'no' }, true, false},
-						LibFact{'Enabled', if pk.enabled { 'yes' } else { 'no' }, pk.enabled, false},
+					compatibility: [
+						LibraryFact{'Targets', tfact, tok, false},
+						LibraryFact{'Docs-only', if pk.docs_only { 'yes (ADR-006)' } else { 'no' }, true, false},
+						LibraryFact{'Enabled', if pk.enabled { 'yes' } else { 'no' }, pk.enabled, false},
 					]
 					prov: [
-						LibFact{'Source', if pk.provenance != '' {
+						LibraryFact{'Source', if pk.provenance != '' {
 							pk.provenance
 						} else {
 							'packs/${pk.id}/config.yaml'
@@ -1309,7 +1295,7 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 					break
 				}
 			}
-			return LibDetail{
+			return LibraryDetail{
 				title: item.name
 				sub: 'products/${pr.id}'
 				desc: pr.description.trim("'")
@@ -1317,13 +1303,13 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 				mark: item.mark
 				primary: 'Install'
 				second: 'Copy id'
-				compat: [
-					LibFact{'Targets', tfact, tok, false},
-					LibFact{'Tools found', '${nfound} of ${found.len} on this computer', nfound > 0, false},
+				compatibility: [
+					LibraryFact{'Targets', tfact, tok, false},
+					LibraryFact{'Tools found', '${nfound} of ${found.len} on this computer', nfound > 0, false},
 				]
 				prov: [
-					LibFact{'Source', 'distributions/products.yaml', false, true},
-					LibFact{'Composition', 'not exposed by Engine yet', false, false},
+					LibraryFact{'Source', 'distributions/products.yaml', false, true},
+					LibraryFact{'Composition', 'not exposed by Engine yet', false, false},
 				]
 				inc_title: ''
 				included: []
@@ -1342,12 +1328,12 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 			if app.mcp_drawer != mp.id {
 				// first selection (or a stale drawer): load the masked
 				// template, receipt and probe once, not per frame
-				lib_select_mcp(mut app, mp.id)
+				library_select_mcp(mut app, mp.id)
 			}
 			probe := if mcp_probe_fresh(app, mp.id) {
-				LibFact{'Probe', utf8_truncate(app.mcp_probe_detail, 30), app.mcp_probe_ok, false}
+				LibraryFact{'Probe', utf8_truncate(app.mcp_probe_detail, 30), app.mcp_probe_ok, false}
 			} else {
-				LibFact{'Probe', 'not run — press Probe', false, false}
+				LibraryFact{'Probe', 'not run — press Probe', false, false}
 			}
 			mut inc := []string{}
 			if app.mcp_drawer == mp.id {
@@ -1364,7 +1350,7 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 			} else {
 				'none — enable to create one'
 			}
-			return LibDetail{
+			return LibraryDetail{
 				title: item.name
 				sub: 'mcp/${mp.id}'
 				desc: item.desc
@@ -1374,25 +1360,25 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 				on: mp.enabled
 				second: 'Probe'
 				third: 'Template'
-				compat: [
-					LibFact{'Targets', tfact, tok, false},
-					LibFact{'Docker', if mp.requires_docker { 'required' } else { 'not required' }, !mp.requires_docker, false},
-					LibFact{'Health', if mp.health != '' { mp.health } else { 'unknown' }, mp.health == 'healthy', false},
+				compatibility: [
+					LibraryFact{'Targets', tfact, tok, false},
+					LibraryFact{'Docker', if mp.requires_docker { 'required' } else { 'not required' }, !mp.requires_docker, false},
+					LibraryFact{'Health', if mp.health != '' { mp.health } else { 'unknown' }, mp.health == 'healthy', false},
 					probe,
 				]
 				prov: [
-					LibFact{'Template', if mp.template_path != '' {
+					LibraryFact{'Template', if mp.template_path != '' {
 						mp.template_path
 					} else {
 						'defaults (no file)'
 					}, mp.template_path != '', true},
-					LibFact{'Registry', if mp.registry_path != '' {
+					LibraryFact{'Registry', if mp.registry_path != '' {
 						mp.registry_path
 					} else {
 						'mcp/registry'
 					}, false, true},
-					LibFact{'Version', if mp.version != '' { mp.version } else { 'unknown' }, mp.version != '', false},
-					LibFact{'Receipt', receipt, false, true},
+					LibraryFact{'Version', if mp.version != '' { mp.version } else { 'unknown' }, mp.version != '', false},
+					LibraryFact{'Receipt', receipt, false, true},
 				]
 				inc_title: 'Template (secrets masked)'
 				included: inc
@@ -1410,7 +1396,7 @@ fn lib_detail(mut app GuiApp, items []LibItem) ?LibDetail {
 // draw_library_detail is the right column while a Library panel is active.
 fn draw_library_detail(mut app GuiApp, w int, h int) {
 	ensure_pixel_cache(mut app)
-	l := lib_layout(mut app, w, h)
+	l := library_layout(mut app, w, h)
 	pid := office_palette_id(app)
 	mut sc := app.pixel_cache
 	x := l.side_x
@@ -1420,9 +1406,9 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 	app.gg.draw_rect_filled(x, y, iw, ih, app.pnl_bg)
 	app.gg.draw_rect_filled(x + 8, y + 6, iw - 16, ih - 12, pc(app, `P`))
 	app.gg.draw_rect_empty(x + 8, y + 6, iw - 16, ih - 12, tint(pc(app, `W`), 60))
-	items := lib_items(mut app)
-	d := lib_detail(mut app, items) or {
-		lib_text(mut app, x + 20, y + 22, 'Select a card to see details', 14, app.pnl_text_mut, false)
+	items := library_items(mut app)
+	d := library_detail(mut app, items) or {
+		library_text(mut app, x + 20, y + 22, 'Select a card to see details', 14, app.pnl_text_mut, false)
 		return
 	}
 	px := x + 16
@@ -1433,8 +1419,8 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 	sc.draw(d.mark, pid, px + 2 + (64 - d.mark.width() * ms) / 2, y + 18 + (64 - d.mark.height() * ms) / 2, ms)
 	tx := px + 80
 	tw := inner - 80
-	lib_text(mut app, tx, y + 18, lib_clip(d.title, onb_fit(tw, 17)), 17, app.pnl_text, true)
-	app.gg.draw_text(tx, y + 40, lib_clip(d.sub, tw / 6), gg.TextCfg{
+	library_text(mut app, tx, y + 18, truncate_with_ellipsis(d.title, text_fit_chars(tw, 17)), 17, app.pnl_text, true)
+	app.gg.draw_text(tx, y + 40, truncate_with_ellipsis(d.sub, tw / 6), gg.TextCfg{
 		color: app.pnl_text_mut
 		size: 11
 		mono: true
@@ -1446,22 +1432,22 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 		if tgx + tw2 > px + inner {
 			break
 		}
-		tgx += lib_tag(mut app, tgx, y + 58, t, false) + 5
+		tgx += library_tag(mut app, tgx, y + 58, t, false) + 5
 	}
 	// description
 	mut dy := y + 92
-	for ln in lib_wrap(d.desc, onb_fit(inner, 12), 5) {
-		lib_text(mut app, px, dy, ln, 12, app.pnl_text, false)
+	for ln in wrap_text_lines(d.desc, text_fit_chars(inner, 12), 5) {
+		library_text(mut app, px, dy, ln, 12, app.pnl_text, false)
 		dy += 14
 	}
 	// actions
-	ay := lib_detail_actions_y(l)
+	ay := library_detail_actions_y(l)
 	if ay < dy + 6 {
 		// long description: still keep buttons visible below it
 		dy = ay - 6
 	}
-	bx, by, bw, bh := lib_btn_rect(l, 0)
-	hov0 := app.lib_hover_ui == lib_ui_primary
+	bx, by, bw, bh := library_btn_rect(l, 0)
+	hov0 := app.library_hover_ui == library_ui_primary
 	if d.on {
 		app.gg.draw_rounded_rect_filled(bx, by, bw, bh, 6, if hov0 {
 			tint(app.pnl_danger, 40)
@@ -1469,7 +1455,7 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 			pc(app, `P`)
 		})
 		app.gg.draw_rounded_rect_empty(bx, by, bw, bh, 6, app.pnl_danger)
-		lib_text(mut app, bx + (bw - d.primary.len * 8) / 2, by + 9, d.primary, 14, app.pnl_danger, true)
+		library_text(mut app, bx + (bw - d.primary.len * 8) / 2, by + 9, d.primary, 14, app.pnl_danger, true)
 	} else if d.quiet {
 		app.gg.draw_rounded_rect_filled(bx, by, bw, bh, 6, if hov0 {
 			tint(pc(app, `m`), 140)
@@ -1477,7 +1463,7 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 			tint(pc(app, `m`), 80)
 		})
 		app.gg.draw_rounded_rect_empty(bx, by, bw, bh, 6, tint(pc(app, `W`), 90))
-		lib_text(mut app, bx + (bw - d.primary.len * 8) / 2, by + 9, d.primary, 14, app.pnl_text, true)
+		library_text(mut app, bx + (bw - d.primary.len * 8) / 2, by + 9, d.primary, 14, app.pnl_text, true)
 	} else {
 		app.gg.draw_rect_filled(bx + 2, by + 3, bw, bh, tint(col_ink, 30))
 		app.gg.draw_rounded_rect_filled(bx, by, bw, bh, 6, if hov0 {
@@ -1485,30 +1471,30 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 		} else {
 			tint(app.pnl_success, 225)
 		})
-		lib_text(mut app, bx + (bw - d.primary.len * 8) / 2, by + 9, d.primary, 14, app.pnl_bg, true)
+		library_text(mut app, bx + (bw - d.primary.len * 8) / 2, by + 9, d.primary, 14, app.pnl_bg, true)
 	}
 	for i, lb in [d.second, d.third] {
 		if lb == '' {
 			continue
 		}
-		sx, sy, sw, sh := lib_btn_rect(l, i + 1)
-		hov := app.lib_hover_ui == lib_ui_second + i
+		sx, sy, sw, sh := library_btn_rect(l, i + 1)
+		hov := app.library_hover_ui == library_ui_second + i
 		app.gg.draw_rounded_rect_filled(sx, sy, sw, sh, 6, if hov {
 			tint(pc(app, `m`), 140)
 		} else {
 			tint(pc(app, `m`), 80)
 		})
 		app.gg.draw_rounded_rect_empty(sx, sy, sw, sh, 6, tint(pc(app, `W`), 90))
-		lib_text(mut app, sx + (sw - lb.len * 7) / 2, sy + 10, utf8_truncate(lb, onb_fit(sw - 8, 12)), 12, app.pnl_text, false)
+		library_text(mut app, sx + (sw - lb.len * 7) / 2, sy + 10, utf8_truncate(lb, text_fit_chars(sw - 8, 12)), 12, app.pnl_text, false)
 	}
 	// fact sections
 	mut fy := ay + 34 + 14
 	bottom := y + ih - 12
-	fy = draw_lib_facts(mut app, px, fy, inner, 'Compatibility', d.compat, bottom)
-	fy = draw_lib_facts(mut app, px, fy, inner, 'Provenance', d.prov, bottom)
+	fy = draw_library_facts(mut app, px, fy, inner, 'Compatibility', d.compatibility, bottom)
+	fy = draw_library_facts(mut app, px, fy, inner, 'Provenance', d.prov, bottom)
 	// what's included checklist
 	if d.included.len > 0 && fy + 40 < bottom {
-		lib_text(mut app, px, fy, d.inc_title, 12, app.pnl_text, true)
+		library_text(mut app, px, fy, d.inc_title, 12, app.pnl_text, true)
 		fy += 18
 		for item in d.included {
 			if fy + 16 > bottom - 6 {
@@ -1522,8 +1508,8 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 				})
 			} else {
 				app.gg.draw_rect_filled(px, fy + 1, 12, 12, tint(app.pnl_success, 60))
-				lib_check(mut app, px + 2, fy + 1, app.pnl_success)
-				lib_text(mut app, px + 18, fy, utf8_truncate(item, onb_fit(inner - 18, 11)), 11, app.pnl_text, false)
+				draw_check_glyph(mut app, px + 2, fy + 1, app.pnl_success)
+				library_text(mut app, px + 18, fy, utf8_truncate(item, text_fit_chars(inner - 18, 11)), 11, app.pnl_text, false)
 			}
 			fy += 15
 		}
@@ -1534,37 +1520,37 @@ fn draw_library_detail(mut app GuiApp, w int, h int) {
 	if fy + qh + 6 < bottom && d.quote != '' {
 		qy := fy + 4
 		app.gg.draw_rounded_rect_filled(px, qy, inner, qh, 6, tint(pc(app, `m`), 60))
-		app.gg.draw_text(px + 12, qy + 10, lib_clip(d.quote, onb_fit(inner - 52, 12)), gg.TextCfg{
+		app.gg.draw_text(px + 12, qy + 10, truncate_with_ellipsis(d.quote, text_fit_chars(inner - 52, 12)), gg.TextCfg{
 			color: app.pnl_text
 			size: 12
 			family: app.fonts.display
 		})
-		lib_text(mut app, px + 12, qy + 30, d.quote_by, 10, app.pnl_text_mut, false)
+		library_text(mut app, px + 12, qy + 30, d.quote_by, 10, app.pnl_text_mut, false)
 		nest := pixelart.environment_for(.nest)
 		sc.draw(nest, pid, px + inner - nest.width() * 2 - 10, qy + qh - nest.height() * 2 - 6, 2)
 	}
 }
 
-// draw_lib_facts draws a titled label/value list and returns the next y.
-fn draw_lib_facts(mut app GuiApp, x int, y0 int, w int, title string, facts []LibFact, bottom int) int {
+// draw_library_facts draws a titled label/value list and returns the next y.
+fn draw_library_facts(mut app GuiApp, x int, y0 int, w int, title string, facts []LibraryFact, bottom int) int {
 	mut y := y0
 	if facts.len == 0 || y + 20 > bottom {
 		return y
 	}
-	lib_text(mut app, x, y, title, 12, app.pnl_text, true)
+	library_text(mut app, x, y, title, 12, app.pnl_text, true)
 	y += 17
 	lw := if w >= 300 { 92 } else { 84 }
 	for f in facts {
 		if y + 16 > bottom - 4 {
 			break
 		}
-		lib_text(mut app, x, y, f.label, 11, app.pnl_text_mut, false)
+		library_text(mut app, x, y, f.label, 11, app.pnl_text_mut, false)
 		if f.ok {
-			lib_check(mut app, x + lw - 16, y + 1, app.pnl_success)
+			draw_check_glyph(mut app, x + lw - 16, y + 1, app.pnl_success)
 		} else {
 			app.gg.draw_rect_filled(x + lw - 14, y + 7, 6, 1, app.pnl_text_mut)
 		}
-		per := if f.mono { (w - lw) / 6 } else { onb_fit(w - lw, 11) }
+		per := if f.mono { (w - lw) / 6 } else { text_fit_chars(w - lw, 11) }
 		app.gg.draw_text(x + lw, y, utf8_truncate(f.value, per), gg.TextCfg{
 			color: app.pnl_text
 			size: 11
@@ -1577,18 +1563,18 @@ fn draw_lib_facts(mut app GuiApp, x int, y0 int, w int, title string, facts []Li
 
 // ── actions (real Engine calls only) ────────────────────────────────────────
 
-// lib_primary runs the primary action for the selected card of the active tab.
-fn lib_primary(mut app GuiApp) {
+// library_primary runs the primary action for the selected card of the active tab.
+fn library_primary(mut app GuiApp) {
 	if app.desktop == unsafe { nil } {
 		return
 	}
-	items := lib_items(mut app)
-	sel := lib_selected(app)
+	items := library_items(mut app)
+	sel := library_selected(app)
 	if sel < 0 || sel >= items.len {
 		return
 	}
 	item := items[sel]
-	match lib_tab_for_panel(app.selected_panel) {
+	match library_tab_for_panel(app.selected_panel) {
 		0 {
 			rev := app.desktop.engine_toggle_skill(item.id) or {
 				app.inspector_msg = 'Skill ${item.id} error: ${err}'
@@ -1602,7 +1588,7 @@ fn lib_primary(mut app GuiApp) {
 			app.api_calls = app.desktop.engine_api_calls()
 			action := if installed_now { 'installed' } else { 'removed' }
 			app.inspector_msg = 'Skill ${item.id} ${action} rev=${rev} • Engine TX ✓'
-			lib_invalidate(mut app)
+			library_invalidate(mut app)
 		}
 		1 {
 			copy_to_clipboard(mut app, item.id)
@@ -1617,7 +1603,7 @@ fn lib_primary(mut app GuiApp) {
 				app.api_calls = app.desktop.engine_api_calls()
 				verb := if item.on { 'disabled' } else { 'enabled' }
 				app.inspector_msg = 'Pack ${item.id} ${verb} rev=${rev} ✓'
-				lib_invalidate(mut app)
+				library_invalidate(mut app)
 				return
 			}
 			rev := app.desktop.onboarding_set_products_bulk([item.id]) or {
@@ -1642,25 +1628,25 @@ fn lib_primary(mut app GuiApp) {
 			}
 			app.api_calls = app.desktop.engine_api_calls()
 			app.inspector_msg = 'MCP ${item.id} toggled rev=${rev} • ${prov_json} • Engine TX'
-			lib_invalidate(mut app)
-			lib_select_mcp(mut app, item.id)
+			library_invalidate(mut app)
+			library_select_mcp(mut app, item.id)
 		}
 		else {}
 	}
 }
 
-// lib_secondary runs the second/third detail button (which = 0/1).
-fn lib_secondary(mut app GuiApp, which int) {
+// library_secondary runs the second/third detail button (which = 0/1).
+fn library_secondary(mut app GuiApp, which int) {
 	if app.desktop == unsafe { nil } {
 		return
 	}
-	items := lib_items(mut app)
-	sel := lib_selected(app)
+	items := library_items(mut app)
+	sel := library_selected(app)
 	if sel < 0 || sel >= items.len {
 		return
 	}
 	item := items[sel]
-	match lib_tab_for_panel(app.selected_panel) {
+	match library_tab_for_panel(app.selected_panel) {
 		3 {
 			if which == 0 {
 				mcp_run_probe(mut app, item.id, true)
@@ -1673,7 +1659,7 @@ fn lib_secondary(mut app GuiApp, which int) {
 					}
 				}
 				if app.mcp_drawer != item.id {
-					lib_select_mcp(mut app, item.id)
+					library_select_mcp(mut app, item.id)
 				}
 				mcp_open_template(mut app, item.id, tpath)
 			}
@@ -1686,9 +1672,9 @@ fn lib_secondary(mut app GuiApp, which int) {
 	}
 }
 
-// lib_select_mcp loads the masked template/receipt/probe cache for the
+// library_select_mcp loads the masked template/receipt/probe cache for the
 // selected provider so the detail pane can show them without per-frame IO.
-fn lib_select_mcp(mut app GuiApp, id string) {
+fn library_select_mcp(mut app GuiApp, id string) {
 	for p in app.desktop.engine_mcp_catalog() {
 		if p.id == id {
 			mcp_drawer_open(mut app, p.id, p.template_path, p.provenance)
@@ -1697,14 +1683,14 @@ fn lib_select_mcp(mut app GuiApp, id string) {
 	}
 }
 
-// lib_select selects card idx and loads tab-specific detail caches.
-fn lib_select(mut app GuiApp, idx int, items []LibItem) {
-	lib_set_selected(mut app, idx)
+// library_select selects card idx and loads tab-specific detail caches.
+fn library_select(mut app GuiApp, idx int, items []LibraryItem) {
+	library_set_selected(mut app, idx)
 	if idx < 0 || idx >= items.len || app.desktop == unsafe { nil } {
 		return
 	}
 	item := items[idx]
-	match lib_tab_for_panel(app.selected_panel) {
+	match library_tab_for_panel(app.selected_panel) {
 		0 {
 			if r := app.desktop.engine_skill_receipt(item.id) {
 				app.inspector_msg = 'Receipt: ${r.skill_id} ${r.installed_at} digest=${r.digest}'
@@ -1713,7 +1699,7 @@ fn lib_select(mut app GuiApp, idx int, items []LibItem) {
 			}
 		}
 		3 {
-			lib_select_mcp(mut app, item.id)
+			library_select_mcp(mut app, item.id)
 		}
 		else {
 			app.inspector_msg = 'Selected ${item.id}'
@@ -1721,16 +1707,16 @@ fn lib_select(mut app GuiApp, idx int, items []LibItem) {
 	}
 }
 
-// lib_switch_tab moves to another Library panel, resetting per-tab state.
-fn lib_switch_tab(mut app GuiApp, tab int) {
-	if tab < 0 || tab >= lib_tab_panels.len {
+// library_switch_tab moves to another Library panel, resetting per-tab state.
+fn library_switch_tab(mut app GuiApp, tab int) {
+	if tab < 0 || tab >= library_tab_panels.len {
 		return
 	}
-	app.lib_filter = ''
-	app.lib_scroll = 0
-	app.lib_sel = 0
-	app.lib_hover = -1
-	select_panel(mut app, lib_tab_panels[tab])
+	app.library_filter = ''
+	app.library_scroll = 0
+	app.library_sel = 0
+	app.library_hover = -1
+	select_panel(mut app, library_tab_panels[tab])
 }
 
 // ── interaction (same geometry as drawing) ──────────────────────────────────
@@ -1738,63 +1724,63 @@ fn lib_switch_tab(mut app GuiApp, tab int) {
 // library_click handles a click for panels 1/2/10/3. Returns true when the
 // click landed inside the Library surface (panel + detail column).
 fn library_click(mut app GuiApp, mx int, my int, w int, h int) bool {
-	l := lib_layout(mut app, w, h)
-	in_panel := onb_hit(mx, my, l.fx, l.fy, l.fw, l.fh)
-	in_side := onb_hit(mx, my, l.side_x, l.fy, l.side_w, l.fh)
+	l := library_layout(mut app, w, h)
+	in_panel := rect_contains(mx, my, l.fx, l.fy, l.fw, l.fh)
+	in_side := rect_contains(mx, my, l.side_x, l.fy, l.side_w, l.fh)
 	_ = l.side_y
 	if !in_panel && !in_side {
 		return false
 	}
-	for i in 0 .. lib_tab_panels.len {
-		tx, ty, tw, th := lib_tab_rect(l, i)
-		if onb_hit(mx, my, tx, ty, tw, th) {
+	for i in 0 .. library_tab_panels.len {
+		tx, ty, tw, th := library_tab_rect(l, i)
+		if rect_contains(mx, my, tx, ty, tw, th) {
 			if i != l.tab {
-				lib_switch_tab(mut app, i)
+				library_switch_tab(mut app, i)
 			}
 			return true
 		}
 	}
-	sx, sy, sw, sh := lib_search_rect(l)
-	if onb_hit(mx, my, sx, sy, sw, sh) {
+	sx, sy, sw, sh := library_search_rect(l)
+	if rect_contains(mx, my, sx, sy, sw, sh) {
 		app.palette_open = false
 		app.ghost_focused = false
 		app.inspector_msg = 'Type to search — Esc clears'
 		return true
 	}
-	labels := lib_chips(mut app)
+	labels := library_chips(mut app)
 	for i, lb in labels {
-		cx, cy, cw, ch := lib_chip_rect(l, labels, i)
-		if cw > 0 && onb_hit(mx, my, cx, cy, cw, ch) {
-			lib_set_chip(mut app, lb)
+		cx, cy, cw, ch := library_chip_rect(l, labels, i)
+		if cw > 0 && rect_contains(mx, my, cx, cy, cw, ch) {
+			library_set_chip(mut app, lb)
 			return true
 		}
 	}
-	items := lib_items(mut app)
+	items := library_items(mut app)
 	if in_panel {
-		start, end := lib_visible_range(mut app, l, items.len)
+		start, end := library_visible_range(mut app, l, items.len)
 		for idx in start .. end {
-			cx, cy, cw, ch := lib_card_rect(l, idx - start)
-			if onb_hit(mx, my, cx, cy, cw, ch) {
-				lib_select(mut app, idx, items)
+			cx, cy, cw, ch := library_card_rect(l, idx - start)
+			if rect_contains(mx, my, cx, cy, cw, ch) {
+				library_select(mut app, idx, items)
 				return true
 			}
 		}
 		return true
 	}
 	// detail column buttons
-	bx, by, bw, bh := lib_btn_rect(l, 0)
-	if onb_hit(mx, my, bx, by, bw, bh) {
-		lib_primary(mut app)
+	bx, by, bw, bh := library_btn_rect(l, 0)
+	if rect_contains(mx, my, bx, by, bw, bh) {
+		library_primary(mut app)
 		return true
 	}
-	d := lib_detail(mut app, items) or { return true }
+	d := library_detail(mut app, items) or { return true }
 	for i, lb in [d.second, d.third] {
 		if lb == '' {
 			continue
 		}
-		x2, y2, w2, h2 := lib_btn_rect(l, i + 1)
-		if onb_hit(mx, my, x2, y2, w2, h2) {
-			lib_secondary(mut app, i)
+		x2, y2, w2, h2 := library_btn_rect(l, i + 1)
+		if rect_contains(mx, my, x2, y2, w2, h2) {
+			library_secondary(mut app, i)
 			return true
 		}
 	}
@@ -1803,43 +1789,43 @@ fn library_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 
 // library_hover_at updates card/chrome hover state.
 fn library_hover_at(mut app GuiApp, mx int, my int, w int, h int) {
-	l := lib_layout(mut app, w, h)
-	app.lib_hover = -1
-	app.lib_hover_ui = -1
-	for i in 0 .. lib_tab_panels.len {
-		tx, ty, tw, th := lib_tab_rect(l, i)
-		if onb_hit(mx, my, tx, ty, tw, th) {
-			app.lib_hover_ui = lib_ui_tab0 + i
+	l := library_layout(mut app, w, h)
+	app.library_hover = -1
+	app.library_hover_ui = -1
+	for i in 0 .. library_tab_panels.len {
+		tx, ty, tw, th := library_tab_rect(l, i)
+		if rect_contains(mx, my, tx, ty, tw, th) {
+			app.library_hover_ui = library_ui_tab0 + i
 			return
 		}
 	}
-	sx, sy, sw, sh := lib_search_rect(l)
-	if onb_hit(mx, my, sx, sy, sw, sh) {
-		app.lib_hover_ui = lib_ui_search
+	sx, sy, sw, sh := library_search_rect(l)
+	if rect_contains(mx, my, sx, sy, sw, sh) {
+		app.library_hover_ui = library_ui_search
 		return
 	}
-	labels := lib_chips(mut app)
+	labels := library_chips(mut app)
 	for i in 0 .. labels.len {
-		cx, cy, cw, ch := lib_chip_rect(l, labels, i)
-		if cw > 0 && onb_hit(mx, my, cx, cy, cw, ch) {
-			app.lib_hover_ui = lib_ui_chip0 + i
+		cx, cy, cw, ch := library_chip_rect(l, labels, i)
+		if cw > 0 && rect_contains(mx, my, cx, cy, cw, ch) {
+			app.library_hover_ui = library_ui_chip0 + i
 			return
 		}
 	}
 	for i in 0 .. 3 {
-		bx, by, bw, bh := lib_btn_rect(l, i)
-		if onb_hit(mx, my, bx, by, bw, bh) {
-			app.lib_hover_ui = lib_ui_primary + i
+		bx, by, bw, bh := library_btn_rect(l, i)
+		if rect_contains(mx, my, bx, by, bw, bh) {
+			app.library_hover_ui = library_ui_primary + i
 			return
 		}
 	}
-	if onb_hit(mx, my, l.fx, l.grid_y, l.fw, l.grid_h) {
-		total := lib_items(mut app).len
-		start, end := lib_visible_range(mut app, l, total)
+	if rect_contains(mx, my, l.fx, l.grid_y, l.fw, l.grid_h) {
+		total := library_items(mut app).len
+		start, end := library_visible_range(mut app, l, total)
 		for idx in start .. end {
-			cx, cy, cw, ch := lib_card_rect(l, idx - start)
-			if onb_hit(mx, my, cx, cy, cw, ch) {
-				app.lib_hover = idx
+			cx, cy, cw, ch := library_card_rect(l, idx - start)
+			if rect_contains(mx, my, cx, cy, cw, ch) {
+				app.library_hover = idx
 				return
 			}
 		}
@@ -1848,11 +1834,11 @@ fn library_hover_at(mut app GuiApp, mx int, my int, w int, h int) {
 
 // library_scroll handles the wheel over the card grid (delta in rows).
 fn library_scroll(mut app GuiApp, mx int, my int, delta int, w int, h int) bool {
-	l := lib_layout(mut app, w, h)
-	if !onb_hit(mx, my, l.fx, l.grid_y, l.fw, l.grid_h) {
+	l := library_layout(mut app, w, h)
+	if !rect_contains(mx, my, l.fx, l.grid_y, l.fw, l.grid_h) {
 		return false
 	}
-	total := lib_items(mut app).len
+	total := library_items(mut app).len
 	if l.cols == 0 {
 		return true
 	}
@@ -1860,7 +1846,7 @@ fn library_scroll(mut app GuiApp, mx int, my int, delta int, w int, h int) bool 
 	step := if delta > 0 {
 		1
 	} else if delta < 0 { -1 } else { 0 }
-	lib_set_scroll_row(mut app, clamp_scroll(lib_scroll_row(app) + step, total_rows, l.rows))
+	library_set_scroll_row(mut app, clamp_scroll(library_scroll_row(app) + step, total_rows, l.rows))
 	return true
 }
 
@@ -1871,36 +1857,36 @@ fn library_key(mut app GuiApp, e &gg.Event) bool {
 		if app.skills_query.len > 0 {
 			app.skills_query = utf8_truncate(app.skills_query, app.skills_query.runes().len - 1)
 		}
-		lib_set_scroll_row(mut app, 0)
+		library_set_scroll_row(mut app, 0)
 		return true
 	}
 	if e.key_code == .escape {
 		app.skills_query = ''
 		app.skills_domain = ''
-		app.lib_filter = ''
+		app.library_filter = ''
 		return true
 	}
 	if e.key_code == .up {
-		lib_set_scroll_row(mut app, lib_scroll_row(app) - 1)
+		library_set_scroll_row(mut app, library_scroll_row(app) - 1)
 		return true
 	}
 	if e.key_code == .down {
-		lib_set_scroll_row(mut app, lib_scroll_row(app) + 1)
+		library_set_scroll_row(mut app, library_scroll_row(app) + 1)
 		return true
 	}
 	if e.key_code == .left || e.key_code == .right {
-		cur := lib_selected(app)
+		cur := library_selected(app)
 		next := if e.key_code == .left { cur - 1 } else { cur + 1 }
 		if next >= 0 {
-			items := lib_items(mut app)
+			items := library_items(mut app)
 			if next < items.len {
-				lib_select(mut app, next, items)
+				library_select(mut app, next, items)
 			}
 		}
 		return true
 	}
 	if e.key_code == .enter {
-		lib_primary(mut app)
+		library_primary(mut app)
 		return true
 	}
 	// the shared search field owns printable text while a Library panel is
@@ -1908,7 +1894,7 @@ fn library_key(mut app GuiApp, e &gg.Event) bool {
 	// documented nav keys (digits, p/i/o) still fall through
 	if e.char_code >= 32 && e.char_code < 127 && !is_panel_nav_key(e.char_code) {
 		app.skills_query += rune(e.char_code).str()
-		lib_set_scroll_row(mut app, 0)
+		library_set_scroll_row(mut app, 0)
 		return true
 	}
 	return false

--- a/cmd/agent-toolkit-desktop/library_view.v
+++ b/cmd/agent-toolkit-desktop/library_view.v
@@ -658,6 +658,17 @@ fn library_pill(mut app GuiApp, x int, y int, w int, h int, label string, active
 	}, active)
 }
 
+// draw_library_card is the soft paper surface every collection card and the
+// detail column sit on: a quiet edge, a faint drop, no wireframe double
+// borders. Cards are intentionally rounded (radius 4); workspace sheets drawn
+// by draw_paper_sheet are sharp — the two components differ by design, so
+// they keep separate painters sharing the same paper/ink tokens.
+fn draw_library_card(mut app GuiApp, x int, y int, w int, h int) {
+	app.gg.draw_rect_filled(x + 2, y + 2, w, h, tint(col_ink, 12))
+	app.gg.draw_rounded_rect_filled(x, y, w, h, 4, pc(app, `P`))
+	app.gg.draw_rounded_rect_empty(x, y, w, h, 4, tint(pc(app, `W`), 60))
+}
+
 // library_tag is the small manila fact chip on cards and in the detail pane.
 fn library_tag(mut app GuiApp, x int, y int, label string, accent bool) int {
 	w := label.len * 6 + 14
@@ -1030,7 +1041,7 @@ fn draw_library_grid(mut app GuiApp, l LibraryLayout, pid pixelart.PaletteId, it
 		cx, cy, cw, ch := library_card_rect(l, idx - start)
 		is_sel := idx == sel
 		is_hover := idx == app.library_hover
-		draw_paper_sheet(mut app, cx, cy, cw, ch)
+		draw_library_card(mut app, cx, cy, cw, ch)
 		if is_sel {
 			app.gg.draw_rounded_rect_filled(cx, cy, cw, ch, 4, tint(app.pnl_success, 28))
 			app.gg.draw_rounded_rect_empty(cx, cy, cw, ch, 4, app.pnl_success)

--- a/cmd/agent-toolkit-desktop/library_view_test.v
+++ b/cmd/agent-toolkit-desktop/library_view_test.v
@@ -2,11 +2,11 @@ module main
 
 import gg
 
-// VC5 (#1173) — Library composition: geometry shared by drawing and
+// Library composition: geometry shared by drawing and
 // hit-testing, tab↔panel mapping, text wrapping, and the keyboard contract.
-// These run without a gg context (lib_layout never touches app.gg).
+// These run without a gg context (library_layout never touches app.gg).
 
-fn lib_test_app(panel int) &GuiApp {
+fn make_library_test_app(panel int) &GuiApp {
 	return &GuiApp{
 		selected_panel: panel
 		hover_panel: -1
@@ -17,24 +17,24 @@ fn lib_test_app(panel int) &GuiApp {
 	}
 }
 
-fn test_lib_tab_panel_mapping() {
-	for i, p in lib_tab_panels {
-		assert lib_is_panel(p)
-		assert lib_tab_for_panel(p) == i
+fn test_library_tab_panel_mapping() {
+	for i, p in library_tab_panels {
+		assert library_is_panel(p)
+		assert library_tab_for_panel(p) == i
 	}
 	for p in [0, 4, 5, 6, 7, 8, 9, 11, 12] {
-		assert !lib_is_panel(p), 'panel ${p} is not a Library panel'
-		assert lib_tab_for_panel(p) == -1
+		assert !library_is_panel(p), 'panel ${p} is not a Library panel'
+		assert library_tab_for_panel(p) == -1
 	}
 }
 
 // The grid, tabs and chips must stay inside the panel frame, the detail
 // column must not overlap the panel, and no two visible cards may overlap —
 // clicks are resolved against exactly these rects.
-fn test_lib_layout_geometry() {
+fn test_library_layout_geometry() {
 	for size in [[1280, 800], [1024, 640], [1440, 900], [900, 600]] {
-		mut app := lib_test_app(1)
-		l := lib_layout(mut app, size[0], size[1])
+		mut app := make_library_test_app(1)
+		l := library_layout(mut app, size[0], size[1])
 		assert l.fx >= dock_w, 'panel starts right of the dock at ${size}'
 		assert l.fx + l.fw <= l.side_x, 'panel must not overlap the detail column at ${size}'
 		assert l.side_x + l.side_w == size[0], 'detail column is flush right at ${size}'
@@ -43,16 +43,16 @@ fn test_lib_layout_geometry() {
 		assert l.cols >= 1 && l.cols <= 4
 		assert l.card_h >= 86 && l.card_h <= 128, 'card height ${l.card_h} within bounds at ${size}'
 		for i in 0 .. 4 {
-			tx, ty, tw, th := lib_tab_rect(l, i)
+			tx, ty, tw, th := library_tab_rect(l, i)
 			assert tx >= l.fx && tx + tw <= l.fx + l.fw, 'tab ${i} inside frame at ${size}'
 			assert ty == l.tabs_y && th == l.tabs_h
 		}
 		n := l.cols * l.rows
 		for a in 0 .. n {
-			ax, ay, aw, ah := lib_card_rect(l, a)
+			ax, ay, aw, ah := library_card_rect(l, a)
 			assert ax >= l.fx && ax + aw <= l.fx + l.fw, 'card ${a} inside frame at ${size}'
 			for b in a + 1 .. n {
-				bx, by, bw, bh := lib_card_rect(l, b)
+				bx, by, bw, bh := library_card_rect(l, b)
 				overlap := ax < bx + bw && bx < ax + aw && ay < by + bh && by < ay + ah
 				assert !overlap, 'cards ${a} and ${b} overlap at ${size}'
 			}
@@ -69,10 +69,10 @@ fn test_lib_layout_geometry() {
 // RTL mirrors the header: the detail column is flush left, the banner takes
 // the left half of the content row and never reaches into the panel's right
 // half where the title/subtitle block is drawn.
-fn test_lib_layout_rtl_banner() {
-	mut app := lib_test_app(1)
+fn test_library_layout_rtl_banner() {
+	mut app := make_library_test_app(1)
 	app.lang = .ar
-	l := lib_layout(mut app, 1280, 800)
+	l := library_layout(mut app, 1280, 800)
 	assert l.side_x == 0
 	assert l.fx == l.side_w + 8
 	assert l.banner_w > 0, 'banner shows at 1280 in RTL'
@@ -84,13 +84,13 @@ fn test_lib_layout_rtl_banner() {
 // Chips: the same label list drives measurement, drawing and hit-testing;
 // every chip has a rect inside the frame and inside the measured chip band —
 // rows grow with the catalog, nothing is silently dropped.
-fn test_lib_chip_rects() {
-	mut app := lib_test_app(2)
-	l := lib_layout(mut app, 1280, 800)
-	labels := lib_chips(mut app)
+fn test_library_chip_rects() {
+	mut app := make_library_test_app(2)
+	l := library_layout(mut app, 1280, 800)
+	labels := library_chips(mut app)
 	assert labels.len == 5 && labels[0] == 'All'
 	for i in 0 .. labels.len {
-		cx, cy, cw, ch := lib_chip_rect(l, labels, i)
+		cx, cy, cw, ch := library_chip_rect(l, labels, i)
 		assert cw > 0, 'agent chip ${i} must fit on one row'
 		assert cx >= l.fx + 12 && cx + cw <= l.fx + l.fw - 12
 		assert cy >= l.chips_y && cy + ch <= l.chips_y + l.chips_h
@@ -99,40 +99,40 @@ fn test_lib_chip_rects() {
 	// rows; every label still gets a rect and the band height covers them
 	many := ['All', 'accessibility', 'agentic-security', 'architecture', 'cloud', 'core', 'data',
 		'delivery', 'design', 'forge', 'integrations', 'loops', 'ops', 'quality', 'tooling']
-	rows := lib_chip_rows_for(many, l.fx, 400)
+	rows := library_chip_rows_for(many, l.fx, 400)
 	assert rows >= 3, 'fifteen domain chips need more than two rows at 400px, got ${rows}'
-	narrow := LibLayout{
+	narrow := LibraryLayout{
 		...l
 		fw: 400
 		chips_h: rows * 24 + (rows - 1) * 4
 	}
 	for i in 0 .. many.len {
-		cx, cy, cw, ch := lib_chip_rect(narrow, many, i)
+		cx, cy, cw, ch := library_chip_rect(narrow, many, i)
 		assert cw > 0, 'chip ${many[i]} must be reachable'
 		assert cx >= narrow.fx + 12 && cx + cw <= narrow.fx + narrow.fw - 12
 		assert cy + ch <= narrow.chips_y + narrow.chips_h
 	}
-	_, _, none_w, _ := lib_chip_rect(l, labels, labels.len)
+	_, _, none_w, _ := library_chip_rect(l, labels, labels.len)
 	assert none_w == 0, 'out-of-range chip has no rect'
 }
 
-fn test_lib_wrap() {
-	assert lib_wrap('', 20, 2).len == 0
-	one := lib_wrap('short line', 20, 2)
+fn test_library_wrap() {
+	assert wrap_text_lines('', 20, 2).len == 0
+	one := wrap_text_lines('short line', 20, 2)
 	assert one == ['short line']
-	two := lib_wrap('alpha beta gamma delta epsilon zeta eta theta', 12, 2)
+	two := wrap_text_lines('alpha beta gamma delta epsilon zeta eta theta', 12, 2)
 	assert two.len == 2
 	assert two[1].ends_with('…'), 'overflow is marked on the last line: ${two}'
 	for ln in two {
 		assert ln.runes().len <= 12
 	}
-	long := lib_wrap('supercalifragilisticexpialidocious', 10, 1)
+	long := wrap_text_lines('supercalifragilisticexpialidocious', 10, 1)
 	assert long.len == 1 && long[0].runes().len <= 10 && long[0].ends_with('…')
-	assert lib_clip('abcdef', 4) == 'abc…'
-	assert lib_clip('abc', 4) == 'abc'
+	assert truncate_with_ellipsis('abcdef', 4) == 'abc…'
+	assert truncate_with_ellipsis('abc', 4) == 'abc'
 }
 
-fn lib_key(code gg.KeyCode, ch u32) &gg.Event {
+fn synth_key_event(code gg.KeyCode, ch u32) &gg.Event {
 	return &gg.Event{
 		typ: .key_down
 		key_code: code
@@ -143,26 +143,26 @@ fn lib_key(code gg.KeyCode, ch u32) &gg.Event {
 // Keyboard: typing filters on every Library tab, Esc clears search and
 // filters, nav keys fall through, arrows never crash without an Engine.
 fn test_library_key_contract() {
-	for p in lib_tab_panels {
-		mut app := lib_test_app(p)
-		assert library_key(mut app, lib_key(.invalid, u32(`q`)))
+	for p in library_tab_panels {
+		mut app := make_library_test_app(p)
+		assert library_key(mut app, synth_key_event(.invalid, u32(`q`)))
 		assert app.skills_query == 'q', 'panel ${p} filters typed text'
-		assert !library_key(mut app, lib_key(.invalid, u32(`3`))), 'nav digit falls through on panel ${p}'
+		assert !library_key(mut app, synth_key_event(.invalid, u32(`3`))), 'nav digit falls through on panel ${p}'
 		assert app.skills_query == 'q'
 		// spaces are typed, not bound to the primary action (multi-word search)
-		assert library_key(mut app, lib_key(.invalid, u32(` `)))
+		assert library_key(mut app, synth_key_event(.invalid, u32(` `)))
 		assert app.skills_query == 'q ', 'space must append to the query on panel ${p}'
-		assert library_key(mut app, lib_key(.backspace, 0))
-		assert library_key(mut app, lib_key(.backspace, 0))
+		assert library_key(mut app, synth_key_event(.backspace, 0))
+		assert library_key(mut app, synth_key_event(.backspace, 0))
 		assert app.skills_query == ''
 		app.skills_domain = 'design'
-		app.lib_filter = 'packs'
-		assert library_key(mut app, lib_key(.escape, 0))
-		assert app.skills_domain == '' && app.lib_filter == ''
-		assert library_key(mut app, lib_key(.down, 0))
-		assert library_key(mut app, lib_key(.up, 0))
-		assert library_key(mut app, lib_key(.right, 0))
+		app.library_filter = 'packs'
+		assert library_key(mut app, synth_key_event(.escape, 0))
+		assert app.skills_domain == '' && app.library_filter == ''
+		assert library_key(mut app, synth_key_event(.down, 0))
+		assert library_key(mut app, synth_key_event(.up, 0))
+		assert library_key(mut app, synth_key_event(.right, 0))
 		// Enter without a booted Engine is a no-op, never a crash
-		assert library_key(mut app, lib_key(.enter, 0))
+		assert library_key(mut app, synth_key_event(.enter, 0))
 	}
 }

--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -13,7 +13,7 @@ import pty as pty_mod
 
 // ── Dunder Mifflin Paper Co. — distinctive signature, not generic ──
 // Anti-slop: no purple/indigo gradients, no Inter-only, no glassmorphism.
-// Colors resolve from desktop.theme via ui_tokens.v (F1 theme tokens):
+// Colors resolve from desktop.theme via ui_tokens.v (theme tokens):
 //   surface.canvas #F3EBDD — main office/map background
 //   surface.paper  #FFF9ED — cards and reading surfaces
 //   surface.cabinet #171C1F — navigation and console
@@ -134,6 +134,7 @@ const font_file_sc = 'NotoSansSC-chrome.ttf'
 const font_embed_sans = $embed_file('../../assets/fonts/IBMPlexSans-Regular.ttf')
 const font_embed_sans_bd = $embed_file('../../assets/fonts/IBMPlexSans-SemiBold.ttf')
 const font_embed_mono = $embed_file('../../assets/fonts/IBMPlexSansMono-Regular.ttf')
+const font_embed_mono_med = $embed_file('../../assets/fonts/IBMPlexMono-Medium.ttf')
 const font_embed_display = $embed_file('../../assets/fonts/Fraunces-Display.ttf')
 const font_embed_displayt = $embed_file('../../assets/fonts/Fraunces-Text.ttf')
 const font_embed_arabic = $embed_file('../../assets/fonts/IBMPlexSansArabic-Regular.ttf')
@@ -146,6 +147,7 @@ fn font_embed_pairs() []FontEmbed {
 		FontEmbed{font_file_sans, font_embed_sans.to_bytes()},
 		FontEmbed{font_file_sans_bold, font_embed_sans_bd.to_bytes()},
 		FontEmbed{font_file_mono, font_embed_mono.to_bytes()},
+		FontEmbed{font_file_mono_med, font_embed_mono_med.to_bytes()},
 		FontEmbed{font_file_display, font_embed_display.to_bytes()},
 		FontEmbed{font_file_display_t, font_embed_displayt.to_bytes()},
 		FontEmbed{font_file_arabic, font_embed_arabic.to_bytes()},
@@ -872,12 +874,12 @@ mut:
 	doctor_preview       string
 	doctor_preview_lines []string
 	doctor_chips         []DoctorChip
-	// VC6 (#1173) Operations command center — see operations_view.v:
+	// Operations command center — see operations_view.v:
 	// focused text field (0 none, 1 search, 2 swarm task), status dropdown
 	// index, hovered element id, Doctor table selection/scroll.
-	ops_focus         int
-	ops_status_filter int
-	ops_hover         int = -1
+	operations_focus         int
+	operations_status_filter int
+	operations_hover         int = -1
 	doctor_selected   int = -1
 	doctor_scroll     int
 	// mcp provider drawer (#1106): open provider + cached template/provenance/
@@ -922,16 +924,16 @@ mut:
 	palette_open     bool
 	palette_query    string
 	palette_selected int
-	// S4A (#1119): shared typed action & entity registry — the palette's data
+	// shared typed action & entity registry — the palette's data
 	// source. Static rows remain only for entries not yet migrated.
 	palette_reg &palette.Registry = unsafe { nil }
-	// VC3 (#1172): pixel-art sprite cache for the Office room. Created lazily
+	// pixel-art sprite cache for the Office room. Created lazily
 	// on first Office draw (frame time, sokol ready); both palettes stay
 	// cached since the key space is bounded. See office_room.v.
 	pixel_cache &pixelart.SpriteCache = unsafe { nil }
 	// #1128: known-workspace folder-tab hit rects (rebuilt every frame)
-	known_ws_rects []KnownWsRect
-	// S4B contextual action flow state
+	known_workspace_rects []KnownWsRect
+	// contextual action flow state
 	palette_expanded    string // entity row id with expanded actions ('' = collapsed)
 	palette_preview     []string // preview mode lines (len 0 = list mode)
 	palette_preview_for string // action id the open preview belongs to
@@ -980,7 +982,7 @@ mut:
 	god_inbox      int
 	god_outbox     int
 	approvals      []string
-	// swarm super-potent — GOD mailbox, Herdr/tmux, pair/team/full launch, approvals spend/scope/destructive, eventbus status/handoffs/logs wired to desktop_engine
+	// swarm Engine-owned — GOD mailbox, Herdr/tmux, pair/team/full launch, approvals spend/scope/destructive, eventbus status/handoffs/logs wired to desktop_engine
 	swarm_backend          string = 'auto'
 	swarm_task             string = 'Implement feature via swarm'
 	swarm_selected         int = -1
@@ -988,7 +990,7 @@ mut:
 	swarm_approvals_scroll int
 	swarm_logs_scroll      int
 	swarm_handoff_hover    int = -1
-	// loops mission control — super potent management via Engine (create/edit/run/schedule)
+	// loops mission control — Engine-owned management (create/edit/run/schedule)
 	selected_loop        int = -1
 	loops_hover_run      int = -1
 	loops_hover_edit     int = -1
@@ -998,7 +1000,7 @@ mut:
 	loops_create_tier    int // 0 L1,1 L2,2 L3
 	loops_create_cadence string = '1d'
 	loops_scroll         int
-	// jobs — super-potent ProcessSupervisor status + approvals queue (distinct from loops budgets)
+	// jobs — Engine-owned ProcessSupervisor status + approvals queue (distinct from loops budgets)
 	jobs_selected         int = -1
 	jobs_hover            int = -1
 	jobs_hover_cancel     int = -1
@@ -1010,7 +1012,7 @@ mut:
 	jobs_show_logs        bool
 	jobs_logs_job         string
 	loops_budget_hover    int = -1
-	// IDE state — file-tree + editor tabs + git rails + skills 227 + memory palace (super potent)
+	// IDE state — file-tree + editor tabs + git rails + skills 227 + memory palace
 	skills_query       string
 	skills_domain      string
 	skills_scroll      int
@@ -1040,7 +1042,7 @@ mut:
 	workspace_notice      string
 	workspace_source      string
 	workspace_initialized bool
-	// super-potent onboarding / capability / target / product / workspace / persona — easy management
+	// onboarding / capability / target / product / workspace / persona — setup-journey state
 	show_onboarding              bool
 	onboarding_step              int // 0 detect,1 capabilities,2 targets,3 products,4 workspace,5 personas,6 done
 	onboarding_harness           string
@@ -1051,23 +1053,23 @@ mut:
 	selected_products_onboarding []string
 	products_scroll              int
 	products_hover               int = -1
-	// VC5 Library (#1173): shared collection state for Agents/Products/MCP
+	// Library: shared collection state for Agents/Products/MCP
 	// tabs (Skills keeps skills_scroll/skills_selected/skills_domain)
-	lib_scroll        int
-	lib_sel           int
-	lib_hover         int = -1
-	lib_hover_ui      int = -1
-	lib_filter        string
-	lib_cache         []LibItem
-	lib_cache_key     string
-	lib_cache_frame   int = -1
+	library_scroll        int
+	library_sel           int
+	library_hover         int = -1
+	library_hover_ui      int = -1
+	library_filter        string
+	library_cache         []LibraryItem
+	library_cache_key     string
+	library_cache_frame   int = -1
 	targets_hover     int = -1
 	onboarding_scroll int
-	// VC4 setup journey (#1173): user-facing choices; Engine keeps the truth
-	onb_choice    int // 0 set up for me, 1 existing setup, 2 find my setup
-	onb_ws_choice int // 0 create new workspace, 1 reuse existing
-	onb_cap_on    []bool = [true, true, true, true]
-	onb_diag      bool // internals live behind Details, not in the journey
+	// setup journey: user-facing choices; Engine keeps the truth
+	onboarding_choice    int // 0 set up for me, 1 existing setup, 2 find my setup
+	onboarding_workspace_choice int // 0 create new workspace, 1 reuse existing
+	onboarding_cap_on    []bool = [true, true, true, true]
+	onboarding_diag      bool // internals live behind Details, not in the journey
 	// global zoom — paper office scaling 0.75-1.50, 60FPS culling safe
 	global_zoom   f64 = 1.0
 	zoom_toast    string
@@ -1077,17 +1079,17 @@ mut:
 	global_search       string
 	header_search_focus bool
 	header_search_hover int = -1
-	// insights — telemetry super-potent (cost ledger, tool waterfall, OTel spans, budget sparks, CI watcher)
+	// insights — Engine-owned telemetry (cost ledger, tool waterfall, OTel spans, budget sparks, CI watcher)
 	insights_scroll int
-	insights_sel    int = -1 // selected row of the current tab (VC7 report details)
-	// VC7: per-frame Insights table cache (draw/metrics/click/details share it)
-	ins_cache       InsTable
-	ins_cache_key   string
-	ins_cache_frame int = -1
-	// VC7: scaffold check cache — six stats per frame otherwise (#1186 review)
-	ws_scaffold_root  string
-	ws_scaffold_vals  []bool
-	ws_scaffold_frame int = -1000
+	insights_sel    int = -1 // selected row of the current tab
+	// per-frame Insights table cache (draw/metrics/click/details share it)
+	insights_cache       InsightsTable
+	insights_cache_key   string
+	insights_cache_frame int = -1
+	// scaffold check cache — six stats per frame otherwise (#1186 review)
+	workspace_scaffold_root  string
+	workspace_scaffold_vals  []bool
+	workspace_scaffold_frame int = -1000
 	insights_hover    int = -1
 	insights_tab      string = 'cost' // cost | waterfall | spans | budgets | ci
 	insights_filter   string
@@ -1177,6 +1179,7 @@ const i18n_table = {
 	'nav.group.office':     I18nRow{'Office', 'Oficina', '办公', 'المكتب'}
 	'nav.group.library':    I18nRow{'Library', 'Biblioteca', '资源库', 'المكتبة'}
 	'lib.subtitle':         I18nRow{'Discover skills, agents, and tools to supercharge your team.', 'Descubre habilidades, agentes y herramientas para potenciar a tu equipo.', '发现技能、代理和工具，助力你的团队。', 'اكتشف المهارات والوكلاء والأدوات لتعزيز فريقك.'}
+	'library.subtitle':     I18nRow{'Discover skills, agents, and tools to supercharge your team.', 'Descubre habilidades, agentes y herramientas para potenciar a tu equipo.', '发现技能、代理和工具，助力你的团队。', 'اكتشف المهارات والوكلاء والأدوات لتعزيز فريقك.'} // alias of lib.subtitle; old key keeps working
 	'nav.group.operations': I18nRow{'Operations', 'Operaciones', '运维', 'العمليات'}
 	'nav.group.workspace':  I18nRow{'Workspace', 'Espacio', '工作区', 'المساحة'}
 	'nav.group.insights':   I18nRow{'Insights', 'Métricas', '洞察', 'الرؤى'}
@@ -1607,8 +1610,8 @@ const dock_w = 184
 const inspector_w = 280
 
 // Shell geometry is authoritative for every destination and its hit regions.
-// VC8-B begins with the legacy values so this refactor has no visual effect;
-// the editorial-shell commit can change them in one place.
+// It starts from the legacy values so there is no visual effect;
+// geometry changes land in one place.
 fn panel_top(app &GuiApp) int {
 	// Pure layout tests construct GuiApp without a renderer; keep their legacy
 	// baseline while production derives the shared masthead from live height.
@@ -1658,12 +1661,11 @@ fn panel_desc(i int) string {
 	}
 }
 
-// fuzzy_score and palette_best_score were removed in S4A (#1119): the palette
-// module's scorer (desktop.palette.fuzzy_score / action_best_score) is the
+// the palette module's scorer (desktop.palette.fuzzy_score / action_best_score) is the
 // single scoring authority shared by registry actions and legacy rows.
 
-// PaletteRow is the merged palette row model: registry-sourced actions (S4A)
-// plus legacy static rows for entries not yet migrated to the registry.
+// PaletteRow is the merged palette row model: registry-sourced actions
+// plus static rows for entries without registry coverage.
 struct PaletteRow {
 	id    string
 	label string
@@ -1677,12 +1679,12 @@ struct PaletteRow {
 	panel              nav.PanelId
 	available          bool
 	unavailable_reason string
-	// S4B contextual action row (derived from a registry action)
+	// contextual action row (derived from a registry action)
 	is_action     bool
 	action_kind   palette.ActionKind
 	needs_preview bool
 	needs_confirm bool
-	// S4D recent execution row (journal-sourced)
+	// recent execution row (journal-sourced)
 	is_recent    bool
 	execution_id u64
 }
@@ -1738,18 +1740,17 @@ fn nav_tr_key(p nav.PanelId) string {
 	}
 }
 
-// filtered_palette merges the shared typed registry (navigation + entities,
-// S4A) with the legacy static rows for not-yet-migrated entries. All rows are
+// filtered_palette merges the shared typed registry (navigation + entities)
+// with the static rows for entries without registry coverage. All rows are
 // scored by the palette module's fuzzy scorer — one scoring authority.
 // Empty query keeps the stable build order: navigation, entities, legacy.
-// filtered_palette derives every row from the shared typed registry (S4A) —
-// navigation, entities and contextual actions. The static command list and
-// its duplicate scorer were deleted in S4C (#1119); the registry's
+// filtered_palette derives every row from the shared typed registry —
+// navigation, entities and contextual actions. The registry's
 // scored_filter is the single ranking authority.
 fn filtered_palette(mut app GuiApp) []PaletteRow {
 	mut scored := []PaletteRow{}
 	if app.palette_reg != unsafe { nil } {
-		// S4D: recent executions first on an empty query — visibly distinct
+		// recent executions first on an empty query — visibly distinct
 		// (↻ prefix, outcome + evidence in the description), bounded display
 		if app.palette_query.trim_space() == '' {
 			// at most 3 recent rows — the palette stays an action/entity
@@ -1905,7 +1906,7 @@ fn rerun_recent(mut app GuiApp, sel PaletteRow) {
 }
 
 // expand_palette_actions inserts the contextual actions of the expanded
-// entity row directly beneath it (S4B). Expansion follows the row: when the
+// entity row directly beneath it. Expansion follows the row: when the
 // query filters the entity out, the actions go with it.
 fn expand_palette_actions(mut app GuiApp, rows []PaletteRow) []PaletteRow {
 	if app.palette_expanded == '' || app.palette_reg == unsafe { nil } {
@@ -2054,10 +2055,6 @@ fn term_level_label(level string) string {
 }
 
 // Production activity is sourced only from Engine state. Empty is a valid state.
-fn mock_term_logs(_ &GuiApp) []TermLine {
-	return []TermLine{}
-}
-
 // collect_engine_logs reads real Engine logs via snapshot data.
 // Wires to desktop_engine logs if available (jobs/*/logs, watcher_* keys) — per spec.
 fn collect_engine_logs(app &GuiApp) []TermLine {
@@ -2299,7 +2296,7 @@ fn main() {
 		selected_desk: -1
 		hover_desk: -1
 	}
-	// S4A (#1119): bind the shared typed registry to the boot Engine so the
+	// bind the shared typed registry to the boot Engine so the
 	// palette derives navigation + entities from authoritative state.
 	app.palette_reg = d.palette_registry()
 	app.gg = gg.new_context(
@@ -2521,14 +2518,14 @@ fn on_init(mut app GuiApp) {
 	// Resolve once through the Engine so every workspace-bound view starts on
 	// the same canonical root with a real brokered file tree.
 	resolve_workspace_on_start(mut app)
-	// skills 227 — init harness root search state from Engine (super potent)
+	// skills 227 — init harness root search state from Engine
 	app.skills_query = ''
 	app.skills_domain = ''
 	app.git_rail = 'CHANGES'
 	// memory palace — semantic recall ready
 	app.memory_query = ''
 	app.memory_semantic = true
-	// super-potent onboarding: auto-show wizard if first run — workspace init, personas, capability, target, product
+	// onboarding: auto-show wizard if first run — workspace init, personas, capability, target, product
 	app.onboarding_harness = app.harness_root
 	app.onboarding_step = 0
 	app.show_onboarding = app.desktop.engine_is_first_run()
@@ -2725,7 +2722,7 @@ fn frame(mut app GuiApp) {
 			else { 120 }
 		}
 		// the onboarding shell owns the screen: cap the terminal at the
-		// source so the VT row budget, draw_terminal and onb_layout all agree
+		// source so the VT row budget, draw_terminal and onboarding_layout all agree
 		// (a MAX terminal would otherwise hide the board entirely)
 		if app.show_onboarding && app.term_height > 120 {
 			app.term_height = 120
@@ -2773,11 +2770,11 @@ fn frame(mut app GuiApp) {
 	h := app.gg.height
 	app.gg.begin()
 	app.gg.draw_rect_filled(0, 0, w, h, col_ink)
-	onb_shell_active := app.show_onboarding
-	// VC8 (#1187): every destination now shares the editorial masthead.
+	onboarding_shell_active := app.show_onboarding
+	// every destination now shares the editorial masthead.
 	// Onboarding keeps its quieter task rail while the setup journey owns focus.
 	draw_header(mut app, w)
-	if onb_shell_active {
+	if onboarding_shell_active {
 		draw_onboarding_sidebar(mut app, w, h)
 	} else {
 		draw_left_dock(mut app, h)
@@ -2785,7 +2782,7 @@ fn frame(mut app GuiApp) {
 	// MAX terminal owns the content area — skip panel + inspector rendering
 	// (negative-height panels would smear texts over the chrome). Not while
 	// onboarding owns the screen: its terminal is capped, the board must draw.
-	if app.term_mode == 2 && !onb_shell_active {
+	if app.term_mode == 2 && !onboarding_shell_active {
 		draw_terminal(mut app, w, h)
 		app.gg.end()
 		return
@@ -2794,16 +2791,16 @@ fn frame(mut app GuiApp) {
 	// panel is behind it — there is nothing to blend or dim underneath, so
 	// the normal panel dispatch is skipped entirely instead of drawing (and
 	// then papering over) the previous panel's geometry.
-	if onb_shell_active {
+	if onboarding_shell_active {
 		draw_onboarding(mut app, w, h)
 	} else {
-		// VC5 (#1173): Skills/Agents/Products/MCP share one Library
+		// Skills/Agents/Products/MCP share one Library
 		// composition (library_view.v) with its own detail column.
 		match app.selected_panel {
 			0 { draw_world(mut app, w, h) }
 			1, 2, 3, 10 { draw_library(mut app, w, h) }
 			4 { draw_targets(mut app, w, h) }
-			// VC6 (#1173): Doctor/Jobs/Loops/Swarm share the Operations
+			// Doctor/Jobs/Loops/Swarm share the Operations
 			// command center (operations_view.v)
 			5, 6, 7, 8 { draw_operations(mut app, w, h) }
 			9 { draw_workspace(mut app, w, h) }
@@ -2814,13 +2811,13 @@ fn frame(mut app GuiApp) {
 	}
 	if app.show_onboarding {
 		draw_onboarding_preview(mut app, w, h)
-	} else if lib_is_panel(app.selected_panel) {
+	} else if library_is_panel(app.selected_panel) {
 		draw_library_detail(mut app, w, h)
-	} else if ops_is_panel(app.selected_panel) {
-		// VC6 (#1173): the Details column replaces the Office inspector
+	} else if operations_is_panel(app.selected_panel) {
+		// the Details column replaces the Office inspector
 		draw_operations_detail(mut app, w, h)
 	} else if app.selected_panel == 9 {
-		// VC7 (#1173): Workspace and Insights own the right column with their
+		// Workspace and Insights own the right column with their
 		// own detail sheets instead of the generic Office inspector.
 		draw_workspace_detail(mut app, w, h)
 	} else if app.selected_panel == 12 {
@@ -3046,6 +3043,20 @@ struct HeaderLayout {
 	command_w   int
 }
 
+// shell_mast_h is shared by onboarding and every regular destination.
+// It follows the reference's editorial band while leaving useful content at
+// compact heights.
+fn shell_mast_h(h int) int {
+	mut m := h * 13 / 100
+	if m < 78 {
+		m = 78
+	}
+	if m > 128 {
+		m = 128
+	}
+	return m
+}
+
 // header_layout is shared by drawing and pointer routing. Controls anchor to
 // the right so the product lockup keeps its editorial measure at every
 // required viewport.
@@ -3166,7 +3177,7 @@ fn draw_header(mut app GuiApp, w int) {
 		size: scaled_size(9, z)
 		bold: true
 	})
-	app.gg.draw_text(l.workspace_x + 8, l.control_y + 17, workspace_path_label(app.harness_root, onb_fit(l.workspace_w - 28, 10)), gg.TextCfg{
+	app.gg.draw_text(l.workspace_x + 8, l.control_y + 17, workspace_path_label(app.harness_root, text_fit_chars(l.workspace_w - 28, 10)), gg.TextCfg{
 		color: if app.workspace_focus { col_paper } else { app.pnl_text }
 		size: scaled_size(10, z)
 		mono: true
@@ -3187,7 +3198,7 @@ fn draw_header(mut app GuiApp, w int) {
 	app.gg.draw_rect_filled(l.search_x, l.control_y, l.search_w, l.control_h, search_bg)
 	app.gg.draw_rect_empty(l.search_x, l.control_y, l.search_w, l.control_h, search_bd)
 	draw_search_lens(mut app, l.search_x + 9, l.control_y + 11)
-	app.gg.draw_text(l.search_x + 25, l.control_y + 10, utf8_truncate(search_txt, onb_fit(l.search_w - 48, 11)), gg.TextCfg{
+	app.gg.draw_text(l.search_x + 25, l.control_y + 10, utf8_truncate(search_txt, text_fit_chars(l.search_w - 48, 11)), gg.TextCfg{
 		color: if app.global_search == '' { col_ink_soft } else { col_ink }
 		size: scaled_size(11, z)
 		family: if app.global_search == '' { family_for(app, search_txt) } else { '' }
@@ -3288,7 +3299,7 @@ fn draw_left_dock(mut app GuiApp, h int) {
 	}
 	land_y := last_y + 8
 	if y1 - land_y >= 58 {
-		draw_onb_landscape(mut app, dock_l, land_y, dock_w, y1 - land_y, pid)
+		draw_onboarding_landscape(mut app, dock_l, land_y, dock_w, y1 - land_y, pid)
 	}
 }
 
@@ -3366,8 +3377,8 @@ fn draw_office_overview(mut app GuiApp, w int, h int) {
 	}
 	attention_jobs := jobs.filter(it.status == .failed || it.status == .queued)
 	running_jobs := jobs.filter(it.status == .running)
-	// VC8 (#1173): office.jpg composition uses four truthful metric cards,
-	// the VC3.5 room as the hero, and the shell detail column for Roster and
+	// office.jpg composition uses four truthful metric cards,
+	// the room as the hero, and the shell detail column for Roster and
 	// Today. All values come from Engine state.
 	ensure_pixel_cache(mut app)
 	draw_office_cards(mut app, l, office_metrics(mut app, attention_jobs.len, agents.len, running_jobs.len))
@@ -3818,7 +3829,7 @@ fn draw_world(mut app GuiApp, w int, h int) {
 	// signature soft shadow under GOD panel — atelier floor shadow (ink 18%)
 	app.gg.draw_rect_filled(god_x + 4, god_y + 64, 76, 4, tint(app.pnl_text, 18))
 	app.gg.draw_rect_filled(god_x + 8, god_y + 66, 68, 2, tint(app.pnl_text, 12))
-	// ── Command deck — kanban / fleet / CI — super-potent workshop command (alt wood divergence, native gg)
+	// ── Command deck — kanban / fleet / CI workshop command (alt wood divergence, native gg)
 	// Signature atelier command deck: wood alt panel with brass grain, three columns for live kanban/fleet/CI
 	deck_x := fx + 8
 	deck_y := fy + fh - 68
@@ -3915,7 +3926,7 @@ fn draw_world(mut app GuiApp, w int, h int) {
 	app.gg.draw_rect_filled(fx, fy + fh - 20, fw, 20, tint(app.pnl_text, 220))
 	draw_floor_legend(mut app, fx + 10, fy + fh - 14)
 	app.gg.draw_text(fx + fw - 148, fy + fh - 14, 'rev ${app.engine_rev}  api ${app.api_calls}', gg.TextCfg{ color: app.pnl_text_mut, size: 12 })
-	// signature fleet minimap dots — 1px per desk status in legend bar (super-potent fleet glance)
+	// signature fleet minimap dots — 1px per desk status in legend bar
 	for i, d in desks {
 		mx2 := fx + fw - 148 - 22 - i * 6
 		mcol := match d.status {
@@ -3929,7 +3940,7 @@ fn draw_world(mut app GuiApp, w int, h int) {
 	}
 }
 
-// ── Skills 227 — super potent, easy to manage ─────────────────────────────────────
+// ── Skills 227 — easy to manage ─────────────────────────────────────
 // Brokered via Desktop.engine_skills_search (Engine typed API, no shell, 227 searchable).
 // Fuzzy: substring + subsequence + word-boundary, ranked, virtualized 60 FPS.
 // Each section is a tiny helper: header → search → domain chips → list → footer.
@@ -4021,7 +4032,7 @@ fn mcp_drawer_open(mut app GuiApp, id string, template_path string, provenance s
 	// no probe and no inspector_msg here: this runs on card *selection* (and
 	// lazily from the detail pane draw), so it must stay cheap and silent —
 	// template + receipt loading only. The probe (synchronous validation +
-	// health check) runs only from the explicit Probe action (lib_secondary),
+	// health check) runs only from the explicit Probe action (library_secondary),
 	// which also owns the toast. The pane shows "not run — press Probe" until then.
 }
 
@@ -4085,7 +4096,7 @@ fn draw_targets(mut app GuiApp, w int, h int) {
 	fw := panel_fw(app, w)
 	fh := content_bottom(app, h) - fy
 	app.gg.draw_rect_filled(fx, fy, fw, fh, app.pnl_bg)
-	// install preview + receipts super-potent
+	// install preview + Engine-owned receipts
 	receipts := app.desktop.engine_list_install_receipts()
 	paper_letterhead(mut app, fx, fy, fw, tr(app, 'panel.targets'), 'receipts ${receipts.len} · dry-run preview · provenance plugins/.provenance.json', 'install → receipt')
 	// dry-run diff for next install
@@ -4098,7 +4109,7 @@ fn draw_targets(mut app GuiApp, w int, h int) {
 	tgts2 := app.desktop.engine_targets().map(it.id)
 	targets := app.desktop.engine_targets_enabled()
 	_ = targets
-	// S4D… er, #1129: typed tool discovery — one authoritative detector
+	// #1129: typed tool discovery — one authoritative detector
 	mut disco_map := map[string]desktop_engine.ToolDiscovery{}
 	if app.desktop != unsafe { nil } {
 		for d in app.desktop.engine_tool_discovery_catalog_cached() {
@@ -4198,7 +4209,7 @@ fn draw_doctor(mut app GuiApp, w int, h int) {
 	fw := panel_fw(app, w)
 	fh := content_bottom(app, h) - fy
 	app.gg.draw_rect_filled(fx, fy, fw, fh, app.pnl_bg)
-	// super-potent Doctor: full Engine.doctor() with categories, receipts/provenance, fixable + Fix All via Engine TX
+	// Engine-owned Doctor: full Engine.doctor() with categories, receipts/provenance, fixable + Fix All via Engine TX
 	checks_engine := app.desktop.engine_doctor()
 	pass_cnt := checks_engine.filter(it.status == 'pass').len
 	warn_cnt := checks_engine.filter(it.status == 'warn').len
@@ -4217,7 +4228,7 @@ fn draw_doctor(mut app GuiApp, w int, h int) {
 		app.pnl_border_hi
 	})
 	app.gg.draw_text(fx + fw - 76, fy + 15, 'Fix All', gg.TextCfg{ color: app.pnl_text, size: 12, bold: true })
-	// category facets row — super-potent easy triage (14 categories via Engine).
+	// category facets row — easy triage over 14 Engine categories.
 	// Click a chip to fix that category via Engine TX (#1108); hit rects are
 	// stored for the mouse handler (rebuilt every frame, same geometry).
 	app.doctor_chips = []
@@ -4514,11 +4525,11 @@ fn draw_jobs(mut app GuiApp, w int, h int) {
 		btn_y := y + 22
 		hover_cancel := app.jobs_hover_cancel == di
 		cbg := if hover_cancel { app.pnl_danger } else { app.pnl_text }
-		cfg := if hover_cancel { app.pnl_bg } else { app.pnl_text_mut }
+		cancel_color := if hover_cancel { app.pnl_bg } else { app.pnl_text_mut }
 		bd2 := if hover_cancel { app.pnl_danger } else { col_line }
 		app.gg.draw_rect_filled(fx + fw - 108, btn_y, 44, 16, cbg)
 		app.gg.draw_rect_empty(fx + fw - 108, btn_y, 44, 16, bd2)
-		app.gg.draw_text(fx + fw - 100, btn_y + 3, 'Cancel', gg.TextCfg{ color: cfg, size: 10 })
+		app.gg.draw_text(fx + fw - 100, btn_y + 3, 'Cancel', gg.TextCfg{ color: cancel_color, size: 10 })
 		hover_retry := app.jobs_hover_retry == di
 		rbg := if hover_retry { app.pnl_select } else { app.pnl_text }
 		rfg := if hover_retry { app.pnl_text } else { app.pnl_card_sel }
@@ -4538,7 +4549,7 @@ fn draw_jobs(mut app GuiApp, w int, h int) {
 		app.gg.draw_rect_filled(fx + fw - 6, list_y0, 3, track_h, tint(app.pnl_text, 30))
 		app.gg.draw_rect_filled(fx + fw - 6, bar_y, 3, bh, app.pnl_border_hi)
 	}
-	// ── Approvals queue — super-potent spend/scope/destructive distinct bottom panel ──
+	// ── Approvals queue — spend/scope/destructive distinct bottom panel ──
 	aq_y := fy + fh - 104
 	app.gg.draw_rect_filled(fx + 8, aq_y, fw - 16, 96, app.pnl_card_sel)
 	app.gg.draw_rect_empty(fx + 8, aq_y, fw - 16, 96, app.pnl_border_hi)
@@ -5320,7 +5331,7 @@ fn draw_swarm(mut app GuiApp, w int, h int) {
 	app.gg.draw_text(rx + 8, col_y + col_h - 14, 'EventBus: state_changed · swarm_handoff · process_log → one tick · rev ${app.engine_rev}', gg.TextCfg{ color: app.pnl_text_mut, size: 10, mono: true })
 }
 
-// ── Workspace IDE — super potent, easy to manage ────────────────────────────────
+// ── Workspace IDE — easy to manage ────────────────────────────────
 // Modular helpers: kanban → file-tree → editor tabs → git rails → diff → memory palace.
 // Each helper is 20-30 lines, single responsibility, brokered via Engine.
 // File-tree: left 180px, virtualized, twisty, git_status dots, click expands.
@@ -5500,10 +5511,10 @@ fn focus_workspace(mut app GuiApp) {
 	app.workspace_focus = true
 }
 
-// ── Products & Packs — super potent easy management ─────────────────────────────────
+// ── Products & Packs — easy management ─────────────────────────────────
 // Brokered via Desktop.engine_products_catalog / packs_catalog (Engine typed, no shell).
 // Easy to manage: product cards, pack chips, membership bulk, build preview, digest.
-// ── Onboarding — super-potent wizard: workspace init, persona bootstrap, capability/target/product ──
+// ── Onboarding — wizard: workspace init, persona bootstrap, capability/target/product ──
 // Single modal wizard where everything is possible and easy to manage. One view, seven steps:
 // Detect → Capabilities (227) → Targets (7) → Products/Packs (5+7) → Workspace Init → Personas → Tour → Done.
 // All actions wire via Desktop.onboarding_* proxies → Engine transactions → EventBus → AppState (no shell).
@@ -5546,7 +5557,7 @@ fn draw_inspector(mut app GuiApp, w int, h int) {
 	iw := inspector_w
 	ih := content_bottom(app, h) - iy
 	app.gg.draw_rect_filled(ix, iy, iw, ih, col_charcoal)
-	// VC3.5 (#1176): cabinet-drawer material. The dark column reads as one
+	// cabinet-drawer material. The dark column reads as one
 	// drawer of a technical filing cabinet: folder tab with the title,
 	// brass top edge, inner drawer inset, brass pull at the bottom. All
 	// content drawing below is unchanged.
@@ -5595,7 +5606,7 @@ fn draw_inspector(mut app GuiApp, w int, h int) {
 	}
 	// ── Signature: per-desk libghostty-vt 40×6 multiplex — live VT preview (visible proof) ──
 	// Each desk owns a 40×6 GhosttyTerminal; selected desk's VT renders inline in inspector
-	// This is the designer's super-potent touch: multiplex is not hidden — it glows in the inspector
+	// multiplex is not hidden — it glows in the inspector
 	if app.selected_desk >= 0 && app.selected_desk < desks.len && app.per_desk_ghost.len > app.selected_desk {
 		vt_y := iy + 272
 		vt_h := 74
@@ -5752,19 +5763,19 @@ fn draw_inspector(mut app GuiApp, w int, h int) {
 	}
 	// bottom hint for inspector scroll
 	app.gg.draw_text(ix + 12, iy + ih - 14, '↑↓ scroll  •  click row to copy  •  / filters', gg.TextCfg{ color: app.pnl_text_mut, size: 11 })
-	// VC3.5 (#1176): brass drawer pull, last so nothing overdraws it. It
+	// brass drawer pull, last so nothing overdraws it. It
 	// lives in the strip reserved by inspector_log_h above the hint text.
 	app.gg.draw_rect_filled(ix + iw / 2 - 22, iy + ih - 22, 44, 4, app.pnl_select_hover)
 	app.gg.draw_rect_filled(ix + iw / 2 - 22, iy + ih - 22, 44, 1, app.pnl_select)
 }
 
-// onb_effective_term_h caps the terminal at a compact height while the
+// onboarding_capped_terminal_height caps the terminal at a compact height while the
 // onboarding shell owns the screen — the reference's terminal well reads as
 // ~12-15% of the window, well under the production 1x/2x heights, which
 // otherwise starve the board of the room its five sheets need.
-pub fn onb_effective_term_h(app &GuiApp) int {
+pub fn onboarding_capped_terminal_height(app &GuiApp) int {
 	// the cap is applied where term_height is computed (frame()); this stays
-	// as the single accessor onb_layout and draw_terminal share
+	// as the single accessor onboarding_layout and draw_terminal share
 	return app.term_height
 }
 
@@ -5786,7 +5797,7 @@ fn terminal_tab_rect(x0 int, y0 int, i int) (int, int, int, int) {
 }
 
 fn terminal_rect(app &GuiApp, w int, h int) (int, int, int, int) {
-	term_h := onb_effective_term_h(app)
+	term_h := onboarding_capped_terminal_height(app)
 	x := if app.lang.is_rtl() { 0 } else { dock_w }
 	return x, h - 28 - term_h, w - dock_w, term_h
 }
@@ -6212,7 +6223,7 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 	}
 	qcol := if app.palette_query == '' { app.pnl_text_mut } else { app.pnl_bg }
 	app.gg.draw_text(cx + 20, cy + 42, '› ${q}', gg.TextCfg{ color: qcol, size: scaled_size(14, z) })
-	// S4B preview mode: show the real dry-run/diff lines instead of rows.
+	// preview mode: show the real dry-run/diff lines instead of rows.
 	if app.palette_preview.len > 0 {
 		app.gg.draw_text(cx + 20, cy + 62, 'Preview — nothing applied yet', gg.TextCfg{ color: app.pnl_select, size: scaled_size(12, z), bold: true })
 		for pi, line in app.palette_preview {
@@ -6245,7 +6256,7 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 			// subtle manila tab on unselected
 			app.gg.draw_rect_filled(cx + pw - 52, y + 4, 36, 6, app.pnl_card_sel)
 		}
-		// S4C: every row is registry-derived. Navigation rows keep localized
+		// every row is registry-derived. Navigation rows keep localized
 		// labels via their i18n key; entities and actions render their own
 		// registry labels.
 		pal_label := if it.is_action {
@@ -6255,7 +6266,7 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 		} else {
 			it.label
 		}
-		// S4C: every row is registry-derived. Navigation rows keep localized
+		// every row is registry-derived. Navigation rows keep localized
 		// labels and descriptions via their i18n keys; entities and actions
 		// render their own registry content; unavailable rows say why.
 		pal_desc := if it.is_action {
@@ -6302,7 +6313,7 @@ fn draw_palette(mut app GuiApp, w int, h int) {
 	if filtered.len == 0 {
 		app.gg.draw_text(cx + 20, cy + 86, 'No matches — try another query', gg.TextCfg{ color: app.pnl_text_mut, size: scaled_size(13, z) })
 	}
-	// footer hint paper tape — reflects the S4B action state honestly
+	// footer hint paper tape — reflects the action state honestly
 	footer := if app.palette_armed != '' {
 		'Enter again to confirm  •  Esc to cancel'
 	} else if filtered.any(it.is_recent) {
@@ -6361,18 +6372,18 @@ fn activate_palette_selection(mut app GuiApp) {
 		app.palette_selected
 	}
 	sel := filtered[clamped]
-	// S4D: recent rows re-run through the current registry (never replay)
+	// recent rows re-run through the current registry (never replay)
 	if sel.is_recent {
 		rerun_recent(mut app, sel)
 		return
 	}
-	// S4B: contextual action rows run through preview → confirm → execute.
+	// contextual action rows run through preview → confirm → execute.
 	if sel.is_action {
 		run_palette_action(mut app, sel)
 		return
 	}
-	// S4A: registry rows navigate to their typed panel destination. Entity
-	// rows open the owning panel and deep-link the canonical entity (S4B).
+	// registry rows navigate to their typed panel destination. Entity
+	// rows open the owning panel and deep-link the canonical entity.
 	if sel.is_entity {
 		idx := panel_index_for(sel.panel)
 		if idx >= 0 {
@@ -6390,14 +6401,14 @@ fn activate_palette_selection(mut app GuiApp) {
 		app.palette_armed = ''
 		return
 	}
-	// S4C: no legacy activation arms remain — every row is a registry entity
+	// no legacy activation arms remain — every row is a registry entity
 	// or action.
 	app.palette_open = false
 	app.palette_query = ''
 	app.palette_selected = 0
 }
 
-// run_palette_action drives the S4B contextual action flow:
+// run_palette_action drives the contextual action flow:
 // preview (real dry-run) → confirmation for mutating actions → execution.
 // Confirmation never comes silently: either the preview was shown or the
 // user pressed Enter twice.
@@ -6571,15 +6582,15 @@ fn onboarding_key(mut app GuiApp, e &gg.Event) bool {
 	if e.key_code == .left || e.char_code == `b` || e.char_code == `B` {
 		if app.onboarding_step > 0 {
 			app.onboarding_step--
-			app.onboarding_msg = '${onb_stages[app.onboarding_step]} — ${onb_stage_hints[app.onboarding_step]}'
+			app.onboarding_msg = '${onboarding_stages[app.onboarding_step]} — ${onboarding_stage_hints[app.onboarding_step]}'
 		}
 		return true
 	}
 	if e.key_code == .enter {
-		if app.onboarding_step >= onb_last_stage {
+		if app.onboarding_step >= onboarding_last_stage {
 			onboarding_advance(mut app)
 		} else {
-			onb_apply_stage(mut app)
+			onboarding_apply_stage(mut app)
 		}
 		return true
 	}
@@ -6678,7 +6689,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 		}
 		if app.palette_open {
 			if e.key_code == .escape {
-				// S4B: Esc unwinds the innermost palette context first —
+				// Esc unwinds the innermost palette context first —
 				// preview mode, then expansion, then the palette itself
 				if app.palette_preview.len > 0 {
 					app.palette_preview = []
@@ -6701,7 +6712,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 			if e.key_code == .u {
-				// S4D: undo the selected recent execution (optimistic exact
+				// undo the selected recent execution (optimistic exact
 				// check runs again right before restoring). Only a recent
 				// row with undo consumes the key — otherwise 'u' falls
 				// through to normal query typing (#1162 review).
@@ -6720,7 +6731,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 			}
 			if e.key_code == .tab {
-				// S4B: expand/collapse contextual actions of the selected
+				// expand/collapse contextual actions of the selected
 				// registry entity row
 				filtered_tab := filtered_palette(mut app)
 				if app.palette_selected >= 0 && app.palette_selected < filtered_tab.len {
@@ -6856,7 +6867,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			return
 		}
-		// VC6 (#1173): Operations text fields (search / swarm task) — an
+		// Operations text fields (search / swarm task) — an
 		// active text field outranks the terminal and panel shortcuts
 		if operations_key(mut app, e) {
 			return
@@ -6878,7 +6889,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 			if app.ghost_focused && app.term_visible {
-				// super potent: Esc first unfocuses Ghostty — preserves terminal data
+				// Esc first unfocuses Ghostty — preserves terminal data
 				app.ghost_focused = false
 				return
 			}
@@ -6890,10 +6901,10 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			// panel-scoped Esc clears search fields — Esc must never hard-quit
 			// the app (that was a data-loss footgun; Ctrl+Q quits explicitly)
-			if lib_is_panel(app.selected_panel) {
+			if library_is_panel(app.selected_panel) {
 				app.skills_query = ''
 				app.skills_domain = ''
-				app.lib_filter = ''
+				app.library_filter = ''
 				return
 			}
 			if app.selected_panel == 9 {
@@ -6915,7 +6926,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			return
 		}
-		// libghostty-vt toggle — Tab flips ghost_focused, the super potent multiplexed terminal
+		// libghostty-vt toggle — Tab flips ghost_focused, the multiplexed terminal
 		if e.key_code == .tab {
 			if app.term_visible {
 				app.ghost_focused = !app.ghost_focused
@@ -6983,14 +6994,14 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			app.palette_selected = 0
 			return
 		}
-		// VC5 (#1173): the Library tabs (Skills/Agents/Products/MCP) share one
+		// the Library tabs (Skills/Agents/Products/MCP) share one
 		// search field and one key handler — typing filters (spaces included),
 		// ←/→ select, ↑/↓ scroll rows, Enter runs the primary Engine action
 		// (library_view.v). Like header_search_focus above, the field owns
 		// printable letters *before* the global letter shortcuts (h help,
 		// r handoff) so "github" / "review" can actually be typed; the
 		// documented nav keys (digits, p/i/o) still fall through.
-		if !app.palette_open && !app.show_help && lib_is_panel(app.selected_panel) {
+		if !app.palette_open && !app.show_help && library_is_panel(app.selected_panel) {
 			if library_key(mut app, e) {
 				return
 			}
@@ -7007,7 +7018,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			return
 		}
-		// super potent IDE typing — skills 227 fuzzy + memory palace semantic recall + file-tree nav
+		// IDE typing — skills 227 fuzzy + memory palace semantic recall + file-tree nav
 		// When skills or workspace panels active, capture typing there instead of ghost (easy to manage, brokered)
 		if !app.palette_open && !app.show_help {
 			// Doctor panel — f fixes all via Engine TX, Enter opens dry-run preview
@@ -7035,7 +7046,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 						doctor_preview_confirm(mut app)
 						return
 					}
-					// open dry-run for first fixable — super-potent easy management
+					// open dry-run for first fixable
 					checks := app.desktop.engine_doctor()
 					for c in checks {
 						if c.fixable && c.status != 'pass' {
@@ -7080,7 +7091,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 				// same nav-key fall-through as the Skills panel (see is_panel_nav_key)
 				if e.char_code > 32 && e.char_code < 127 && !is_panel_nav_key(e.char_code) {
-					// typing goes to memory palace semantic recall when workspace active (super potent)
+					// typing goes to memory palace semantic recall when workspace active
 					app.memory_query += rune(e.char_code).str()
 					return
 				}
@@ -7108,8 +7119,8 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 		}
 		// libghostty-vt — when focused, route typing to Ghostty terminal (libghostty-vt)
-		// Terminal is bottom strip; ghost has priority over log scroll when focused — super potent
-		// Exclude skills/MCP/doctor/workspace when they need typed search (super-potent easy management)
+		// Terminal is bottom strip; ghost has priority over log scroll when focused
+		// Exclude skills/MCP/doctor/workspace when they need typed search
 		if !app.palette_open && !app.show_help && app.ghost_focused && app.term_visible && app.selected_panel != 1 && app.selected_panel != 3 && app.selected_panel != 5 && app.selected_panel != 9 {
 			// Ctrl+L clears Ghostty (like terminal clear), Ctrl+C copies Ghostty visible
 			if (e.modifiers & u32(gg.Modifier.ctrl)) != 0 {
@@ -7354,7 +7365,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 		}
 		if app.term_visible && app.mouse_x >= x0 && app.mouse_x <= x0 + tw
 			&& app.mouse_y >= y0 && app.mouse_y < y0 + term_h {
-			// super potent: when ghost_focused, wheel scrolls Ghostty scrollback 1000; otherwise logs
+			// when ghost_focused, wheel scrolls Ghostty scrollback 1000; otherwise logs
 			if app.ghost_focused {
 				app.ghost.scroll_by(delta)
 			} else {
@@ -7395,19 +7406,19 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 		}
 		// Library card-grid scroll uses the same layout as drawing and clicks.
-		if lib_is_panel(app.selected_panel)
+		if library_is_panel(app.selected_panel)
 			&& library_scroll(mut app, app.mouse_x, app.mouse_y, delta, w3, h3) {
 			return
 		}
-		// VC6 (#1173): Operations table scroll (Doctor/Jobs/Loops/Swarm)
+		// Operations table scroll (Doctor/Jobs/Loops/Swarm)
 		if operations_scroll(mut app, delta, w3, h3) {
 			return
 		}
-		// insights tables scroll (VC7) — same geometry as draw_ins_table
+		// insights tables scroll — same geometry as draw_insights_table
 		if app.selected_panel == 12 && insights_scroll_by(mut app, delta, w3, h3) {
 			return
 		}
-		// workspace IDE scroll — file tree, editor, git, memory palace (super potent)
+		// workspace IDE scroll — file tree, editor, git, memory palace
 		if app.selected_panel == 9 {
 			l := workspace_layout(app, w3, h3)
 			// file tree left
@@ -7433,12 +7444,12 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			if app.mouse_x >= gx && app.mouse_x <= gx + l.git_w && app.mouse_y >= l.mid_y && app.mouse_y < l.mid_y + l.mid_h {
 				if app.git_rail == 'CHANGES' {
 					changes := app.desktop.engine_git_changes()
-					visible := ws_git_changes_visible(l.mid_h)
+					visible := workspace_git_changes_visible(l.mid_h)
 					app.git_scroll += delta
 					app.git_scroll = clamp_scroll(app.git_scroll, changes.len, visible)
 				} else if app.git_rail == 'HISTORY' {
 					graph := app.desktop.engine_git_graph(20)
-					visible := ws_git_history_visible(l.mid_h)
+					visible := workspace_git_history_visible(l.mid_h)
 					app.git_scroll += delta
 					app.git_scroll = clamp_scroll(app.git_scroll, graph.commits.len, visible)
 				} else {
@@ -7512,14 +7523,14 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 		// navigation while a setup stage owns focus.
 		w := app.gg.width
 		h := app.gg.height
-		onb_shell_active := app.show_onboarding
+		onboarding_shell_active := app.show_onboarding
 		hl := header_layout(w, h)
-		if !onb_shell_active && my >= 0 && my <= hl.mast_h {
-			if onb_hit(mx, my, hl.workspace_x, hl.control_y, hl.workspace_w, hl.control_h) {
+		if !onboarding_shell_active && my >= 0 && my <= hl.mast_h {
+			if rect_contains(mx, my, hl.workspace_x, hl.control_y, hl.workspace_w, hl.control_h) {
 				focus_workspace(mut app)
 				return
 			}
-			if onb_hit(mx, my, hl.search_x, hl.control_y, hl.search_w, hl.control_h) {
+			if rect_contains(mx, my, hl.search_x, hl.control_y, hl.search_w, hl.control_h) {
 				if mx >= hl.search_x + hl.search_w - 20 && app.global_search != '' {
 					app.global_search = ''
 					app.skills_query = ''
@@ -7531,11 +7542,11 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 				return
 			}
-			if onb_hit(mx, my, hl.theme_x, hl.control_y, hl.theme_w, hl.control_h) {
+			if rect_contains(mx, my, hl.theme_x, hl.control_y, hl.theme_w, hl.control_h) {
 				cycle_appearance(mut app)
 				return
 			}
-			if onb_hit(mx, my, hl.lang_x, hl.control_y, hl.lang_w, hl.control_h) {
+			if rect_contains(mx, my, hl.lang_x, hl.control_y, hl.lang_w, hl.control_h) {
 				app.lang = match app.lang {
 					.en { Lang.es }
 					.es { Lang.zh }
@@ -7547,7 +7558,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				app.workspace_focus = false
 				return
 			}
-			if onb_hit(mx, my, hl.command_x, hl.control_y, hl.command_w, hl.control_h) {
+			if rect_contains(mx, my, hl.command_x, hl.control_y, hl.command_w, hl.control_h) {
 				app.palette_open = true
 				app.palette_query = ''
 				app.palette_selected = 0
@@ -7586,37 +7597,37 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 		}
-		// VC5 (#1173): Library panels own every click inside the panel and
+		// Library panels own every click inside the panel and
 		// its detail column (tabs, search, chips, cards, actions) — same
 		// geometry as draw_library / draw_library_detail.
-		if lib_is_panel(app.selected_panel) && !app.show_onboarding {
+		if library_is_panel(app.selected_panel) && !app.show_onboarding {
 			if library_click(mut app, mx, my, w, h) {
 				return
 			}
 		}
-		// VC6 (#1173): Operations panels (Doctor/Jobs/Loops/Swarm) own their
+		// Operations panels (Doctor/Jobs/Loops/Swarm) own their
 		// content area and the Details column — one shared layout for draw
 		// and hit-testing (operations_view.v)
 		if operations_click(mut app, mx, my, w, h) {
 			return
 		}
-		// VC8 (#1173): Office overview roster rows select a desk (same geometry
+		// Office overview roster rows select a desk (same geometry
 		// as draw_office_roster)
 		if app.selected_panel == 0 && !app.office_map_view && !app.show_onboarding {
 			if office_roster_click(mut app, mx, my, w, h) {
 				return
 			}
 		}
-		// VC7 (#1173): Workspace / Insights own the right column — their tabs,
+		// Workspace / Insights own the right column — their tabs,
 		// rows and detail sheets take the click before the inspector geometry.
-		if !onb_shell_active && app.selected_panel == 9
+		if !onboarding_shell_active && app.selected_panel == 9
 			&& workspace_detail_click(mut app, mx, my, w, h) {
 			return
 		}
-		if !onb_shell_active && app.selected_panel == 12 && insights_click(mut app, mx, my, w, h) {
+		if !onboarding_shell_active && app.selected_panel == 12 && insights_click(mut app, mx, my, w, h) {
 			return
 		}
-		if !onb_shell_active && app.selected_panel == 11 && settings_click(mut app, mx, my, w, h) {
+		if !onboarding_shell_active && app.selected_panel == 11 && settings_click(mut app, mx, my, w, h) {
 			return
 		}
 		// Inspector buttons — clickable
@@ -7635,7 +7646,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				return
 			}
 		}
-		// Terminal click — super potent: focus Ghostty + copy
+		// Terminal click — focus Ghostty + copy
 		if app.term_visible {
 			w3 := app.gg.width
 			h3 := app.gg.height
@@ -7654,7 +7665,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 				for i, tab in terminal_tabs(app) {
 					tx, ty, tab_w, tab_h := terminal_tab_rect(x0, y0, i)
-					if onb_hit(mx, my, tx, ty, tab_w, tab_h) {
+					if rect_contains(mx, my, tx, ty, tab_w, tab_h) {
 						app.term_view = tab.view
 						app.ghost_focused = tab.view < 0
 						return
@@ -7830,20 +7841,20 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 			}
 		}
-		// Onboarding wizard click handling — super-potent easy management via Engine
+		// Onboarding wizard click handling via Engine
 		if app.show_onboarding {
 			if onboarding_click(mut app, int(e.mouse_x), int(e.mouse_y), app.gg.width, app.gg.height) {
 				return
 			}
 		}
-		// Insights tabs / rows / details: handled by insights_click above (VC7).
+		// Insights tabs / rows / details: handled by insights_click above.
 		// Workspace IDE — file-tree, editor tabs, git rails CHANGES/HISTORY/COMPARE, commit graph, diff, memory palace
 		// Super potent: brokered fs via Engine.open_path_validated (harness_root_escape), syntax, graph lanes, semantic recall
 		if app.selected_panel == 9 {
 			l := workspace_layout(app, w, h)
 			// #1128: known-workspace folder tabs — click fills the draft for
 			// the Validate/Switch controls (discovery never switches itself)
-			for kr in app.known_ws_rects {
+			for kr in app.known_workspace_rects {
 				if mx >= kr.x && mx <= kr.x + kr.w && my >= kr.y && my <= kr.y + kr.h2 {
 					app.workspace_draft = kr.path
 					validate_workspace_draft(mut app)
@@ -7970,7 +7981,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				graph := app.desktop.engine_git_graph(20)
 				row_h := 22
 				y0 := rail_y2 + 14
-				visible := ws_git_history_visible(l.mid_h)
+				visible := workspace_git_history_visible(l.mid_h)
 				if visible > 0 {
 					start := clamp_scroll(app.git_scroll, graph.commits.len, visible)
 					for idx in start .. graph.commits.len {
@@ -8163,10 +8174,10 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 			}
 		}
-		// VC5 (#1173): Library card/chrome hover shares lib_layout geometry
-		app.lib_hover = -1
-		app.lib_hover_ui = -1
-		if lib_is_panel(app.selected_panel) && !app.show_onboarding {
+		// Library card/chrome hover shares library_layout geometry
+		app.library_hover = -1
+		app.library_hover_ui = -1
+		if library_is_panel(app.selected_panel) && !app.show_onboarding {
 			library_hover_at(mut app, app.mouse_x, app.mouse_y, app.gg.width, app.gg.height)
 		}
 		// workspace file-tree hover — left 180
@@ -8198,7 +8209,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			if app.git_rail == 'CHANGES' {
 				changes := app.desktop.engine_git_changes()
 				row_h2 := 20
-				vis2 := ws_git_changes_visible(l.mid_h)
+				vis2 := workspace_git_changes_visible(l.mid_h)
 				start2 := clamp_scroll(app.git_scroll, changes.len, vis2)
 				mut end2_ch := start2 + vis2
 				if end2_ch > changes.len {
@@ -8215,7 +8226,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			} else if app.git_rail == 'HISTORY' {
 				graph := app.desktop.engine_git_graph(20)
 				row_h2 := 22
-				vis2 := ws_git_history_visible(l.mid_h)
+				vis2 := workspace_git_history_visible(l.mid_h)
 				start2 := clamp_scroll(app.git_scroll, graph.commits.len, vis2)
 				mut end2_hi := start2 + vis2
 				if end2_hi > graph.commits.len {
@@ -8250,9 +8261,9 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				}
 			}
 		}
-		// VC6 (#1173): Operations hover (tabs, controls, rows, detail actions)
+		// Operations hover (tabs, controls, rows, detail actions)
 		operations_hover(mut app, app.gg.width, app.gg.height)
-		// insights hover — tabs share insights_layout with drawing (VC7)
+		// insights hover — tabs share insights_layout with drawing
 		if app.selected_panel == 12 {
 			insights_hover_at(mut app, app.mouse_x, app.mouse_y, app.gg.width, app.gg.height)
 		}

--- a/cmd/agent-toolkit-desktop/office_room.v
+++ b/cmd/agent-toolkit-desktop/office_room.v
@@ -3,7 +3,7 @@ module main
 import desktop.pixelart
 import gg
 
-// VC3 Office room (#1172) — the flagship visual composition for the Office
+// Office room — the flagship visual composition for the Office
 // overview. Truth comes from desks_for_app (catalog identity) and Engine job
 // counts (attention/running, passed in by the caller); this file owns only
 // visual composition. Static first: no walking, no bobbing, no ambient
@@ -36,7 +36,7 @@ fn pc(app &GuiApp, k u8) gg.Color {
 	}
 }
 
-// zone_plate draws a small mounted sign behind a zone label (VC3.5):
+// zone_plate draws a small mounted sign behind a zone label:
 // cream paper plate with a wood frame, deterministic, no per-frame variation.
 fn zone_plate(mut app GuiApp, gx int, gy int, txt string, txt_col gg.Color) {
 	pw := txt.len * 7 + 12
@@ -205,16 +205,16 @@ fn draw_office_room(mut app GuiApp, x int, y int, w int, h int, desks []Desk, at
 	}
 
 	// ── workstation clusters (right): paired desks with aisles ──────────
-	ws_x := x + 16 + mz_w + 20
+	workspace_x := x + 16 + mz_w + 20
 	couch := pixelart.environment_for(.couch)
 	// lounge geometry is computed first so the desk grid can keep clear of
-	// the couch corner both vertically (avail_h) and horizontally (ws_w)
+	// the couch corner both vertically (avail_h) and horizontally (workspace_w)
 	lounge_w := couch.width() * s + rug.width() * s + 20
 	lounge_x := x + w - 16 - lounge_w
 	lounge_y := y + h - couch.height() * s - 12
-	lounge_ok := w >= 620 && lounge_x > ws_x && lounge_y > table_y + table.height() * s
-	ws_w := x + w - 16 - ws_x - if lounge_ok { lounge_w - 8 } else { 0 }
-	if ws_w < 40 * s || desks.len == 0 {
+	lounge_ok := w >= 620 && lounge_x > workspace_x && lounge_y > table_y + table.height() * s
+	workspace_w := x + w - 16 - workspace_x - if lounge_ok { lounge_w - 8 } else { 0 }
+	if workspace_w < 40 * s || desks.len == 0 {
 		return
 	}
 	desk := pixelart.environment_for(.desk)
@@ -226,7 +226,7 @@ fn draw_office_room(mut app GuiApp, x int, y int, w int, h int, desks []Desk, at
 	chh := chair.height() * s
 	cell_h := 42 * s
 	// lounge reserve: the couch corner keeps the bottom band clear of desks
-	// The lounge is already excluded horizontally by ws_w. Reserving it a
+	// The lounge is already excluded horizontally by workspace_w. Reserving it a
 	// second time vertically reduced a tall room to one sparse desk row.
 	lounge_h := 0
 	avail_h := y + h - 12 - lounge_h - (floor_y + 8 * s)
@@ -240,7 +240,7 @@ fn draw_office_room(mut app GuiApp, x int, y int, w int, h int, desks []Desk, at
 	pod_w := 2 * dw + 4
 	// wide rooms breathe: wider aisles keep clusters from huddling left
 	aisle := if w >= 900 { 18 * s } else { 12 * s }
-	mut pods_per_row := (ws_w + aisle) / (pod_w + aisle)
+	mut pods_per_row := (workspace_w + aisle) / (pod_w + aisle)
 	pods_per_row = if pods_per_row < 1 {
 		1
 	} else if pods_per_row > 3 { 3 } else { pods_per_row }
@@ -250,7 +250,7 @@ fn draw_office_room(mut app GuiApp, x int, y int, w int, h int, desks []Desk, at
 	pods := pods_per_row * rows
 	capacity := if desks.len < pods * 2 { desks.len } else { pods * 2 }
 	total_w := pods_per_row * pod_w + (pods_per_row - 1) * aisle
-	grid_x := ws_x + (ws_w - total_w) / 2
+	grid_x := workspace_x + (workspace_w - total_w) / 2
 	// vertical breathing: spread the pod rows across the available floor
 	// and center the block, so large rooms read composed instead of like
 	// a small grid floating in empty space

--- a/cmd/agent-toolkit-desktop/office_view.v
+++ b/cmd/agent-toolkit-desktop/office_view.v
@@ -4,9 +4,9 @@ import gg
 import desktop.pixelart
 import desktop_engine
 
-// VC8 (#1173) — Office overview refinement against office.jpg.
+// Office overview against office.jpg.
 //
-// The room itself is the VC3.5-locked composition (office_room.v). This
+// The room itself is composed in office_room.v and left untouched here. This
 // file adds the surrounding operational UI the reference shows around it:
 // four metric cards across the top, and — to the right of the room — an
 // Agent Roster and a Today column. Every number is real Engine state; on an
@@ -156,7 +156,7 @@ fn draw_office_cards(mut app GuiApp, l OfficeLayout, metrics []OfficeMetric) {
 			bold: true
 		})
 		if ch >= 66 {
-			app.gg.draw_text(tx, cy + ch - 18, utf8_truncate(m.sub, onb_fit(cx + cw - tx - 8, 11)), gg.TextCfg{
+			app.gg.draw_text(tx, cy + ch - 18, utf8_truncate(m.sub, text_fit_chars(cx + cw - tx - 8, 11)), gg.TextCfg{
 				color: app.pnl_text_mut
 				size: 11
 			})
@@ -203,13 +203,13 @@ fn draw_office_roster(mut app GuiApp, l OfficeLayout, agents []desktop_engine.Ag
 		}
 		agent := pixelart.with_identity(pixelart.agent_for_state(.idle), i % 3)
 		sc.draw(agent, pid, x + 12, ry + 2, 2)
-		app.gg.draw_text(x + 44, ry + 1, utf8_truncate(agent_entry.id, onb_fit(w - 120, 12)), gg.TextCfg{
+		app.gg.draw_text(x + 44, ry + 1, utf8_truncate(agent_entry.id, text_fit_chars(w - 120, 12)), gg.TextCfg{
 			color: app.pnl_text
 			size: 12
 			bold: true
 		})
 		role := if agent_entry.role == '' { agent_entry.tier } else { agent_entry.role }
-		app.gg.draw_text(x + 44, ry + 16, utf8_truncate(role, onb_fit(w - 60, 10)), gg.TextCfg{
+		app.gg.draw_text(x + 44, ry + 16, utf8_truncate(role, text_fit_chars(w - 60, 10)), gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 10
 		})
@@ -263,7 +263,7 @@ fn draw_office_today(mut app GuiApp, l OfficeLayout, attention []desktop_engine.
 			if ry + 16 > y0 + h - 8 {
 				break
 			}
-			app.gg.draw_text(x + 16, ry, utf8_truncate('${j.status} · ${j.id}', onb_fit(w - 28, 11)), gg.TextCfg{
+			app.gg.draw_text(x + 16, ry, utf8_truncate('${j.status} · ${j.id}', text_fit_chars(w - 28, 11)), gg.TextCfg{
 				color: app.pnl_text
 				size: 11
 			})
@@ -291,7 +291,7 @@ fn draw_office_today(mut app GuiApp, l OfficeLayout, attention []desktop_engine.
 			bold: true
 		})
 		ry += 18
-		app.gg.draw_text(x + 16, ry, utf8_truncate('${first_warn} — see Operations', onb_fit(w - 28, 11)), gg.TextCfg{
+		app.gg.draw_text(x + 16, ry, utf8_truncate('${first_warn} — see Operations', text_fit_chars(w - 28, 11)), gg.TextCfg{
 			color: app.pnl_text
 			size: 11
 		})
@@ -315,7 +315,7 @@ fn draw_office_today(mut app GuiApp, l OfficeLayout, attention []desktop_engine.
 				break
 			}
 			app.gg.draw_rect_empty(x + 16, ry + 2, 10, 10, app.pnl_border_hi)
-			app.gg.draw_text(x + 32, ry, utf8_truncate(s, onb_fit(w - 44, 11)), gg.TextCfg{
+			app.gg.draw_text(x + 32, ry, utf8_truncate(s, text_fit_chars(w - 44, 11)), gg.TextCfg{
 				color: app.pnl_text_mut
 				size: 11
 			})

--- a/cmd/agent-toolkit-desktop/onboarding_view.v
+++ b/cmd/agent-toolkit-desktop/onboarding_view.v
@@ -4,18 +4,15 @@ import gg
 import desktop.pixelart
 import desktop_engine
 
-// VC4 (#1173) — Paper Co. setup journey, second visual-lock pass.
+// Paper Co. setup journey: five user-facing stages in a dedicated editorial shell.
 //
 // Canonical visual reference: docs/desktop/assets/design/onboarding.jpg with
-// concept-board.jpg as the shell/material authority. The first VC4 pass
-// closed structural gaps (masthead content, card clipping, review rows,
-// responsive recomposition) but still read as a bordered utility screen. This
-// pass changes HOW onboarding occupies the whole window: it replaces the
-// generic header + production sidebar with a dedicated editorial shell
-// (draw_onboarding_masthead_shell + draw_onboarding_sidebar, wired from
-// frame() in main.v), enlarges type across the board, trades hard borders
-// for warm paper/manila fills, and composes each illustration as a small
-// scene instead of one centered icon.
+// concept-board.jpg as the shell/material authority. Onboarding occupies the
+// whole window: the generic header + production sidebar are replaced with a
+// dedicated editorial shell (draw_onboarding_masthead_shell +
+// draw_onboarding_sidebar, wired from frame() in main.v), type is enlarged
+// across the board, warm paper/manila fills replace hard borders, and each
+// illustration is composed as a small scene instead of one centered icon.
 //
 // Truth: every value shown here comes from Engine (onboarding_status, tool
 // discovery, targets, skills, products, personas). Illustration is
@@ -23,45 +20,31 @@ import desktop_engine
 // (revision, api counters, root-resolution chain, ADR ids) live behind the
 // Details affordance instead of dominating first run.
 
-// five user-facing stages; the Engine work each one commits is in onb_apply_stage
-const onb_stages = ['Setup Choice', 'Tools', 'Workspace', 'Capabilities', 'Review']
+// five user-facing stages; the Engine work each one commits is in onboarding_apply_stage
+const onboarding_stages = ['Setup Choice', 'Tools', 'Workspace', 'Capabilities', 'Review']
 
-const onb_stage_hints = ['How would you like to begin?', "We'll find what you have",
+const onboarding_stage_hints = ['How would you like to begin?', "We'll find what you have",
 	'Choose where agents live', 'Recommended for you', 'Confirm and finish']
 
-const onb_last_stage = 4
+const onboarding_last_stage = 4
 
 // setup-choice cards (stage 0) — each maps to real product behaviour
-const onb_choices = ['Set up for me', 'Existing setup', 'Find my setup']
+const onboarding_choices = ['Set up for me', 'Existing setup', 'Find my setup']
 
-const onb_choice_copy = ['Create a new workspace.', 'Use a configured setup.',
+const onboarding_choice_copy = ['Create a new workspace.', 'Use a configured setup.',
 	'Find existing workspaces.']
 
 // workspace cards (stage 2)
-const onb_ws_choices = ['Create workspace', 'Reuse a workspace']
+const onboarding_workspace_choices = ['Create workspace', 'Reuse a workspace']
 
-const onb_ws_copy = ['Create a fresh workspace.', 'Use an existing folder.']
+const onboarding_workspace_copy = ['Create a fresh workspace.', 'Use an existing folder.']
 
 // recommended capabilities (stage 3) — labels are user-facing, the sub-line is
 // the real catalog fact behind each one
-const onb_caps = ['Multi-agent collaboration (MCP)', 'Task planning and execution', 'Workspace memory',
+const onboarding_caps = ['Multi-agent collaboration (MCP)', 'Task planning and execution', 'Workspace memory',
 	'Observability and insights']
 
 // ── the editorial shell (replaces the generic header + production sidebar) ──
-
-// shell_mast_h is shared by onboarding and every regular destination.
-// It follows the reference's editorial band while leaving useful content at
-// compact heights.
-fn shell_mast_h(h int) int {
-	mut m := h * 13 / 100
-	if m < 78 {
-		m = 78
-	}
-	if m > 128 {
-		m = 128
-	}
-	return m
-}
 
 // draw_onboarding_sidebar replaces the production nav with the reference's
 // simplified onboarding rail: brand, three quiet rows, and a landscape
@@ -108,14 +91,14 @@ pub fn draw_onboarding_sidebar(mut app GuiApp, w int, h int) {
 	land_y := y0 + 74 + rows.len * 34 + 14
 	land_h := y1 - land_y
 	if land_h > 60 {
-		draw_onb_landscape(mut app, x0, land_y, dock_w, land_h, pid)
+		draw_onboarding_landscape(mut app, x0, land_y, dock_w, land_h, pid)
 	}
 }
 
-// draw_onb_landscape is a small original pixel-art panorama: two hill bands,
+// draw_onboarding_landscape is a small original pixel-art panorama: two hill bands,
 // a tree line and the hornero nest, closing the sidebar the way the
 // reference's village/hills illustration does.
-fn draw_onb_landscape(mut app GuiApp, x int, y int, w int, h int, pid pixelart.PaletteId) {
+fn draw_onboarding_landscape(mut app GuiApp, x int, y int, w int, h int, pid pixelart.PaletteId) {
 	mut sc := app.pixel_cache
 	ground := y + h - 44
 	app.gg.draw_rect_filled(x, y, w, h, col_ink700)
@@ -174,9 +157,9 @@ fn draw_onb_landscape(mut app GuiApp, x int, y int, w int, h int, pid pixelart.P
 	})
 }
 
-// OnbLayout is computed once per frame and reused by drawing, clicking and
+// OnboardingLayout is computed once per frame and reused by drawing, clicking and
 // hovering, so the interactive geometry can never drift from the drawn one.
-struct OnbLayout {
+struct OnboardingLayout {
 	fx      int
 	fy      int
 	fw      int
@@ -195,8 +178,8 @@ struct OnbLayout {
 	active  int // current stage — the only one shown full-width when compact
 }
 
-fn onb_layout(app &GuiApp, w int, h int) OnbLayout {
-	term_h := if app.term_visible { onb_effective_term_h(app) } else { 0 }
+fn onboarding_layout(app &GuiApp, w int, h int) OnboardingLayout {
+	term_h := if app.term_visible { onboarding_capped_terminal_height(app) } else { 0 }
 	mh := shell_mast_h(h)
 	fy := mh
 	fh := h - mh - 28 - term_h
@@ -212,7 +195,7 @@ fn onb_layout(app &GuiApp, w int, h int) OnbLayout {
 	step_h := if compact { 38 } else { 56 }
 	body_y := step_y + step_h + 8
 	foot_y := fy + fh - 28
-	return OnbLayout{
+	return OnboardingLayout{
 		fx: fx
 		fy: fy
 		fw: fw
@@ -234,12 +217,12 @@ fn onb_layout(app &GuiApp, w int, h int) OnbLayout {
 
 // ── shared rects ────────────────────────────────────────────────────────────
 
-// onb_sec_rect returns the sheet rectangle for section i (0..4) in the
+// onboarding_sec_rect returns the sheet rectangle for section i (0..4) in the
 // reference's board layout: sections 1/2 on the top row, 3/4 below, and the
 // review strip spanning the full width underneath. Compact: only the active
 // stage renders, full-width, like a focused single-stage view — a
 // recomposition, not a shrink.
-fn onb_sec_rect(l OnbLayout, i int) (int, int, int, int) {
+fn onboarding_sec_rect(l OnboardingLayout, i int) (int, int, int, int) {
 	if l.compact {
 		if i == l.active {
 			return l.fx, l.body_y, l.fw, l.body_h
@@ -293,14 +276,14 @@ fn onb_sec_rect(l OnbLayout, i int) (int, int, int, int) {
 	return l.fx, cy, l.fw, rn[i]
 }
 
-fn onb_step_rect(l OnbLayout, i int) (int, int, int, int) {
-	cw := l.fw / onb_stages.len
+fn onboarding_step_rect(l OnboardingLayout, i int) (int, int, int, int) {
+	cw := l.fw / onboarding_stages.len
 	return l.fx + i * cw, l.step_y, cw, l.step_h
 }
 
 // decision cards inside a section sheet (setup choice, workspace)
-fn onb_card_rect(l OnbLayout, sec int, i int, total int) (int, int, int, int) {
-	sx, sy, sw, sh := onb_sec_rect(l, sec)
+fn onboarding_card_rect(l OnboardingLayout, sec int, i int, total int) (int, int, int, int) {
+	sx, sy, sw, sh := onboarding_sec_rect(l, sec)
 	if sh < 40 {
 		return 0, 0, 0, 0
 	}
@@ -314,8 +297,8 @@ fn onb_card_rect(l OnbLayout, sec int, i int, total int) (int, int, int, int) {
 }
 
 // tool discovery cards inside section 1, two columns
-fn onb_tool_rect(l OnbLayout, i int) (int, int, int, int) {
-	sx, sy, sw, sh := onb_sec_rect(l, 1)
+fn onboarding_tool_rect(l OnboardingLayout, i int) (int, int, int, int) {
+	sx, sy, sw, sh := onboarding_sec_rect(l, 1)
 	if sh < 40 {
 		return 0, 0, 0, 0
 	}
@@ -329,20 +312,20 @@ fn onb_tool_rect(l OnbLayout, i int) (int, int, int, int) {
 	return sx + col * (cw + gap), sy + 40 + row * (ch + gap), cw, ch
 }
 
-fn onb_cap_rect(l OnbLayout, i int) (int, int, int, int) {
-	sx, sy, sw, sh := onb_sec_rect(l, 3)
+fn onboarding_cap_rect(l OnboardingLayout, i int) (int, int, int, int) {
+	sx, sy, sw, sh := onboarding_sec_rect(l, 3)
 	if sh < 40 {
 		return 0, 0, 0, 0
 	}
-	mut rh := (sh - 40) / onb_caps.len
+	mut rh := (sh - 40) / onboarding_caps.len
 	if rh < 22 {
 		rh = 22 // floor: an 18px box + 13px label fit; rows past the sheet are dropped
 	}
 	return sx, sy + 40 + i * rh, sw, rh - 4
 }
 
-fn onb_cta_rect(l OnbLayout) (int, int, int, int) {
-	sx, sy, sw, sh := onb_sec_rect(l, 4)
+fn onboarding_cta_rect(l OnboardingLayout) (int, int, int, int) {
+	sx, sy, sw, sh := onboarding_sec_rect(l, 4)
 	if sh < 40 {
 		return 0, 0, 0, 0
 	}
@@ -350,33 +333,33 @@ fn onb_cta_rect(l OnbLayout) (int, int, int, int) {
 	return sx + sw - cw, sy + sh - 46, cw, 38
 }
 
-fn onb_next_rect(l OnbLayout) (int, int, int, int) {
+fn onboarding_next_rect(l OnboardingLayout) (int, int, int, int) {
 	return l.fx + l.fw - 116, l.foot_y + 2, 100, 30
 }
 
-fn onb_back_rect(l OnbLayout) (int, int, int, int) {
+fn onboarding_back_rect(l OnboardingLayout) (int, int, int, int) {
 	return l.fx + l.fw - 220, l.foot_y + 2, 92, 30
 }
 
-fn onb_skip_rect(l OnbLayout) (int, int, int, int) {
+fn onboarding_skip_rect(l OnboardingLayout) (int, int, int, int) {
 	return l.fx, l.foot_y + 6, 50, 22
 }
 
-fn onb_diag_rect(l OnbLayout) (int, int, int, int) {
+fn onboarding_diag_rect(l OnboardingLayout) (int, int, int, int) {
 	return l.fx + 62, l.foot_y + 6, 66, 22
 }
 
-fn onb_rescan_rect(l OnbLayout) (int, int, int, int) {
-	sx, sy, sw, sh := onb_sec_rect(l, 1)
+fn onboarding_rescan_rect(l OnboardingLayout) (int, int, int, int) {
+	sx, sy, sw, sh := onboarding_sec_rect(l, 1)
 	if sh < 40 {
 		return 0, 0, 0, 0
 	}
 	return sx + sw - 96, sy + 8, 84, 24
 }
 
-// onb_art_scale keeps pixel art integral: the largest whole multiplier that
+// onboarding_art_scale keeps pixel art integral: the largest whole multiplier that
 // fits the available band, never a stretched sprite.
-fn onb_art_scale(sw int, sh int, aw int, ah int) int {
+fn onboarding_art_scale(sw int, sh int, aw int, ah int) int {
 	mut sc := 1
 	for m := 8; m >= 1; m-- {
 		if sw * m <= aw && sh * m <= ah {
@@ -387,18 +370,18 @@ fn onb_art_scale(sw int, sh int, aw int, ah int) int {
 	return sc
 }
 
-// onb_check draws a checkmark from pixel runs — the brand fonts do not carry a
+// draw_check_glyph draws a checkmark from pixel runs — the brand fonts do not carry a
 // dependable ✓ glyph and fell back to a stray letterform.
-fn onb_check(mut app GuiApp, x int, y int, c gg.Color) {
+fn draw_check_glyph(mut app GuiApp, x int, y int, c gg.Color) {
 	app.gg.draw_rect_filled(x + 1, y + 5, 2, 4, c)
 	app.gg.draw_rect_filled(x + 3, y + 7, 2, 3, c)
 	app.gg.draw_rect_filled(x + 5, y + 4, 2, 4, c)
 	app.gg.draw_rect_filled(x + 7, y + 1, 2, 4, c)
 }
 
-// onb_fit returns how many characters of the UI font fit in px at a size.
+// text_fit_chars returns how many characters of the UI font fit in px at a size.
 // Plex Sans averages ~0.56em, so this is deliberately slightly conservative.
-fn onb_fit(px int, size int) int {
+fn text_fit_chars(px int, size int) int {
 	adv := if size <= 10 {
 		5
 	} else if size <= 13 {
@@ -410,30 +393,15 @@ fn onb_fit(px int, size int) int {
 	return if n < 4 { 4 } else { n }
 }
 
-fn onb_hit(mx int, my int, x int, y int, w int, h int) bool {
-	return mx >= x && mx < x + w && my >= y && my < y + h
-}
-
-// onb_sheet_fill is the soft material surface every sheet/card sits on:
-// warm cream when active, a quieter manila tint otherwise, and a brass
-// accent bar instead of a hard outline. This is the deliberate replacement
-// for the bordered-panel treatment the first VC4 pass over-used.
-fn onb_sheet_fill(mut app GuiApp, x int, y int, w int, h int, active bool) {
-	// the reference's sheets are light paper on the warm canvas with a very
-	// quiet edge — hierarchy comes from tone and whitespace, not outlines
-	app.gg.draw_rect_filled(x + 2, y + 3, w, h, tint(col_ink, 14))
-	app.gg.draw_rect_filled(x, y, w, h, pc(app, `P`))
-	app.gg.draw_rect_empty(x, y, w, h, tint(pc(app, `W`), 70))
-	if active {
-		app.gg.draw_rect_filled(x, y, w, 3, app.pnl_select)
-	}
-}
+// text_fit_chars and draw_check_glyph live here as the single shared
+// definitions; rect_contains lives in operations_view.v and the paper surface
+// draw_paper_sheet lives in workspace_view.v.
 
 // ── truth helpers ───────────────────────────────────────────────────────────
 
-// onb_cap_fact returns the real catalog fact behind each recommended
+// onboarding_cap_fact returns the real catalog fact behind each recommended
 // capability. Nothing here claims runtime activity.
-fn onb_cap_fact(mut app GuiApp, i int) string {
+fn onboarding_cap_fact(mut app GuiApp, i int) string {
 	return match i {
 		0 { '${mcp_total(mut app)} MCP providers in catalog' }
 		1 { '${agents_active_total(mut app)} agent personas available' }
@@ -442,8 +410,8 @@ fn onb_cap_fact(mut app GuiApp, i int) string {
 	}
 }
 
-fn onb_choice_verb(app &GuiApp) string {
-	return match app.onb_choice {
+fn onboarding_choice_verb(app &GuiApp) string {
+	return match app.onboarding_choice {
 		1 { 'Connect to existing setup' }
 		2 { 'Search this computer' }
 		else { 'Set everything up for me' }
@@ -454,38 +422,41 @@ fn onb_choice_verb(app &GuiApp) string {
 
 fn draw_onboarding(mut app GuiApp, w int, h int) {
 	ensure_pixel_cache(mut app)
-	l := onb_layout(app, w, h)
+	l := onboarding_layout(app, w, h)
 	pid := office_palette_id(app)
 	st := app.desktop.onboarding_status(app.harness_root)
 
 	// warm paper world behind the whole journey
 	app.gg.draw_rect_filled(l.fx - 16, l.fy, l.fw + 32, l.fh, app.pnl_bg)
 
-	draw_onb_welcome(mut app, l)
-	draw_onb_steps(mut app, l)
+	draw_onboarding_welcome(mut app, l)
+	draw_onboarding_steps(mut app, l)
 
 	// the reference is a board, not a one-screen-at-a-time wizard: every
 	// setup sheet gets a soft material surface, the active one accented
-	for i in 0 .. onb_stages.len {
-		sx, sy, sw, sh := onb_sec_rect(l, i)
+	for i in 0 .. onboarding_stages.len {
+		sx, sy, sw, sh := onboarding_sec_rect(l, i)
 		if sh < 40 {
 			continue
 		}
-		onb_sheet_fill(mut app, sx, sy, sw, sh, i == app.onboarding_step)
+		draw_paper_sheet(mut app, sx, sy, sw, sh)
+		if i == app.onboarding_step {
+			app.gg.draw_rect_filled(sx, sy, sw, 3, app.pnl_select)
+		}
 	}
-	draw_onb_choice(mut app, l, pid)
-	draw_onb_tools(mut app, l)
-	draw_onb_workspace(mut app, l, pid, st)
-	draw_onb_capabilities(mut app, l)
-	draw_onb_review(mut app, l, st)
+	draw_onboarding_choice(mut app, l, pid)
+	draw_onboarding_tools(mut app, l)
+	draw_onboarding_workspace(mut app, l, pid, st)
+	draw_onboarding_capabilities(mut app, l)
+	draw_onboarding_review(mut app, l, st)
 
-	if app.onb_diag {
-		draw_onb_diagnostics(mut app, l, st)
+	if app.onboarding_diag {
+		draw_onboarding_diagnostics(mut app, l, st)
 	}
-	draw_onb_footer(mut app, l, st)
+	draw_onboarding_footer(mut app, l, st)
 }
 
-fn draw_onb_welcome(mut app GuiApp, l OnbLayout) {
+fn draw_onboarding_welcome(mut app GuiApp, l OnboardingLayout) {
 	y := l.welc_y
 	app.gg.draw_text(l.fx, y, 'Welcome to', gg.TextCfg{
 		color: app.pnl_text_mut
@@ -521,13 +492,13 @@ fn draw_onb_welcome(mut app GuiApp, l OnbLayout) {
 	}
 }
 
-fn draw_onb_steps(mut app GuiApp, l OnbLayout) {
+fn draw_onboarding_steps(mut app GuiApp, l OnboardingLayout) {
 	md := if l.step_h >= 52 { 36 } else { 26 }
 	// one continuous journey rule behind every medallion, like the reference
 	rule_y := l.step_y + md / 2 + 2
 	app.gg.draw_rect_filled(l.fx + md / 2, rule_y, l.fw - md, 2, tint(pc(app, `W`), 90))
-	for i, name in onb_stages {
-		sx, sy, sw, sh := onb_step_rect(l, i)
+	for i, name in onboarding_stages {
+		sx, sy, sw, sh := onboarding_step_rect(l, i)
 		done := i < app.onboarding_step
 		here := i == app.onboarding_step
 		mx0 := sx
@@ -547,7 +518,7 @@ fn draw_onb_steps(mut app GuiApp, l OnbLayout) {
 			tint(pc(app, `W`), 120)
 		})
 		if done {
-			onb_check(mut app, mx0 + md / 2 - 4, my0 + md / 2 - 3, app.pnl_bg)
+			draw_check_glyph(mut app, mx0 + md / 2 - 4, my0 + md / 2 - 3, app.pnl_bg)
 		} else {
 			app.gg.draw_text(mx0 + md / 2 - 5, my0 + md / 2 - 8, '${i + 1}', gg.TextCfg{
 				color: if here { app.pnl_bg } else { app.pnl_text_mut }
@@ -563,7 +534,7 @@ fn draw_onb_steps(mut app GuiApp, l OnbLayout) {
 		})
 		hint_px := sx + sw - label_x - 8
 		if sh >= 52 && hint_px > 40 {
-			app.gg.draw_text(label_x, sy + 20, utf8_truncate(onb_stage_hints[i], onb_fit(hint_px, 11)), gg.TextCfg{
+			app.gg.draw_text(label_x, sy + 20, utf8_truncate(onboarding_stage_hints[i], text_fit_chars(hint_px, 11)), gg.TextCfg{
 				color: app.pnl_text_mut
 				size: 11
 			})
@@ -571,8 +542,8 @@ fn draw_onb_steps(mut app GuiApp, l OnbLayout) {
 	}
 }
 
-fn draw_onb_sheet_title(mut app GuiApp, l OnbLayout, sec int, title string, sub string) {
-	sx, sy, sw, sh := onb_sec_rect(l, sec)
+fn draw_onboarding_sheet_title(mut app GuiApp, l OnboardingLayout, sec int, title string, sub string) {
+	sx, sy, sw, sh := onboarding_sec_rect(l, sec)
 	if sh < 40 {
 		return // compact: this sheet is not the active one, its rect is inert
 	}
@@ -582,7 +553,7 @@ fn draw_onb_sheet_title(mut app GuiApp, l OnbLayout, sec int, title string, sub 
 		family: app.fonts.display
 	})
 	if sub != '' && sw > 300 {
-		app.gg.draw_text(sx + 14, sy + 28, utf8_truncate(sub, onb_fit(sw - 130, 11)), gg.TextCfg{
+		app.gg.draw_text(sx + 14, sy + 28, utf8_truncate(sub, text_fit_chars(sw - 130, 11)), gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 11
 		})
@@ -590,14 +561,14 @@ fn draw_onb_sheet_title(mut app GuiApp, l OnbLayout, sec int, title string, sub 
 }
 
 // stage 0 — three illustrated choices, each a small composed scene
-fn draw_onb_choice(mut app GuiApp, l OnbLayout, pid pixelart.PaletteId) {
-	draw_onb_sheet_title(mut app, l, 0, 'How would you like to get started?', '')
-	for i, title in onb_choices {
-		cx, cy, cw, ch := onb_card_rect(l, 0, i, onb_choices.len)
+fn draw_onboarding_choice(mut app GuiApp, l OnboardingLayout, pid pixelart.PaletteId) {
+	draw_onboarding_sheet_title(mut app, l, 0, 'How would you like to get started?', '')
+	for i, title in onboarding_choices {
+		cx, cy, cw, ch := onboarding_card_rect(l, 0, i, onboarding_choices.len)
 		if ch == 0 {
 			continue
 		}
-		sel := app.onb_choice == i
+		sel := app.onboarding_choice == i
 		// unselected: warm manila card on the paper sheet; selected: a sage
 		// wash with a sage edge — the reference's green-highlighted choice
 		card_tone := if sel { tint(app.pnl_success, 170) } else { tint(pc(app, `m`), 90) }
@@ -613,7 +584,7 @@ fn draw_onb_choice(mut app GuiApp, l OnbLayout, pid pixelart.PaletteId) {
 			app.gg.draw_rect_filled(cx + cw - 21, cy + 11, 8, 8, app.pnl_success)
 		}
 		band := if ch * 44 / 100 < 42 { 42 } else { ch * 44 / 100 }
-		draw_onb_choice_scene(mut app, i, cx + 8, cy + 4, cw - 16, band, pid)
+		draw_onboarding_choice_scene(mut app, i, cx + 8, cy + 4, cw - 16, band, pid)
 		ty := cy + band + 6
 		app.gg.draw_text(cx + 12, ty, title, gg.TextCfg{
 			color: app.pnl_text
@@ -624,13 +595,13 @@ fn draw_onb_choice(mut app GuiApp, l OnbLayout, pid pixelart.PaletteId) {
 		if lines > 3 {
 			lines = 3
 		}
-		draw_onb_wrapped(mut app, cx + 12, ty + 19, cw - 24, onb_choice_copy[i], lines)
+		draw_wrapped_text(mut app, cx + 12, ty + 19, cw - 24, onboarding_choice_copy[i], lines)
 	}
 }
 
-// draw_onb_choice_scene composes 2-3 sprites into a small cluster per choice
+// draw_onboarding_choice_scene composes 2-3 sprites into a small cluster per choice
 // instead of one icon centered in empty space.
-fn draw_onb_choice_scene(mut app GuiApp, i int, x int, y int, w int, h int, pid pixelart.PaletteId) {
+fn draw_onboarding_choice_scene(mut app GuiApp, i int, x int, y int, w int, h int, pid pixelart.PaletteId) {
 	mut sc := app.pixel_cache
 	base := y + h - 4
 	match i {
@@ -638,7 +609,7 @@ fn draw_onb_choice_scene(mut app GuiApp, i int, x int, y int, w int, h int, pid 
 			desk := pixelart.environment_for(.welcome_desk)
 			chair := pixelart.environment_for(.chair)
 			plant := pixelart.environment_for(.plant)
-			s := onb_art_scale(desk.width() + chair.width() + 4, desk.height(), w - 8, h - 8)
+			s := onboarding_art_scale(desk.width() + chair.width() + 4, desk.height(), w - 8, h - 8)
 			gx := x + (w - (desk.width() + chair.width() + 4) * s) / 2
 			sc.draw(chair, pid, gx, base - chair.height() * s, s)
 			sc.draw(desk, pid, gx + chair.width() * s + 4 * s, base - desk.height() * s, s)
@@ -649,7 +620,7 @@ fn draw_onb_choice_scene(mut app GuiApp, i int, x int, y int, w int, h int, pid 
 		1 {
 			cabinet := pixelart.environment_for(.cabinet)
 			books := pixelart.environment_for(.books)
-			s := onb_art_scale(cabinet.width() + books.width() + 4, cabinet.height(), w - 8, h - 8)
+			s := onboarding_art_scale(cabinet.width() + books.width() + 4, cabinet.height(), w - 8, h - 8)
 			gx := x + (w - (cabinet.width() + books.width() + 4) * s) / 2
 			sc.draw(cabinet, pid, gx, base - cabinet.height() * s, s)
 			sc.draw(books, pid, gx + cabinet.width() * s + 4 * s, base - books.height() * s, s)
@@ -657,7 +628,7 @@ fn draw_onb_choice_scene(mut app GuiApp, i int, x int, y int, w int, h int, pid 
 		else {
 			shelf := pixelart.environment_for(.shelf)
 			window := pixelart.environment_for(.window)
-			s := onb_art_scale(shelf.width() + window.width() + 4, shelf.height(), w - 8, h - 8)
+			s := onboarding_art_scale(shelf.width() + window.width() + 4, shelf.height(), w - 8, h - 8)
 			gx := x + (w - (shelf.width() + window.width() + 4) * s) / 2
 			sc.draw(shelf, pid, gx, base - shelf.height() * s, s)
 			sc.draw(window, pid, gx + shelf.width() * s + 4 * s, base - window.height() * s, s)
@@ -666,15 +637,15 @@ fn draw_onb_choice_scene(mut app GuiApp, i int, x int, y int, w int, h int, pid 
 }
 
 // stage 1 — tool discovery as product UI, not a diagnostic dump
-fn draw_onb_tools(mut app GuiApp, l OnbLayout) {
+fn draw_onboarding_tools(mut app GuiApp, l OnboardingLayout) {
 	cat := app.desktop.engine_tool_discovery_catalog_cached()
 	found := cat.filter(it.found).len
-	_, _, _, sh_t := onb_sec_rect(l, 1)
+	_, _, _, sh_t := onboarding_sec_rect(l, 1)
 	if sh_t < 40 {
 		return
 	}
-	draw_onb_sheet_title(mut app, l, 1, 'Detected developer tools', '${found} of ${cat.len} found on this computer')
-	rx, ry, rw, rh := onb_rescan_rect(l)
+	draw_onboarding_sheet_title(mut app, l, 1, 'Detected developer tools', '${found} of ${cat.len} found on this computer')
+	rx, ry, rw, rh := onboarding_rescan_rect(l)
 	if rh > 0 {
 		app.gg.draw_rect_filled(rx, ry, rw, rh, if app.onboarding_hover == 20 {
 			app.pnl_card_sel
@@ -686,7 +657,7 @@ fn draw_onb_tools(mut app GuiApp, l OnbLayout) {
 			size: 12
 		})
 	}
-	_, ssy, _, ssh := onb_sec_rect(l, 1)
+	_, ssy, _, ssh := onboarding_sec_rect(l, 1)
 	mut roster := cat.filter(it.found)
 	roster << cat.filter(!it.found)
 	mut shown := 0
@@ -694,7 +665,7 @@ fn draw_onb_tools(mut app GuiApp, l OnbLayout) {
 		if shown >= 4 {
 			break
 		}
-		cx, cy, cw, ch := onb_tool_rect(l, shown)
+		cx, cy, cw, ch := onboarding_tool_rect(l, shown)
 		if ch == 0 || cy + ch > ssy + ssh - 6 {
 			break
 		}
@@ -713,7 +684,7 @@ fn draw_onb_tools(mut app GuiApp, l OnbLayout) {
 		pill_c := if t.found { app.pnl_success } else { app.pnl_text_mut }
 		name_x := cx + 16 + mk
 		pw := label.len * 7 + 16
-		app.gg.draw_text(name_x, cy + 12, utf8_truncate(t.display_name, onb_fit(cw - (mk + 26) - pw, 14)), gg.TextCfg{
+		app.gg.draw_text(name_x, cy + 12, utf8_truncate(t.display_name, text_fit_chars(cw - (mk + 26) - pw, 14)), gg.TextCfg{
 			color: app.pnl_text
 			size: 14
 			bold: true
@@ -729,14 +700,14 @@ fn draw_onb_tools(mut app GuiApp, l OnbLayout) {
 		} else {
 			'Install to enable seamless integration'
 		}
-		app.gg.draw_text(name_x, cy + 32, utf8_truncate(detail, onb_fit(cw - mk - 30, 11)), gg.TextCfg{
+		app.gg.draw_text(name_x, cy + 32, utf8_truncate(detail, text_fit_chars(cw - mk - 30, 11)), gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 11
 			mono: t.found
 		})
 		shown++
 	}
-	sx1, sy1, sw1, sh1 := onb_sec_rect(l, 1)
+	sx1, sy1, sw1, sh1 := onboarding_sec_rect(l, 1)
 	if cat.len > shown && sh1 >= 40 {
 		app.gg.draw_text(sx1 + sw1 - 190, sy1 + sh1 - 15, '+${cat.len - shown} more in Settings → Targets', gg.TextCfg{
 			color: app.pnl_text_mut
@@ -746,14 +717,14 @@ fn draw_onb_tools(mut app GuiApp, l OnbLayout) {
 }
 
 // stage 2 — where the agents live
-fn draw_onb_workspace(mut app GuiApp, l OnbLayout, pid pixelart.PaletteId, st desktop_engine.OnboardingStatus) {
-	draw_onb_sheet_title(mut app, l, 2, 'Workspace setup', 'Where agents and data live')
-	for i, title in onb_ws_choices {
-		cx, cy, cw, ch := onb_card_rect(l, 2, i, onb_ws_choices.len)
+fn draw_onboarding_workspace(mut app GuiApp, l OnboardingLayout, pid pixelart.PaletteId, st desktop_engine.OnboardingStatus) {
+	draw_onboarding_sheet_title(mut app, l, 2, 'Workspace setup', 'Where agents and data live')
+	for i, title in onboarding_workspace_choices {
+		cx, cy, cw, ch := onboarding_card_rect(l, 2, i, onboarding_workspace_choices.len)
 		if ch == 0 {
 			continue
 		}
-		sel := app.onb_ws_choice == i
+		sel := app.onboarding_workspace_choice == i
 		// unselected: warm manila card on the paper sheet; selected: a sage
 		// wash with a sage edge — the reference's green-highlighted choice
 		card_tone := if sel { tint(app.pnl_success, 170) } else { tint(pc(app, `m`), 90) }
@@ -768,7 +739,7 @@ fn draw_onb_workspace(mut app GuiApp, l OnbLayout, pid pixelart.PaletteId, st de
 			app.gg.draw_rect_filled(cx + cw - 21, cy + 11, 8, 8, app.pnl_success)
 		}
 		band := if ch * 52 / 100 < 40 { 40 } else { ch * 52 / 100 }
-		draw_onb_choice_scene(mut app, i, cx + 8, cy + 4, cw - 16, band, pid)
+		draw_onboarding_choice_scene(mut app, i, cx + 8, cy + 4, cw - 16, band, pid)
 		ty := cy + band + 4
 		app.gg.draw_text(cx + 12, ty, title, gg.TextCfg{
 			color: app.pnl_text
@@ -779,13 +750,13 @@ fn draw_onb_workspace(mut app GuiApp, l OnbLayout, pid pixelart.PaletteId, st de
 		if wlines > 2 {
 			wlines = 2
 		}
-		draw_onb_wrapped(mut app, cx + 12, ty + 19, cw - 24, onb_ws_copy[i], wlines)
+		draw_wrapped_text(mut app, cx + 12, ty + 19, cw - 24, onboarding_workspace_copy[i], wlines)
 	}
-	sx, sy, sw, sh := onb_sec_rect(l, 2)
+	sx, sy, sw, sh := onboarding_sec_rect(l, 2)
 	if sh > 0 {
 		path := if app.onboarding_harness != '' { app.onboarding_harness } else { app.harness_root }
 		state := if st.workspace_exists { 'ready' } else { 'not created yet' }
-		app.gg.draw_text(sx + 14, sy + sh - 16, utf8_truncate(path, onb_fit(sw - 140, 11)), gg.TextCfg{
+		app.gg.draw_text(sx + 14, sy + sh - 16, utf8_truncate(path, text_fit_chars(sw - 140, 11)), gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 11
 			mono: true
@@ -798,15 +769,15 @@ fn draw_onb_workspace(mut app GuiApp, l OnbLayout, pid pixelart.PaletteId, st de
 }
 
 // stage 3 — recommended capabilities in user language, real catalog facts
-fn draw_onb_capabilities(mut app GuiApp, l OnbLayout) {
-	draw_onb_sheet_title(mut app, l, 3, 'Recommended capabilities', 'A useful starting point')
-	_, s3y, _, s3h := onb_sec_rect(l, 3)
-	for i, name in onb_caps {
-		cx, cy, cw, ch := onb_cap_rect(l, i)
+fn draw_onboarding_capabilities(mut app GuiApp, l OnboardingLayout) {
+	draw_onboarding_sheet_title(mut app, l, 3, 'Recommended capabilities', 'A useful starting point')
+	_, s3y, _, s3h := onboarding_sec_rect(l, 3)
+	for i, name in onboarding_caps {
+		cx, cy, cw, ch := onboarding_cap_rect(l, i)
 		if ch == 0 || cy + ch > s3y + s3h - 4 {
 			break
 		}
-		on := app.onb_cap_on[i]
+		on := app.onboarding_cap_on[i]
 		box := if ch > 34 { 22 } else { 16 }
 		app.gg.draw_rect_filled(cx + 14, cy + (ch - box) / 2, box, box, if on {
 			app.pnl_success
@@ -819,15 +790,15 @@ fn draw_onb_capabilities(mut app GuiApp, l OnbLayout) {
 			app.pnl_border_hi
 		})
 		if on {
-			onb_check(mut app, cx + 14 + box / 2 - 4, cy + (ch - box) / 2 + box / 2 - 3, app.pnl_bg)
+			draw_check_glyph(mut app, cx + 14 + box / 2 - 4, cy + (ch - box) / 2 + box / 2 - 3, app.pnl_bg)
 		}
-		app.gg.draw_text(cx + 46, cy + ch / 2 - 15, utf8_truncate(name, onb_fit(cw - 60, 13)), gg.TextCfg{
+		app.gg.draw_text(cx + 46, cy + ch / 2 - 15, utf8_truncate(name, text_fit_chars(cw - 60, 13)), gg.TextCfg{
 			color: app.pnl_text
 			size: 13
 			bold: true
 		})
 		if ch >= 34 {
-			app.gg.draw_text(cx + 46, cy + ch / 2 + 1, utf8_truncate(onb_cap_fact(mut app, i), onb_fit(cw - 60, 11)), gg.TextCfg{
+			app.gg.draw_text(cx + 46, cy + ch / 2 + 1, utf8_truncate(onboarding_cap_fact(mut app, i), text_fit_chars(cw - 60, 11)), gg.TextCfg{
 				color: app.pnl_text_mut
 				size: 11
 			})
@@ -836,8 +807,8 @@ fn draw_onb_capabilities(mut app GuiApp, l OnbLayout) {
 }
 
 // stage 4 — truthful summary + finish
-fn draw_onb_review(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStatus) {
-	draw_onb_sheet_title(mut app, l, 4, 'Review and finish', '')
+fn draw_onboarding_review(mut app GuiApp, l OnboardingLayout, st desktop_engine.OnboardingStatus) {
+	draw_onboarding_sheet_title(mut app, l, 4, 'Review and finish', '')
 	cat := app.desktop.engine_tool_discovery_catalog_cached()
 	found := cat.filter(it.found)
 	tools := if found.len == 0 {
@@ -845,20 +816,20 @@ fn draw_onb_review(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStat
 	} else {
 		'${found.len} found'
 	}
-	caps_on := app.onb_cap_on.filter(it).len
+	caps_on := app.onboarding_cap_on.filter(it).len
 	rows := [
-		['Setup method', onb_choice_verb(app)],
+		['Setup method', onboarding_choice_verb(app)],
 		['Tools detected', tools],
 		['Workspace',
-			if st.workspace_exists { app.harness_root } else { onb_ws_choices[app.onb_ws_choice] }],
-		['Capabilities', '${caps_on} of ${onb_caps.len} enabled'],
+			if st.workspace_exists { app.harness_root } else { onboarding_workspace_choices[app.onboarding_workspace_choice] }],
+		['Capabilities', '${caps_on} of ${onboarding_caps.len} enabled'],
 		['Personas', if st.persona_count > 0 {
 			'${st.persona_count} bootstrapped'
 		} else {
 			'created on finish'
 		}],
 	]
-	sx, sy, sw, sh := onb_sec_rect(l, 4)
+	sx, sy, sw, sh := onboarding_sec_rect(l, 4)
 	if sh == 0 {
 		return
 	}
@@ -877,14 +848,14 @@ fn draw_onb_review(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStat
 			color: app.pnl_text_mut
 			size: 12
 		})
-		app.gg.draw_text(rx + 96, ry, utf8_truncate(r[1], onb_fit(col_w - 96, 12)), gg.TextCfg{
+		app.gg.draw_text(rx + 96, ry, utf8_truncate(r[1], text_fit_chars(col_w - 96, 12)), gg.TextCfg{
 			color: app.pnl_text
 			size: 12
 		})
 	}
 	// primary call to action — the wording matches what really happens: every
 	// stage already committed its own transaction, this finalizes onboarding
-	cx, cy, cw, ch := onb_cta_rect(l)
+	cx, cy, cw, ch := onboarding_cta_rect(l)
 	if ch == 0 {
 		return
 	}
@@ -902,7 +873,7 @@ fn draw_onb_review(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStat
 	})
 }
 
-fn draw_onb_diagnostics(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStatus) {
+fn draw_onboarding_diagnostics(mut app GuiApp, l OnboardingLayout, st desktop_engine.OnboardingStatus) {
 	dh := 96
 	dy := l.foot_y - dh - 6
 	app.gg.draw_rect_filled(l.fx, dy, l.fw, dh, col_ink700)
@@ -926,15 +897,15 @@ fn draw_onb_diagnostics(mut app GuiApp, l OnbLayout, st desktop_engine.Onboardin
 	}
 }
 
-fn draw_onb_footer(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStatus) {
-	sx, sy, sw, sh := onb_skip_rect(l)
+fn draw_onboarding_footer(mut app GuiApp, l OnboardingLayout, st desktop_engine.OnboardingStatus) {
+	sx, sy, sw, sh := onboarding_skip_rect(l)
 	app.gg.draw_text(sx, sy, 'Skip', gg.TextCfg{
 		color: if app.onboarding_hover == 12 { app.pnl_text } else { app.pnl_text_mut }
 		size: 12
 	})
-	dx, dy, dw, dh := onb_diag_rect(l)
-	app.gg.draw_text(dx, dy, if app.onb_diag { 'Hide details' } else { 'Details' }, gg.TextCfg{
-		color: if app.onb_diag || app.onboarding_hover == 13 {
+	dx, dy, dw, dh := onboarding_diag_rect(l)
+	app.gg.draw_text(dx, dy, if app.onboarding_diag { 'Hide details' } else { 'Details' }, gg.TextCfg{
+		color: if app.onboarding_diag || app.onboarding_hover == 13 {
 			app.pnl_text
 		} else {
 			app.pnl_text_mut
@@ -946,7 +917,7 @@ fn draw_onb_footer(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStat
 	_ = dw
 	_ = dh
 	if app.onboarding_step > 0 {
-		bx, by, bw, bh := onb_back_rect(l)
+		bx, by, bw, bh := onboarding_back_rect(l)
 		app.gg.draw_rect_filled(bx, by, bw, bh, if app.onboarding_hover == 10 {
 			app.pnl_card_sel
 		} else {
@@ -957,8 +928,8 @@ fn draw_onb_footer(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStat
 			size: 13
 		})
 	}
-	nx, ny, nw, nh := onb_next_rect(l)
-	is_last := app.onboarding_step >= onb_last_stage
+	nx, ny, nw, nh := onboarding_next_rect(l)
+	is_last := app.onboarding_step >= onboarding_last_stage
 	app.gg.draw_rect_filled(nx, ny, nw, nh, if app.onboarding_hover == 11 {
 		tint(app.pnl_select, 200)
 	} else {
@@ -972,16 +943,16 @@ fn draw_onb_footer(mut app GuiApp, l OnbLayout, st desktop_engine.OnboardingStat
 	msg := if app.onboarding_msg != '' {
 		app.onboarding_msg
 	} else {
-		'step ${app.onboarding_step + 1} of ${onb_stages.len} · ${st.pending_items.len} pending'
+		'step ${app.onboarding_step + 1} of ${onboarding_stages.len} · ${st.pending_items.len} pending'
 	}
-	app.gg.draw_text(l.fx + 130, l.foot_y + 8, utf8_truncate(msg, onb_fit(l.fw - 380, 11)), gg.TextCfg{
+	app.gg.draw_text(l.fx + 130, l.foot_y + 8, utf8_truncate(msg, text_fit_chars(l.fw - 380, 11)), gg.TextCfg{
 		color: app.pnl_text_mut
 		size: 11
 	})
 }
 
-fn draw_onb_wrapped(mut app GuiApp, x int, y int, w int, s string, max_lines int) {
-	per := onb_fit(w, 12)
+fn draw_wrapped_text(mut app GuiApp, x int, y int, w int, s string, max_lines int) {
+	per := text_fit_chars(w, 12)
 	words := s.split(' ')
 	mut line := ''
 	mut ln := 0
@@ -1013,7 +984,7 @@ fn draw_onb_wrapped(mut app GuiApp, x int, y int, w int, s string, max_lines int
 
 fn draw_onboarding_preview(mut app GuiApp, w int, h int) {
 	ensure_pixel_cache(mut app)
-	l := onb_layout(app, w, h)
+	l := onboarding_layout(app, w, h)
 	if l.side_w == 0 {
 		return
 	}
@@ -1036,12 +1007,12 @@ fn draw_onboarding_preview(mut app GuiApp, w int, h int) {
 	// office, not a narrow inspector strip
 	sy := y + 34
 	sh := ih * 50 / 100
-	draw_onb_scene(mut app, x + 8, sy, iw - 16, sh, pid)
+	draw_onboarding_scene(mut app, x + 8, sy, iw - 16, sh, pid)
 
 	// compact truthful facts strip — two columns so it never sprawls
 	fy0 := sy + sh + 12
 	mut rows := [][]string{}
-	rows << ['Setup', onb_choice_verb(app)]
+	rows << ['Setup', onboarding_choice_verb(app)]
 	cat := app.desktop.engine_tool_discovery_catalog_cached()
 	rows << ['Tools', '${cat.filter(it.found).len} of ${cat.len} found']
 	rows << ['Workspace', if st.workspace_exists { 'ready' } else { 'not created yet' }]
@@ -1089,12 +1060,12 @@ fn draw_onboarding_preview(mut app GuiApp, w int, h int) {
 	}
 }
 
-// draw_onb_scene composes a dense welcome office: wood wall with a framed
+// draw_onboarding_scene composes a dense welcome office: wood wall with a framed
 // sign and picture, a shelf of books, a window, a reception desk with an
 // idle builder and a visitor chair, a lounge corner with a couch, and
 // plants/lamp/nest — an original miniature scene, not isolated icons.
 // Static and deterministic; illustration only, never runtime state.
-fn draw_onb_scene(mut app GuiApp, x int, y int, w int, h int, pid pixelart.PaletteId) {
+fn draw_onboarding_scene(mut app GuiApp, x int, y int, w int, h int, pid pixelart.PaletteId) {
 	mut sc := app.pixel_cache
 	scale := if w >= 300 && h >= 220 {
 		4
@@ -1175,28 +1146,28 @@ fn draw_onb_scene(mut app GuiApp, x int, y int, w int, h int, pid pixelart.Palet
 // ── interaction (single source of geometry, shared with drawing) ────────────
 
 fn onboarding_click(mut app GuiApp, mx int, my int, w int, h int) bool {
-	l := onb_layout(app, w, h)
+	l := onboarding_layout(app, w, h)
 	// step medallions jump to a visited stage only — never skip work forward
-	for i in 0 .. onb_stages.len {
-		sx, sy, sw, sh := onb_step_rect(l, i)
-		if onb_hit(mx, my, sx, sy, sw, sh) && i <= app.onboarding_step {
+	for i in 0 .. onboarding_stages.len {
+		sx, sy, sw, sh := onboarding_step_rect(l, i)
+		if rect_contains(mx, my, sx, sy, sw, sh) && i <= app.onboarding_step {
 			app.onboarding_step = i
-			app.onboarding_msg = '${onb_stages[i]} — ${onb_stage_hints[i]}'
+			app.onboarding_msg = '${onboarding_stages[i]} — ${onboarding_stage_hints[i]}'
 			return true
 		}
 	}
-	bx, by, bw, bh := onb_back_rect(l)
-	if app.onboarding_step > 0 && onb_hit(mx, my, bx, by, bw, bh) {
+	bx, by, bw, bh := onboarding_back_rect(l)
+	if app.onboarding_step > 0 && rect_contains(mx, my, bx, by, bw, bh) {
 		app.onboarding_step--
 		return true
 	}
-	nx, ny, nw, nh := onb_next_rect(l)
-	if onb_hit(mx, my, nx, ny, nw, nh) {
+	nx, ny, nw, nh := onboarding_next_rect(l)
+	if rect_contains(mx, my, nx, ny, nw, nh) {
 		onboarding_advance(mut app)
 		return true
 	}
-	sx2, sy2, sw2, sh2 := onb_skip_rect(l)
-	if onb_hit(mx, my, sx2 - 4, sy2 - 4, sw2 + 8, sh2 + 8) {
+	sx2, sy2, sw2, sh2 := onboarding_skip_rect(l)
+	if rect_contains(mx, my, sx2 - 4, sy2 - 4, sw2 + 8, sh2 + 8) {
 		app.show_onboarding = false
 		if app.selected_panel == 11 {
 			app.selected_panel = 0
@@ -1204,92 +1175,92 @@ fn onboarding_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 		app.onboarding_msg = 'Setup skipped — press o to resume'
 		return true
 	}
-	dx, dy, dw, dh := onb_diag_rect(l)
-	if onb_hit(mx, my, dx - 4, dy - 4, dw + 8, dh + 8) {
-		app.onb_diag = !app.onb_diag
+	dx, dy, dw, dh := onboarding_diag_rect(l)
+	if rect_contains(mx, my, dx - 4, dy - 4, dw + 8, dh + 8) {
+		app.onboarding_diag = !app.onboarding_diag
 		return true
 	}
 	// simplified onboarding sidebar rows — Get Started is the active row and
 	// stays put; Help/Settings are decorative during first run (no
 	// navigation surface exists to jump to yet without leaving the journey)
 	// every sheet on the board is live, not only the active one
-	for i in 0 .. onb_choices.len {
-		cx, cy, cw, ch := onb_card_rect(l, 0, i, onb_choices.len)
-		if onb_hit(mx, my, cx, cy, cw, ch) {
-			app.onb_choice = i
+	for i in 0 .. onboarding_choices.len {
+		cx, cy, cw, ch := onboarding_card_rect(l, 0, i, onboarding_choices.len)
+		if rect_contains(mx, my, cx, cy, cw, ch) {
+			app.onboarding_choice = i
 			app.onboarding_step = 0
-			app.onboarding_msg = onb_choices[i]
+			app.onboarding_msg = onboarding_choices[i]
 			return true
 		}
 	}
-	rx, ry, rw, rh := onb_rescan_rect(l)
-	if onb_hit(mx, my, rx, ry, rw, rh) {
+	rx, ry, rw, rh := onboarding_rescan_rect(l)
+	if rect_contains(mx, my, rx, ry, rw, rh) {
 		cat := app.desktop.engine_tool_discovery_catalog()
 		app.onboarding_step = 1
 		app.onboarding_msg = 'Rescanned — ${cat.filter(it.found).len} of ${cat.len} tools found'
 		return true
 	}
-	for i in 0 .. onb_ws_choices.len {
-		cx, cy, cw, ch := onb_card_rect(l, 2, i, onb_ws_choices.len)
-		if onb_hit(mx, my, cx, cy, cw, ch) {
-			app.onb_ws_choice = i
+	for i in 0 .. onboarding_workspace_choices.len {
+		cx, cy, cw, ch := onboarding_card_rect(l, 2, i, onboarding_workspace_choices.len)
+		if rect_contains(mx, my, cx, cy, cw, ch) {
+			app.onboarding_workspace_choice = i
 			app.onboarding_step = 2
-			app.onboarding_msg = onb_ws_choices[i]
+			app.onboarding_msg = onboarding_workspace_choices[i]
 			return true
 		}
 	}
-	for i in 0 .. onb_caps.len {
-		cx, cy, cw, ch := onb_cap_rect(l, i)
-		if onb_hit(mx, my, cx, cy, cw, ch) {
-			app.onb_cap_on[i] = !app.onb_cap_on[i]
+	for i in 0 .. onboarding_caps.len {
+		cx, cy, cw, ch := onboarding_cap_rect(l, i)
+		if rect_contains(mx, my, cx, cy, cw, ch) {
+			app.onboarding_cap_on[i] = !app.onboarding_cap_on[i]
 			app.onboarding_step = 3
 			return true
 		}
 	}
-	cx4, cy4, cw4, ch4 := onb_cta_rect(l)
-	if onb_hit(mx, my, cx4, cy4, cw4, ch4) {
-		app.onboarding_step = onb_last_stage
+	cx4, cy4, cw4, ch4 := onboarding_cta_rect(l)
+	if rect_contains(mx, my, cx4, cy4, cw4, ch4) {
+		app.onboarding_step = onboarding_last_stage
 		onboarding_advance(mut app)
 		return true
 	}
 	// clicking a sheet focuses its stage so Next commits the right work
-	for i in 0 .. onb_stages.len {
-		sx3, sy3, sw3, sh3 := onb_sec_rect(l, i)
-		if onb_hit(mx, my, sx3, sy3, sw3, sh3) {
+	for i in 0 .. onboarding_stages.len {
+		sx3, sy3, sw3, sh3 := onboarding_sec_rect(l, i)
+		if rect_contains(mx, my, sx3, sy3, sw3, sh3) {
 			app.onboarding_step = i
 			return true
 		}
 	}
 	// clicks inside the onboarding surface never fall through to the panel below
-	return onb_hit(mx, my, l.fx - 16, l.fy, l.fw + 32, l.fh)
-		|| onb_hit(mx, my, 0, 0, dock_w, app.gg.height)
+	return rect_contains(mx, my, l.fx - 16, l.fy, l.fw + 32, l.fh)
+		|| rect_contains(mx, my, 0, 0, dock_w, app.gg.height)
 }
 
 fn onboarding_hover_at(mut app GuiApp, mx int, my int, w int, h int) {
-	l := onb_layout(app, w, h)
+	l := onboarding_layout(app, w, h)
 	app.onboarding_hover = -1
-	bx, by, bw, bh := onb_back_rect(l)
-	if onb_hit(mx, my, bx, by, bw, bh) {
+	bx, by, bw, bh := onboarding_back_rect(l)
+	if rect_contains(mx, my, bx, by, bw, bh) {
 		app.onboarding_hover = 10
 	}
-	nx, ny, nw, nh := onb_next_rect(l)
-	if onb_hit(mx, my, nx, ny, nw, nh) {
+	nx, ny, nw, nh := onboarding_next_rect(l)
+	if rect_contains(mx, my, nx, ny, nw, nh) {
 		app.onboarding_hover = 11
 	}
-	sx, sy, sw, sh := onb_skip_rect(l)
-	if onb_hit(mx, my, sx - 4, sy - 4, sw + 8, sh + 8) {
+	sx, sy, sw, sh := onboarding_skip_rect(l)
+	if rect_contains(mx, my, sx - 4, sy - 4, sw + 8, sh + 8) {
 		app.onboarding_hover = 12
 	}
-	dxr, dyr, dwr, dhr := onb_diag_rect(l)
-	if onb_hit(mx, my, dxr - 4, dyr - 4, dwr + 8, dhr + 8) {
+	dxr, dyr, dwr, dhr := onboarding_diag_rect(l)
+	if rect_contains(mx, my, dxr - 4, dyr - 4, dwr + 8, dhr + 8) {
 		app.onboarding_hover = 13
 	}
-	rx, ry, rw, rh := onb_rescan_rect(l)
-	if onb_hit(mx, my, rx, ry, rw, rh) {
+	rx, ry, rw, rh := onboarding_rescan_rect(l)
+	if rect_contains(mx, my, rx, ry, rw, rh) {
 		app.onboarding_hover = 20
 	}
-	cx, cy, cw, ch := onb_cta_rect(l)
-	if onb_hit(mx, my, cx, cy, cw, ch) {
+	cx, cy, cw, ch := onboarding_cta_rect(l)
+	if rect_contains(mx, my, cx, cy, cw, ch) {
 		app.onboarding_hover = 30
 	}
 }
@@ -1299,8 +1270,8 @@ fn onboarding_hover_at(mut app GuiApp, mx int, my int, w int, h int) {
 // apply, so the CTA honestly finishes the journey instead of pretending to
 // perform everything at once.
 fn onboarding_advance(mut app GuiApp) {
-	onb_apply_stage(mut app)
-	if app.onboarding_step < onb_last_stage {
+	onboarding_apply_stage(mut app)
+	if app.onboarding_step < onboarding_last_stage {
 		app.onboarding_step++
 		return
 	}
@@ -1314,10 +1285,10 @@ fn onboarding_advance(mut app GuiApp) {
 	app.workspace_initialized = app.desktop.onboarding_status(app.harness_root).workspace_exists
 	app.show_onboarding = false
 	app.selected_panel = 0
-	app.onb_diag = false
+	app.onboarding_diag = false
 }
 
-fn onb_apply_stage(mut app GuiApp) {
+fn onboarding_apply_stage(mut app GuiApp) {
 	harness := if app.onboarding_harness != '' { app.onboarding_harness } else { app.harness_root }
 	match app.onboarding_step {
 		1 {
@@ -1333,7 +1304,7 @@ fn onb_apply_stage(mut app GuiApp) {
 			app.onboarding_msg = '${ids.len} tools enabled (rev ${rev})'
 		}
 		2 {
-			if app.onb_ws_choice == 0 {
+			if app.onboarding_workspace_choice == 0 {
 				rev := app.desktop.onboarding_init_with_templates(harness, false) or {
 					app.onboarding_msg = 'Workspace: ${err}'
 					return

--- a/cmd/agent-toolkit-desktop/operations_view.v
+++ b/cmd/agent-toolkit-desktop/operations_view.v
@@ -5,13 +5,12 @@ import time
 import desktop.pixelart
 import desktop_engine
 
-// VC6 (#1173) — Operations visual convergence: the operational command center.
+// Operations: the operational command center.
 //
 // Canonical visual reference: docs/desktop/assets/design/operations.jpg with
 // concept-board.jpg as the shell/material authority. The four Operations
-// panels (Doctor 5, Jobs 6, Loops 7, Swarm 8) used to be four unrelated
-// bordered utility screens. They now share one composition: an editorial
-// header band, four metric cards, the pixel-art Operations Floor on the left,
+// panels (Doctor 5, Jobs 6, Loops 7, Swarm 8) share one composition: an
+// editorial header band, four metric cards, the pixel-art Operations Floor on the left,
 // a tabbed dense table on the right, and a "Details" column that replaces the
 // Office inspector while an Operations panel is selected.
 //
@@ -26,24 +25,24 @@ import desktop_engine
 //   approve/fix) and report the actual result. Nothing is drawn that has no
 //   real handler behind it.
 //
-// One layout struct per frame (OpsLayout) drives drawing, hover, click and
+// One layout struct per frame (OperationsLayout) drives drawing, hover, click and
 // scroll so hit-testing can never drift from the pixels.
 
 // ── tabs ────────────────────────────────────────────────────────────────────
 
-const ops_tab_labels = ['Jobs', 'Loops', 'Swarms', 'Doctor']
+const operations_tab_labels = ['Jobs', 'Loops', 'Swarms', 'Doctor']
 
-const ops_tab_panels = [6, 7, 8, 5]
+const operations_tab_panels = [6, 7, 8, 5]
 
-const ops_tab_marks = [pixelart.EnvironmentAsset.play_mark, .calendar_mark, .swarm_mark, .alert_mark]
+const operations_tab_marks = [pixelart.EnvironmentAsset.play_mark, .calendar_mark, .swarm_mark, .alert_mark]
 
-const ops_detail_titles = ['Job Details', 'Loop Details', 'Swarm Details', 'Check Details']
+const operations_detail_titles = ['Job Details', 'Loop Details', 'Swarm Details', 'Check Details']
 
-const ops_search_hints = ['Search jobs…', 'Search loops…', 'Search swarms…', 'Search checks…']
+const operations_search_hints = ['Search jobs…', 'Search loops…', 'Search swarms…', 'Search checks…']
 
-// ops_tab_for_panel maps a nav panel id to its Operations tab (0..3), or -1.
-fn ops_tab_for_panel(panel int) int {
-	for i, p in ops_tab_panels {
+// operations_tab_for_panel maps a nav panel id to its Operations tab (0..3), or -1.
+fn operations_tab_for_panel(panel int) int {
+	for i, p in operations_tab_panels {
 		if p == panel {
 			return i
 		}
@@ -51,16 +50,16 @@ fn ops_tab_for_panel(panel int) int {
 	return -1
 }
 
-// ops_is_panel reports whether the panel belongs to Operations.
-fn ops_is_panel(panel int) bool {
-	return ops_tab_for_panel(panel) >= 0
+// operations_is_panel reports whether the panel belongs to Operations.
+fn operations_is_panel(panel int) bool {
+	return operations_tab_for_panel(panel) >= 0
 }
 
 // ── layout ──────────────────────────────────────────────────────────────────
 
-// OpsLayout is computed once per frame and shared by draw, hover, click and
+// OperationsLayout is computed once per frame and shared by draw, hover, click and
 // scroll. Rects with w == 0 or h == 0 are absent at this window size.
-struct OpsLayout {
+struct OperationsLayout {
 	tab     int
 	fx      int
 	fy      int
@@ -98,8 +97,8 @@ struct OpsLayout {
 	compact bool
 }
 
-fn ops_layout(app &GuiApp, w int, h int) OpsLayout {
-	tab := ops_tab_for_panel(app.selected_panel)
+fn operations_layout(app &GuiApp, w int, h int) OperationsLayout {
+	tab := operations_tab_for_panel(app.selected_panel)
 	fx := panel_fx(app)
 	fy := shell_mast_h(h)
 	fw := panel_fw(app, w)
@@ -142,7 +141,7 @@ fn ops_layout(app &GuiApp, w int, h int) OpsLayout {
 		table_h -= topo_h + 8
 	}
 	topo_y := table_y + table_h + 8
-	return OpsLayout{
+	return OperationsLayout{
 		tab: tab
 		fx: fx
 		fy: fy
@@ -183,7 +182,7 @@ fn ops_layout(app &GuiApp, w int, h int) OpsLayout {
 
 // ── shared rects (draw == hit) ──────────────────────────────────────────────
 
-fn ops_card_rect(l OpsLayout, i int) (int, int, int, int) {
+fn operations_card_rect(l OperationsLayout, i int) (int, int, int, int) {
 	gap := 10
 	cw := (l.fw - 24 - (l.cards_n - 1) * gap) / l.cards_n
 	col := i % l.cards_n
@@ -191,38 +190,38 @@ fn ops_card_rect(l OpsLayout, i int) (int, int, int, int) {
 	return l.fx + 12 + col * (cw + gap), l.cards_y + row * (l.card_h + gap), cw, l.card_h
 }
 
-fn ops_tab_rect(l OpsLayout, i int) (int, int, int, int) {
+fn operations_tab_rect(l OperationsLayout, i int) (int, int, int, int) {
 	tw := if l.right_w >= 420 { 96 } else { l.right_w / 4 }
 	return l.right_x + i * tw, l.tab_y, tw, l.tab_h
 }
 
-fn ops_search_rect(l OpsLayout) (int, int, int, int) {
-	fw := ops_filter_w(l)
+fn operations_search_rect(l OperationsLayout) (int, int, int, int) {
+	fw := operations_filter_w(l)
 	return l.right_x, l.ctl_y, l.right_w - fw - 8, l.ctl_h
 }
 
-fn ops_filter_w(l OpsLayout) int {
+fn operations_filter_w(l OperationsLayout) int {
 	return if l.right_w >= 420 { 130 } else { 104 }
 }
 
-fn ops_filter_rect(l OpsLayout) (int, int, int, int) {
-	fw := ops_filter_w(l)
+fn operations_filter_rect(l OperationsLayout) (int, int, int, int) {
+	fw := operations_filter_w(l)
 	return l.right_x + l.right_w - fw, l.ctl_y, fw, l.ctl_h
 }
 
-// ops_visible_rows is the number of table rows that fit under the header.
-fn ops_visible_rows(l OpsLayout) int {
+// operations_visible_rows is the number of table rows that fit under the header.
+fn operations_visible_rows(l OperationsLayout) int {
 	// 18px reserved under the last row for the 'a–b of N' footer note
 	n := (l.table_h - l.hdr_h - 22) / l.row_h
 	return if n < 0 { 0 } else { n }
 }
 
-fn ops_row_rect(l OpsLayout, vis int) (int, int, int, int) {
+fn operations_row_rect(l OperationsLayout, vis int) (int, int, int, int) {
 	return l.right_x, l.table_y + l.hdr_h + 2 + vis * l.row_h, l.right_w, l.row_h
 }
 
 // swarm launch strip: task field, three backend chips, three recipe buttons
-fn ops_task_rect(l OpsLayout) (int, int, int, int) {
+fn operations_task_rect(l OperationsLayout) (int, int, int, int) {
 	mut tw := l.right_w - 3 * 54 - 3 * 62 - 24
 	if tw < 120 {
 		tw = 120
@@ -230,87 +229,87 @@ fn ops_task_rect(l OpsLayout) (int, int, int, int) {
 	return l.right_x, l.strip_y + 4, tw, l.strip_h - 8
 }
 
-fn ops_backend_rect(l OpsLayout, i int) (int, int, int, int) {
-	_, _, tw, _ := ops_task_rect(l)
+fn operations_backend_rect(l OperationsLayout, i int) (int, int, int, int) {
+	_, _, tw, _ := operations_task_rect(l)
 	return l.right_x + tw + 8 + i * 54, l.strip_y + 5, 50, l.strip_h - 10
 }
 
-fn ops_recipe_rect(l OpsLayout, i int) (int, int, int, int) {
-	_, _, tw, _ := ops_task_rect(l)
+fn operations_recipe_rect(l OperationsLayout, i int) (int, int, int, int) {
+	_, _, tw, _ := operations_task_rect(l)
 	return l.right_x + tw + 8 + 3 * 54 + 8 + i * 62, l.strip_y + 4, 58, l.strip_h - 8
 }
 
 // doctor repair strip: Fix All + category chips (stored in app.doctor_chips)
-fn ops_fixall_rect(l OpsLayout) (int, int, int, int) {
+fn operations_fixall_rect(l OperationsLayout) (int, int, int, int) {
 	return l.right_x, l.strip_y + 4, 72, l.strip_h - 8
 }
 
 // topology zoom buttons (− / +) in the strip header
-fn ops_zoom_rects(l OpsLayout) (int, int, int, int, int, int) {
+fn operations_zoom_rects(l OperationsLayout) (int, int, int, int, int, int) {
 	return l.right_x + l.right_w - 56, l.topo_y + 4, l.right_x + l.right_w - 28, l.topo_y + 4, 24, 18
 }
 
 // detail column geometry — fixed anchors so draw and click agree regardless
 // of how many fact rows the selected record carries
-fn ops_action_rect(l OpsLayout, i int, n int) (int, int, int, int) {
+fn operations_action_rect(l OperationsLayout, i int, n int) (int, int, int, int) {
 	gap := 6
 	bw := (l.side_w - 24 - (n - 1) * gap) / n
 	return l.side_x + 12 + i * (bw + gap), l.side_y + l.side_h - 82, bw, 28
 }
 
-fn ops_related_rect(l OpsLayout, i int) (int, int, int, int) {
+fn operations_related_rect(l OperationsLayout, i int) (int, int, int, int) {
 	return l.side_x + 12 + i * ((l.side_w - 24) / 2), l.side_y + l.side_h - 40, (l.side_w - 24) / 2, 20
 }
 
 // approvals (Swarms) live above the action row, max three rows
-fn ops_approval_rect(l OpsLayout, i int) (int, int, int, int) {
+fn operations_approval_rect(l OperationsLayout, i int) (int, int, int, int) {
 	return l.side_x + 12, l.side_y + l.side_h - 82 - 12 - (3 - i) * 22, l.side_w - 24, 20
 }
 
-fn ops_hit(mx int, my int, x int, y int, w int, h int) bool {
+fn rect_contains(mx int, my int, x int, y int, w int, h int) bool {
 	return w > 0 && h > 0 && mx >= x && mx < x + w && my >= y && my < y + h
 }
 
 // ── data model ──────────────────────────────────────────────────────────────
 
-// OpsRow is one table row projected from an Engine record. idx points back
+// OperationsRow is one table row projected from an Engine record. idx points back
 // into the unfiltered Engine list (selection stays stable while filtering).
-struct OpsRow {
+struct OperationsRow {
 	idx     int
 	id      string
 	cells   []string
-	status  string // semantic key, see ops_pill
+	status  string // semantic key, see operations_pill
 	fixable bool
 }
 
-// OpsColumns describes the per-tab table: headers, relative widths and which
+// OperationsColumns describes the per-tab table: headers, relative widths and which
 // column renders as a status pill.
-struct OpsColumns {
+struct OperationsColumns {
 	headers    []string
 	weights    []int
 	status_idx int
 }
 
-fn ops_columns(tab int) OpsColumns {
+fn operations_columns(tab int) OperationsColumns {
 	return match tab {
 		0 {
-			OpsColumns{['Name', 'ID', 'Status', 'Started', 'Elapsed'], [34, 18, 16, 16, 16], 2}
+			OperationsColumns{['Name', 'ID', 'Status', 'Started', 'Elapsed'], [34, 18, 16, 16, 16], 2}
 		}
 		1 {
-			OpsColumns{['Name', 'Tier', 'Cadence', 'Schedule', 'Last run'], [30, 9, 13, 26, 22], 3}
+			OperationsColumns{['Name', 'Tier', 'Cadence', 'Schedule', 'Last run'], [30, 9, 13, 26, 22], 3}
 		}
 		2 {
-			OpsColumns{['Name', 'Recipe', 'Backend', 'Status', 'Started'], [34, 14, 16, 20, 16], 3}
+			OperationsColumns{['Name', 'Recipe', 'Backend', 'Status', 'Started'], [34, 14, 16, 20, 16], 3}
 		}
 		else {
-			OpsColumns{['Check', 'Category', 'Status', 'Message', 'Fix'], [26, 16, 14, 36, 8], 2}
+			OperationsColumns{['Check', 'Category', 'Status', 'Message', 'Fix'], [26, 16, 14, 36, 8], 2}
 		}
 	}
 }
 
-// ops_filter_options returns the status dropdown entries per tab. Entry 0 is
+// operations_filter_options returns the status dropdown entries per tab. Entry 0 is
 // always "All"; the rest are semantic status keys with display labels.
-fn ops_filter_options(tab int) ([]string, []string) {
+fn operations_filter_options(tab int) ([]string, []string) {
 	return match tab {
 		0 {
 			['All statuses', 'Running', 'Queued', 'Done', 'Failed', 'Canceled'], ['', 'running',
@@ -329,9 +328,9 @@ fn ops_filter_options(tab int) ([]string, []string) {
 	}
 }
 
-// ops_filter_key resolves the active dropdown index to a status key ('' = all).
-fn ops_filter_key(tab int, idx int) string {
-	_, keys := ops_filter_options(tab)
+// operations_filter_key resolves the active dropdown index to a status key ('' = all).
+fn operations_filter_key(tab int, idx int) string {
+	_, keys := operations_filter_options(tab)
 	if keys.len == 0 {
 		return ''
 	}
@@ -339,15 +338,15 @@ fn ops_filter_key(tab int, idx int) string {
 	return keys[i]
 }
 
-fn ops_filter_label(tab int, idx int) string {
-	labels, _ := ops_filter_options(tab)
+fn operations_filter_label(tab int, idx int) string {
+	labels, _ := operations_filter_options(tab)
 	i := ((idx % labels.len) + labels.len) % labels.len
 	return labels[i]
 }
 
-// ops_fmt_duration renders milliseconds the way the reference does
+// format_duration_ms renders milliseconds the way the reference does
 // ("4m 37s") — '—' when nothing was measured.
-fn ops_fmt_duration(ms int) string {
+fn format_duration_ms(ms int) string {
 	if ms <= 0 {
 		return '—'
 	}
@@ -365,9 +364,9 @@ fn ops_fmt_duration(ms int) string {
 	return '${m / 60}h ${m % 60:02d}m'
 }
 
-// ops_fmt_started renders a unix timestamp as a local clock (today) or a
+// format_started_time renders a unix timestamp as a local clock (today) or a
 // short date + clock; 0 means the record never started ('—').
-fn ops_fmt_started(unix i64) string {
+fn format_started_time(unix i64) string {
 	if unix <= 0 {
 		return '—'
 	}
@@ -380,8 +379,8 @@ fn ops_fmt_started(unix i64) string {
 	return '${t.smonth()} ${t.day} ${clock}'
 }
 
-// ops_job_status_key maps the Engine enum to the semantic status key.
-fn ops_job_status_key(s desktop_engine.JobStatus) string {
+// job_status_key maps the Engine enum to the semantic status key.
+fn job_status_key(s desktop_engine.JobStatus) string {
 	return match s {
 		.running { 'running' }
 		.queued { 'queued' }
@@ -391,7 +390,7 @@ fn ops_job_status_key(s desktop_engine.JobStatus) string {
 	}
 }
 
-fn ops_swarm_status_key(s desktop_engine.SwarmRunStatus) string {
+fn swarm_status_key(s desktop_engine.SwarmRunStatus) string {
 	return match s {
 		.requested { 'requested' }
 		.pending { 'pending' }
@@ -403,7 +402,7 @@ fn ops_swarm_status_key(s desktop_engine.SwarmRunStatus) string {
 	}
 }
 
-fn ops_tier_label(t desktop_engine.LoopTier) string {
+fn loop_tier_label(t desktop_engine.LoopTier) string {
 	return match t {
 		.l1 { 'L1' }
 		.l2 { 'L2' }
@@ -411,9 +410,9 @@ fn ops_tier_label(t desktop_engine.LoopTier) string {
 	}
 }
 
-// ops_job_name gives a job a human name: the command's last path segment
+// job_display_name gives a job a human name: the command's last path segment
 // plus its first argument — the id stays in its own column.
-fn ops_job_name(j desktop_engine.JobRecord) string {
+fn job_display_name(j desktop_engine.JobRecord) string {
 	mut base := j.cmd.trim_space()
 	if base == '' {
 		return j.id
@@ -430,10 +429,10 @@ fn ops_job_name(j desktop_engine.JobRecord) string {
 	return name
 }
 
-// ops_rows projects the active tab's Engine records into table rows. No
+// operations_rows projects the active tab's Engine records into table rows. No
 // fallbacks, no placeholders: an empty Engine list is an empty table.
-fn ops_rows(mut app GuiApp, tab int) []OpsRow {
-	mut rows := []OpsRow{}
+fn operations_rows(mut app GuiApp, tab int) []OperationsRow {
+	mut rows := []OperationsRow{}
 	if app.desktop == unsafe { nil } {
 		return rows
 	}
@@ -441,12 +440,12 @@ fn ops_rows(mut app GuiApp, tab int) []OpsRow {
 		0 {
 			for i, j in app.desktop.engine_jobs_catalog() {
 				short := if j.id.len > 14 { j.id[..14] } else { j.id }
-				rows << OpsRow{
+				rows << OperationsRow{
 					idx: i
 					id: j.id
-					cells: [ops_job_name(j), short, ops_job_status_key(j.status),
-						ops_fmt_started(j.started_at), ops_fmt_duration(j.duration_ms)]
-					status: ops_job_status_key(j.status)
+					cells: [job_display_name(j), short, job_status_key(j.status),
+						format_started_time(j.started_at), format_duration_ms(j.duration_ms)]
+					status: job_status_key(j.status)
 				}
 			}
 		}
@@ -454,22 +453,22 @@ fn ops_rows(mut app GuiApp, tab int) []OpsRow {
 			for i, e in app.desktop.loops_catalog() {
 				sched := if e.cron_enabled { 'scheduled' } else { 'on_demand' }
 				last := if e.last_run.trim_space() != '' { e.last_run } else { '—' }
-				rows << OpsRow{
+				rows << OperationsRow{
 					idx: i
 					id: e.name
-					cells: [e.name, ops_tier_label(e.tier), e.cadence, sched, last]
+					cells: [e.name, loop_tier_label(e.tier), e.cadence, sched, last]
 					status: sched
 				}
 			}
 		}
 		2 {
 			for i, s in app.desktop.swarm_list() {
-				rows << OpsRow{
+				rows << OperationsRow{
 					idx: i
 					id: s.id
-					cells: [s.id, s.recipe.str(), s.backend.str(), ops_swarm_status_key(s.status),
-						ops_fmt_started(s.created_at)]
-					status: ops_swarm_status_key(s.status)
+					cells: [s.id, s.recipe.str(), s.backend.str(), swarm_status_key(s.status),
+						format_started_time(s.created_at)]
+					status: swarm_status_key(s.status)
 				}
 			}
 		}
@@ -477,7 +476,7 @@ fn ops_rows(mut app GuiApp, tab int) []OpsRow {
 			for i, c in app.desktop.engine_doctor() {
 				st := if c.status == 'ok' { 'pass' } else { c.status }
 				fix := if c.fixable && st != 'pass' { 'fix →' } else { '' }
-				rows << OpsRow{
+				rows << OperationsRow{
 					idx: i
 					id: c.id
 					cells: [c.name, c.category, st, c.message, fix]
@@ -490,11 +489,11 @@ fn ops_rows(mut app GuiApp, tab int) []OpsRow {
 	return rows
 }
 
-// ops_apply_filter keeps rows matching the search text (any cell) and the
+// operations_apply_filter keeps rows matching the search text (any cell) and the
 // status key ('' keeps everything).
-fn ops_apply_filter(rows []OpsRow, query string, status_key string) []OpsRow {
+fn operations_apply_filter(rows []OperationsRow, query string, status_key string) []OperationsRow {
 	q := query.trim_space().to_lower()
-	mut out := []OpsRow{}
+	mut out := []OperationsRow{}
 	for r in rows {
 		if status_key != '' && r.status != status_key {
 			continue
@@ -516,10 +515,10 @@ fn ops_apply_filter(rows []OpsRow, query string, status_key string) []OpsRow {
 	return out
 }
 
-// ops_selected returns the selected index (into the unfiltered list) for the
+// operations_selected returns the selected index (into the unfiltered list) for the
 // tab, or -1. Selection is revalidated against the current length so a
 // stale index never reads past the Engine list.
-fn ops_selected(app &GuiApp, tab int, total int) int {
+fn operations_selected(app &GuiApp, tab int, total int) int {
 	sel := match tab {
 		0 { app.jobs_selected }
 		1 { app.selected_loop }
@@ -529,7 +528,7 @@ fn ops_selected(app &GuiApp, tab int, total int) int {
 	return if sel >= 0 && sel < total { sel } else { -1 }
 }
 
-fn ops_set_selected(mut app GuiApp, tab int, idx int) {
+fn operations_set_selected(mut app GuiApp, tab int, idx int) {
 	match tab {
 		0 {
 			app.jobs_selected = idx
@@ -546,7 +545,7 @@ fn ops_set_selected(mut app GuiApp, tab int, idx int) {
 	}
 }
 
-fn ops_scroll_of(app &GuiApp, tab int) int {
+fn operations_scroll_of(app &GuiApp, tab int) int {
 	return match tab {
 		0 { app.jobs_scroll }
 		1 { app.loops_scroll }
@@ -555,7 +554,7 @@ fn ops_scroll_of(app &GuiApp, tab int) int {
 	}
 }
 
-fn ops_set_scroll(mut app GuiApp, tab int, v int) {
+fn operations_set_scroll(mut app GuiApp, tab int, v int) {
 	match tab {
 		0 {
 			app.jobs_scroll = v
@@ -574,7 +573,7 @@ fn ops_set_scroll(mut app GuiApp, tab int, v int) {
 
 // ── metric cards: real counts + truthful sub-lines ──────────────────────────
 
-struct OpsMetric {
+struct OperationsMetric {
 	mark  pixelart.EnvironmentAsset
 	value int
 	label string
@@ -582,8 +581,8 @@ struct OpsMetric {
 	alert bool // rust accent when the number means trouble
 }
 
-fn ops_metrics(mut app GuiApp) []OpsMetric {
-	mut out := []OpsMetric{}
+fn operations_metrics(mut app GuiApp) []OperationsMetric {
+	mut out := []OperationsMetric{}
 	if app.desktop == unsafe { nil } {
 		return out
 	}
@@ -593,7 +592,7 @@ fn ops_metrics(mut app GuiApp) []OpsMetric {
 	} else {
 		'${stats.queued} queued · ${stats.done} done'
 	}
-	out << OpsMetric{.play_mark, stats.running, 'Running jobs', jobs_sub, false}
+	out << OperationsMetric{.play_mark, stats.running, 'Running jobs', jobs_sub, false}
 	loops := app.desktop.loops_catalog()
 	scheduled := loops.filter(it.cron_enabled).len
 	loops_sub := if loops.len == 0 {
@@ -603,7 +602,7 @@ fn ops_metrics(mut app GuiApp) []OpsMetric {
 	} else {
 		'${loops.len - scheduled} on demand'
 	}
-	out << OpsMetric{.calendar_mark, scheduled, 'Scheduled loops', loops_sub, false}
+	out << OperationsMetric{.calendar_mark, scheduled, 'Scheduled loops', loops_sub, false}
 	swarms := app.desktop.swarm_list()
 	active := swarms.filter(it.status == .running || it.status == .awaiting_approval).len
 	swarm_sub := if swarms.len == 0 {
@@ -613,7 +612,7 @@ fn ops_metrics(mut app GuiApp) []OpsMetric {
 	} else {
 		'${active} active'
 	}
-	out << OpsMetric{.swarm_mark, swarms.len, 'Swarm sessions', swarm_sub, false}
+	out << OperationsMetric{.swarm_mark, swarms.len, 'Swarm sessions', swarm_sub, false}
 	checks := app.desktop.engine_doctor()
 	fail := checks.filter(it.status == 'fail').len
 	warn := checks.filter(it.status == 'warn').len
@@ -625,24 +624,17 @@ fn ops_metrics(mut app GuiApp) []OpsMetric {
 	} else {
 		'${fail} fail · ${warn} warn'
 	}
-	out << OpsMetric{.alert_mark, issues, 'Doctor issues', doc_sub, issues > 0}
+	out << OperationsMetric{.alert_mark, issues, 'Doctor issues', doc_sub, issues > 0}
 	return out
 }
 
 // ── material helpers ────────────────────────────────────────────────────────
+// (the paper surface draw_paper_sheet lives once in workspace_view.v.)
 
-// ops_sheet is the soft paper surface every Operations block sits on: warm
-// paper fill with a quiet wood edge instead of the double pixel_panel border.
-fn ops_sheet(mut app GuiApp, x int, y int, w int, h int) {
-	app.gg.draw_rect_filled(x + 2, y + 3, w, h, tint(col_ink, 12))
-	app.gg.draw_rect_filled(x, y, w, h, pc(app, `P`))
-	app.gg.draw_rect_empty(x, y, w, h, tint(pc(app, `W`), 70))
-}
-
-// ops_pc resolves a palette key without requiring the GPU sprite cache, so
+// operations_pc resolves a palette key without requiring the GPU sprite cache, so
 // pure helpers (pills) stay testable headless; at frame time it is the same
 // authored palette pc() reads.
-fn ops_pc(app &GuiApp, k u8) gg.Color {
+fn operations_pc(app &GuiApp, k u8) gg.Color {
 	if app.pixel_cache != unsafe { nil } {
 		return pc(app, k)
 	}
@@ -655,19 +647,19 @@ fn ops_pc(app &GuiApp, k u8) gg.Color {
 	}
 }
 
-// ops_pill resolves a semantic status key to (label, color). Status is never
+// operations_pill resolves a semantic status key to (label, color). Status is never
 // color-only: the label is always drawn next to the dot.
-fn ops_pill(app &GuiApp, status string) (string, gg.Color) {
+fn operations_pill(app &GuiApp, status string) (string, gg.Color) {
 	return match status {
 		'running' { 'Running', app.pnl_success }
-		'queued' { 'Queued', ops_pc(app, `C`) }
-		'pending', 'requested' { 'Pending', ops_pc(app, `C`) }
+		'queued' { 'Queued', operations_pc(app, `C`) }
+		'pending', 'requested' { 'Pending', operations_pc(app, `C`) }
 		'awaiting' { 'Awaiting', app.pnl_select }
 		'paused' { 'Paused', app.pnl_select }
 		'warn' { 'Warn', app.pnl_select }
 		'done', 'completed' { 'Done', app.pnl_text_mut }
 		'pass' { 'Pass', app.pnl_success }
-		'fail', 'failed' { 'Failed', ops_pc(app, `a`) }
+		'fail', 'failed' { 'Failed', operations_pc(app, `a`) }
 		'canceled' { 'Canceled', app.pnl_text_mut }
 		'scheduled' { 'Scheduled', app.pnl_success }
 		'on_demand' { 'On demand', app.pnl_text_mut }
@@ -675,8 +667,8 @@ fn ops_pill(app &GuiApp, status string) (string, gg.Color) {
 	}
 }
 
-fn ops_draw_pill(mut app GuiApp, x int, y int, status string, max_w int) {
-	label, col := ops_pill(app, status)
+fn operations_draw_pill(mut app GuiApp, x int, y int, status string, max_w int) {
+	label, col := operations_pill(app, status)
 	mut pw := label.len * 7 + 22
 	if pw > max_w && max_w > 30 {
 		pw = max_w
@@ -691,8 +683,8 @@ fn ops_draw_pill(mut app GuiApp, x int, y int, status string, max_w int) {
 	})
 }
 
-// ops_button draws a quiet paper button; primary gets the brass fill.
-fn ops_button(mut app GuiApp, x int, y int, w int, h int, label string, hover bool, primary bool, danger bool) {
+// operations_button draws a quiet paper button; primary gets the brass fill.
+fn operations_button(mut app GuiApp, x int, y int, w int, h int, label string, hover bool, primary bool, danger bool) {
 	bg := if danger {
 		if hover { pc(app, `a`) } else { tint(pc(app, `a`), 60) }
 	} else if primary {
@@ -725,8 +717,8 @@ fn ops_button(mut app GuiApp, x int, y int, w int, h int, label string, hover bo
 	})
 }
 
-// ops_field draws a text field (search / task) with placeholder and caret.
-fn ops_field(mut app GuiApp, x int, y int, w int, h int, value string, hint string, focused bool, lens bool) {
+// operations_field draws a text field (search / task) with placeholder and caret.
+fn operations_field(mut app GuiApp, x int, y int, w int, h int, value string, hint string, focused bool, lens bool) {
 	app.gg.draw_rect_filled(x, y, w, h, app.pnl_bg)
 	app.gg.draw_rect_empty(x, y, w, h, if focused { app.pnl_success } else { app.pnl_border })
 	mut tx := x + 8
@@ -747,52 +739,43 @@ fn ops_field(mut app GuiApp, x int, y int, w int, h int, value string, hint stri
 	}
 }
 
-// ops_check draws a checkmark from pixel runs (brand fonts carry no ✓).
-fn ops_check(mut app GuiApp, x int, y int, c gg.Color) {
-	onb_check(mut app, x, y, c)
-}
-
-// ops_fit is the conservative characters-per-width estimate shared with the
-// onboarding board.
-fn ops_fit(px int, size int) int {
-	return onb_fit(px, size)
-}
+// draw_check_glyph and text_fit_chars live once in onboarding_view.v.
 
 // ── drawing: panel ──────────────────────────────────────────────────────────
 
 // draw_operations is the shared panel body for Doctor/Jobs/Loops/Swarm.
 fn draw_operations(mut app GuiApp, w int, h int) {
 	ensure_pixel_cache(mut app)
-	l := ops_layout(app, w, h)
+	l := operations_layout(app, w, h)
 	app.gg.draw_rect_filled(l.fx, l.fy, l.fw, l.fh, app.pnl_bg)
-	draw_ops_header(mut app, l)
-	draw_ops_cards(mut app, l)
+	draw_operations_header(mut app, l)
+	draw_operations_cards(mut app, l)
 	if l.body_h < 60 {
 		return
 	}
-	stats_running, stats_attention := ops_floor_counts(mut app)
+	stats_running, stats_attention := operations_floor_counts(mut app)
 	if l.floor_w > 0 {
 		draw_operations_floor(mut app, l.floor_x, l.floor_y, l.floor_w, l.floor_h, stats_running, stats_attention)
 	}
-	draw_ops_tabs(mut app, l)
-	draw_ops_controls(mut app, l)
+	draw_operations_tabs(mut app, l)
+	draw_operations_controls(mut app, l)
 	if l.tab == 2 {
-		draw_ops_launch_strip(mut app, l)
+		draw_operations_launch_strip(mut app, l)
 	} else if l.tab == 3 {
-		draw_ops_repair_strip(mut app, l)
+		draw_operations_repair_strip(mut app, l)
 	}
-	draw_ops_table(mut app, l)
+	draw_operations_table(mut app, l)
 	if l.tab == 2 {
-		draw_ops_topology(mut app, l)
+		draw_operations_topology(mut app, l)
 	}
 	if l.tab == 3 && app.doctor_preview != '' {
-		draw_ops_doctor_preview(mut app, l)
+		draw_operations_doctor_preview(mut app, l)
 	}
 }
 
-// ops_floor_counts returns the real running and attention job counts that
+// operations_floor_counts returns the real running and attention job counts that
 // dress the floor (running agents, board plate). Zero means calm.
-fn ops_floor_counts(mut app GuiApp) (int, int) {
+fn operations_floor_counts(mut app GuiApp) (int, int) {
 	if app.desktop == unsafe { nil } {
 		return 0, 0
 	}
@@ -801,7 +784,7 @@ fn ops_floor_counts(mut app GuiApp) (int, int) {
 		|| it.status == .queued).len
 }
 
-fn draw_ops_header(mut app GuiApp, l OpsLayout) {
+fn draw_operations_header(mut app GuiApp, l OperationsLayout) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	big := l.head_h >= 70
@@ -859,13 +842,13 @@ fn draw_ops_header(mut app GuiApp, l OpsLayout) {
 	}
 }
 
-fn draw_ops_cards(mut app GuiApp, l OpsLayout) {
+fn draw_operations_cards(mut app GuiApp, l OperationsLayout) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
-	metrics := ops_metrics(mut app)
+	metrics := operations_metrics(mut app)
 	for i, m in metrics {
-		cx, cy, cw, ch := ops_card_rect(l, i)
-		ops_sheet(mut app, cx, cy, cw, ch)
+		cx, cy, cw, ch := operations_card_rect(l, i)
+		draw_paper_sheet(mut app, cx, cy, cw, ch)
 		accent := if m.alert { pc(app, `a`) } else { app.pnl_success }
 		app.gg.draw_rect_filled(cx, cy, 3, ch, tint(accent, 170))
 		mark := pixelart.environment_for(m.mark)
@@ -886,7 +869,7 @@ fn draw_ops_cards(mut app GuiApp, l OpsLayout) {
 			bold: true
 		})
 		if ch >= 66 {
-			app.gg.draw_text(tx, cy + ch - 18, utf8_truncate(m.sub, ops_fit(cx + cw - tx - 8, 11)), gg.TextCfg{
+			app.gg.draw_text(tx, cy + ch - 18, utf8_truncate(m.sub, text_fit_chars(cx + cw - tx - 8, 11)), gg.TextCfg{
 				color: app.pnl_text_mut
 				size: 11
 			})
@@ -894,22 +877,22 @@ fn draw_ops_cards(mut app GuiApp, l OpsLayout) {
 	}
 }
 
-fn draw_ops_tabs(mut app GuiApp, l OpsLayout) {
+fn draw_operations_tabs(mut app GuiApp, l OperationsLayout) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	// tab rail baseline
 	app.gg.draw_rect_filled(l.right_x, l.tab_y + l.tab_h - 1, l.right_w, 1, tint(pc(app, `W`), 90))
-	for i, label in ops_tab_labels {
-		tx, ty, tw, th := ops_tab_rect(l, i)
+	for i, label in operations_tab_labels {
+		tx, ty, tw, th := operations_tab_rect(l, i)
 		active := i == l.tab
-		hover := app.ops_hover == 1 + i
+		hover := app.operations_hover == 1 + i
 		if active {
 			app.gg.draw_rect_filled(tx, ty, tw, th - 1, pc(app, `P`))
 			app.gg.draw_rect_filled(tx, ty + th - 3, tw, 3, app.pnl_success)
 		} else if hover {
 			app.gg.draw_rect_filled(tx, ty, tw, th - 1, app.pnl_hover)
 		}
-		mark := pixelart.environment_for(ops_tab_marks[i])
+		mark := pixelart.environment_for(operations_tab_marks[i])
 		mx := tx + 10
 		sc.draw(mark, pid, mx, ty + (th - 12) / 2 - 1, 1)
 		app.gg.draw_text(mx + 18, ty + (th - 15) / 2, label, gg.TextCfg{
@@ -920,14 +903,14 @@ fn draw_ops_tabs(mut app GuiApp, l OpsLayout) {
 	}
 }
 
-fn draw_ops_controls(mut app GuiApp, l OpsLayout) {
-	sx, sy, sw, sh := ops_search_rect(l)
-	ops_field(mut app, sx, sy, sw, sh, app.jobs_filter, ops_search_hints[l.tab], app.ops_focus == 1, true)
-	fx, fy, fw, fh := ops_filter_rect(l)
-	hover := app.ops_hover == 11
+fn draw_operations_controls(mut app GuiApp, l OperationsLayout) {
+	sx, sy, sw, sh := operations_search_rect(l)
+	operations_field(mut app, sx, sy, sw, sh, app.jobs_filter, operations_search_hints[l.tab], app.operations_focus == 1, true)
+	fx, fy, fw, fh := operations_filter_rect(l)
+	hover := app.operations_hover == 11
 	app.gg.draw_rect_filled(fx, fy, fw, fh, if hover { app.pnl_hover } else { app.pnl_card_sel })
 	app.gg.draw_rect_empty(fx, fy, fw, fh, app.pnl_border)
-	label := ops_filter_label(l.tab, app.ops_status_filter)
+	label := operations_filter_label(l.tab, app.operations_status_filter)
 	app.gg.draw_text(fx + 8, fy + (fh - 14) / 2, utf8_truncate(label, (fw - 26) / 7), gg.TextCfg{
 		color: app.pnl_text
 		size: 12
@@ -940,18 +923,18 @@ fn draw_ops_controls(mut app GuiApp, l OpsLayout) {
 	app.gg.draw_rect_filled(cxv + 4, cyv, 2, 2, app.pnl_text_mut)
 }
 
-// draw_ops_launch_strip is the real swarm launch affordance: editable task,
+// draw_operations_launch_strip is the real swarm launch affordance: editable task,
 // backend choice, and pair/team/full — all executing Engine.swarm_launch.
-fn draw_ops_launch_strip(mut app GuiApp, l OpsLayout) {
-	tx, ty, tw, th := ops_task_rect(l)
-	ops_field(mut app, tx, ty, tw, th, app.swarm_task, 'Task for the swarm…', app.ops_focus == 2, false)
+fn draw_operations_launch_strip(mut app GuiApp, l OperationsLayout) {
+	tx, ty, tw, th := operations_task_rect(l)
+	operations_field(mut app, tx, ty, tw, th, app.swarm_task, 'Task for the swarm…', app.operations_focus == 2, false)
 	for i, bname in ['auto', 'herdr', 'tmux'] {
-		bx, by, bw, bh := ops_backend_rect(l, i)
+		bx, by, bw, bh := operations_backend_rect(l, i)
 		if bx + bw > l.right_x + l.right_w {
 			break
 		}
 		sel := app.swarm_backend == bname
-		hover := app.ops_hover == 20 + i
+		hover := app.operations_hover == 20 + i
 		app.gg.draw_rect_filled(bx, by, bw, bh, if sel {
 			pc(app, `P`)
 		} else if hover {
@@ -967,19 +950,19 @@ fn draw_ops_launch_strip(mut app GuiApp, l OpsLayout) {
 		})
 	}
 	for i, rname in ['pair', 'team', 'full'] {
-		rx, ry, rw, rh := ops_recipe_rect(l, i)
+		rx, ry, rw, rh := operations_recipe_rect(l, i)
 		if rx + rw > l.right_x + l.right_w {
 			break
 		}
-		ops_button(mut app, rx, ry, rw, rh, rname, app.ops_hover == 24 + i, true, false)
+		operations_button(mut app, rx, ry, rw, rh, rname, app.operations_hover == 24 + i, true, false)
 	}
 }
 
-// draw_ops_repair_strip carries Doctor's real repair actions: Fix All and the
+// draw_operations_repair_strip carries Doctor's real repair actions: Fix All and the
 // per-category chips (each fixes its category through the Engine).
-fn draw_ops_repair_strip(mut app GuiApp, l OpsLayout) {
-	fx, fy, fw, fh := ops_fixall_rect(l)
-	ops_button(mut app, fx, fy, fw, fh, 'Fix All', app.ops_hover == 30, true, false)
+fn draw_operations_repair_strip(mut app GuiApp, l OperationsLayout) {
+	fx, fy, fw, fh := operations_fixall_rect(l)
+	operations_button(mut app, fx, fy, fw, fh, 'Fix All', app.operations_hover == 30, true, false)
 	app.doctor_chips = []
 	if app.desktop == unsafe { nil } {
 		return
@@ -1000,7 +983,7 @@ fn draw_ops_repair_strip(mut app GuiApp, l OpsLayout) {
 			break
 		}
 		bad := checks.filter(it.category == cat && it.status != 'pass' && it.status != 'ok').len
-		hover := app.ops_hover == 40 + app.doctor_chips.len
+		hover := app.operations_hover == 40 + app.doctor_chips.len
 		app.gg.draw_rect_filled(cx, cy, tw, 20, if hover { app.pnl_hover } else { app.pnl_card_sel })
 		app.gg.draw_rect_empty(cx, cy, tw, 20, if bad > 0 { app.pnl_select } else { app.pnl_border })
 		app.gg.draw_text(cx + 6, cy + 3, label, gg.TextCfg{
@@ -1012,14 +995,14 @@ fn draw_ops_repair_strip(mut app GuiApp, l OpsLayout) {
 	}
 }
 
-fn draw_ops_table(mut app GuiApp, l OpsLayout) {
+fn draw_operations_table(mut app GuiApp, l OperationsLayout) {
 	if l.table_h < l.hdr_h + l.row_h {
 		return
 	}
-	ops_sheet(mut app, l.right_x, l.table_y, l.right_w, l.table_h)
-	cols := ops_columns(l.tab)
-	all := ops_rows(mut app, l.tab)
-	rows := ops_apply_filter(all, app.jobs_filter, ops_filter_key(l.tab, app.ops_status_filter))
+	draw_paper_sheet(mut app, l.right_x, l.table_y, l.right_w, l.table_h)
+	cols := operations_columns(l.tab)
+	all := operations_rows(mut app, l.tab)
+	rows := operations_apply_filter(all, app.jobs_filter, operations_filter_key(l.tab, app.operations_status_filter))
 	// column geometry: weights share the width left of the ⋯ column
 	act_w := 28
 	avail := l.right_w - 16 - act_w
@@ -1048,25 +1031,25 @@ fn draw_ops_table(mut app GuiApp, l OpsLayout) {
 	}
 	app.gg.draw_rect_filled(l.right_x + 1, hy + l.hdr_h, l.right_w - 2, 1, tint(pc(app, `W`), 70))
 	if rows.len == 0 {
-		draw_ops_empty(mut app, l, all.len)
+		draw_operations_empty(mut app, l, all.len)
 		return
 	}
-	visible := ops_visible_rows(l)
+	visible := operations_visible_rows(l)
 	if visible == 0 {
 		return
 	}
-	start := clamp_scroll(ops_scroll_of(app, l.tab), rows.len, visible)
-	ops_set_scroll(mut app, l.tab, start)
-	sel := ops_selected(app, l.tab, all.len)
+	start := clamp_scroll(operations_scroll_of(app, l.tab), rows.len, visible)
+	operations_set_scroll(mut app, l.tab, start)
+	sel := operations_selected(app, l.tab, all.len)
 	for vi in 0 .. visible {
 		ri := start + vi
 		if ri >= rows.len {
 			break
 		}
 		r := rows[ri]
-		rx, ry, rw, rh := ops_row_rect(l, vi)
+		rx, ry, rw, rh := operations_row_rect(l, vi)
 		is_sel := r.idx == sel
-		is_hover := app.ops_hover == 100 + vi
+		is_hover := app.operations_hover == 100 + vi
 		if is_sel {
 			app.gg.draw_rect_filled(rx + 1, ry, rw - 2, rh, tint(app.pnl_success, 60))
 			app.gg.draw_rect_filled(rx + 1, ry, 3, rh, app.pnl_success)
@@ -1080,7 +1063,7 @@ fn draw_ops_table(mut app GuiApp, l OpsLayout) {
 				break
 			}
 			if ci == cols.status_idx {
-				ops_draw_pill(mut app, col_x[ci] + 2, ry + 4, r.status, col_w[ci] - 6)
+				operations_draw_pill(mut app, col_x[ci] + 2, ry + 4, r.status, col_w[ci] - 6)
 				continue
 			}
 			fix_col := l.tab == 3 && ci == 4
@@ -1125,9 +1108,9 @@ fn draw_ops_table(mut app GuiApp, l OpsLayout) {
 	}
 }
 
-// draw_ops_empty is the truthful empty state: a paper sheet with a small
+// draw_operations_empty is the truthful empty state: a paper sheet with a small
 // scene and the real way to create work — never a placeholder row.
-fn draw_ops_empty(mut app GuiApp, l OpsLayout, total int) {
+fn draw_operations_empty(mut app GuiApp, l OperationsLayout, total int) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	ex := l.right_x + 24
@@ -1189,14 +1172,14 @@ fn draw_ops_empty(mut app GuiApp, l OpsLayout, total int) {
 		family: app.fonts.display
 	})
 	if ty + 40 < ey + eh {
-		cw := utf8_truncate(copy, ops_fit(ew - 24, 12))
+		cw := utf8_truncate(copy, text_fit_chars(ew - 24, 12))
 		app.gg.draw_text(ex + (ew - cw.len * 6) / 2, ty + 22, cw, gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 12
 		})
 	}
 	if hint != '' && ty + 58 < ey + eh {
-		hw := utf8_truncate(hint, ops_fit(ew - 24, 11))
+		hw := utf8_truncate(hint, text_fit_chars(ew - 24, 11))
 		app.gg.draw_text(ex + (ew - hw.len * 6) / 2, ty + 40, hw, gg.TextCfg{
 			color: app.pnl_success
 			size: 11
@@ -1205,14 +1188,14 @@ fn draw_ops_empty(mut app GuiApp, l OpsLayout, total int) {
 	}
 }
 
-// draw_ops_topology renders the swarm handoff graph under the table when a
+// draw_operations_topology renders the swarm handoff graph under the table when a
 // run exists; nodes/edges hit-rects are stored for the click handler exactly
 // as before (#1101 behaviour preserved).
-fn draw_ops_topology(mut app GuiApp, l OpsLayout) {
+fn draw_operations_topology(mut app GuiApp, l OperationsLayout) {
 	mut handoffs := []string{}
 	if app.desktop != unsafe { nil } {
 		list := app.desktop.swarm_list()
-		sel := ops_selected(app, 2, list.len)
+		sel := operations_selected(app, 2, list.len)
 		pick := if sel >= 0 { sel } else { 0 }
 		if list.len > 0 {
 			handoffs = app.desktop.swarm_handoffs(list[pick].id)
@@ -1250,22 +1233,22 @@ fn draw_ops_topology(mut app GuiApp, l OpsLayout) {
 	app.swarm_nodes = []
 	app.swarm_edges = []
 	if roles.len == 0 || l.topo_h == 0 {
-		// no strip this frame; ops_layout re-reads swarm_nodes next frame
+		// no strip this frame; operations_layout re-reads swarm_nodes next frame
 		if roles.len > 0 {
 			// first frame with handoffs: reserve the strip by seeding one node
 			app.swarm_nodes << SwarmNode{roles[0], 0, 0, 0}
 		}
 		return
 	}
-	ops_sheet(mut app, l.right_x, l.topo_y, l.right_w, l.topo_h)
+	draw_paper_sheet(mut app, l.right_x, l.topo_y, l.right_w, l.topo_h)
 	app.gg.draw_text(l.right_x + 10, l.topo_y + 6, 'Handoff topology', gg.TextCfg{
 		color: app.pnl_text
 		size: 12
 		bold: true
 	})
-	zx, zy, pxz, pyz, zw, zh := ops_zoom_rects(l)
-	ops_button(mut app, zx, zy, zw, zh, '−', app.ops_hover == 50, false, false)
-	ops_button(mut app, pxz, pyz, zw, zh, '+', app.ops_hover == 51, false, false)
+	zx, zy, pxz, pyz, zw, zh := operations_zoom_rects(l)
+	operations_button(mut app, zx, zy, zw, zh, '−', app.operations_hover == 50, false, false)
+	operations_button(mut app, pxz, pyz, zw, zh, '+', app.operations_hover == 51, false, false)
 	working := swarm_working_roles(handoffs)
 	node_w := 96 + app.swarm_zoom * 24
 	node_h := 30
@@ -1318,9 +1301,9 @@ fn draw_ops_topology(mut app GuiApp, l OpsLayout) {
 	}
 }
 
-// draw_ops_doctor_preview is the dry-run confirm card (#1108) — same
+// draw_operations_doctor_preview is the dry-run confirm card (#1108) — same
 // geometry helper as before so the keyboard path (Enter confirms) matches.
-fn draw_ops_doctor_preview(mut app GuiApp, l OpsLayout) {
+fn draw_operations_doctor_preview(mut app GuiApp, l OperationsLayout) {
 	px, py, pw, ph := doctor_preview_geom(l.fx, l.fy, l.fw)
 	pixel_panel(mut app, px, py, pw, ph, 'dialog')
 	app.gg.draw_text(px + 14, py + 10, 'Dry-run preview — ${app.doctor_preview}', gg.TextCfg{
@@ -1342,8 +1325,8 @@ fn draw_ops_doctor_preview(mut app GuiApp, l OpsLayout) {
 			mono: true
 		})
 	}
-	ops_button(mut app, px + 14, py + ph - 32, 120, 22, 'Confirm fix', false, true, false)
-	ops_button(mut app, px + 144, py + ph - 32, 90, 22, 'Cancel', false, false, false)
+	operations_button(mut app, px + 14, py + ph - 32, 120, 22, 'Confirm fix', false, true, false)
+	operations_button(mut app, px + 144, py + ph - 32, 90, 22, 'Cancel', false, false, false)
 }
 
 // ── the Operations Floor ────────────────────────────────────────────────────
@@ -1491,8 +1474,8 @@ fn draw_operations_floor(mut app GuiApp, x int, y int, w int, h int, running int
 
 	// workstations: rows of desk pods between the lamp and the rack
 	desks := desks_for_app(app)
-	ws_x := ix + 14 + lamp.width() * s + 8
-	ws_w := rack_x - 12 - ws_x
+	workspace_x := ix + 14 + lamp.width() * s + 8
+	workspace_w := rack_x - 12 - workspace_x
 	dw := desk.width() * s
 	aw := pixelart.agent_for_state(.idle).width() * s
 	ah := pixelart.agent_for_state(.idle).height() * s
@@ -1500,10 +1483,10 @@ fn draw_operations_floor(mut app GuiApp, x int, y int, w int, h int, running int
 	// the wall plates ('board · clear') hang 18px into the floor: reserve it
 	grid_top := floor_y + 8 + 18
 	avail_h := (iy + ih - 26) - grid_top
-	if ws_w < dw + 8 || avail_h < cell_h || desks.len == 0 {
+	if workspace_w < dw + 8 || avail_h < cell_h || desks.len == 0 {
 		return
 	}
-	per_row := (ws_w + 6 * s) / (dw + 6 * s)
+	per_row := (workspace_w + 6 * s) / (dw + 6 * s)
 	rows := avail_h / cell_h
 	capacity := per_row * rows
 	shown_n := if desks.len < capacity { desks.len } else { capacity }
@@ -1514,10 +1497,10 @@ fn draw_operations_floor(mut app GuiApp, x int, y int, w int, h int, running int
 		cell_h
 	}
 	total_w := per_row * dw + (per_row - 1) * 6 * s
-	grid_x := ws_x + (ws_w - total_w) / 2
+	grid_x := workspace_x + (workspace_w - total_w) / 2
 	// rug under the first row anchors the cluster
-	rug_s := if rug.width() * s <= ws_w { s } else { 2 }
-	sc.draw(rug, pid, ws_x + (ws_w - rug.width() * rug_s) / 2, grid_top + (used_rows - 1) * step + ah - 8, rug_s)
+	rug_s := if rug.width() * s <= workspace_w { s } else { 2 }
+	sc.draw(rug, pid, workspace_x + (workspace_w - rug.width() * rug_s) / 2, grid_top + (used_rows - 1) * step + ah - 8, rug_s)
 	mut shown := 0
 	for i in 0 .. shown_n {
 		r := i / per_row
@@ -1559,17 +1542,17 @@ fn draw_operations_floor(mut app GuiApp, x int, y int, w int, h int, running int
 
 // ── detail column (replaces the Office inspector on Operations panels) ──────
 
-// OpsAction is a real Engine action drawn in the detail column.
-struct OpsAction {
+// OperationsAction is a real Engine action drawn in the detail column.
+struct OperationsAction {
 	label   string
 	kind    string // cancel | retry | logs | run | schedule | fix | copy
 	primary bool
 	danger  bool
 }
 
-// ops_actions lists only the actions that exist for the selected record.
-fn ops_actions(mut app GuiApp, tab int, sel int) []OpsAction {
-	mut out := []OpsAction{}
+// operations_actions lists only the actions that exist for the selected record.
+fn operations_actions(mut app GuiApp, tab int, sel int) []OperationsAction {
+	mut out := []OperationsAction{}
 	if app.desktop == unsafe { nil } || sel < 0 {
 		return out
 	}
@@ -1581,14 +1564,14 @@ fn ops_actions(mut app GuiApp, tab int, sel int) []OpsAction {
 			}
 			j := jobs[sel]
 			if j.status == .queued || j.status == .running {
-				out << OpsAction{'Cancel', 'cancel', false, true}
+				out << OperationsAction{'Cancel', 'cancel', false, true}
 			}
 			if j.status == .failed || j.status == .canceled || j.status == .done {
-				out << OpsAction{'Retry', 'retry', true, false}
+				out << OperationsAction{'Retry', 'retry', true, false}
 			}
 			logs := app.desktop.engine_job_logs(j.id)
 			if logs.len > 0 || j.logs.len > 0 {
-				out << OpsAction{if app.jobs_show_logs && app.jobs_logs_job == j.id {
+				out << OperationsAction{if app.jobs_show_logs && app.jobs_logs_job == j.id {
 					'Hide logs'
 				} else {
 					'Open logs'
@@ -1600,11 +1583,11 @@ fn ops_actions(mut app GuiApp, tab int, sel int) []OpsAction {
 			if sel >= loops.len {
 				return out
 			}
-			out << OpsAction{'Run', 'run', true, false}
-			out << OpsAction{if loops[sel].cron_enabled { 'Unschedule' } else { 'Schedule' }, 'schedule', false, false}
+			out << OperationsAction{'Run', 'run', true, false}
+			out << OperationsAction{if loops[sel].cron_enabled { 'Unschedule' } else { 'Schedule' }, 'schedule', false, false}
 		}
 		2 {
-			out << OpsAction{'Copy id', 'copy', false, false}
+			out << OperationsAction{'Copy id', 'copy', false, false}
 		}
 		else {
 			checks := app.desktop.engine_doctor()
@@ -1613,9 +1596,9 @@ fn ops_actions(mut app GuiApp, tab int, sel int) []OpsAction {
 			}
 			c := checks[sel]
 			if c.fixable && c.status != 'pass' && c.status != 'ok' {
-				out << OpsAction{'Preview fix', 'fix', true, false}
+				out << OperationsAction{'Preview fix', 'fix', true, false}
 			}
-			out << OpsAction{'Copy message', 'copy', false, false}
+			out << OperationsAction{'Copy message', 'copy', false, false}
 		}
 	}
 	return out
@@ -1623,48 +1606,48 @@ fn ops_actions(mut app GuiApp, tab int, sel int) []OpsAction {
 
 fn draw_operations_detail(mut app GuiApp, w int, h int) {
 	ensure_pixel_cache(mut app)
-	l := ops_layout(app, w, h)
+	l := operations_layout(app, w, h)
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	x, y, iw, ih := l.side_x, l.side_y, l.side_w, l.side_h
 	app.gg.draw_rect_filled(x, y, iw, ih, app.pnl_bg)
 	app.gg.draw_line(x, y, x, y + ih, app.pnl_border)
-	app.gg.draw_text(x + 16, y + 12, ops_detail_titles[l.tab], gg.TextCfg{
+	app.gg.draw_text(x + 16, y + 12, operations_detail_titles[l.tab], gg.TextCfg{
 		color: app.pnl_text
 		size: 17
 		family: app.fonts.display
 	})
-	all := ops_rows(mut app, l.tab)
-	sel := ops_selected(app, l.tab, all.len)
+	all := operations_rows(mut app, l.tab)
+	sel := operations_selected(app, l.tab, all.len)
 	if sel < 0 {
-		draw_ops_detail_empty(mut app, l, all.len)
+		draw_operations_detail_empty(mut app, l, all.len)
 		return
 	}
 	row := all[sel]
 	// status pill top-right, mark + name below the title
-	label, _ := ops_pill(app, row.status)
+	label, _ := operations_pill(app, row.status)
 	pw := label.len * 7 + 22
-	ops_draw_pill(mut app, x + iw - pw - 14, y + 12, row.status, pw)
-	mark := pixelart.environment_for(ops_tab_marks[l.tab])
+	operations_draw_pill(mut app, x + iw - pw - 14, y + 12, row.status, pw)
+	mark := pixelart.environment_for(operations_tab_marks[l.tab])
 	sc.draw(mark, pid, x + 16, y + 44, 3)
 	name_x := x + 16 + mark.width() * 3 + 12
-	app.gg.draw_text(name_x, y + 44, utf8_truncate(row.cells[0], ops_fit(x + iw - name_x - 12, 15)), gg.TextCfg{
+	app.gg.draw_text(name_x, y + 44, utf8_truncate(row.cells[0], text_fit_chars(x + iw - name_x - 12, 15)), gg.TextCfg{
 		color: app.pnl_text
 		size: 15
 		bold: true
 	})
-	facts, desc := ops_detail_facts(mut app, l.tab, sel)
+	facts, desc := operations_detail_facts(mut app, l.tab, sel)
 	mut cy := y + 64
 	if desc != '' {
-		draw_onb_wrapped(mut app, name_x, cy, x + iw - name_x - 12, desc, 2)
+		draw_wrapped_text(mut app, name_x, cy, x + iw - name_x - 12, desc, 2)
 		cy += 30
 	}
 	cy += 12
 	app.gg.draw_rect_filled(x + 12, cy, iw - 24, 1, tint(pc(app, `W`), 70))
 	cy += 10
 	// fact rows: label column + value column; stop before the action zone
-	acts := ops_actions(mut app, l.tab, sel)
-	appr_top := ops_detail_content_bottom(l)
+	acts := operations_actions(mut app, l.tab, sel)
+	appr_top := operations_detail_content_bottom(l)
 	for f in facts {
 		if cy + 18 > appr_top {
 			break
@@ -1675,9 +1658,9 @@ fn draw_operations_detail(mut app GuiApp, w int, h int) {
 		})
 		vx := x + 96
 		if f[0] == 'Status' {
-			ops_draw_pill(mut app, vx, cy - 3, row.status, x + iw - vx - 14)
+			operations_draw_pill(mut app, vx, cy - 3, row.status, x + iw - vx - 14)
 		} else {
-			app.gg.draw_text(vx, cy, utf8_truncate(f[1], ops_fit(x + iw - vx - 12, 12)), gg.TextCfg{
+			app.gg.draw_text(vx, cy, utf8_truncate(f[1], text_fit_chars(x + iw - vx - 12, 12)), gg.TextCfg{
 				color: app.pnl_text
 				size: 12
 				mono: f[0] in ['ID', 'Command', 'Work dir', 'Worktree', 'Schedule', 'Budget']
@@ -1710,17 +1693,17 @@ fn draw_operations_detail(mut app GuiApp, w int, h int) {
 	}
 	// pending approvals for the selected swarm — real gates, real resolve
 	if l.tab == 2 {
-		draw_ops_approvals(mut app, l, row.id)
+		draw_operations_approvals(mut app, l, row.id)
 	}
 	for i, a in acts {
-		ax, ay, aw, ah := ops_action_rect(l, i, acts.len)
-		ops_button(mut app, ax, ay, aw, ah, a.label, app.ops_hover == 60 + i, a.primary, a.danger)
+		ax, ay, aw, ah := operations_action_rect(l, i, acts.len)
+		operations_button(mut app, ax, ay, aw, ah, a.label, app.operations_hover == 60 + i, a.primary, a.danger)
 	}
 	// related destinations — the real places that produce or consume this work
-	rel := ops_related(l.tab)
+	rel := operations_related(l.tab)
 	for i, r in rel {
-		rx, ry, rw, rh := ops_related_rect(l, i)
-		hover := app.ops_hover == 70 + i
+		rx, ry, rw, rh := operations_related_rect(l, i)
+		hover := app.operations_hover == 70 + i
 		app.gg.draw_text(rx, ry + 3, utf8_truncate(r[0] + ' →', (rw - 4) / 7), gg.TextCfg{
 			color: if hover { app.pnl_text } else { app.pnl_success }
 			size: 12
@@ -1736,20 +1719,20 @@ fn draw_operations_detail(mut app GuiApp, w int, h int) {
 	}
 }
 
-// ops_detail_content_bottom is where fact rows must stop: above approvals
+// operations_detail_content_bottom is where fact rows must stop: above approvals
 // (Swarms) or above the action row.
-fn ops_detail_content_bottom(l OpsLayout) int {
-	_, act_y, _, _ := ops_action_rect(l, 0, 1)
+fn operations_detail_content_bottom(l OperationsLayout) int {
+	_, act_y, _, _ := operations_action_rect(l, 0, 1)
 	if l.tab == 2 {
-		_, ty, _, _ := ops_approval_rect(l, 0)
+		_, ty, _, _ := operations_approval_rect(l, 0)
 		return ty - 20
 	}
 	return act_y - 8
 }
 
-// ops_related lists the destinations linked from each detail kind:
+// operations_related lists the destinations linked from each detail kind:
 // (label, panel id).
-fn ops_related(tab int) [][]string {
+fn operations_related(tab int) [][]string {
 	return match tab {
 		0 { [['View loops', '7'], ['View swarms', '8']] }
 		1 { [['View jobs', '6'], ['Open Office', '0']] }
@@ -1758,10 +1741,10 @@ fn ops_related(tab int) [][]string {
 	}
 }
 
-// ops_detail_facts returns (label, value) rows plus a description for the
+// operations_detail_facts returns (label, value) rows plus a description for the
 // selected record. Only measured or configured facts are emitted — a missing
 // value is omitted, not filled.
-fn ops_detail_facts(mut app GuiApp, tab int, sel int) ([][]string, string) {
+fn operations_detail_facts(mut app GuiApp, tab int, sel int) ([][]string, string) {
 	mut rows := [][]string{}
 	if app.desktop == unsafe { nil } {
 		return rows, ''
@@ -1774,12 +1757,12 @@ fn ops_detail_facts(mut app GuiApp, tab int, sel int) ([][]string, string) {
 			}
 			j := jobs[sel]
 			rows << ['ID', j.id]
-			rows << ['Status', ops_job_status_key(j.status)]
-			rows << ['Started', ops_fmt_started(j.started_at)]
+			rows << ['Status', job_status_key(j.status)]
+			rows << ['Started', format_started_time(j.started_at)]
 			if j.finished_at > 0 {
-				rows << ['Finished', ops_fmt_started(j.finished_at)]
+				rows << ['Finished', format_started_time(j.finished_at)]
 			}
-			rows << ['Duration', ops_fmt_duration(j.duration_ms)]
+			rows << ['Duration', format_duration_ms(j.duration_ms)]
 			if j.status == .done || j.status == .failed {
 				rows << ['Exit code', '${j.exit_code}']
 			}
@@ -1801,7 +1784,7 @@ fn ops_detail_facts(mut app GuiApp, tab int, sel int) ([][]string, string) {
 				return rows, ''
 			}
 			e := loops[sel]
-			rows << ['Tier', ops_tier_label(e.tier)]
+			rows << ['Tier', loop_tier_label(e.tier)]
 			rows << ['Cadence', e.cadence]
 			rows << ['Schedule', if e.cron_enabled { 'cron ${e.schedule}' } else { 'On demand' }]
 			if e.verifier.trim_space() != '' {
@@ -1849,8 +1832,8 @@ fn ops_detail_facts(mut app GuiApp, tab int, sel int) ([][]string, string) {
 			s := list[sel]
 			rows << ['Recipe', s.recipe.str()]
 			rows << ['Backend', s.backend.str()]
-			rows << ['Status', ops_swarm_status_key(s.status)]
-			rows << ['Started', ops_fmt_started(s.created_at)]
+			rows << ['Status', swarm_status_key(s.status)]
+			rows << ['Started', format_started_time(s.created_at)]
 			if s.budget_total > 0 {
 				rows << ['Budget', '${s.budget_spent} / ${s.budget_total} tok']
 			}
@@ -1877,9 +1860,9 @@ fn ops_detail_facts(mut app GuiApp, tab int, sel int) ([][]string, string) {
 	return rows, ''
 }
 
-fn draw_ops_approvals(mut app GuiApp, l OpsLayout, run_id string) {
+fn draw_operations_approvals(mut app GuiApp, l OperationsLayout, run_id string) {
 	pending := app.desktop.swarm_approvals(run_id)
-	_, ty, _, _ := ops_approval_rect(l, 0)
+	_, ty, _, _ := operations_approval_rect(l, 0)
 	app.gg.draw_text(l.side_x + 16, ty - 16, if pending.len == 0 {
 		'No pending approvals'
 	} else {
@@ -1893,7 +1876,7 @@ fn draw_ops_approvals(mut app GuiApp, l OpsLayout, run_id string) {
 		if i >= 3 {
 			break
 		}
-		ax, ay, aw, ah := ops_approval_rect(l, i)
+		ax, ay, aw, ah := operations_approval_rect(l, i)
 		kind := p.kind.str()
 		kcol := match p.kind {
 			.spend { app.pnl_select }
@@ -1908,7 +1891,7 @@ fn draw_ops_approvals(mut app GuiApp, l OpsLayout, run_id string) {
 		})
 		// approve (sage check) · reject (rust ×) — real Engine gates
 		app.gg.draw_rect_filled(ax + aw - 48, ay + 2, 20, 16, app.pnl_success)
-		ops_check(mut app, ax + aw - 43, ay + 4, app.pnl_bg)
+		draw_check_glyph(mut app, ax + aw - 43, ay + 4, app.pnl_bg)
 		app.gg.draw_rect_filled(ax + aw - 24, ay + 2, 20, 16, pc(app, `a`))
 		app.gg.draw_text(ax + aw - 18, ay + 1, '×', gg.TextCfg{
 			color: pc(app, `e`)
@@ -1918,9 +1901,9 @@ fn draw_ops_approvals(mut app GuiApp, l OpsLayout, run_id string) {
 	}
 }
 
-// draw_ops_detail_empty is the truthful "nothing selected" card: a small
+// draw_operations_detail_empty is the truthful "nothing selected" card: a small
 // scene and the real totals behind the table.
-fn draw_ops_detail_empty(mut app GuiApp, l OpsLayout, total int) {
+fn draw_operations_detail_empty(mut app GuiApp, l OperationsLayout, total int) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	x, y, iw := l.side_x, l.side_y, l.side_w
@@ -1928,7 +1911,7 @@ fn draw_ops_detail_empty(mut app GuiApp, l OpsLayout, total int) {
 	cy := y + 44
 	scene_h := if l.side_h > 360 { 118 } else { 84 }
 	ch := scene_h + 92
-	ops_sheet(mut app, x + 12, cy, iw - 24, ch)
+	draw_paper_sheet(mut app, x + 12, cy, iw - 24, ch)
 	s := if scene_h >= 110 { 3 } else { 2 }
 	tray := pixelart.environment_for(.tray)
 	lamp := pixelart.environment_for(.lamp)
@@ -1970,87 +1953,87 @@ fn draw_ops_detail_empty(mut app GuiApp, l OpsLayout, total int) {
 
 // ── interaction ─────────────────────────────────────────────────────────────
 
-// operations_hover records the hovered element id (app.ops_hover) from the
+// operations_hover records the hovered element id (app.operations_hover) from the
 // same layout the frame draws.
 fn operations_hover(mut app GuiApp, w int, h int) {
-	app.ops_hover = -1
-	if !ops_is_panel(app.selected_panel) {
+	app.operations_hover = -1
+	if !operations_is_panel(app.selected_panel) {
 		return
 	}
-	l := ops_layout(app, w, h)
+	l := operations_layout(app, w, h)
 	mx, my := app.mouse_x, app.mouse_y
-	for i in 0 .. ops_tab_labels.len {
-		tx, ty, tw, th := ops_tab_rect(l, i)
-		if ops_hit(mx, my, tx, ty, tw, th) {
-			app.ops_hover = 1 + i
+	for i in 0 .. operations_tab_labels.len {
+		tx, ty, tw, th := operations_tab_rect(l, i)
+		if rect_contains(mx, my, tx, ty, tw, th) {
+			app.operations_hover = 1 + i
 			return
 		}
 	}
-	fx, fy, fw, fh := ops_filter_rect(l)
-	if ops_hit(mx, my, fx, fy, fw, fh) {
-		app.ops_hover = 11
+	fx, fy, fw, fh := operations_filter_rect(l)
+	if rect_contains(mx, my, fx, fy, fw, fh) {
+		app.operations_hover = 11
 		return
 	}
 	if l.tab == 2 {
 		for i in 0 .. 3 {
-			bx, by, bw, bh := ops_backend_rect(l, i)
-			if ops_hit(mx, my, bx, by, bw, bh) {
-				app.ops_hover = 20 + i
+			bx, by, bw, bh := operations_backend_rect(l, i)
+			if rect_contains(mx, my, bx, by, bw, bh) {
+				app.operations_hover = 20 + i
 				return
 			}
-			rx, ry, rw, rh := ops_recipe_rect(l, i)
-			if ops_hit(mx, my, rx, ry, rw, rh) {
-				app.ops_hover = 24 + i
+			rx, ry, rw, rh := operations_recipe_rect(l, i)
+			if rect_contains(mx, my, rx, ry, rw, rh) {
+				app.operations_hover = 24 + i
 				return
 			}
 		}
 		if l.topo_h > 0 {
-			zx, zy, pxz, pyz, zw, zh := ops_zoom_rects(l)
-			if ops_hit(mx, my, zx, zy, zw, zh) {
-				app.ops_hover = 50
+			zx, zy, pxz, pyz, zw, zh := operations_zoom_rects(l)
+			if rect_contains(mx, my, zx, zy, zw, zh) {
+				app.operations_hover = 50
 				return
 			}
-			if ops_hit(mx, my, pxz, pyz, zw, zh) {
-				app.ops_hover = 51
+			if rect_contains(mx, my, pxz, pyz, zw, zh) {
+				app.operations_hover = 51
 				return
 			}
 		}
 	}
 	if l.tab == 3 {
-		ax, ay, aw, ah := ops_fixall_rect(l)
-		if ops_hit(mx, my, ax, ay, aw, ah) {
-			app.ops_hover = 30
+		ax, ay, aw, ah := operations_fixall_rect(l)
+		if rect_contains(mx, my, ax, ay, aw, ah) {
+			app.operations_hover = 30
 			return
 		}
 		for i, chip in app.doctor_chips {
-			if ops_hit(mx, my, chip.x, chip.y, chip.w, chip.h) {
-				app.ops_hover = 40 + i
+			if rect_contains(mx, my, chip.x, chip.y, chip.w, chip.h) {
+				app.operations_hover = 40 + i
 				return
 			}
 		}
 	}
-	visible := ops_visible_rows(l)
+	visible := operations_visible_rows(l)
 	for vi in 0 .. visible {
-		rx, ry, rw, rh := ops_row_rect(l, vi)
-		if ops_hit(mx, my, rx, ry, rw, rh) {
-			app.ops_hover = 100 + vi
+		rx, ry, rw, rh := operations_row_rect(l, vi)
+		if rect_contains(mx, my, rx, ry, rw, rh) {
+			app.operations_hover = 100 + vi
 			return
 		}
 	}
 	// detail column
 	n_act := 3
 	for i in 0 .. n_act {
-		ax, ay, aw, ah := ops_action_rect(l, i, n_act)
+		ax, ay, aw, ah := operations_action_rect(l, i, n_act)
 		_ = ax
 		_ = aw
 		if my >= ay && my < ay + ah && mx >= l.side_x && mx < l.side_x + l.side_w {
 			// resolve against the real action count for the selection
-			all := ops_rows(mut app, l.tab)
-			acts := ops_actions(mut app, l.tab, ops_selected(app, l.tab, all.len))
+			all := operations_rows(mut app, l.tab)
+			acts := operations_actions(mut app, l.tab, operations_selected(app, l.tab, all.len))
 			for j in 0 .. acts.len {
-				bx, by, bw, bh := ops_action_rect(l, j, acts.len)
-				if ops_hit(mx, my, bx, by, bw, bh) {
-					app.ops_hover = 60 + j
+				bx, by, bw, bh := operations_action_rect(l, j, acts.len)
+				if rect_contains(mx, my, bx, by, bw, bh) {
+					app.operations_hover = 60 + j
 					return
 				}
 			}
@@ -2058,9 +2041,9 @@ fn operations_hover(mut app GuiApp, w int, h int) {
 		}
 	}
 	for i in 0 .. 2 {
-		rx, ry, rw, rh := ops_related_rect(l, i)
-		if ops_hit(mx, my, rx, ry, rw, rh) {
-			app.ops_hover = 70 + i
+		rx, ry, rw, rh := operations_related_rect(l, i)
+		if rect_contains(mx, my, rx, ry, rw, rh) {
+			app.operations_hover = 70 + i
 			return
 		}
 	}
@@ -2069,19 +2052,19 @@ fn operations_hover(mut app GuiApp, w int, h int) {
 // operations_click handles every Operations hit. Returns true when consumed.
 // Any click clears the text-field focus first (focus follows the pointer).
 fn operations_click(mut app GuiApp, mx int, my int, w int, h int) bool {
-	if !ops_is_panel(app.selected_panel) {
+	if !operations_is_panel(app.selected_panel) {
 		return false
 	}
-	l := ops_layout(app, w, h)
-	app.ops_focus = 0
+	l := operations_layout(app, w, h)
+	app.operations_focus = 0
 	// dry-run preview is modal inside the panel (#1108)
 	if l.tab == 3 && app.doctor_preview != '' {
 		px, py, _, ph := doctor_preview_geom(l.fx, l.fy, l.fw)
-		if ops_hit(mx, my, px + 14, py + ph - 32, 120, 22) {
+		if rect_contains(mx, my, px + 14, py + ph - 32, 120, 22) {
 			doctor_preview_confirm(mut app)
 			return true
 		}
-		if ops_hit(mx, my, px + 144, py + ph - 32, 90, 22) {
+		if rect_contains(mx, my, px + 144, py + ph - 32, 90, 22) {
 			app.doctor_preview = ''
 			app.doctor_preview_lines = []
 			app.inspector_msg = 'Doctor dry-run cancelled — nothing was written'
@@ -2090,51 +2073,51 @@ fn operations_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 		return true
 	}
 	// tabs → the four Operations panels (nav and tabs stay in sync)
-	for i in 0 .. ops_tab_labels.len {
-		tx, ty, tw, th := ops_tab_rect(l, i)
-		if ops_hit(mx, my, tx, ty, tw, th) {
-			if ops_tab_panels[i] != app.selected_panel {
-				select_panel(mut app, ops_tab_panels[i])
-				app.ops_status_filter = 0
+	for i in 0 .. operations_tab_labels.len {
+		tx, ty, tw, th := operations_tab_rect(l, i)
+		if rect_contains(mx, my, tx, ty, tw, th) {
+			if operations_tab_panels[i] != app.selected_panel {
+				select_panel(mut app, operations_tab_panels[i])
+				app.operations_status_filter = 0
 			}
 			return true
 		}
 	}
-	sx, sy, sw, sh := ops_search_rect(l)
-	if ops_hit(mx, my, sx, sy, sw, sh) {
-		app.ops_focus = 1
+	sx, sy, sw, sh := operations_search_rect(l)
+	if rect_contains(mx, my, sx, sy, sw, sh) {
+		app.operations_focus = 1
 		app.header_search_focus = false
 		app.workspace_focus = false
 		app.ghost_focused = false
 		return true
 	}
-	fx, fy, fw, fh := ops_filter_rect(l)
-	if ops_hit(mx, my, fx, fy, fw, fh) {
-		labels, _ := ops_filter_options(l.tab)
-		app.ops_status_filter = (app.ops_status_filter + 1) % labels.len
-		ops_set_scroll(mut app, l.tab, 0)
+	fx, fy, fw, fh := operations_filter_rect(l)
+	if rect_contains(mx, my, fx, fy, fw, fh) {
+		labels, _ := operations_filter_options(l.tab)
+		app.operations_status_filter = (app.operations_status_filter + 1) % labels.len
+		operations_set_scroll(mut app, l.tab, 0)
 		return true
 	}
-	if l.tab == 2 && ops_click_swarm_strip(mut app, l, mx, my) {
+	if l.tab == 2 && operations_click_swarm_strip(mut app, l, mx, my) {
 		return true
 	}
-	if l.tab == 3 && ops_click_doctor_strip(mut app, l, mx, my) {
+	if l.tab == 3 && operations_click_doctor_strip(mut app, l, mx, my) {
 		return true
 	}
 	// table rows
-	all := ops_rows(mut app, l.tab)
-	rows := ops_apply_filter(all, app.jobs_filter, ops_filter_key(l.tab, app.ops_status_filter))
-	visible := ops_visible_rows(l)
-	start := clamp_scroll(ops_scroll_of(app, l.tab), rows.len, visible)
+	all := operations_rows(mut app, l.tab)
+	rows := operations_apply_filter(all, app.jobs_filter, operations_filter_key(l.tab, app.operations_status_filter))
+	visible := operations_visible_rows(l)
+	start := clamp_scroll(operations_scroll_of(app, l.tab), rows.len, visible)
 	for vi in 0 .. visible {
 		ri := start + vi
 		if ri >= rows.len {
 			break
 		}
-		rx, ry, rw, rh := ops_row_rect(l, vi)
-		if ops_hit(mx, my, rx, ry, rw, rh) {
+		rx, ry, rw, rh := operations_row_rect(l, vi)
+		if rect_contains(mx, my, rx, ry, rw, rh) {
 			r := rows[ri]
-			ops_set_selected(mut app, l.tab, r.idx)
+			operations_set_selected(mut app, l.tab, r.idx)
 			if l.tab == 0 && app.jobs_logs_job != r.id {
 				app.jobs_show_logs = false
 			}
@@ -2143,23 +2126,23 @@ fn operations_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 				doctor_preview_open(mut app, r.id)
 				return true
 			}
-			app.inspector_msg = ops_select_msg(l.tab, r)
+			app.inspector_msg = operations_select_msg(l.tab, r)
 			return true
 		}
 	}
 	// topology nodes / edges (Swarms) — attach desk VT / copy artifact (#1101)
-	if l.tab == 2 && l.topo_h > 0 && ops_click_topology(mut app, l, mx, my) {
+	if l.tab == 2 && l.topo_h > 0 && operations_click_topology(mut app, l, mx, my) {
 		return true
 	}
 	// detail column: approvals, actions, related links
-	if ops_hit(mx, my, l.side_x, l.side_y, l.side_w, l.side_h) {
-		return ops_click_detail(mut app, l, mx, my, all.len)
+	if rect_contains(mx, my, l.side_x, l.side_y, l.side_w, l.side_h) {
+		return operations_click_detail(mut app, l, mx, my, all.len)
 	}
 	// anything else inside the panel is consumed (no other handler owns it)
-	return ops_hit(mx, my, l.fx, l.fy, l.fw, l.fh)
+	return rect_contains(mx, my, l.fx, l.fy, l.fw, l.fh)
 }
 
-fn ops_select_msg(tab int, r OpsRow) string {
+fn operations_select_msg(tab int, r OperationsRow) string {
 	return match tab {
 		0 { 'Job selected: ${r.id}' }
 		1 { 'Loop selected: ${r.id}' }
@@ -2168,39 +2151,39 @@ fn ops_select_msg(tab int, r OpsRow) string {
 	}
 }
 
-fn ops_click_swarm_strip(mut app GuiApp, l OpsLayout, mx int, my int) bool {
-	tx, ty, tw, th := ops_task_rect(l)
-	if ops_hit(mx, my, tx, ty, tw, th) {
-		app.ops_focus = 2
+fn operations_click_swarm_strip(mut app GuiApp, l OperationsLayout, mx int, my int) bool {
+	tx, ty, tw, th := operations_task_rect(l)
+	if rect_contains(mx, my, tx, ty, tw, th) {
+		app.operations_focus = 2
 		app.header_search_focus = false
 		app.workspace_focus = false
 		app.ghost_focused = false
 		return true
 	}
 	for i, bname in ['auto', 'herdr', 'tmux'] {
-		bx, by, bw, bh := ops_backend_rect(l, i)
+		bx, by, bw, bh := operations_backend_rect(l, i)
 		if bx + bw > l.right_x + l.right_w {
-			break // same overflow guard as draw_ops_launch_strip: undrawn = inert
+			break // same overflow guard as draw_operations_launch_strip: undrawn = inert
 		}
-		if ops_hit(mx, my, bx, by, bw, bh) {
+		if rect_contains(mx, my, bx, by, bw, bh) {
 			app.swarm_backend = bname
 			app.inspector_msg = 'Swarm backend: ${bname}'
 			return true
 		}
 	}
 	for i, rname in ['pair', 'team', 'full'] {
-		rx, ry, rw, rh := ops_recipe_rect(l, i)
+		rx, ry, rw, rh := operations_recipe_rect(l, i)
 		if rx + rw > l.right_x + l.right_w {
 			break // undrawn recipe buttons must not launch swarms
 		}
-		if ops_hit(mx, my, rx, ry, rw, rh) {
+		if rect_contains(mx, my, rx, ry, rw, rh) {
 			if app.desktop == unsafe { nil } {
 				return true
 			}
 			task := app.swarm_task.trim_space()
 			if task == '' {
 				app.inspector_msg = 'Swarm launch needs a task — type one in the Task field'
-				app.ops_focus = 2
+				app.operations_focus = 2
 				return true
 			}
 			run_id := app.desktop.swarm_launch(rname, app.swarm_backend, task) or {
@@ -2222,9 +2205,9 @@ fn ops_click_swarm_strip(mut app GuiApp, l OpsLayout, mx int, my int) bool {
 	return false
 }
 
-fn ops_click_doctor_strip(mut app GuiApp, l OpsLayout, mx int, my int) bool {
-	ax, ay, aw, ah := ops_fixall_rect(l)
-	if ops_hit(mx, my, ax, ay, aw, ah) {
+fn operations_click_doctor_strip(mut app GuiApp, l OperationsLayout, mx int, my int) bool {
+	ax, ay, aw, ah := operations_fixall_rect(l)
+	if rect_contains(mx, my, ax, ay, aw, ah) {
 		if app.desktop == unsafe { nil } {
 			return true
 		}
@@ -2247,7 +2230,7 @@ fn ops_click_doctor_strip(mut app GuiApp, l OpsLayout, mx int, my int) bool {
 		return true
 	}
 	for chip in app.doctor_chips {
-		if ops_hit(mx, my, chip.x, chip.y, chip.w, chip.h) {
+		if rect_contains(mx, my, chip.x, chip.y, chip.w, chip.h) {
 			rev := app.desktop.engine_doctor_fix_category(chip.cat) or {
 				app.inspector_msg = 'Doctor category fix ${chip.cat} failed: ${err}'
 				return true
@@ -2268,16 +2251,16 @@ fn ops_click_doctor_strip(mut app GuiApp, l OpsLayout, mx int, my int) bool {
 	return false
 }
 
-fn ops_click_topology(mut app GuiApp, l OpsLayout, mx int, my int) bool {
-	zx, zy, pxz, pyz, zw, zh := ops_zoom_rects(l)
-	if ops_hit(mx, my, zx, zy, zw, zh) {
+fn operations_click_topology(mut app GuiApp, l OperationsLayout, mx int, my int) bool {
+	zx, zy, pxz, pyz, zw, zh := operations_zoom_rects(l)
+	if rect_contains(mx, my, zx, zy, zw, zh) {
 		if app.swarm_zoom > -1 {
 			app.swarm_zoom--
 		}
 		app.inspector_msg = 'Swarm topology zoom ${app.swarm_zoom}'
 		return true
 	}
-	if ops_hit(mx, my, pxz, pyz, zw, zh) {
+	if rect_contains(mx, my, pxz, pyz, zw, zh) {
 		if app.swarm_zoom < 1 {
 			app.swarm_zoom++
 		}
@@ -2285,7 +2268,7 @@ fn ops_click_topology(mut app GuiApp, l OpsLayout, mx int, my int) bool {
 		return true
 	}
 	for n in app.swarm_nodes {
-		if n.w > 0 && ops_hit(mx, my, n.x, n.y, n.w, 30) {
+		if n.w > 0 && rect_contains(mx, my, n.x, n.y, n.w, 30) {
 			di := swarm_role_desk(app, n.role)
 			if di < 0 {
 				app.inspector_msg = 'Swarm ${n.role}: no office desk to attach'
@@ -2317,16 +2300,16 @@ fn ops_click_topology(mut app GuiApp, l OpsLayout, mx int, my int) bool {
 	return false
 }
 
-fn ops_click_detail(mut app GuiApp, l OpsLayout, mx int, my int, total int) bool {
-	sel := ops_selected(app, l.tab, total)
+fn operations_click_detail(mut app GuiApp, l OperationsLayout, mx int, my int, total int) bool {
+	sel := operations_selected(app, l.tab, total)
 	if sel < 0 || app.desktop == unsafe { nil } {
 		return true
 	}
 	// related links work for every selection
-	rel := ops_related(l.tab)
+	rel := operations_related(l.tab)
 	for i, r in rel {
-		rx, ry, rw, rh := ops_related_rect(l, i)
-		if ops_hit(mx, my, rx, ry, rw, rh) {
+		rx, ry, rw, rh := operations_related_rect(l, i)
+		if rect_contains(mx, my, rx, ry, rw, rh) {
 			select_panel(mut app, r[1].int())
 			return true
 		}
@@ -2339,8 +2322,8 @@ fn ops_click_detail(mut app GuiApp, l OpsLayout, mx int, my int, total int) bool
 				if i >= 3 {
 					break
 				}
-				ax, ay, aw, ah := ops_approval_rect(l, i)
-				if ops_hit(mx, my, ax + aw - 48, ay, 20, ah) || ops_hit(mx, my, ax + aw - 24, ay, 20, ah) {
+				ax, ay, aw, ah := operations_approval_rect(l, i)
+				if rect_contains(mx, my, ax + aw - 48, ay, 20, ah) || rect_contains(mx, my, ax + aw - 24, ay, 20, ah) {
 					approved := mx < ax + aw - 26
 					rev := app.desktop.swarm_approve(list[sel].id, p.id, approved) or {
 						app.inspector_msg = 'Approval ${p.id} failed: ${err.msg()}'
@@ -2360,20 +2343,20 @@ fn ops_click_detail(mut app GuiApp, l OpsLayout, mx int, my int, total int) bool
 			}
 		}
 	}
-	acts := ops_actions(mut app, l.tab, sel)
+	acts := operations_actions(mut app, l.tab, sel)
 	for i, a in acts {
-		ax, ay, aw, ah := ops_action_rect(l, i, acts.len)
-		if ops_hit(mx, my, ax, ay, aw, ah) {
-			ops_run_action(mut app, l.tab, sel, a.kind)
+		ax, ay, aw, ah := operations_action_rect(l, i, acts.len)
+		if rect_contains(mx, my, ax, ay, aw, ah) {
+			operations_run_action(mut app, l.tab, sel, a.kind)
 			return true
 		}
 	}
 	return true
 }
 
-// ops_run_action executes a detail action through the Engine and reports the
+// operations_run_action executes a detail action through the Engine and reports the
 // actual outcome. Failures are shown as failures.
-fn ops_run_action(mut app GuiApp, tab int, sel int, kind string) {
+fn operations_run_action(mut app GuiApp, tab int, sel int, kind string) {
 	match tab {
 		0 {
 			jobs := app.desktop.engine_jobs_catalog()
@@ -2460,38 +2443,38 @@ fn ops_run_action(mut app GuiApp, tab int, sel int, kind string) {
 
 // operations_scroll scrolls the table when the wheel is over it.
 fn operations_scroll(mut app GuiApp, delta int, w int, h int) bool {
-	if !ops_is_panel(app.selected_panel) {
+	if !operations_is_panel(app.selected_panel) {
 		return false
 	}
-	l := ops_layout(app, w, h)
-	if !ops_hit(app.mouse_x, app.mouse_y, l.right_x, l.table_y, l.right_w, l.table_h) {
+	l := operations_layout(app, w, h)
+	if !rect_contains(app.mouse_x, app.mouse_y, l.right_x, l.table_y, l.right_w, l.table_h) {
 		return false
 	}
-	all := ops_rows(mut app, l.tab)
-	rows := ops_apply_filter(all, app.jobs_filter, ops_filter_key(l.tab, app.ops_status_filter))
-	visible := ops_visible_rows(l)
-	ops_set_scroll(mut app, l.tab, clamp_scroll(ops_scroll_of(app, l.tab) + delta, rows.len, visible))
+	all := operations_rows(mut app, l.tab)
+	rows := operations_apply_filter(all, app.jobs_filter, operations_filter_key(l.tab, app.operations_status_filter))
+	visible := operations_visible_rows(l)
+	operations_set_scroll(mut app, l.tab, clamp_scroll(operations_scroll_of(app, l.tab) + delta, rows.len, visible))
 	return true
 }
 
 // operations_key feeds the focused Operations text field (search or swarm
 // task). Returns true when the key was consumed. Escape releases focus.
 fn operations_key(mut app GuiApp, e &gg.Event) bool {
-	if app.ops_focus == 0 || !ops_is_panel(app.selected_panel) {
+	if app.operations_focus == 0 || !operations_is_panel(app.selected_panel) {
 		return false
 	}
 	if e.key_code == .escape {
-		app.ops_focus = 0
+		app.operations_focus = 0
 		return true
 	}
 	if e.key_code == .enter || e.key_code == .tab {
-		app.ops_focus = 0
+		app.operations_focus = 0
 		return true
 	}
 	if e.key_code == .backspace {
-		if app.ops_focus == 1 && app.jobs_filter.len > 0 {
+		if app.operations_focus == 1 && app.jobs_filter.len > 0 {
 			app.jobs_filter = app.jobs_filter[..app.jobs_filter.len - 1]
-		} else if app.ops_focus == 2 && app.swarm_task.len > 0 {
+		} else if app.operations_focus == 2 && app.swarm_task.len > 0 {
 			app.swarm_task = app.swarm_task[..app.swarm_task.len - 1]
 		}
 		return true
@@ -2499,9 +2482,9 @@ fn operations_key(mut app GuiApp, e &gg.Event) bool {
 	is_mod := (e.modifiers & u32(gg.Modifier.ctrl)) != 0 || (e.modifiers & u32(gg.Modifier.super)) != 0
 	if !is_mod && ((e.char_code >= 32 && e.char_code < 127) || e.char_code > 127) {
 		ch := rune(e.char_code).str()
-		if app.ops_focus == 1 {
+		if app.operations_focus == 1 {
 			app.jobs_filter += ch
-			ops_set_scroll(mut app, ops_tab_for_panel(app.selected_panel), 0)
+			operations_set_scroll(mut app, operations_tab_for_panel(app.selected_panel), 0)
 		} else {
 			app.swarm_task += ch
 		}

--- a/cmd/agent-toolkit-desktop/operations_view_test.v
+++ b/cmd/agent-toolkit-desktop/operations_view_test.v
@@ -2,27 +2,27 @@ module main
 
 import desktop_engine
 
-// VC6 (#1173) — Operations command center: geometry sharing, truthful empty
+// Operations command center: geometry sharing, truthful empty
 // states, and the Engine → row projection helpers.
 
-fn test_ops_tab_panel_mapping() {
-	assert ops_tab_for_panel(6) == 0 // Jobs
-	assert ops_tab_for_panel(7) == 1 // Loops
-	assert ops_tab_for_panel(8) == 2 // Swarms
-	assert ops_tab_for_panel(5) == 3 // Doctor
-	assert ops_tab_for_panel(0) == -1
-	assert ops_is_panel(5) && ops_is_panel(8)
-	assert !ops_is_panel(1) && !ops_is_panel(11)
-	for i, p in ops_tab_panels {
-		assert ops_tab_for_panel(p) == i
+fn test_operations_tab_panel_mapping() {
+	assert operations_tab_for_panel(6) == 0 // Jobs
+	assert operations_tab_for_panel(7) == 1 // Loops
+	assert operations_tab_for_panel(8) == 2 // Swarms
+	assert operations_tab_for_panel(5) == 3 // Doctor
+	assert operations_tab_for_panel(0) == -1
+	assert operations_is_panel(5) && operations_is_panel(8)
+	assert !operations_is_panel(1) && !operations_is_panel(11)
+	for i, p in operations_tab_panels {
+		assert operations_tab_for_panel(p) == i
 	}
-	assert ops_tab_labels.len == 4 && ops_tab_marks.len == 4 && ops_detail_titles.len == 4
+	assert operations_tab_labels.len == 4 && operations_tab_marks.len == 4 && operations_detail_titles.len == 4
 }
 
-fn test_ops_layout_shares_geometry_and_collapses_floor() {
+fn test_operations_layout_shares_geometry_and_collapses_floor() {
 	mut app := &GuiApp{}
 	app.selected_panel = 6
-	l := ops_layout(app, 1280, 800)
+	l := operations_layout(app, 1280, 800)
 	// panel and detail column agree with the shell constants
 	assert l.fx == panel_fx(app) && l.fw == panel_fw(app, 1280)
 	assert l.side_x == inspector_x(app, 1280) && l.side_w == inspector_w
@@ -33,122 +33,122 @@ fn test_ops_layout_shares_geometry_and_collapses_floor() {
 	assert l.table_y + l.table_h <= l.fy + l.fh
 	// four cards on one row at the canonical width
 	assert l.cards_n == 4
-	x3, _, w3, _ := ops_card_rect(l, 3)
+	x3, _, w3, _ := operations_card_rect(l, 3)
 	assert x3 + w3 <= l.fx + l.fw
 	// tabs sit inside the right column
-	tx, _, tw, _ := ops_tab_rect(l, 3)
+	tx, _, tw, _ := operations_tab_rect(l, 3)
 	assert tx + tw <= l.right_x + l.right_w
 	// narrow window: the floor collapses before the table loses rows, cards
 	// reflow to two per row, the table takes the full width
 	app.selected_panel = 5
-	n := ops_layout(app, 900, 620)
+	n := operations_layout(app, 900, 620)
 	assert n.floor_w == 0
 	assert n.right_x == n.fx + 12
 	assert n.cards_n == 2
-	assert ops_visible_rows(n) >= 3
+	assert operations_visible_rows(n) >= 3
 	// Doctor/Swarms carry a strip; Jobs/Loops do not
 	assert n.strip_h > 0
 	app.selected_panel = 7
-	assert ops_layout(app, 900, 620).strip_h == 0
+	assert operations_layout(app, 900, 620).strip_h == 0
 }
 
-fn test_ops_rows_are_never_fabricated_without_engine() {
+fn test_operations_rows_are_never_fabricated_without_engine() {
 	mut app := &GuiApp{}
 	for tab in 0 .. 4 {
-		assert ops_rows(mut app, tab).len == 0
+		assert operations_rows(mut app, tab).len == 0
 	}
-	assert ops_metrics(mut app).len == 0
-	assert ops_actions(mut app, 0, 0).len == 0
+	assert operations_metrics(mut app).len == 0
+	assert operations_actions(mut app, 0, 0).len == 0
 	// selection is revalidated against the real list length
 	app.jobs_selected = 3
-	assert ops_selected(app, 0, 0) == -1
-	assert ops_selected(app, 0, 4) == 3
+	assert operations_selected(app, 0, 0) == -1
+	assert operations_selected(app, 0, 4) == 3
 	app.doctor_selected = 0
-	assert ops_selected(app, 3, 0) == -1
+	assert operations_selected(app, 3, 0) == -1
 }
 
-fn test_ops_filter_and_search() {
+fn test_operations_filter_and_search() {
 	rows := [
-		OpsRow{0, 'job-a', ['build cli', 'job-a', 'running', '10:22', '2m 14s'], 'running', false},
-		OpsRow{1, 'job-b', ['test desktop', 'job-b', 'failed', '10:25', '4s'], 'failed', false},
-		OpsRow{2, 'job-c', ['serve', 'job-c', 'queued', '—', '—'], 'queued', false},
+		OperationsRow{0, 'job-a', ['build cli', 'job-a', 'running', '10:22', '2m 14s'], 'running', false},
+		OperationsRow{1, 'job-b', ['test desktop', 'job-b', 'failed', '10:25', '4s'], 'failed', false},
+		OperationsRow{2, 'job-c', ['serve', 'job-c', 'queued', '—', '—'], 'queued', false},
 	]
-	assert ops_apply_filter(rows, '', '').len == 3
-	assert ops_apply_filter(rows, '', 'failed').len == 1
-	assert ops_apply_filter(rows, 'DESKTOP', '').len == 1
-	assert ops_apply_filter(rows, 'job-', 'queued')[0].idx == 2
-	assert ops_apply_filter(rows, 'nothing', '').len == 0
+	assert operations_apply_filter(rows, '', '').len == 3
+	assert operations_apply_filter(rows, '', 'failed').len == 1
+	assert operations_apply_filter(rows, 'DESKTOP', '').len == 1
+	assert operations_apply_filter(rows, 'job-', 'queued')[0].idx == 2
+	assert operations_apply_filter(rows, 'nothing', '').len == 0
 	// dropdown index wraps per tab and index 0 is always "all"
-	assert ops_filter_key(0, 0) == ''
-	assert ops_filter_key(0, 1) == 'running'
-	labels, keys := ops_filter_options(0)
+	assert operations_filter_key(0, 0) == ''
+	assert operations_filter_key(0, 1) == 'running'
+	labels, keys := operations_filter_options(0)
 	assert labels.len == keys.len
-	assert ops_filter_key(0, keys.len) == ''
-	assert ops_filter_label(1, 1) == 'Scheduled'
-	assert ops_filter_key(3, 3) == 'fail'
+	assert operations_filter_key(0, keys.len) == ''
+	assert operations_filter_label(1, 1) == 'Scheduled'
+	assert operations_filter_key(3, 3) == 'fail'
 }
 
-fn test_ops_formatting_is_honest_about_missing_values() {
-	assert ops_fmt_duration(0) == '—'
-	assert ops_fmt_duration(-5) == '—'
-	assert ops_fmt_duration(850) == '850ms'
-	assert ops_fmt_duration(4000) == '4s'
-	assert ops_fmt_duration(137000) == '2m 17s'
-	assert ops_fmt_duration(3720000) == '1h 02m'
-	assert ops_fmt_started(0) == '—'
-	assert ops_fmt_started(1700000000).len > 0
-	assert ops_job_status_key(.running) == 'running'
-	assert ops_job_status_key(.canceled) == 'canceled'
-	assert ops_swarm_status_key(.awaiting_approval) == 'awaiting'
-	assert ops_tier_label(.l3) == 'L3'
+fn test_operations_formatting_is_honest_about_missing_values() {
+	assert format_duration_ms(0) == '—'
+	assert format_duration_ms(-5) == '—'
+	assert format_duration_ms(850) == '850ms'
+	assert format_duration_ms(4000) == '4s'
+	assert format_duration_ms(137000) == '2m 17s'
+	assert format_duration_ms(3720000) == '1h 02m'
+	assert format_started_time(0) == '—'
+	assert format_started_time(1700000000).len > 0
+	assert job_status_key(.running) == 'running'
+	assert job_status_key(.canceled) == 'canceled'
+	assert swarm_status_key(.awaiting_approval) == 'awaiting'
+	assert loop_tier_label(.l3) == 'L3'
 }
 
-fn test_ops_job_name_from_command() {
+fn test_operations_job_name_from_command() {
 	j := desktop_engine.JobRecord{
 		id: 'job-7f3a'
 		cmd: '/usr/bin/agent-toolkit loop run daily-triage'
 	}
-	assert ops_job_name(j) == 'agent-toolkit loop'
+	assert job_display_name(j) == 'agent-toolkit loop'
 	bare := desktop_engine.JobRecord{
 		id: 'job-9c1e'
 		cmd: 'v'
 		args: ['test', 'modules/desktop']
 	}
-	assert ops_job_name(bare) == 'v test'
+	assert job_display_name(bare) == 'v test'
 	empty := desktop_engine.JobRecord{
 		id: 'job-x'
 	}
-	assert ops_job_name(empty) == 'job-x'
+	assert job_display_name(empty) == 'job-x'
 }
 
-fn test_ops_pill_labels_are_textual() {
+fn test_operations_pill_labels_are_textual() {
 	app := &GuiApp{}
 	for key in ['running', 'queued', 'done', 'failed', 'canceled', 'pass', 'warn', 'fail', 'scheduled',
 		'on_demand', 'awaiting', 'pending'] {
-		label, _ := ops_pill(app, key)
+		label, _ := operations_pill(app, key)
 		assert label.len > 0, 'status ${key} needs a text label (never color-only)'
 	}
 	// the Doctor "fail" and job "failed" share the rust semantic
-	l1, c1 := ops_pill(app, 'fail')
-	l2, c2 := ops_pill(app, 'failed')
+	l1, c1 := operations_pill(app, 'fail')
+	l2, c2 := operations_pill(app, 'failed')
 	assert l1 == l2 && c1 == c2
 }
 
-fn test_ops_detail_anchors_stay_inside_column() {
+fn test_operations_detail_anchors_stay_inside_column() {
 	mut app := &GuiApp{}
 	app.selected_panel = 8
-	l := ops_layout(app, 1280, 800)
+	l := operations_layout(app, 1280, 800)
 	for n in 1 .. 4 {
 		for i in 0 .. n {
-			ax, ay, aw, ah := ops_action_rect(l, i, n)
+			ax, ay, aw, ah := operations_action_rect(l, i, n)
 			assert ax >= l.side_x && ax + aw <= l.side_x + l.side_w
 			assert ay + ah <= l.side_y + l.side_h
 		}
 	}
-	_, ry, _, _ := ops_related_rect(l, 1)
-	_, ay0, _, _ := ops_action_rect(l, 0, 1)
+	_, ry, _, _ := operations_related_rect(l, 1)
+	_, ay0, _, _ := operations_action_rect(l, 0, 1)
 	assert ry > ay0
-	_, apy, _, _ := ops_approval_rect(l, 2)
+	_, apy, _, _ := operations_approval_rect(l, 2)
 	assert apy < ay0
-	assert ops_detail_content_bottom(l) < apy
+	assert operations_detail_content_bottom(l) < apy
 }

--- a/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
+++ b/cmd/agent-toolkit-desktop/palette_actions_flow_test.v
@@ -5,26 +5,26 @@ import desktop.palette
 import os
 import time
 
-// S4B production-flow tests: preview → confirm → execute through the real
+// Production-flow tests: preview → confirm → execute through the real
 // registry, honest unavailability, requested-vs-running, canonical deep-link.
 
-struct S4bFixture {
+struct PaletteActionFlowFixture {
 mut:
 	app &GuiApp = unsafe { nil }
 	d   &desktop.Desktop = unsafe { nil }
-	tmp string
+	scratch_dir string
 }
 
-// s4b_app boots a headless Desktop + GuiApp with the registry bound. The
+// boot_palette_flow_app boots a headless Desktop + GuiApp with the registry bound. The
 // fixture owns its exact temp directory and removes it in cleanup().
-fn s4b_app(label string) &S4bFixture {
-	tmp := os.join_path(os.temp_dir(), 'atk-s4b-flow-${label}-${os.getpid()}-${time.now().unix_nano()}')
-	os.mkdir_all(tmp) or { panic(err.msg()) }
+fn boot_palette_flow_app(label string) &PaletteActionFlowFixture {
+	scratch_dir := os.join_path(os.temp_dir(), 'atk-palette-flow-${label}-${os.getpid()}-${time.now().unix_nano()}')
+	os.mkdir_all(scratch_dir) or { panic(err.msg()) }
 	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
 		config: desktop.DesktopConfig{
 			headless: true
 		}
-		persist_path: os.join_path(tmp, 'state.json')
+		persist_path: os.join_path(scratch_dir, 'state.json')
 	})
 	d.boot() or { panic(err.msg()) }
 	mut app := &GuiApp{
@@ -36,19 +36,19 @@ fn s4b_app(label string) &S4bFixture {
 	}
 	app.palette_reg = d.palette_registry()
 	app.palette_open = true
-	return &S4bFixture{
+	return &PaletteActionFlowFixture{
 		app: app
 		d: d
-		tmp: tmp
+		scratch_dir: scratch_dir
 	}
 }
 
 // cleanup stops the Desktop and removes this fixture's exact temp path.
-fn (mut f S4bFixture) cleanup() {
+fn (mut f PaletteActionFlowFixture) cleanup() {
 	f.d.shutdown() or {}
-	if f.tmp != '' {
-		os.rmdir_all(f.tmp) or {}
-		f.tmp = ''
+	if f.scratch_dir != '' {
+		os.rmdir_all(f.scratch_dir) or {}
+		f.scratch_dir = ''
 	}
 }
 
@@ -64,7 +64,7 @@ fn find_row(rows []PaletteRow, pred fn (PaletteRow) bool) ?PaletteRow {
 // preview → informed execution: the real dry-run is shown first and the
 // execution mutates real configuration state.
 fn test_palette_action_flow_preview_then_execute() {
-	mut f := s4b_app('flow')
+	mut f := boot_palette_flow_app('flow')
 	defer {
 		f.cleanup()
 	}
@@ -96,7 +96,7 @@ fn test_palette_action_flow_preview_then_execute() {
 
 // unavailable action rows never fake success.
 fn test_palette_action_unavailable_honest() {
-	mut f := s4b_app('unavail')
+	mut f := boot_palette_flow_app('unavail')
 	defer {
 		f.cleanup()
 	}
@@ -121,7 +121,7 @@ fn test_palette_action_unavailable_honest() {
 // swarm launch routes to the swarm panel launch form (task text + recipe +
 // backend are real typed inputs the palette cannot provide honestly).
 fn test_palette_swarm_launch_routes_to_panel_form() {
-	mut f := s4b_app('swarm')
+	mut f := boot_palette_flow_app('swarm')
 	defer {
 		f.cleanup()
 	}
@@ -143,7 +143,7 @@ fn test_palette_swarm_launch_routes_to_panel_form() {
 
 // deep-link preserves canonical entity identity: selection is resolved by id.
 fn test_deep_link_selects_canonical_skill() {
-	mut f := s4b_app('deeplink')
+	mut f := boot_palette_flow_app('deeplink')
 	defer {
 		f.cleanup()
 	}

--- a/cmd/agent-toolkit-desktop/palette_recents_flow_test.v
+++ b/cmd/agent-toolkit-desktop/palette_recents_flow_test.v
@@ -5,27 +5,27 @@ import desktop.palette
 import os
 import time
 
-// S4D shell-flow tests: recents render distinctly, rerun re-resolves current
+// Shell-flow tests: recents render distinctly, rerun re-resolves current
 // availability, undo is single-use and guarded by live exact-state checks.
 
-struct S4dFixture {
+struct PaletteRecentsFixture {
 mut:
 	app &GuiApp = unsafe { nil }
 	d   &desktop.Desktop = unsafe { nil }
-	tmp string
+	scratch_dir string
 }
 
-fn s4d_app(label string) &S4dFixture {
-	tmp := os.join_path(os.temp_dir(), 'atk-s4d-flow-${label}-${os.getpid()}-${time.now().unix_nano()}')
-	os.mkdir_all(tmp) or { panic(err.msg()) }
+fn boot_palette_recents_app(label string) &PaletteRecentsFixture {
+	scratch_dir := os.join_path(os.temp_dir(), 'atk-palette-recents-${label}-${os.getpid()}-${time.now().unix_nano()}')
+	os.mkdir_all(scratch_dir) or { panic(err.msg()) }
 	// appearance persistence (save_ui_state) must never touch the real user
 	// cache from tests — point XDG_CACHE_HOME at the fixture dir
-	os.setenv('XDG_CACHE_HOME', tmp, true)
+	os.setenv('XDG_CACHE_HOME', scratch_dir, true)
 	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
 		config: desktop.DesktopConfig{
 			headless: true
 		}
-		persist_path: os.join_path(tmp, 'state.json')
+		persist_path: os.join_path(scratch_dir, 'state.json')
 	})
 	d.boot() or { panic(err.msg()) }
 	mut app := &GuiApp{
@@ -37,17 +37,17 @@ fn s4d_app(label string) &S4dFixture {
 	}
 	app.palette_reg = d.palette_registry()
 	app.palette_open = true
-	return &S4dFixture{
+	return &PaletteRecentsFixture{
 		app: app
 		d: d
-		tmp: tmp
+		scratch_dir: scratch_dir
 	}
 }
 
-fn (mut f S4dFixture) cleanup() {
+fn (mut f PaletteRecentsFixture) cleanup() {
 	f.d.shutdown() or {}
-	os.rmdir_all(f.tmp) or {}
-	f.tmp = ''
+	os.rmdir_all(f.scratch_dir) or {}
+	f.scratch_dir = ''
 }
 
 fn find_recent_row(rows []PaletteRow) ?PaletteRow {
@@ -62,7 +62,7 @@ fn find_recent_row(rows []PaletteRow) ?PaletteRow {
 // a real executed action produces a recent row that is visibly distinct,
 // and the fresh session starts with none.
 fn test_recents_appear_after_execution() {
-	mut f := s4d_app('recents')
+	mut f := boot_palette_recents_app('recents')
 	defer {
 		f.cleanup()
 	}
@@ -96,7 +96,7 @@ fn test_recents_appear_after_execution() {
 // rerun of a recent action goes through the CURRENT registry (revalidation),
 // and the second toggle records another recent (not a blind replay).
 fn test_recents_rerun_revalidates() {
-	mut f := s4d_app('rerun')
+	mut f := boot_palette_recents_app('rerun')
 	defer {
 		f.cleanup()
 	}
@@ -143,7 +143,7 @@ fn test_recents_rerun_revalidates() {
 // undo through the shell path: exact restore, single use; a diverged state
 // refuses without overwriting.
 fn test_recents_undo_shell_path() {
-	mut f := s4d_app('undo')
+	mut f := boot_palette_recents_app('undo')
 	defer {
 		f.cleanup()
 	}
@@ -173,7 +173,7 @@ fn test_recents_undo_shell_path() {
 // theme is recorded by the shell through the real setter and its undo
 // restores the exact previous appearance via the same setter.
 fn test_theme_shell_undo() {
-	mut f := s4d_app('theme')
+	mut f := boot_palette_recents_app('theme')
 	defer {
 		f.cleanup()
 	}

--- a/cmd/agent-toolkit-desktop/palette_rows_test.v
+++ b/cmd/agent-toolkit-desktop/palette_rows_test.v
@@ -6,10 +6,10 @@ import desktop.palette
 import desktop_engine
 import os
 
-// test_palette_merged_rows_registry_authority verifies the S4A production
-// palette data source: registry navigation rows lead in shell order, legacy
-// static rows remain appended, and queries surface registry entities with
-// preserved canonical identity.
+// test_palette_merged_rows_registry_authority verifies the production
+// palette data source: registry navigation rows lead in shell order, static
+// rows for entries without registry coverage remain appended, and queries
+// surface registry entities with preserved canonical identity.
 fn test_palette_merged_rows_registry_authority() {
 	tmp := os.join_path(os.temp_dir(), 'atk-palette-rows-${os.getpid()}')
 	os.mkdir_all(tmp) or { panic(err.msg()) }
@@ -42,7 +42,7 @@ fn test_palette_merged_rows_registry_authority() {
 	assert rows[1].id == 'nav:/skills'
 	assert rows[0].is_entity
 	assert rows[0].panel == nav.PanelId.world_view
-	// S4C: the static command authority is retired — every row is
+	// the static command authority is retired — every row is
 	// registry-shaped (known action-id prefixes), no bare legacy ids
 	known_prefixes := ['nav:', 'app:', 'skill:', 'agent:', 'target:', 'mcp:', 'product:', 'pack:',
 		'loop:', 'doctor:', 'job:', 'swarm_run:', 'action:']

--- a/cmd/agent-toolkit-desktop/panel_nav_test.v
+++ b/cmd/agent-toolkit-desktop/panel_nav_test.v
@@ -34,7 +34,7 @@ fn test_panel_nav_from_skills() {
 
 	on_event(nav_key_event(u32(`x`)), mut app)
 	assert app.selected_panel == 2, 'filter char must not navigate'
-	// VC5: the four Library tabs share one search field, so Agents filters too
+	// the four Library tabs share one search field, so Agents filters too
 	assert app.skills_query == 'x', 'Library tabs share the search field, got: ${app.skills_query}'
 	app.skills_query = ''
 

--- a/cmd/agent-toolkit-desktop/registry_reachability_test.v
+++ b/cmd/agent-toolkit-desktop/registry_reachability_test.v
@@ -7,7 +7,7 @@ import desktop_engine
 import os
 import time
 
-// S4C reachability gate (#1119): the canonical set of critical user
+// Reachability gate: the canonical set of critical user
 // workflows must be reachable through the typed registry's semantics —
 // not through CLI command parity. This test is the coverage authority;
 // scripts/gui-coverage.py is only a human-readable report.
@@ -16,17 +16,17 @@ struct ReachFixture {
 mut:
 	app &GuiApp = unsafe { nil }
 	d   &desktop.Desktop = unsafe { nil }
-	tmp string
+	scratch_dir string
 }
 
 fn reach_app(label string) &ReachFixture {
-	tmp := os.join_path(os.temp_dir(), 'atk-s4c-reach-${label}-${os.getpid()}-${time.now().unix_nano()}')
-	os.mkdir_all(tmp) or { panic(err.msg()) }
+	scratch_dir := os.join_path(os.temp_dir(), 'atk-reach-${label}-${os.getpid()}-${time.now().unix_nano()}')
+	os.mkdir_all(scratch_dir) or { panic(err.msg()) }
 	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
 		config: desktop.DesktopConfig{
 			headless: true
 		}
-		persist_path: os.join_path(tmp, 'state.json')
+		persist_path: os.join_path(scratch_dir, 'state.json')
 	})
 	d.boot() or { panic(err.msg()) }
 	mut app := &GuiApp{
@@ -41,14 +41,14 @@ fn reach_app(label string) &ReachFixture {
 	return &ReachFixture{
 		app: app
 		d: d
-		tmp: tmp
+		scratch_dir: scratch_dir
 	}
 }
 
 fn (mut f ReachFixture) cleanup() {
 	f.d.shutdown() or {}
-	os.rmdir_all(f.tmp) or {}
-	f.tmp = ''
+	os.rmdir_all(f.scratch_dir) or {}
+	f.scratch_dir = ''
 }
 
 fn has_action(acts []palette.RegistryAction, kind palette.ActionKind) bool {

--- a/cmd/agent-toolkit-desktop/settings_view.v
+++ b/cmd/agent-toolkit-desktop/settings_view.v
@@ -3,7 +3,7 @@ module main
 import gg
 import desktop.pixelart
 
-// VC7 (#1173) — Preferences sheet.
+// Preferences sheet.
 //
 // Settings is a real destination and setup is an explicit overlay journey.
 // This sheet exposes ONLY the settings
@@ -57,7 +57,7 @@ fn draw_preferences_sheet(mut app GuiApp, x int, y int, w int) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	h := prefs_sheet_height()
-	paper_sheet(mut app, x, y, w, h)
+	draw_paper_sheet(mut app, x, y, w, h)
 	sc.draw(pixelart.environment_for(.gear), pid, x + 10, y + 6, 2)
 	app.gg.draw_text(x + 40, y + 6, 'Preferences', gg.TextCfg{
 		color: app.pnl_text
@@ -79,7 +79,7 @@ fn draw_preferences_sheet(mut app GuiApp, x int, y int, w int) {
 		for i, seg in segs {
 			sx, sy, sw, sh := prefs_seg_rect(x, y, w, r, i, segs.len)
 			on := i == active
-			hover := onb_hit(app.mouse_x, app.mouse_y, sx, sy, sw, sh)
+			hover := rect_contains(app.mouse_x, app.mouse_y, sx, sy, sw, sh)
 			app.gg.draw_rect_filled(sx, sy, sw, sh, if on {
 				app.pnl_text
 			} else if hover {
@@ -114,7 +114,7 @@ fn preferences_click(mut app GuiApp, x int, y int, w int, mx int, my int) bool {
 		segs := prefs_row_segments(r)
 		for i in 0 .. segs.len {
 			sx, sy, sw, sh := prefs_seg_rect(x, y, w, r, i, segs.len)
-			if !onb_hit(mx, my, sx, sy, sw, sh) {
+			if !rect_contains(mx, my, sx, sy, sw, sh) {
 				continue
 			}
 			match r {
@@ -206,7 +206,7 @@ fn settings_layout(app &GuiApp, w int, h int) SettingsLayout {
 	}
 }
 
-// draw_settings promotes the real VC7 preferences into their own product
+// draw_settings promotes the real preferences into their own product
 // destination. It exposes only state GuiApp can actually mutate and keeps the
 // setup journey as an explicit action rather than conflating Settings with it.
 fn draw_settings(mut app GuiApp, w int, h int) {
@@ -230,7 +230,7 @@ fn draw_settings(mut app GuiApp, w int, h int) {
 	if l.setup_h < 58 {
 		return
 	}
-	paper_sheet(mut app, l.prefs_x, l.setup_y, l.prefs_w, l.setup_h)
+	draw_paper_sheet(mut app, l.prefs_x, l.setup_y, l.prefs_w, l.setup_h)
 	st := app.desktop.onboarding_status(app.harness_root)
 	app.gg.draw_text(l.prefs_x + 14, l.setup_y + 12, 'Workspace setup', gg.TextCfg{
 		color: app.pnl_text
@@ -247,7 +247,7 @@ fn draw_settings(mut app GuiApp, w int, h int) {
 		'No active workspace selected'
 	} else {
 		app.harness_root
-	}, onb_fit(l.prefs_w - 32, 10)), gg.TextCfg{
+	}, text_fit_chars(l.prefs_w - 32, 10)), gg.TextCfg{
 		color: app.pnl_text_mut
 		size: 10
 		mono: true
@@ -256,10 +256,10 @@ fn draw_settings(mut app GuiApp, w int, h int) {
 		// Static workshop scenery gives Preferences the same physical world as
 		// Office and Onboarding without claiming runtime activity.
 		scene_x := l.prefs_x + l.prefs_w * 42 / 100
-		draw_onb_scene(mut app, scene_x, l.setup_y + 12, l.prefs_x + l.prefs_w - 14 - scene_x, l.setup_h - 24, office_palette_id(app))
+		draw_onboarding_scene(mut app, scene_x, l.setup_y + 12, l.prefs_x + l.prefs_w - 14 - scene_x, l.setup_h - 24, office_palette_id(app))
 	}
 	if l.setup_h >= 102 {
-		hover := onb_hit(app.mouse_x, app.mouse_y, l.button_x, l.button_y, l.button_w, l.button_h)
+		hover := rect_contains(app.mouse_x, app.mouse_y, l.button_x, l.button_y, l.button_w, l.button_h)
 		app.gg.draw_rect_filled(l.button_x, l.button_y, l.button_w, l.button_h, if hover {
 			app.pnl_select_hover
 		} else {
@@ -313,7 +313,7 @@ fn draw_settings_detail(mut app GuiApp, w int, h int) {
 	if ih > 410 {
 		nook_y := iy + 220
 		nook_h := ih - 300
-		paper_sheet(mut app, ix + 12, nook_y, inspector_w - 24, nook_h)
+		draw_paper_sheet(mut app, ix + 12, nook_y, inspector_w - 24, nook_h)
 		shelf := pixelart.environment_for(.shelf)
 		couch := pixelart.environment_for(.couch)
 		lamp := pixelart.environment_for(.lamp)
@@ -335,10 +335,10 @@ fn settings_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 		&& preferences_click(mut app, l.prefs_x, l.prefs_y, l.prefs_w, mx, my) {
 		return true
 	}
-	if l.setup_h >= 102 && onb_hit(mx, my, l.button_x, l.button_y, l.button_w, l.button_h) {
+	if l.setup_h >= 102 && rect_contains(mx, my, l.button_x, l.button_y, l.button_w, l.button_h) {
 		app.show_onboarding = true
 		app.onboarding_msg = 'Setup journey opened — five stages, press o to toggle'
 		return true
 	}
-	return onb_hit(mx, my, inspector_x(app, w), panel_top(app), inspector_w, content_bottom(app, h) - panel_top(app))
+	return rect_contains(mx, my, inspector_x(app, w), panel_top(app), inspector_w, content_bottom(app, h) - panel_top(app))
 }

--- a/cmd/agent-toolkit-desktop/shell_layout_test.v
+++ b/cmd/agent-toolkit-desktop/shell_layout_test.v
@@ -2,7 +2,7 @@ module main
 
 import gg
 
-// VC8 (#1187): shared editorial-shell geometry, truthful Settings routing,
+// Shared editorial-shell geometry, truthful Settings routing,
 // and terminal tabs backed only by available views.
 
 fn test_shell_masthead_is_responsive_and_bounded() {
@@ -257,7 +257,7 @@ fn test_short_tall_terminal_suppresses_operations_controls() {
 		term_mode: 1
 		term_height: 320
 	}
-	l := ops_layout(app, 1024, 640)
+	l := operations_layout(app, 1024, 640)
 	assert l.body_h == 0
 	assert l.tab_h == 0
 	assert l.ctl_h == 0
@@ -280,11 +280,11 @@ fn test_destination_layouts_use_production_masthead_height() {
 	mut library_app := &GuiApp{
 		selected_panel: 1
 	}
-	assert lib_layout(mut library_app, 1024, 640).fy == shell_mast_h(640)
+	assert library_layout(mut library_app, 1024, 640).fy == shell_mast_h(640)
 	operations_app := &GuiApp{
 		selected_panel: 6
 	}
-	assert ops_layout(operations_app, 1024, 640).fy == shell_mast_h(640)
+	assert operations_layout(operations_app, 1024, 640).fy == shell_mast_h(640)
 	workspace_app := &GuiApp{
 		selected_panel: 9
 	}

--- a/cmd/agent-toolkit-desktop/theme_apply_test.v
+++ b/cmd/agent-toolkit-desktop/theme_apply_test.v
@@ -1,5 +1,7 @@
 module main
 
+import os
+
 // Paper mode must resolve every panel field to the exact startup const
 // values — the scripted col_* → app.pnl_* sweep is value-preserving by
 // construction, and this test locks it. If it fails, Paper goldens would
@@ -63,4 +65,49 @@ fn test_system_appearance_resolves() {
 	app.apply_appearance(.system)
 	assert app.appearance == .system
 	assert app.appearance_dark == (appearance_theme(.system).kind == .dark)
+}
+
+// Every bundled font file must have embedded bytes so released single
+// binaries extract the full set to the cache dir. A font_file_* const
+// without a font_embed_pairs() entry would silently fall back to the
+// system sans at runtime — this test fails loudly instead.
+fn test_every_font_file_has_embedded_bytes() {
+	want := [font_file_sans, font_file_sans_bold, font_file_mono, font_file_mono_med,
+		font_file_display, font_file_display_t, font_file_arabic, font_file_arabic_bd,
+		font_file_sc]
+	pairs := font_embed_pairs()
+	mut names := []string{}
+	for pair in pairs {
+		assert pair.data.len > 0, 'embedded bytes for ${pair.name} must not be empty'
+		names << pair.name
+	}
+	assert names.len == want.len, 'font_embed_pairs must cover every font_file_* const: got ${names.len}, want ${want.len}'
+	for f in want {
+		assert f in names, 'font file ${f} has no entry in font_embed_pairs()'
+	}
+	// future fonts fail loudly too: every .ttf shipped in assets/fonts must
+	// be embedded somewhere — by cache name, or by bytes (font_file_mono
+	// intentionally maps to the SansMono bytes per CHANGELOG 1.30.0, so
+	// that source file is covered by content, not by name). Resolved from
+	// this file's path like repo_version_path.
+	fonts_dir := os.join_path(os.dir(os.dir(os.dir(@FILE))), 'assets', 'fonts')
+	if os.is_dir(fonts_dir) {
+		for name in os.ls(fonts_dir) or { []string{} } {
+			if !name.ends_with('.ttf') {
+				continue
+			}
+			if name in names {
+				continue
+			}
+			blob := os.read_bytes(os.join_path(fonts_dir, name)) or { []u8{} }
+			mut embedded := false
+			for pair in pairs {
+				if pair.data == blob {
+					embedded = true
+					break
+				}
+			}
+			assert embedded, 'shipped font ${name} has no entry in font_embed_pairs()'
+		}
+	}
 }

--- a/cmd/agent-toolkit-desktop/ui_tokens.v
+++ b/cmd/agent-toolkit-desktop/ui_tokens.v
@@ -82,7 +82,7 @@ fn detect_system_dark() bool {
 	return false
 }
 
-// ── F1 theme bridge — the ONLY path from theme tokens to renderer color ──
+// ── Theme bridge — the ONLY path from theme tokens to renderer color ──
 // The renderer (main.v) must not contain raw hex or duplicate color constants:
 // every color below resolves from theme.ColorTokens. main.v keeps thin
 // `const col_*` aliases (the compiler requires consts for the shared palette),
@@ -212,7 +212,7 @@ pub fn ui_hover_tint(t theme.Theme) gg.Color {
 // app.pnl_*; chrome (header/dock/status/terminal) keeps the startup consts.
 pub fn (mut app GuiApp) apply_appearance(a Appearance) {
 	app.appearance = a
-	// S4D: appearance-undo prechecks compare the real observed value;
+	// appearance-undo prechecks compare the real observed value;
 	// apply_appearance is the single appearance mutation point
 	if app.palette_reg != unsafe { nil } {
 		app.palette_reg.observe_appearance(app.appearance.str())

--- a/cmd/agent-toolkit-desktop/workspace_insights_settings_layout_test.v
+++ b/cmd/agent-toolkit-desktop/workspace_insights_settings_layout_test.v
@@ -4,14 +4,14 @@ import desktop
 import os
 import time
 
-// VC7 (#1173) — Workspace / Insights / Settings convergence: geometry shared
+// Workspace / Insights / Settings: geometry shared
 // between drawing and hit-testing, truthful scaffold checks, and the
 // preferences sheet wired to the real state fields.
 
-fn vc7_tmp(label string) string {
-	tmp := os.join_path(os.temp_dir(), 'atk-vc7-${label}-${os.getpid()}-${time.now().unix_nano()}')
-	os.mkdir_all(tmp) or { panic(err.msg()) }
-	return tmp
+fn make_scratch_dir(label string) string {
+	scratch_dir := os.join_path(os.temp_dir(), 'atk-desktop-${label}-${os.getpid()}-${time.now().unix_nano()}')
+	os.mkdir_all(scratch_dir) or { panic(err.msg()) }
+	return scratch_dir
 }
 
 // ── Workspace layout ────────────────────────────────────────────────────────
@@ -79,17 +79,17 @@ fn test_workspace_layout_compact_drops_scene() {
 
 // ── scaffold truth ──────────────────────────────────────────────────────────
 
-fn test_ws_scaffold_present_reads_real_directories() {
-	tmp := vc7_tmp('scaffold')
+fn test_workspace_scaffold_present_reads_real_directories() {
+	scratch_dir := make_scratch_dir('scaffold')
 	defer {
-		os.rmdir_all(tmp) or {}
+		os.rmdir_all(scratch_dir) or {}
 	}
-	os.mkdir_all(os.join_path(tmp, 'knowledge')) or { panic(err.msg()) }
-	os.write_file(os.join_path(tmp, 'AGENTS.md'), '# contract\n') or { panic(err.msg()) }
+	os.mkdir_all(os.join_path(scratch_dir, 'knowledge')) or { panic(err.msg()) }
+	os.write_file(os.join_path(scratch_dir, 'AGENTS.md'), '# contract\n') or { panic(err.msg()) }
 	// a FILE named packs must not count as the packs/ directory
-	os.write_file(os.join_path(tmp, 'packs'), '') or { panic(err.msg()) }
-	present := ws_scaffold_present(tmp)
-	assert present.len == ws_scaffold_names.len
+	os.write_file(os.join_path(scratch_dir, 'packs'), '') or { panic(err.msg()) }
+	present := workspace_scaffold_present(scratch_dir)
+	assert present.len == workspace_scaffold_names.len
 	assert present[0], 'knowledge/ exists'
 	assert !present[1], 'personas/ missing'
 	assert !present[2], 'packs is a file, not the packs/ directory'
@@ -97,25 +97,25 @@ fn test_ws_scaffold_present_reads_real_directories() {
 	assert present[5], 'AGENTS.md exists'
 }
 
-fn test_ws_scaffold_present_unknown_root_is_empty_not_missing() {
-	assert ws_scaffold_present('').len == 0, 'no root → unknown, never "missing"'
-	assert ws_scaffold_present('/definitely/not/a/dir/${os.getpid()}').len == 0
+fn test_workspace_scaffold_present_unknown_root_is_empty_not_missing() {
+	assert workspace_scaffold_present('').len == 0, 'no root → unknown, never "missing"'
+	assert workspace_scaffold_present('/definitely/not/a/dir/${os.getpid()}').len == 0
 }
 
-fn test_ws_state_label_follows_engine_truth() {
+fn test_workspace_state_label_follows_engine_truth() {
 	none_app := &GuiApp{}
-	l0, _ := ws_state_label(none_app)
+	l0, _ := workspace_state_label(none_app)
 	assert l0 == 'No workspace'
 	ready := &GuiApp{
 		harness_root: '/tmp'
 		workspace_initialized: true
 	}
-	l1, _ := ws_state_label(ready)
+	l1, _ := workspace_state_label(ready)
 	assert l1 == 'Ready'
 	folder := &GuiApp{
 		harness_root: '/tmp'
 	}
-	l2, _ := ws_state_label(folder)
+	l2, _ := workspace_state_label(folder)
 	assert l2 == 'Needs setup'
 }
 
@@ -156,18 +156,18 @@ fn test_insights_table_without_engine_is_empty_and_honest() {
 }
 
 fn test_insights_click_selects_tab_and_row() {
-	tmp := vc7_tmp('insights')
-	os.setenv('XDG_CACHE_HOME', tmp, true)
+	scratch_dir := make_scratch_dir('insights')
+	os.setenv('XDG_CACHE_HOME', scratch_dir, true)
 	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
 		config: desktop.DesktopConfig{
 			headless: true
 		}
-		persist_path: os.join_path(tmp, 'state.json')
+		persist_path: os.join_path(scratch_dir, 'state.json')
 	})
 	d.boot() or { panic(err.msg()) }
 	defer {
 		d.shutdown() or {}
-		os.rmdir_all(tmp) or {}
+		os.rmdir_all(scratch_dir) or {}
 	}
 	mut app := &GuiApp{
 		desktop: d
@@ -197,10 +197,10 @@ fn test_insights_click_selects_tab_and_row() {
 // ── Preferences sheet ───────────────────────────────────────────────────────
 
 fn test_preferences_click_mutates_real_state_fields() {
-	tmp := vc7_tmp('prefs')
-	os.setenv('XDG_CACHE_HOME', tmp, true)
+	scratch_dir := make_scratch_dir('prefs')
+	os.setenv('XDG_CACHE_HOME', scratch_dir, true)
 	defer {
-		os.rmdir_all(tmp) or {}
+		os.rmdir_all(scratch_dir) or {}
 	}
 	mut app := &GuiApp{
 		selected_panel: 9
@@ -250,11 +250,11 @@ fn test_preferences_segments_stay_inside_sheet() {
 	}
 }
 
-fn test_ws_detail_layout_drops_sections_from_the_bottom() {
+fn test_workspace_detail_layout_drops_sections_from_the_bottom() {
 	tall := &GuiApp{
 		selected_panel: 9
 	}
-	d := ws_detail_layout(tall, 1280, 800)
+	d := workspace_detail_layout(tall, 1280, 800)
 	assert d.prefs_y > 0, 'preferences fit in a full-height column'
 	assert d.quote_y > d.prefs_y, 'quote sits under preferences'
 	short := &GuiApp{
@@ -262,13 +262,13 @@ fn test_ws_detail_layout_drops_sections_from_the_bottom() {
 		term_visible: true
 		term_height: 320
 	}
-	ds := ws_detail_layout(short, 1024, 640)
+	ds := workspace_detail_layout(short, 1024, 640)
 	assert ds.prefs_y == 0, 'a short column drops the preferences sheet instead of overlapping'
 	assert ds.quote_y == 0, 'and the editorial card'
 	// whatever still fits must end inside the column; the scaffold checklist
 	// (the primary truth) is always present
 	limit := ds.iy + ds.ih - 8
-	assert ds.scaffold_y + 22 + ws_scaffold_names.len * 17 <= limit
+	assert ds.scaffold_y + 22 + workspace_scaffold_names.len * 17 <= limit
 	if ds.seed_y > 0 {
 		assert ds.seed_y + 54 <= limit
 	}

--- a/cmd/agent-toolkit-desktop/workspace_view.v
+++ b/cmd/agent-toolkit-desktop/workspace_view.v
@@ -5,7 +5,7 @@ import os
 import desktop.pixelart
 import desktop_engine
 
-// VC7 (#1173) — Workspace destination, visual convergence pass.
+// Workspace destination: every workspace action re-composed as one Paper Co. page.
 //
 // No dedicated reference exists for Workspace: the composition is derived
 // from concept-board.jpg (materials), office.jpg (shell + card grammar) and
@@ -149,10 +149,10 @@ fn workspace_layout(app &GuiApp, w int, h int) WorkspaceLayout {
 
 // ── shared Paper Co. primitives (used by the Insights and Settings sheets too) ──
 
-// paper_sheet is the soft material surface: warm paper, a quiet wood-tinted
+// draw_paper_sheet is the soft material surface: warm paper, a quiet wood-tinted
 // edge and a hard 2px shadow — the same treatment onboarding settled on,
 // deliberately not the bordered pixel_panel.
-fn paper_sheet(mut app GuiApp, x int, y int, w int, h int) {
+fn draw_paper_sheet(mut app GuiApp, x int, y int, w int, h int) {
 	ensure_pixel_cache(mut app)
 	app.gg.draw_rect_filled(x + 2, y + 3, w, h, tint(col_ink, 14))
 	app.gg.draw_rect_filled(x, y, w, h, pc(app, `P`))
@@ -227,7 +227,7 @@ fn destination_header(mut app GuiApp, fx int, fy int, fw int, head_h int, mark p
 	stamp, clock := local_stamp()
 	clock_w := if fw > 560 { 96 } else { 0 }
 	if big {
-		app.gg.draw_text(tx + 2, fy + 38, utf8_truncate(subtitle, onb_fit(fw - (tx - fx) - clock_w - 24, 12)), gg.TextCfg{
+		app.gg.draw_text(tx + 2, fy + 38, utf8_truncate(subtitle, text_fit_chars(fw - (tx - fx) - clock_w - 24, 12)), gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 12
 		})
@@ -250,47 +250,47 @@ fn destination_header(mut app GuiApp, fx int, fy int, fw int, head_h int, mark p
 
 // ── truth helpers ───────────────────────────────────────────────────────────
 
-// ws_scaffold_names are the scaffold entries the Engine seeds
+// workspace_scaffold_names are the scaffold entries the Engine seeds
 // (onboarding_ensure_workspace) plus the AGENTS.md contract that marks a
 // workspace as initialized (workspace_is_initialized).
-const ws_scaffold_names = ['knowledge/', 'personas/', 'packs/', 'repos/', 'projects/', 'AGENTS.md']
+const workspace_scaffold_names = ['knowledge/', 'personas/', 'packs/', 'repos/', 'projects/', 'AGENTS.md']
 
-// ws_scaffold_present checks the REAL directory state of root for each
+// workspace_scaffold_present checks the REAL directory state of root for each
 // scaffold entry. A trailing '/' entry must be a directory; a plain entry a
 // file. Returns an empty list when there is no root — unknown, not missing.
-fn ws_scaffold_present(root string) []bool {
+fn workspace_scaffold_present(root string) []bool {
 	clean := os.expand_tilde_to_home(root.trim_space())
 	if clean == '' || !os.is_dir(clean) {
 		return []bool{}
 	}
-	mut out := []bool{cap: ws_scaffold_names.len}
-	for name in ws_scaffold_names {
+	mut out := []bool{cap: workspace_scaffold_names.len}
+	for name in workspace_scaffold_names {
 		p := os.join_path(clean, name.trim_right('/'))
 		out << if name.ends_with('/') { os.is_dir(p) } else { os.is_file(p) }
 	}
 	return out
 }
 
-// ws_scaffold_cached memoizes ws_scaffold_present by root, refreshed every
+// workspace_scaffold_cached memoizes workspace_scaffold_present by root, refreshed every
 // ~2s (120 frames) so a network mount cannot stall the render thread.
-fn ws_scaffold_cached(mut app GuiApp, root string) []bool {
+fn workspace_scaffold_cached(mut app GuiApp, root string) []bool {
 	// keyed by root AND engine revision: Initialize/Switch bump the revision,
 	// so the checklist flips from 'missing' to present on the very next frame
 	// instead of after the time window (a stale 'missing' was visible after
 	// Initialize while testing the lifecycle harness)
 	key := '${root}@${app.engine_rev}'
-	if app.ws_scaffold_root == key && app.frame - app.ws_scaffold_frame < 120 {
-		return app.ws_scaffold_vals
+	if app.workspace_scaffold_root == key && app.frame - app.workspace_scaffold_frame < 120 {
+		return app.workspace_scaffold_vals
 	}
-	app.ws_scaffold_root = key
-	app.ws_scaffold_vals = ws_scaffold_present(root)
-	app.ws_scaffold_frame = app.frame
-	return app.ws_scaffold_vals
+	app.workspace_scaffold_root = key
+	app.workspace_scaffold_vals = workspace_scaffold_present(root)
+	app.workspace_scaffold_frame = app.frame
+	return app.workspace_scaffold_vals
 }
 
-// ws_seed_warnings returns the persisted seed warnings of the last
+// workspace_seed_warnings returns the persisted seed warnings of the last
 // initialization (workspace/seed_warnings), empty when none were recorded.
-fn ws_seed_warnings(mut app GuiApp) []string {
+fn workspace_seed_warnings(mut app GuiApp) []string {
 	if app.desktop == unsafe { nil } {
 		return []string{}
 	}
@@ -298,8 +298,8 @@ fn ws_seed_warnings(mut app GuiApp) []string {
 	return raw.split('|').filter(it.trim_space() != '')
 }
 
-// ws_state_label maps the active-workspace truth to a label + tone.
-fn ws_state_label(app &GuiApp) (string, gg.Color) {
+// workspace_state_label maps the active-workspace truth to a label + tone.
+fn workspace_state_label(app &GuiApp) (string, gg.Color) {
 	if app.harness_root == '' {
 		return 'No workspace', app.pnl_text_mut
 	}
@@ -317,12 +317,12 @@ fn draw_workspace(mut app GuiApp, w int, h int) {
 	app.gg.draw_rect_filled(l.fx, l.fy, l.fw, l.fh, app.pnl_bg)
 	destination_header(mut app, l.fx, l.fy, l.fw, l.head_h, pixelart.environment_for(.cabinet_tall), tr(app, 'panel.workspace'), 'Files, project context and memory for the active workspace')
 	if l.hero_h > 0 {
-		draw_ws_hero(mut app, l)
+		draw_workspace_hero(mut app, l)
 	}
 	if l.known_h > 0 {
-		draw_ws_known(mut app, l)
+		draw_workspace_known(mut app, l)
 	} else {
-		app.known_ws_rects.clear()
+		app.known_workspace_rects.clear()
 	}
 	// IDE block — the existing brokered surfaces, unchanged renderers
 	if l.mid_h > 0 {
@@ -339,19 +339,19 @@ fn draw_workspace(mut app GuiApp, w int, h int) {
 	}
 }
 
-// draw_ws_hero is the "Active workspace" paper sheet: state pill, path
+// draw_workspace_hero is the "Active workspace" paper sheet: state pill, path
 // field, the three real actions, the last notice, and a small filing scene.
-fn draw_ws_hero(mut app GuiApp, l WorkspaceLayout) {
+fn draw_workspace_hero(mut app GuiApp, l WorkspaceLayout) {
 	x := l.fx + 12
 	y := l.hero_y
 	w := l.fw - 24
-	paper_sheet(mut app, x, y, w, l.hero_h)
+	draw_paper_sheet(mut app, x, y, w, l.hero_h)
 	app.gg.draw_text(x + 12, y + 8, 'Active workspace', gg.TextCfg{
 		color: app.pnl_text
 		size: 17
 		family: app.fonts.display
 	})
-	label, tone := ws_state_label(app)
+	label, tone := workspace_state_label(app)
 	paper_pill(mut app, x + 12 + 'Active workspace'.len * 9 + 8, y + 11, label, tone)
 	if !l.compact {
 		src := if app.workspace_source == '' { '—' } else { app.workspace_source }
@@ -396,7 +396,7 @@ fn draw_ws_hero(mut app GuiApp, l WorkspaceLayout) {
 	if app.workspace_notice != '' {
 		bad := app.workspace_notice.contains('error') || app.workspace_notice.contains('Could not')
 			|| app.workspace_notice.contains('failed')
-		app.gg.draw_text(l.field_x, l.field_y + 34, utf8_truncate(app.workspace_notice, onb_fit(l.field_w + 180, 11)), gg.TextCfg{
+		app.gg.draw_text(l.field_x, l.field_y + 34, utf8_truncate(app.workspace_notice, text_fit_chars(l.field_w + 180, 11)), gg.TextCfg{
 			color: if bad { app.pnl_danger } else { app.pnl_text_mut }
 			size: 11
 		})
@@ -407,13 +407,13 @@ fn draw_ws_hero(mut app GuiApp, l WorkspaceLayout) {
 		})
 	}
 	if l.scene_w > 0 {
-		draw_ws_scene(mut app, l.scene_x, y + 8, l.scene_w - 8, l.hero_h - 16)
+		draw_workspace_scene(mut app, l.scene_x, y + 8, l.scene_w - 8, l.hero_h - 16)
 	}
 }
 
-// draw_ws_scene is a small filing corner: tall cabinet, a desk with a folder
+// draw_workspace_scene is a small filing corner: tall cabinet, a desk with a folder
 // stack, a plant — illustration only, static, no runtime meaning.
-fn draw_ws_scene(mut app GuiApp, x int, y int, w int, h int) {
+fn draw_workspace_scene(mut app GuiApp, x int, y int, w int, h int) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	wall_h := h * 45 / 100
@@ -431,7 +431,7 @@ fn draw_ws_scene(mut app GuiApp, x int, y int, w int, h int) {
 	desk := pixelart.environment_for(.desk)
 	folders := pixelart.environment_for(.folder_stack)
 	plant := pixelart.environment_for(.plant)
-	s := onb_art_scale(cabinet.width() + desk.width() + plant.width() + 10, cabinet.height(), w - 12, h - 10)
+	s := onboarding_art_scale(cabinet.width() + desk.width() + plant.width() + 10, cabinet.height(), w - 12, h - 10)
 	total := (cabinet.width() + desk.width() + plant.width()) * s + 10 * s
 	mut gx := x + (w - total) / 2
 	sc.draw(cabinet, pid, gx, base - cabinet.height() * s, s)
@@ -443,18 +443,18 @@ fn draw_ws_scene(mut app GuiApp, x int, y int, w int, h int) {
 	sc.draw(plant, pid, gx, base - plant.height() * s, s)
 }
 
-// draw_ws_known renders the bounded discovery list (Engine known_workspaces)
+// draw_workspace_known renders the bounded discovery list (Engine known_workspaces)
 // as folder cards: leaf name, truthful state, why it is listed, path. Click
 // fills the draft for Validate/Switch — discovery never switches by itself.
 // Hit rects are rebuilt every frame from this same geometry
-// (app.known_ws_rects; the click handler in main.v reads them).
-fn draw_ws_known(mut app GuiApp, l WorkspaceLayout) {
+// (app.known_workspace_rects; the click handler in main.v reads them).
+fn draw_workspace_known(mut app GuiApp, l WorkspaceLayout) {
 	x := l.fx + 12
 	y := l.known_y
 	w := l.fw - 24
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
-	app.known_ws_rects.clear()
+	app.known_workspace_rects.clear()
 	known := if app.desktop != unsafe { nil } {
 		app.desktop.engine_known_workspaces()
 	} else {
@@ -508,9 +508,9 @@ fn draw_ws_known(mut app GuiApp, l WorkspaceLayout) {
 				mono: true
 				bold: k.is_active
 			})
-			_, tone := ws_known_state(app, k)
+			_, tone := workspace_known_state(app, k)
 			app.gg.draw_rect_filled(cx + cw - 10, cy + 9, 5, 5, tone)
-			app.known_ws_rects << KnownWsRect{
+			app.known_workspace_rects << KnownWsRect{
 				x: cx
 				y: cy
 				w: cw
@@ -537,8 +537,8 @@ fn draw_ws_known(mut app GuiApp, l WorkspaceLayout) {
 			break
 		}
 		cx := x + i * (card_w + gap)
-		draw_ws_known_card(mut app, cx, cy, card_w, 56, k)
-		app.known_ws_rects << KnownWsRect{
+		draw_workspace_known_card(mut app, cx, cy, card_w, 56, k)
+		app.known_workspace_rects << KnownWsRect{
 			x: cx
 			y: cy
 			w: card_w
@@ -548,9 +548,9 @@ fn draw_ws_known(mut app GuiApp, l WorkspaceLayout) {
 	}
 }
 
-// ws_known_state is the truthful chip for a discovered workspace:
+// workspace_known_state is the truthful chip for a discovered workspace:
 // missing beats everything (the directory is gone), then active, ready, folder.
-fn ws_known_state(app &GuiApp, k desktop_engine.KnownWorkspace) (string, gg.Color) {
+fn workspace_known_state(app &GuiApp, k desktop_engine.KnownWorkspace) (string, gg.Color) {
 	if !k.exists {
 		return 'Missing', app.pnl_danger
 	}
@@ -563,7 +563,7 @@ fn ws_known_state(app &GuiApp, k desktop_engine.KnownWorkspace) (string, gg.Colo
 	return 'Folder', app.pnl_select
 }
 
-fn draw_ws_known_card(mut app GuiApp, x int, y int, w int, h int, k desktop_engine.KnownWorkspace) {
+fn draw_workspace_known_card(mut app GuiApp, x int, y int, w int, h int, k desktop_engine.KnownWorkspace) {
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	hover := app.mouse_x >= x && app.mouse_x < x + w && app.mouse_y >= y && app.mouse_y < y + h
@@ -586,7 +586,7 @@ fn draw_ws_known_card(mut app GuiApp, x int, y int, w int, h int, k desktop_engi
 	folders := pixelart.environment_for(.folder_stack)
 	sc.draw(folders, pid, x + 8, y + (h - folders.height() * 2) / 2, 2)
 	leaf := k.path.all_after_last('/')
-	label, tone := ws_known_state(app, k)
+	label, tone := workspace_known_state(app, k)
 	pill_w := label.len * 6 + 18
 	name_max := (w - 44 - pill_w - 16) / 7
 	app.gg.draw_text(x + 40, y + 7, utf8_truncate(leaf, if name_max < 6 { 6 } else { name_max }), gg.TextCfg{
@@ -595,7 +595,7 @@ fn draw_ws_known_card(mut app GuiApp, x int, y int, w int, h int, k desktop_engi
 		bold: true
 	})
 	paper_pill(mut app, x + w - pill_w - 8, y + 7, label, tone)
-	app.gg.draw_text(x + 40, y + 25, utf8_truncate(k.path, onb_fit(w - 48, 10)), gg.TextCfg{
+	app.gg.draw_text(x + 40, y + 25, utf8_truncate(k.path, text_fit_chars(w - 48, 10)), gg.TextCfg{
 		color: app.pnl_text_mut
 		size: 10
 		mono: true
@@ -609,10 +609,10 @@ fn draw_ws_known_card(mut app GuiApp, x int, y int, w int, h int, k desktop_engi
 
 // ── right column: "Workspace details" (replaces the inspector on panel 9) ──
 
-// WsDetailLayout — fixed section rhythm so the click geometry (preferences
+// WorkspaceDetailLayout — fixed section rhythm so the click geometry (preferences
 // sheet) is shared with drawing. Sections that do not fit are dropped from
 // the bottom up: quote first, then preferences.
-struct WsDetailLayout {
+struct WorkspaceDetailLayout {
 	ix         int
 	iy         int
 	iw         int
@@ -625,14 +625,14 @@ struct WsDetailLayout {
 	quote_y    int // 0 when the editorial card does not fit
 }
 
-fn ws_detail_layout(app &GuiApp, w int, h int) WsDetailLayout {
+fn workspace_detail_layout(app &GuiApp, w int, h int) WorkspaceDetailLayout {
 	ix := inspector_x(app, w)
 	iy := panel_top(app)
 	iw := inspector_w
 	ih := content_bottom(app, h) - iy
 	limit := iy + ih - 8
 	scaffold_y := iy + 40
-	mut y := scaffold_y + 22 + ws_scaffold_names.len * 17 + 10
+	mut y := scaffold_y + 22 + workspace_scaffold_names.len * 17 + 10
 	// secondary truth sections drop out (0) when the column is too short —
 	// e.g. a tall terminal on a small window — rather than overlapping
 	mut seed_y := 0
@@ -659,7 +659,7 @@ fn ws_detail_layout(app &GuiApp, w int, h int) WsDetailLayout {
 	if y + 62 <= limit {
 		quote_y = limit - 62
 	}
-	return WsDetailLayout{
+	return WorkspaceDetailLayout{
 		ix: ix
 		iy: iy
 		iw: iw
@@ -673,7 +673,7 @@ fn ws_detail_layout(app &GuiApp, w int, h int) WsDetailLayout {
 	}
 }
 
-fn ws_section_label(mut app GuiApp, x int, y int, label string) {
+fn workspace_section_label(mut app GuiApp, x int, y int, label string) {
 	app.gg.draw_text(x, y, label, gg.TextCfg{
 		color: app.pnl_text_mut
 		size: 10
@@ -684,7 +684,7 @@ fn ws_section_label(mut app GuiApp, x int, y int, label string) {
 
 fn draw_workspace_detail(mut app GuiApp, w int, h int) {
 	ensure_pixel_cache(mut app)
-	d := ws_detail_layout(app, w, h)
+	d := workspace_detail_layout(app, w, h)
 	mut sc := app.pixel_cache
 	pid := office_palette_id(app)
 	x := d.ix
@@ -699,9 +699,9 @@ fn draw_workspace_detail(mut app GuiApp, w int, h int) {
 	sc.draw(pixelart.environment_for(.folder_stack), pid, x + d.iw - 44, y + 10, 2)
 
 	// scaffold checklist — real os.exists on the active root
-	ws_section_label(mut app, x + 16, d.scaffold_y, 'SCAFFOLD')
-	present := ws_scaffold_cached(mut app, app.harness_root)
-	for i, name in ws_scaffold_names {
+	workspace_section_label(mut app, x + 16, d.scaffold_y, 'SCAFFOLD')
+	present := workspace_scaffold_cached(mut app, app.harness_root)
+	for i, name in workspace_scaffold_names {
 		ry := d.scaffold_y + 22 + i * 17
 		app.gg.draw_text(x + 36, ry, name, gg.TextCfg{
 			color: app.pnl_text
@@ -716,7 +716,7 @@ fn draw_workspace_detail(mut app GuiApp, w int, h int) {
 			continue
 		}
 		if present[i] {
-			onb_check(mut app, x + 16, ry + 1, app.pnl_success)
+			draw_check_glyph(mut app, x + 16, ry + 1, app.pnl_success)
 			app.gg.draw_text(x + d.iw - 70, ry, 'present', gg.TextCfg{
 				color: app.pnl_text_mut
 				size: 10
@@ -733,20 +733,20 @@ fn draw_workspace_detail(mut app GuiApp, w int, h int) {
 		}
 	}
 	if present.len == 0 {
-		app.gg.draw_text(x + 16, d.scaffold_y + 22 + ws_scaffold_names.len * 17 - 4, 'No active workspace — nothing was checked.', gg.TextCfg{
+		app.gg.draw_text(x + 16, d.scaffold_y + 22 + workspace_scaffold_names.len * 17 - 4, 'No active workspace — nothing was checked.', gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 10
 		})
 	}
 
 	if d.seed_y > 0 {
-		draw_ws_detail_seed(mut app, x, d)
+		draw_workspace_detail_seed(mut app, x, d)
 	}
 	if d.editor_y > 0 {
-		draw_ws_detail_editor(mut app, x, d)
+		draw_workspace_detail_editor(mut app, x, d)
 	}
 	if d.git_y > 0 {
-		draw_ws_detail_git(mut app, x, d)
+		draw_workspace_detail_git(mut app, x, d)
 	}
 	if d.prefs_y > 0 {
 		draw_preferences_sheet(mut app, x + 8, d.prefs_y, d.iw - 16)
@@ -756,11 +756,11 @@ fn draw_workspace_detail(mut app GuiApp, w int, h int) {
 	}
 }
 
-// draw_ws_detail_seed — seed warnings persisted by the last initialization (workspace/seed_warnings).
-fn draw_ws_detail_seed(mut app GuiApp, x int, d WsDetailLayout) {
+// draw_workspace_detail_seed — seed warnings persisted by the last initialization (workspace/seed_warnings).
+fn draw_workspace_detail_seed(mut app GuiApp, x int, d WorkspaceDetailLayout) {
 	// seed warnings — persisted by the last initialization
-	ws_section_label(mut app, x + 16, d.seed_y, 'SEED WARNINGS')
-	warns := ws_seed_warnings(mut app)
+	workspace_section_label(mut app, x + 16, d.seed_y, 'SEED WARNINGS')
+	warns := workspace_seed_warnings(mut app)
 	if warns.len == 0 {
 		app.gg.draw_text(x + 16, d.seed_y + 20, 'None recorded by the last initialization.', gg.TextCfg{
 			color: app.pnl_text_mut
@@ -772,7 +772,7 @@ fn draw_ws_detail_seed(mut app GuiApp, x int, d WsDetailLayout) {
 			size: 11
 			bold: true
 		})
-		app.gg.draw_text(x + 16, d.seed_y + 34, utf8_truncate(warns[0], onb_fit(d.iw - 32, 10)), gg.TextCfg{
+		app.gg.draw_text(x + 16, d.seed_y + 34, utf8_truncate(warns[0], text_fit_chars(d.iw - 32, 10)), gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 10
 			mono: true
@@ -780,20 +780,20 @@ fn draw_ws_detail_seed(mut app GuiApp, x int, d WsDetailLayout) {
 	}
 }
 
-// draw_ws_detail_editor — the active editor tab — MCP templates opened from the MCP drawer land here.
-fn draw_ws_detail_editor(mut app GuiApp, x int, d WsDetailLayout) {
+// draw_workspace_detail_editor — the active editor tab — MCP templates opened from the MCP drawer land here.
+fn draw_workspace_detail_editor(mut app GuiApp, x int, d WorkspaceDetailLayout) {
 	// editor — what the IDE block currently holds (MCP templates route here)
-	ws_section_label(mut app, x + 16, d.editor_y, 'EDITOR')
+	workspace_section_label(mut app, x + 16, d.editor_y, 'EDITOR')
 	if app.editor_tabs.len > 0 && app.active_tab >= 0 && app.active_tab < app.editor_tabs.len {
 		t := app.editor_tabs[app.active_tab]
 		kind := if t.syntax == 'json' && t.path.contains('mcp') { 'MCP template' } else { t.syntax }
-		app.gg.draw_text(x + 16, d.editor_y + 20, utf8_truncate(t.title, onb_fit(d.iw - 120, 12)), gg.TextCfg{
+		app.gg.draw_text(x + 16, d.editor_y + 20, utf8_truncate(t.title, text_fit_chars(d.iw - 120, 12)), gg.TextCfg{
 			color: app.pnl_text
 			size: 12
 			bold: true
 		})
 		paper_pill(mut app, x + d.iw - 16 - (kind.len * 6 + 18), d.editor_y + 18, kind, app.pnl_select)
-		app.gg.draw_text(x + 16, d.editor_y + 35, utf8_truncate(t.path, onb_fit(d.iw - 32, 10)), gg.TextCfg{
+		app.gg.draw_text(x + 16, d.editor_y + 35, utf8_truncate(t.path, text_fit_chars(d.iw - 32, 10)), gg.TextCfg{
 			color: app.pnl_text_mut
 			size: 10
 			mono: true
@@ -806,10 +806,10 @@ fn draw_ws_detail_editor(mut app GuiApp, x int, d WsDetailLayout) {
 	}
 }
 
-// draw_ws_detail_git — git availability before counts: no root / not a repo / backend unavailable.
-fn draw_ws_detail_git(mut app GuiApp, x int, d WsDetailLayout) {
+// draw_workspace_detail_git — git availability before counts: no root / not a repo / backend unavailable.
+fn draw_workspace_detail_git(mut app GuiApp, x int, d WorkspaceDetailLayout) {
 	// git — availability before counts
-	ws_section_label(mut app, x + 16, d.git_y, 'GIT')
+	workspace_section_label(mut app, x + 16, d.git_y, 'GIT')
 	if app.desktop == unsafe { nil } {
 		app.gg.draw_text(x + 16, d.git_y + 20, '—', gg.TextCfg{
 			color: app.pnl_text_mut
@@ -865,8 +865,8 @@ fn draw_paper_quote(mut app GuiApp, x int, y int, w int, l1 string, l2 string, b
 // workspace_detail_click routes clicks inside the right column. Only the
 // preferences sheet is interactive today; the truth sections are read-only.
 fn workspace_detail_click(mut app GuiApp, mx int, my int, w int, h int) bool {
-	d := ws_detail_layout(app, w, h)
-	if !onb_hit(mx, my, d.ix, d.iy, d.iw, d.ih) {
+	d := workspace_detail_layout(app, w, h)
+	if !rect_contains(mx, my, d.ix, d.iy, d.iw, d.ih) {
 		return false
 	}
 	if d.prefs_y > 0 && preferences_click(mut app, d.ix + 8, d.prefs_y, d.iw - 16, mx, my) {
@@ -885,8 +885,8 @@ fn workspace_detail_click(mut app GuiApp, mx int, my int, w int, h int) bool {
 // x+6+i*git_tab_w, git_tab_w-4 wide, y..y+22; CHANGES rows at y+40 (20px), HISTORY rows at
 // y+40 (22px); memory field at y+20..y+40 and result rows at y+44 (18px).
 
-// ws_sheet_title is the 14px Fraunces title every IDE sheet opens with.
-fn ws_sheet_title(mut app GuiApp, x int, y int, title string) {
+// workspace_sheet_title is the 14px Fraunces title every IDE sheet opens with.
+fn workspace_sheet_title(mut app GuiApp, x int, y int, title string) {
 	app.gg.draw_text(x, y, title, gg.TextCfg{
 		color: app.pnl_text
 		size: 14
@@ -894,22 +894,22 @@ fn ws_sheet_title(mut app GuiApp, x int, y int, title string) {
 	})
 }
 
-// ws_empty_copy renders product copy (12px) with the technical detail as a
+// workspace_empty_copy renders product copy (12px) with the technical detail as a
 // second muted line (11px) — never implementation-speak as the headline.
-fn ws_empty_copy(mut app GuiApp, x int, y int, w int, head string, detail string) {
-	app.gg.draw_text(x, y, utf8_truncate(head, onb_fit(w, 12)), gg.TextCfg{
+fn workspace_empty_copy(mut app GuiApp, x int, y int, w int, head string, detail string) {
+	app.gg.draw_text(x, y, utf8_truncate(head, text_fit_chars(w, 12)), gg.TextCfg{
 		color: app.pnl_text
 		size: 12
 	})
 	if detail != '' {
-		draw_onb_wrapped(mut app, x, y + 16, w, detail, 3)
+		draw_wrapped_text(mut app, x, y + 16, w, detail, 3)
 	}
 }
 
-// ws_underline_tab draws a library-style tab label: bold + sage underline
+// workspace_underline_tab draws a library-style tab label: bold + sage underline
 // when active, muted otherwise. The rect is the hit target the handler uses.
-fn ws_underline_tab(mut app GuiApp, x int, y int, w int, h int, label string, active bool, size int) {
-	hover := onb_hit(app.mouse_x, app.mouse_y, x, y, w, h)
+fn workspace_underline_tab(mut app GuiApp, x int, y int, w int, h int, label string, active bool, size int) {
+	hover := rect_contains(app.mouse_x, app.mouse_y, x, y, w, h)
 	if hover && !active {
 		app.gg.draw_rect_filled(x, y, w, h, app.pnl_card_sel)
 	}
@@ -924,9 +924,9 @@ fn ws_underline_tab(mut app GuiApp, x int, y int, w int, h int, label string, ac
 	}
 }
 
-// ws_git_unavailable returns the product copy for a git rail that cannot
+// workspace_git_unavailable returns the product copy for a git rail that cannot
 // show data yet: headline + technical detail, or empty strings when it can.
-fn ws_git_unavailable(st desktop_engine.GitWorkspaceStatus) (string, string) {
+fn workspace_git_unavailable(st desktop_engine.GitWorkspaceStatus) (string, string) {
 	if st.root == '' {
 		return 'No workspace yet', 'Choose a workspace above to inspect its repository.'
 	}
@@ -941,8 +941,8 @@ fn ws_git_unavailable(st desktop_engine.GitWorkspaceStatus) (string, string) {
 
 // draw_file_tree_panel — left column: twisty, kind mark, git dot, virtualized.
 fn draw_file_tree_panel(mut app GuiApp, x int, y int, w int, h int) {
-	paper_sheet(mut app, x, y, w, h)
-	ws_sheet_title(mut app, x + 10, y + 4, 'Files')
+	draw_paper_sheet(mut app, x, y, w, h)
+	workspace_sheet_title(mut app, x + 10, y + 4, 'Files')
 	flat := file_tree_visible(app)
 	row_h := 18
 	visible := (h - 28) / row_h
@@ -964,7 +964,7 @@ fn draw_file_tree_panel(mut app GuiApp, x int, y int, w int, h int) {
 		} else {
 			'No files yet', 'The workspace folder has nothing to list.'
 		}
-		ws_empty_copy(mut app, x + 10, y + 32, w - 20, head, detail)
+		workspace_empty_copy(mut app, x + 10, y + 32, w - 20, head, detail)
 		return
 	}
 	app.file_tree_scroll = clamp_scroll(app.file_tree_scroll, flat.len, visible)
@@ -1028,11 +1028,11 @@ fn draw_file_tree_panel(mut app GuiApp, x int, y int, w int, h int) {
 
 // draw_editor_panel — centre column: underlined tabs, gutter + syntax lines.
 fn draw_editor_panel(mut app GuiApp, x int, y int, w int, h int) {
-	paper_sheet(mut app, x, y, w, h)
+	draw_paper_sheet(mut app, x, y, w, h)
 	tab_h := 28
 	if app.editor_tabs.len == 0 {
-		ws_sheet_title(mut app, x + 12, y + 6, 'Nothing open')
-		ws_empty_copy(mut app, x + 12, y + 30, w - 24, 'Click a file in the tree to open it here.', 'Files stay inside the active workspace.')
+		workspace_sheet_title(mut app, x + 12, y + 6, 'Nothing open')
+		workspace_empty_copy(mut app, x + 12, y + 30, w - 24, 'Click a file in the tree to open it here.', 'Files stay inside the active workspace.')
 		return
 	}
 	mut tx := x + 6
@@ -1042,7 +1042,7 @@ fn draw_editor_panel(mut app GuiApp, x int, y int, w int, h int) {
 		if tx + tw > x + w - 6 {
 			break
 		}
-		ws_underline_tab(mut app, tx, y + 6, tw, 18, tab.title, active, 12)
+		workspace_underline_tab(mut app, tx, y + 6, tw, 18, tab.title, active, 12)
 		if tab.dirty {
 			app.gg.draw_rect_filled(tx + tw - 12, y + 12, 5, 5, app.pnl_danger)
 		}
@@ -1118,20 +1118,20 @@ fn draw_editor_panel(mut app GuiApp, x int, y int, w int, h int) {
 // Git-rail visible-row budgets, shared by drawing (draw_git_rails_panel) and
 // the wheel/hover paths in main.v so scroll clamps match what is drawn.
 // mid_h is the rail's full height; the panel reserves 30px for its tab strip.
-fn ws_git_changes_visible(mid_h int) int {
+fn workspace_git_changes_visible(mid_h int) int {
 	v := (mid_h - 30 - 20) / 20
 	return if v < 0 { 0 } else { v }
 }
 
-fn ws_git_history_visible(mid_h int) int {
+fn workspace_git_history_visible(mid_h int) int {
 	v := (mid_h - 30 - 40) / 22
 	return if v < 0 { 0 } else { v }
 }
 
 fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
-	paper_sheet(mut app, x, y, w, h)
+	draw_paper_sheet(mut app, x, y, w, h)
 	for ri, rn in ['CHANGES', 'HISTORY', 'COMPARE'] {
-		ws_underline_tab(mut app, x + 6 + ri * tab_w, y + 2, tab_w - 4, 20, rn.to_lower().capitalize(), app.git_rail == rn, 11)
+		workspace_underline_tab(mut app, x + 6 + ri * tab_w, y + 2, tab_w - 4, 20, rn.to_lower().capitalize(), app.git_rail == rn, 11)
 	}
 	app.gg.draw_rect_filled(x + 8, y + 24, w - 16, 1, tint(pc(app, `W`), 70))
 	y0 := y + 26
@@ -1141,9 +1141,9 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
 	}
 	st := app.desktop.engine_git_workspace_status()
 	if app.git_rail == 'CHANGES' {
-		head, detail := ws_git_unavailable(st)
+		head, detail := workspace_git_unavailable(st)
 		if head != '' {
-			ws_empty_copy(mut app, x + 10, y0 + 6, w - 20, head, detail)
+			workspace_empty_copy(mut app, x + 10, y0 + 6, w - 20, head, detail)
 			return
 		}
 		changes := app.desktop.engine_git_changes()
@@ -1157,7 +1157,7 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
 			size: 11
 		})
 		row_h := 20
-		visible := ws_git_changes_visible(h)
+		visible := workspace_git_changes_visible(h)
 		if visible < 1 {
 			return
 		}
@@ -1207,9 +1207,9 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
 			app.gg.draw_rect_filled(x + w - 4, bar_y, 2, bar_h, app.pnl_select)
 		}
 	} else if app.git_rail == 'HISTORY' {
-		head, detail := ws_git_unavailable(st)
+		head, detail := workspace_git_unavailable(st)
 		if head != '' {
-			ws_empty_copy(mut app, x + 10, y0 + 6, w - 20, head, detail)
+			workspace_empty_copy(mut app, x + 10, y0 + 6, w - 20, head, detail)
 			return
 		}
 		graph := app.desktop.engine_git_graph(20)
@@ -1218,7 +1218,7 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
 			size: 11
 		})
 		row_h := 22
-		visible := ws_git_history_visible(h)
+		visible := workspace_git_history_visible(h)
 		if visible < 1 {
 			return
 		}
@@ -1295,9 +1295,9 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
 			}
 		}
 	} else { // COMPARE
-		head, detail := ws_git_unavailable(st)
+		head, detail := workspace_git_unavailable(st)
 		if head != '' {
-			ws_empty_copy(mut app, x + 10, y0 + 6, w - 20, head, detail)
+			workspace_empty_copy(mut app, x + 10, y0 + 6, w - 20, head, detail)
 			return
 		}
 		hunks := app.desktop.engine_git_compare('HEAD~1', 'HEAD')
@@ -1311,7 +1311,7 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
 			return
 		}
 		if hunks.len == 0 {
-			ws_empty_copy(mut app, x + 10, y0 + 20, w - 20, 'Nothing to compare', 'The last two commits do not differ, or there is only one commit.')
+			workspace_empty_copy(mut app, x + 10, y0 + 20, w - 20, 'Nothing to compare', 'The last two commits do not differ, or there is only one commit.')
 			return
 		}
 		// flatten hunks into one line list so the wheel scroll (diff_scroll)
@@ -1362,8 +1362,8 @@ fn draw_git_rails_panel(mut app GuiApp, x int, y int, w int, h int, tab_w int) {
 // draw_memory_palace_panel — bottom strip: recall query field + results.
 // Diagnostics (embedding scheme, broker path) are not user-facing copy.
 fn draw_memory_palace_panel(mut app GuiApp, x int, y int, w int, h int) {
-	paper_sheet(mut app, x, y, w, h)
-	ws_sheet_title(mut app, x + 10, y + 2, 'Memory')
+	draw_paper_sheet(mut app, x, y, w, h)
+	workspace_sheet_title(mut app, x + 10, y + 2, 'Memory')
 	mode := if app.memory_semantic { 'semantic' } else { 'keyword' }
 	paper_pill(mut app, x + w - 10 - (mode.len * 6 + 18), y + 3, mode, app.pnl_select)
 	// query field — same hit rect as before (y+20..y+40)
@@ -1422,7 +1422,7 @@ fn draw_memory_palace_panel(mut app GuiApp, x int, y int, w int, h int) {
 			})
 		}
 		if results.len == 0 {
-			ws_empty_copy(mut app, x + 14, y + 46, w - 28, 'No matches for "${app.memory_query}"', '')
+			workspace_empty_copy(mut app, x + 14, y + 46, w - 28, 'No matches for "${app.memory_query}"', '')
 		}
 		return
 	}
@@ -1432,7 +1432,7 @@ fn draw_memory_palace_panel(mut app GuiApp, x int, y int, w int, h int) {
 	} else {
 		'${entries.len} memories recorded'
 	}
-	app.gg.draw_text(x + 14, y + 48, utf8_truncate(line, onb_fit(w - 28, 11)), gg.TextCfg{
+	app.gg.draw_text(x + 14, y + 48, utf8_truncate(line, text_fit_chars(w - 28, 11)), gg.TextCfg{
 		color: app.pnl_text_mut
 		size: 11
 	})


### PR DESCRIPTION
## Summary

Replaces Visual-Convergence campaign vocabulary with permanent domain language across `cmd/agent-toolkit-desktop/`. No intended visual or behavior change.

- **Files**: `vc7_views_test.v`->`workspace_insights_settings_layout_test.v`, `vc8_shell_test.v`->`shell_layout_test.v` (git mv)
- **Prefixes**: `onb_`->`onboarding_`, `lib_`->`library_`, `ops_`->`operations_`, `ins_`->`insights_`, `ws_`->`workspace_` (incl. structs, `app.library_*`, test fixtures, `.scratch_dir`)
- **Unification**: triplicated generic helpers -> one definition each (`rect_contains`, `text_fit_chars`, `draw_check_glyph`, `draw_paper_sheet`, `draw_wrapped_text`, formatters/keys); `shell_mast_h` relocated to main.v shell geometry
- **Fixes in passing**: deleted dead `mock_term_logs`; added missing `mono_med` embed pair + `test_every_font_file_has_embedded_bytes` guard
- **Comments**: VC/S/F milestone tags -> behavior language; `super-potent` dropped (Engine-owned kept where marking authority)
- **Pixel-safety fixup** (coordinator review catch): unification briefly made Library cards sharp; restored exact rounded card surface as `draw_library_card` (helper body proven byte-identical to pre-rename `lib_sheet`; cards vs sheets differ by design)

## Validation (coordinator re-ran)

- `v vet cmd/agent-toolkit-desktop/` exit 0 (pre-existing doc warnings only)
- `v test cmd/agent-toolkit-desktop/` 12/12 green
- Production binary compiles (`-d gg_text_buff_size=4096`, 24MB)
- Residue rg: zero campaign-vocabulary hits in production code (documented KEEP list in PR files)

## Known limitations

- Operations shadow alpha harmonized 12->14/255 in the unification (sub-perceptual; disclosed, not rebaselined)
- No Xvfb on this dev machine: golden-ui CI job is the pixel backstop (advisory); no goldens were recaptured or hand-edited here