### PR TITLE
fix(release): single-source prod-link flags+gates, uniform -prod on all OSes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
     paths:
       - ".github/workflows/release.yml"
       - ".github/actions/setup-v/**"
+      - "scripts/release-linkage.sh"
       - "cmd/agent-toolkit/**"
       - "cmd/agent-toolkit-desktop/**"
       - "modules/**"
@@ -210,47 +211,16 @@ jobs:
           fi
           mkdir -p build
           COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
-          # Release linkage: production builds must not use V's default tcc
-          # backend — on macOS it bakes a runner-absolute @rpath/libgc.dylib
-          # (~/vlang-master/thirdparty/tcc) that dyld cannot load on user
-          # machines (dyld: Library not loaded). Upstream V reserves tcc for
-          # dev builds and recommends clang/gcc for -prod release builds.
-          # Windows keeps default flags: that leg runs the 0.5.2 fallback
-          # toolchain, which cannot -prod the stdlib `import json` still
-          # present in modules/agent_toolkit_server/server.veb.v.
-          VFLAGS=""
-          case "${RUNNER_OS:-}" in
-            macOS) VFLAGS="-prod -cc clang" ;;
-            Linux) VFLAGS="-prod -cc gcc" ;;
-          esac
+          # Release link flags + portability gate: single source of truth in
+          # scripts/release-linkage.sh (#1199) — never re-inline per-OS flags
+          # here, or the linkage-smoke job stops proving the release build.
+          VFLAGS="$("${GITHUB_WORKSPACE}/scripts/release-linkage.sh" flags)"
           # shellcheck disable=SC2086
           "${VBIN}" ${VFLAGS} -d "commit=${COMMIT}" -o "build/${OUT_BIN}" cmd/agent-toolkit
           cp -f "build/${OUT_BIN}" "build/${ASSET}"
           "build/${OUT_BIN}" --version
           "build/${OUT_BIN}" --help | head -n 20
-          # Linkage gates: never ship runner-absolute or unbundled native refs.
-          case "${RUNNER_OS:-}" in
-            macOS)
-              otool -L "build/${OUT_BIN}"
-              if otool -L "build/${OUT_BIN}" | grep -E '/Users/runner|thirdparty/tcc|@rpath/libgc'; then
-                echo "::error::non-portable libgc linkage in build/${OUT_BIN} (see otool above)" >&2
-                exit 1
-              fi
-              echo "macOS linkage: portable (no runner-absolute libgc)"
-              ;;
-            Linux)
-              ldd "build/${OUT_BIN}"
-              if ldd "build/${OUT_BIN}" | grep -q 'not found'; then
-                echo "::error::unresolved shared libraries in build/${OUT_BIN} (see ldd above)" >&2
-                exit 1
-              fi
-              echo "Linux linkage: all shared libraries resolved"
-              ;;
-            Windows*)
-              # log-only: inventory binary-vs-system DLLs for review
-              (objdump -p "build/${OUT_BIN}" 2>/dev/null | grep 'DLL Name' || echo "objdump unavailable") | sort -u
-              ;;
-          esac
+          "${GITHUB_WORKSPACE}/scripts/release-linkage.sh" gate "build/${OUT_BIN}"
           # #1057/#1116/#1130: validate the launcher entry shipped in the
           # desktop archives (ubuntu legs have desktop-file-utils)
           if [[ "${ASSET}" == *desktop* ]] && command -v desktop-file-validate >/dev/null 2>&1; then
@@ -341,19 +311,10 @@ jobs:
           fi
           mkdir -p build
           COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
-          # Release linkage: production builds must not use V's default tcc
-          # backend — on macOS it bakes a runner-absolute @rpath/libgc.dylib
-          # (~/vlang-master/thirdparty/tcc) that dyld cannot load on user
-          # machines (dyld: Library not loaded). Upstream V reserves tcc for
-          # dev builds and recommends clang/gcc for -prod release builds.
-          # Windows keeps default flags: that leg runs the 0.5.2 fallback
-          # toolchain, which cannot -prod the stdlib `import json` still
-          # present in modules/agent_toolkit_server/server.veb.v.
-          VFLAGS=""
-          case "${RUNNER_OS:-}" in
-            macOS) VFLAGS="-prod -cc clang" ;;
-            Linux) VFLAGS="-prod -cc gcc" ;;
-          esac
+          # Release link flags + portability gate: single source of truth in
+          # scripts/release-linkage.sh (#1199) — never re-inline per-OS flags
+          # here, or the linkage-smoke job stops proving the release build.
+          VFLAGS="$("${GITHUB_WORKSPACE}/scripts/release-linkage.sh" flags)"
           if [[ "${ASSET}" == *desktop* ]]; then
             # gg_text_buff_size=4096 — 4096² fontstash atlas: room for Fraunces + Plex + Plex Mono + CJK/Arabic i18n at every type-ramp size (sfons cannot expand the atlas at runtime)
             # shellcheck disable=SC2086
@@ -365,29 +326,7 @@ jobs:
           cp -f "build/${OUT_BIN}" "build/${ASSET}"
           "build/${OUT_BIN}" --version
           "build/${OUT_BIN}" --help | head -n 20
-          # Linkage gates: never ship runner-absolute or unbundled native refs.
-          case "${RUNNER_OS:-}" in
-            macOS)
-              otool -L "build/${OUT_BIN}"
-              if otool -L "build/${OUT_BIN}" | grep -E '/Users/runner|thirdparty/tcc|@rpath/libgc'; then
-                echo "::error::non-portable libgc linkage in build/${OUT_BIN} (see otool above)" >&2
-                exit 1
-              fi
-              echo "macOS linkage: portable (no runner-absolute libgc)"
-              ;;
-            Linux)
-              ldd "build/${OUT_BIN}"
-              if ldd "build/${OUT_BIN}" | grep -q 'not found'; then
-                echo "::error::unresolved shared libraries in build/${OUT_BIN} (see ldd above)" >&2
-                exit 1
-              fi
-              echo "Linux linkage: all shared libraries resolved"
-              ;;
-            Windows*)
-              # log-only: inventory binary-vs-system DLLs for review
-              (objdump -p "build/${OUT_BIN}" 2>/dev/null | grep 'DLL Name' || echo "objdump unavailable") | sort -u
-              ;;
-          esac
+          "${GITHUB_WORKSPACE}/scripts/release-linkage.sh" gate "build/${OUT_BIN}"
           # #1057/#1116/#1130: validate the launcher entry shipped in the
           # desktop archives (ubuntu legs have desktop-file-utils)
           if [[ "${ASSET}" == *desktop* ]] && command -v desktop-file-validate >/dev/null 2>&1; then
@@ -441,12 +380,10 @@ jobs:
           set -euo pipefail
           mkdir -p build
           COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
-          # Same per-OS release flags as build-binaries/build-desktop above.
-          VFLAGS=""
-          case "${RUNNER_OS:-}" in
-            macOS) VFLAGS="-prod -cc clang" ;;
-            Linux) VFLAGS="-prod -cc gcc" ;;
-          esac
+          # Flags and gate come from the same helper as the release jobs, so
+          # this job proves the exact release build instead of a copy of it.
+          LINKAGE_HELPER="${GITHUB_WORKSPACE}/scripts/release-linkage.sh"
+          VFLAGS="$("${LINKAGE_HELPER}" flags)"
           CLI_BIN=agent-toolkit
           DESK_BIN=agent-toolkit-desktop
           case "${RUNNER_OS:-}" in
@@ -458,30 +395,7 @@ jobs:
           "${VBIN}" ${VFLAGS} -d "commit=${COMMIT}" -d gg_text_buff_size=4096 -o "build/${DESK_BIN}" cmd/agent-toolkit-desktop
           "build/${CLI_BIN}" --version
           "build/${DESK_BIN}" --version
-          case "${RUNNER_OS:-}" in
-            macOS)
-              otool -L "build/${CLI_BIN}"
-              otool -L "build/${DESK_BIN}"
-              if otool -L "build/${CLI_BIN}" "build/${DESK_BIN}" | grep -E '/Users/runner|/home/runner|thirdparty/tcc|@rpath/libgc'; then
-                echo "::error::non-portable linkage (see otool above)" >&2
-                exit 1
-              fi
-              echo "macOS linkage: portable"
-              ;;
-            Linux)
-              ldd "build/${CLI_BIN}"
-              ldd "build/${DESK_BIN}"
-              if ldd "build/${CLI_BIN}" "build/${DESK_BIN}" | grep -q 'not found'; then
-                echo "::error::unresolved shared libraries (see ldd above)" >&2
-                exit 1
-              fi
-              echo "Linux linkage: all shared libraries resolved"
-              ;;
-            Windows*)
-              (objdump -p "build/${CLI_BIN}" 2>/dev/null | grep 'DLL Name' || echo "objdump unavailable") | sort -u
-              (objdump -p "build/${DESK_BIN}" 2>/dev/null | grep 'DLL Name' || echo "objdump unavailable") | sort -u
-              ;;
-          esac
+          "${LINKAGE_HELPER}" gate "build/${CLI_BIN}" "build/${DESK_BIN}"
 
   upload-assets:
     name: Attach V binaries, archives, SHA256SUMS, manifest

--- a/modules/pty/pty.v
+++ b/modules/pty/pty.v
@@ -3,7 +3,7 @@
 // Spawns agent CLIs (claude, opencode, cursor-agent, muse, pi, …) attached to
 // a pseudo-terminal so the GUI can run them interactively. The reader is
 // NON-BLOCKING and drained per frame by the caller — no threads, no races.
-// See modules/pty/README in the issue for the agent detection matrix.
+// Agent CLI detection matrix: see detect() below.
 //
 // Windows has no forkpty/pty.h: spawn() returns a clean error there (the
 // desktop surfaces it in the inspector message) and every other method is a

--- a/scripts/release-linkage.sh
+++ b/scripts/release-linkage.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# release-linkage.sh — single source of truth for V production link flags
+# and binary portability gates (follow-up to #1199).
+#
+# Usage:
+#   scripts/release-linkage.sh flags
+#       Print the `v` flags for production release builds on this runner OS.
+#   scripts/release-linkage.sh gate <binary>...
+#       Enforce the per-OS portability gate; exit 1 on violation.
+#
+# OS resolution: $RUNNER_OS on GitHub Actions, otherwise `uname -s`
+# (Darwin -> macOS, MINGW*/MSYS*/CYGWIN* -> Windows), so the gate doubles
+# as a local release-verification tool.
+#
+# Flag policy (proven by the release.yml `linkage-smoke` job on all 3 OSes):
+#   macOS: -prod -cc clang — V's default tcc backend bakes a
+#     runner-absolute @rpath/libgc.dylib (~/vlang-master/thirdparty/tcc)
+#     that aborts user machines with `dyld: Library not loaded` (1.30.0);
+#     upstream V reserves tcc for dev builds.
+#   Linux: -prod -cc gcc — same tcc avoidance; the ldd gate proves it.
+#   Windows: -prod over the toolchain default — uniform production flags on
+#     every OS (that leg runs the V 0.5.2 fallback, see setup-v).
+#
+# Gate policy:
+#   macOS: otool -L must show no /Users/runner, /home/runner,
+#     thirdparty/tcc or @rpath/libgc refs.
+#   Linux: ldd must show no `not found` entries.
+#   Windows: DLL inventory is logged for review (log-only — there is no
+#     curated system-DLL allowlist to gate against).
+#
+# Do NOT re-inline per-OS flags or gate patterns in release.yml: the smoke
+# job only proves the release build while both call this script.
+set -euo pipefail
+
+os_name() {
+  # A set-but-unknown RUNNER_OS is a hard error: silently falling back to
+  # `uname` would apply the wrong flags on a misconfigured runner.
+  if [ -n "${RUNNER_OS:-}" ]; then
+    case "${RUNNER_OS}" in
+      macOS | Linux) printf '%s' "${RUNNER_OS}" && return 0 ;;
+      Windows*) printf 'Windows' && return 0 ;;
+      *)
+        echo "release-linkage: unsupported RUNNER_OS=${RUNNER_OS}" >&2
+        return 1
+        ;;
+    esac
+  fi
+  case "$(uname -s)" in
+    Darwin) printf 'macOS' ;;
+    Linux) printf 'Linux' ;;
+    MINGW* | MSYS* | CYGWIN* | Windows*) printf 'Windows' ;;
+    *)
+      echo "release-linkage: unsupported OS (RUNNER_OS=${RUNNER_OS:-}, uname=$(uname -s))" >&2
+      return 1
+      ;;
+  esac
+}
+
+gh_error() {
+  if [ "${GITHUB_ACTIONS:-}" = 'true' ]; then
+    echo "::error::$1" >&2
+  else
+    echo "ERROR: $1" >&2
+  fi
+}
+
+cmd_flags() {
+  # NOTE: `case "$(os_name)"` would swallow os_name's failure (an empty
+  # substitution matches no branch and the case exits 0), so resolve first.
+  _os="$(os_name)" || return 1
+  case "${_os}" in
+    macOS) printf '%s' '-prod -cc clang' ;;
+    Linux) printf '%s' '-prod -cc gcc' ;;
+    Windows) printf '%s' '-prod' ;;
+  esac
+}
+
+cmd_gate() {
+  if [ "$#" -eq 0 ]; then
+    echo 'release-linkage: gate needs at least one binary' >&2
+    return 1
+  fi
+  # See cmd_flags: resolve the OS first so a detection failure is fatal.
+  _os="$(os_name)" || return 1
+  case "${_os}" in
+    macOS)
+      otool -L "$@"
+      if otool -L "$@" | grep -E '/Users/runner|/home/runner|thirdparty/tcc|@rpath/libgc'; then
+        gh_error "non-portable linkage (see otool above)"
+        return 1
+      fi
+      echo 'macOS linkage: portable (no runner-absolute libgc)'
+      ;;
+    Linux)
+      ldd "$@"
+      if ldd "$@" | grep -q 'not found'; then
+        gh_error "unresolved shared libraries (see ldd above)"
+        return 1
+      fi
+      echo 'Linux linkage: all shared libraries resolved'
+      ;;
+    Windows)
+      # log-only inventory for review (see header: no allowlist to gate on)
+      for bin in "$@"; do
+        (objdump -p "${bin}" 2>/dev/null | grep 'DLL Name' || echo 'objdump unavailable') | sort -u
+      done
+      ;;
+  esac
+}
+
+case "${1:-}" in
+  flags) cmd_flags ;;
+  gate)
+    shift
+    cmd_gate "$@"
+    ;;
+  *)
+    echo "usage: $0 {flags|gate <binary>...}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Follow-up to #1199 — implements its intent (portable production binaries on every OS) with clean code.

## What

- **New scripts/release-linkage.sh** — single source of truth for per-OS v release flags (flags) and binary portability gates (gate): macOS otool -L (no runner-absolute/@rpath/libgc), Linux ldd (no not found), Windows DLL inventory (log-only). build-binaries, build-desktop and linkage-smoke call it instead of three copy-pasted inline blocks (the smoke job previously said "same flags as above" — a drift hazard).
- **Uniform -prod on all three OSes** — #1199 excluded Windows because the V 0.5.2 fallback toolchain "cannot -prod the stdlib import json", but that same line of work already migrated server.veb.v to x.json2, leaving the exclusion justified by a stale comment. Windows now builds -prod too; **the linkage-smoke (windows-latest) run on this PR is the oracle** — if it goes red, this PR reverts Windows to default flags with the real error documented.
- **Trigger fix** — release.yml PR paths now watch scripts/release-linkage.sh (a helper change previously would not run the smoke job at all).
- **Drive-by doc truth** — pty.v header pointed at a non-existent modules/pty/README; now points at detect().

## Verification

- bash -n + shellcheck -S warning clean on the helper.
- Helper executed locally: flags resolves per OS (RUNNER_OS overrides exercised for macOS/Windows, unknown RUNNER_OS fails fatal — two real bugs found and fixed during probing); gate passes on the installed GUI binary (19/19 shared libs resolved).
- YAML parses; no inline flag/gate logic left in release.yml (verified by grep).
- Full proof arrives via CI: linkage-smoke on ubuntu/macos/windows with the exact release flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Automation**
  - Standardized release builds across macOS, Linux, and Windows.
  - Added consistent binary portability checks to help ensure published binaries run correctly on supported platforms.
  - Updated release workflows to automatically rerun when portability rules change.

- **Documentation**
  - Updated the terminal module documentation to reference the current agent CLI detection guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->