### PR TITLE
refactor: Engine owns workspace scaffold, dock and UI-state persistence

### DIFF
--- a/cmd/agent-toolkit-desktop/insights_view.v
+++ b/cmd/agent-toolkit-desktop/insights_view.v
@@ -144,6 +144,13 @@ fn insights_or_dash(s string) string {
 	return if s.trim_space() == '' { '—' } else { s }
 }
 
+// loops_with_budget counts loop templates declaring a budget. Presentation
+// count over the Engine loops catalog; the budget rule lives here once so
+// both budgets views share it.
+fn loops_with_budget(loops []desktop_engine.LoopEntry) int {
+	return loops.filter(it.budget.max_tokens > 0 || it.budget.max_wall_seconds > 0).len
+}
+
 fn insights_status_tone(s string) string {
 	low := s.to_lower()
 	if low.contains('fail') || low.contains('error') || low.contains('cancel') {
@@ -286,7 +293,7 @@ fn insights_table_build(mut app GuiApp, tab string, inner_w int) InsightsTable {
 			} else {
 				[]desktop_engine.LoopHistory{}
 			}
-			with_budget := loops.filter(it.budget.max_tokens > 0 || it.budget.max_wall_seconds > 0).len
+			with_budget := loops_with_budget(loops)
 			mut rows := []InsightsRow{}
 			for hrow in hist {
 				rows << InsightsRow{
@@ -399,7 +406,7 @@ fn draw_insights_metrics(mut app GuiApp, l InsightsLayout) {
 	for r in swarms {
 		spent += r.budget_spent
 	}
-	with_budget := loops.filter(it.budget.max_tokens > 0 || it.budget.max_wall_seconds > 0).len
+	with_budget := loops_with_budget(loops)
 	runs := swarms.len + jobs.len
 	cards := [
 		['${runs}', 'Runs recorded', if runs == 0 {

--- a/cmd/agent-toolkit-desktop/main.v
+++ b/cmd/agent-toolkit-desktop/main.v
@@ -225,84 +225,84 @@ pub:
 	sc       string // Noto Sans SC subset — 中文 chrome
 }
 
-// ui_state_path — ~/.cache/agent-toolkit/desktop/ui_state.env
+// ui_state_path — default shell-layout path. Owned by the Engine projection
+// (desktop_engine.ui_state_default_path); per-Engine overrides live in
+// Engine.ui_state_path (sibling of the Engine state file).
 fn ui_state_path() string {
-	base := if os.getenv('XDG_CACHE_HOME') != '' {
-		os.getenv('XDG_CACHE_HOME')
-	} else {
-		os.join_path(os.home_dir(), '.cache')
-	}
-	return os.join_path(base, 'agent-toolkit', 'desktop', 'ui_state.env')
+	return desktop_engine.ui_state_default_path()
 }
 
-// save_ui_state — best-effort persist of the shell layout (k=v, no json deps).
+// persisted_terminal_mode clamps a terminal mode for persistence. Owned by
+// the Engine (desktop_engine.persisted_terminal_mode); MAX (2) is
+// session-only and restarts as compact (0).
 fn persisted_terminal_mode(mode int) int {
-	if mode == 2 {
-		return 0
+	return desktop_engine.persisted_terminal_mode(mode)
+}
+
+// ui_shell_state_of maps view enums to the Engine typed shell projection.
+fn ui_shell_state_of(app &GuiApp) desktop_engine.UiShellState {
+	return desktop_engine.UiShellState{
+		term_mode: desktop_engine.persisted_terminal_mode(app.term_mode)
+		zoom: app.global_zoom
+		lang: int(app.lang)
+		insights_tab: app.insights_tab
+		swarm_backend: app.swarm_backend
+		appearance: '${app.appearance}'
 	}
-	return if mode >= 0 && mode <= 3 { mode } else { 3 }
 }
 
-fn save_ui_state(app &GuiApp) {
-	// MAX is a session-only takeover; restart it as compact rather than
-	// covering the whole application before the user asks again.
-	term_mode := persisted_terminal_mode(app.term_mode)
-	lines := [
-		'term_mode=${term_mode}',
-		'zoom=${app.global_zoom}',
-		'lang=${int(app.lang)}',
-		'insights_tab=${app.insights_tab}',
-		'swarm_backend=${app.swarm_backend}',
-		'appearance=${app.appearance}',
-	]
-	os.mkdir_all(os.dir(ui_state_path())) or {}
-	os.write_file(ui_state_path(), lines.join('\n')) or {}
+// apply_ui_shell_state maps the Engine typed shell projection back onto view
+// enums (values clamped by callers).
+fn apply_ui_shell_state(mut app GuiApp, s desktop_engine.UiShellState) {
+	app.term_mode = desktop_engine.persisted_terminal_mode(s.term_mode)
+	app.global_zoom = clamp_zoom(s.zoom)
+	match s.lang {
+		1 {
+			app.lang = Lang.es
+		}
+		2 {
+			app.lang = Lang.zh
+		}
+		3 {
+			app.lang = Lang.ar
+		}
+		else {}
+	}
+	app.insights_tab = s.insights_tab
+	app.appearance = appearance_from_string(s.appearance)
+	app.swarm_backend = s.swarm_backend
 }
 
-// load_ui_state — restore the last shell layout (values clamped by callers).
+// save_ui_state — best-effort persist of the shell layout via Engine
+// persistence (StateRepository mirror + derived ui_state.env file). Falls
+// back to the legacy direct file write only when no Desktop is attached
+// (pure tests) or the Engine write fails.
+fn save_ui_state(mut app GuiApp) {
+	if app.desktop != unsafe { nil } {
+		app.desktop.engine_save_ui_state(ui_shell_state_of(app)) or {
+			write_ui_state_file(ui_state_path(), ui_shell_state_of(app))
+		}
+		return
+	}
+	write_ui_state_file(ui_state_path(), ui_shell_state_of(app))
+}
+
+// write_ui_state_file is the legacy direct file write: headless-test
+// fallback only, never the production path.
+fn write_ui_state_file(path string, s desktop_engine.UiShellState) {
+	os.mkdir_all(os.dir(path)) or {}
+	os.write_file(path, desktop_engine.encode_ui_state_env(s)) or {}
+}
+
+// load_ui_state — restore the last shell layout via Engine persistence.
+// Falls back to the legacy direct file read only when no Desktop is attached.
 fn load_ui_state(mut app GuiApp) {
-	txt := os.read_file(ui_state_path()) or { return }
-	for line in txt.split('\n') {
-		kv := line.split('=')
-		if kv.len != 2 {
-			continue
-		}
-		k, v := kv[0], kv[1]
-		match k {
-			'term_mode' {
-				mode := v.int()
-				app.term_mode = persisted_terminal_mode(mode)
-			}
-			'zoom' {
-				app.global_zoom = clamp_zoom(v.f64())
-			}
-			'lang' {
-				li := v.int()
-				match li {
-					1 {
-						app.lang = Lang.es
-					}
-					2 {
-						app.lang = Lang.zh
-					}
-					3 {
-						app.lang = Lang.ar
-					}
-					else {}
-				}
-			}
-			'insights_tab' {
-				app.insights_tab = v
-			}
-			'appearance' {
-				app.appearance = appearance_from_string(v)
-			}
-			'swarm_backend' {
-				app.swarm_backend = v
-			}
-			else {}
-		}
+	if app.desktop != unsafe { nil } {
+		apply_ui_shell_state(mut app, app.desktop.engine_load_ui_state())
+		return
 	}
+	txt := os.read_file(ui_state_path()) or { return }
+	apply_ui_shell_state(mut app, desktop_engine.decode_ui_state_env(txt))
 }
 
 // vt_for — resolve a view id to its VT: -1 fleet, 0..14 desks, 15+ sessions.
@@ -1838,7 +1838,7 @@ fn handle_palette_undo(mut app GuiApp, sel PaletteRow) {
 				return
 			}
 			app.apply_appearance(appearance_from_string(spec.previous_appearance))
-			save_ui_state(app)
+			save_ui_state(mut app)
 			out := app.palette_reg.mark_undo_consumed(sel.execution_id, 0)
 			app.inspector_msg = out.summary
 		}
@@ -2552,7 +2552,7 @@ fn frame(mut app GuiApp) {
 	}
 	// persist the shell layout every ~10s and at frame 60 (first settle)
 	if app.frame == 60 || app.frame % 600 == 0 {
-		save_ui_state(app)
+		save_ui_state(mut app)
 	}
 	// walk cycle 4 frames 8fps, 80px/s, bob ±1 (munder spec)
 	if app.frame % 4 == 0 {
@@ -4177,7 +4177,7 @@ fn doctor_preview_open(mut app GuiApp, check_id string) {
 		}
 		app.term_visible = true
 		app.ghost_focused = true
-		save_ui_state(app)
+		save_ui_state(mut app)
 		app.inspector_msg = 'Doctor terminal: focused — restart or dismiss the exited sessions'
 		return
 	}
@@ -5527,7 +5527,7 @@ fn cycle_appearance(mut app GuiApp) {
 		.system { Appearance.paper }
 	}
 	app.apply_appearance(app.appearance)
-	save_ui_state(app)
+	save_ui_state(mut app)
 	app.inspector_msg = 'Appearance: ${appearance_label(app.appearance)} — panel theme applied, chrome unchanged'
 }
 
@@ -7009,7 +7009,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 			}
 			if e.key_code == .q {
 				// Ctrl+Q — explicit quit (Esc never kills the app; it cancels layers)
-				save_ui_state(app)
+				save_ui_state(mut app)
 				app.gg.quit()
 				return
 			}
@@ -7272,7 +7272,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 				// persisted mode instead of toggling the derived field.
 				app.term_mode = if app.term_mode == 3 { 0 } else { 3 }
 				app.term_visible = app.term_mode != 3
-				save_ui_state(app)
+				save_ui_state(mut app)
 				return
 			}
 		}
@@ -7592,7 +7592,7 @@ fn on_event(e &gg.Event, mut app GuiApp) {
 					.zh { Lang.ar }
 					.ar { Lang.en }
 				}
-				save_ui_state(app)
+				save_ui_state(mut app)
 				app.header_search_focus = false
 				app.workspace_focus = false
 				return

--- a/cmd/agent-toolkit-desktop/settings_view.v
+++ b/cmd/agent-toolkit-desktop/settings_view.v
@@ -9,9 +9,9 @@ import desktop.pixelart
 // This sheet exposes ONLY the settings
 // that already exist in GuiApp today — appearance, language, terminal
 // height mode, zoom — wired to the same state fields the header chips,
-// status bar and keyboard shortcuts mutate, and persisted through the
-// existing ui_state.env path (save_ui_state). It is mounted in the
-// Workspace details column, where it fits the "most technical destination".
+// status bar and keyboard shortcuts mutate, and persisted through Engine
+// persistence (save_ui_state → Engine ui shell projection). It is mounted in
+// the Workspace details column, where it fits the "most technical destination".
 
 const prefs_rows = ['Appearance', 'Language', 'Terminal', 'Zoom']
 
@@ -155,7 +155,7 @@ fn preferences_click(mut app GuiApp, x int, y int, w int, mx int, my int) bool {
 					app.zoom_toast_at = app.frame
 				}
 			}
-			save_ui_state(app)
+			save_ui_state(mut app)
 			return true
 		}
 	}

--- a/cmd/agent-toolkit-desktop/workspace_insights_settings_layout_test.v
+++ b/cmd/agent-toolkit-desktop/workspace_insights_settings_layout_test.v
@@ -1,6 +1,7 @@
 module main
 
 import desktop
+import desktop_engine
 import os
 import time
 
@@ -100,6 +101,83 @@ fn test_workspace_scaffold_present_reads_real_directories() {
 fn test_workspace_scaffold_present_unknown_root_is_empty_not_missing() {
 	assert workspace_scaffold_present('').len == 0, 'no root → unknown, never "missing"'
 	assert workspace_scaffold_present('/definitely/not/a/dir/${os.getpid()}').len == 0
+}
+
+fn test_workspace_scaffold_view_matches_engine_projection() {
+	// the view alias must never drift from the Engine-owned canonical list
+	assert workspace_scaffold_names == desktop_engine.workspace_scaffold_entry_names
+	scratch_dir := make_scratch_dir('scaffold-engine')
+	defer {
+		os.rmdir_all(scratch_dir) or {}
+	}
+	os.mkdir_all(os.join_path(scratch_dir, 'repos')) or { panic(err.msg()) }
+	// view wrapper and Engine probe agree on every entry
+	assert workspace_scaffold_present(scratch_dir) == desktop_engine.probe_workspace_scaffold(scratch_dir).present_flags()
+	// attached Desktop: the cached checklist consumes the Engine projection
+	persist := os.join_path(scratch_dir, 'state.json')
+	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
+		config: desktop.DesktopConfig{
+			headless: true
+		}
+		persist_path: persist
+	})
+	d.boot() or { panic(err.msg()) }
+	defer {
+		d.shutdown() or {}
+	}
+	mut app := &GuiApp{
+		desktop: d
+		harness_root: scratch_dir
+		engine_rev: 0
+		frame: 1000
+	}
+	got := workspace_scaffold_cached(mut app, scratch_dir)
+	assert got == d.engine_workspace_scaffold(scratch_dir).present_flags()
+	assert got[3], 'repos/ present via the Engine projection'
+	assert !got[0], 'knowledge/ missing via the Engine projection'
+}
+
+fn test_save_load_ui_state_round_trips_through_engine() {
+	scratch_dir := make_scratch_dir('uistate-engine')
+	defer {
+		os.rmdir_all(scratch_dir) or {}
+	}
+	persist := os.join_path(scratch_dir, 'state.json')
+	mut d := desktop.new_desktop(desktop.DesktopBootArgs{
+		config: desktop.DesktopConfig{
+			headless: true
+		}
+		persist_path: persist
+	})
+	d.boot() or { panic(err.msg()) }
+	defer {
+		d.shutdown() or {}
+	}
+	mut app := &GuiApp{
+		desktop: d
+		term_mode: 2
+		global_zoom: 1.0
+		lang: .es
+		insights_tab: 'waterfall'
+		swarm_backend: 'local'
+		appearance: .ink
+	}
+	save_ui_state(mut app)
+	// Engine mirror holds the clamped layout (MAX → compact)
+	stored := d.engine_load_ui_state()
+	assert stored.term_mode == 0, 'MAX persists as compact, got ${stored.term_mode}'
+	assert stored.lang == 1
+	assert stored.appearance == 'ink'
+	// a fresh view restores the same layout through the Engine
+	mut restored := &GuiApp{
+		desktop: d
+	}
+	load_ui_state(mut restored)
+	assert restored.term_mode == 0
+	assert restored.lang == .es
+	assert restored.insights_tab == 'waterfall'
+	assert restored.swarm_backend == 'local'
+	assert restored.appearance == .ink
 }
 
 fn test_workspace_state_label_follows_engine_truth() {

--- a/cmd/agent-toolkit-desktop/workspace_view.v
+++ b/cmd/agent-toolkit-desktop/workspace_view.v
@@ -1,7 +1,6 @@
 module main
 
 import gg
-import os
 import desktop.pixelart
 import desktop_engine
 
@@ -17,8 +16,8 @@ import desktop_engine
 // block below, and a "Workspace details" column on the right that replaces
 // the generic inspector.
 //
-// Truth: every value here comes from the Engine or a real filesystem check
-// (os.exists on the active root). Unknown renders as "—"; empty renders as
+// Truth: every value here comes from the Engine (the scaffold checklist via
+// the Engine scaffold projection). Unknown renders as "—"; empty renders as
 // an honest sentence. Nothing is inferred from the illustration.
 
 // WorkspaceLayout is computed once per frame and shared by drawing, click,
@@ -252,27 +251,25 @@ fn destination_header(mut app GuiApp, fx int, fy int, fw int, head_h int, mark p
 
 // workspace_scaffold_names are the scaffold entries the Engine seeds
 // (onboarding_ensure_workspace) plus the AGENTS.md contract that marks a
-// workspace as initialized (workspace_is_initialized).
-const workspace_scaffold_names = ['knowledge/', 'personas/', 'packs/', 'repos/', 'projects/', 'AGENTS.md']
+// workspace as initialized (workspace_is_initialized). Canonical list lives
+// in desktop_engine.workspace_scaffold_entry_names; this alias keeps view
+// indexing stable (locked by test).
+const workspace_scaffold_names = ['knowledge/', 'personas/', 'packs/', 'repos/', 'projects/',
+	'AGENTS.md']
 
 // workspace_scaffold_present checks the REAL directory state of root for each
-// scaffold entry. A trailing '/' entry must be a directory; a plain entry a
-// file. Returns an empty list when there is no root — unknown, not missing.
+// scaffold entry. Owned by the Engine projection
+// (desktop_engine.probe_workspace_scaffold); this wrapper keeps the
+// per-entry []bool shape views render. Empty list when there is no root —
+// unknown, not missing.
 fn workspace_scaffold_present(root string) []bool {
-	clean := os.expand_tilde_to_home(root.trim_space())
-	if clean == '' || !os.is_dir(clean) {
-		return []bool{}
-	}
-	mut out := []bool{cap: workspace_scaffold_names.len}
-	for name in workspace_scaffold_names {
-		p := os.join_path(clean, name.trim_right('/'))
-		out << if name.ends_with('/') { os.is_dir(p) } else { os.is_file(p) }
-	}
-	return out
+	return desktop_engine.probe_workspace_scaffold(root).present_flags()
 }
 
-// workspace_scaffold_cached memoizes workspace_scaffold_present by root, refreshed every
-// ~2s (120 frames) so a network mount cannot stall the render thread.
+// workspace_scaffold_cached memoizes the Engine scaffold projection by root,
+// refreshed every ~2s (120 frames) so a network mount cannot stall the render
+// thread. Consumes the Engine projection via Desktop; falls back to the pure
+// probe only when no Desktop is attached (pure layout tests).
 fn workspace_scaffold_cached(mut app GuiApp, root string) []bool {
 	// keyed by root AND engine revision: Initialize/Switch bump the revision,
 	// so the checklist flips from 'missing' to present on the very next frame
@@ -283,7 +280,11 @@ fn workspace_scaffold_cached(mut app GuiApp, root string) []bool {
 		return app.workspace_scaffold_vals
 	}
 	app.workspace_scaffold_root = key
-	app.workspace_scaffold_vals = workspace_scaffold_present(root)
+	if app.desktop != unsafe { nil } {
+		app.workspace_scaffold_vals = app.desktop.engine_workspace_scaffold(root).present_flags()
+	} else {
+		app.workspace_scaffold_vals = workspace_scaffold_present(root)
+	}
 	app.workspace_scaffold_frame = app.frame
 	return app.workspace_scaffold_vals
 }
@@ -698,7 +699,7 @@ fn draw_workspace_detail(mut app GuiApp, w int, h int) {
 	})
 	sc.draw(pixelart.environment_for(.folder_stack), pid, x + d.iw - 44, y + 10, 2)
 
-	// scaffold checklist — real os.exists on the active root
+	// scaffold checklist — Engine scaffold projection for the active root
 	workspace_section_label(mut app, x + 16, d.scaffold_y, 'SCAFFOLD')
 	present := workspace_scaffold_cached(mut app, app.harness_root)
 	for i, name in workspace_scaffold_names {

--- a/modules/desktop/desktop_test.v
+++ b/modules/desktop/desktop_test.v
@@ -8,6 +8,7 @@ import desktop.state as app_state
 import desktop.backend
 import desktop_engine.state as engine_state
 import desktop_engine.eventbus
+import desktop_engine
 
 fn test_desktop_window_opens_headless_and_closes_cleanly() {
 	tmp := os.join_path(os.temp_dir(), 'desktop-boot-${os.getpid()}')
@@ -344,6 +345,85 @@ fn test_localbackend_seam_injected_not_direct_os_calls() {
 	} else {
 		assert true
 	}
+}
+
+// --- Engine-owned projections: scaffold, dock persistence, ui state ---
+fn test_engine_workspace_scaffold_projection_matches_filesystem() {
+	tmp := os.join_path(os.temp_dir(), 'desktop-scaffold-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	os.mkdir_all(os.join_path(tmp, 'knowledge')) or { panic(err.msg()) }
+	os.write_file(os.join_path(tmp, 'AGENTS.md'), '# contract\n') or { panic(err.msg()) }
+	mut d := new_desktop(DesktopBootArgs{
+		config: DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	defer { d.shutdown() or {} }
+	s := d.engine_workspace_scaffold(tmp)
+	assert s.entries.len == 6
+	flags := s.present_flags()
+	assert flags[0] && flags[5], 'knowledge/ and AGENTS.md present'
+	assert !flags[1] && !flags[2], 'personas/ and packs/ missing'
+	assert d.engine_api_calls() > 0
+	unknown := d.engine_workspace_scaffold('')
+	assert unknown.present_flags().len == 0, 'no root → unknown, never missing'
+}
+
+fn test_update_dock_persists_via_engine_projection() {
+	tmp := os.join_path(os.temp_dir(), 'desktop-dock-engine-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut d := new_desktop(DesktopBootArgs{
+		config: DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	defer { d.shutdown() or {} }
+	// derived dock path is Engine-owned (sibling of the state file)
+	assert d.engine_dock_persist_path() == os.join_path(tmp, 'dock.json')
+	layout := shell.default_dock_layout()
+	next := layout.drag_to_target('doctor', 'left') or { panic(err.msg()) }
+	d.update_dock(next) or { panic(err.msg()) }
+	// payload round-trips through the Engine mirror + derived file
+	loaded := d.engine_load_dock_snapshot() or { panic('dock snapshot missing') }
+	assert loaded.contains('doctor')
+	assert loaded.contains('"revision":${next.revision}')
+	path := d.engine_dock_persist_path()
+	assert os.is_file(path), 'derived dock.json must exist at ${path}'
+	assert os.read_file(path) or { '' } == loaded
+	assert d.engine_api_calls() > 0
+}
+
+fn test_engine_ui_state_save_load_roundtrip_via_desktop() {
+	tmp := os.join_path(os.temp_dir(), 'desktop-uistate-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut d := new_desktop(DesktopBootArgs{
+		config: DesktopConfig{
+			headless: true
+		}
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	d.boot() or { panic(err.msg()) }
+	defer { d.shutdown() or {} }
+	d.engine_save_ui_state(desktop_engine.UiShellState{
+		term_mode: 2
+		zoom: 1.0
+		lang: 1
+		insights_tab: 'cost'
+		swarm_backend: 'auto'
+		appearance: 'ink'
+	}) or { panic(err.msg()) }
+	loaded := d.engine_load_ui_state()
+	assert loaded.appearance == 'ink'
+	assert loaded.lang == 1
+	assert loaded.term_mode == 0, 'MAX persists as compact'
+	assert d.engine_api_calls() > 0
 }
 
 // --- Vet green checklist ---

--- a/modules/desktop/shell/dock.v
+++ b/modules/desktop/shell/dock.v
@@ -226,19 +226,10 @@ pub fn (d DockLayout) resize_split(split_id string, position f64) !DockLayout {
 	return next
 }
 
-// default_persist_path returns derived persistence path (XDG cache, not canonical).
-fn default_persist_path() string {
-	base := os.getenv('XDG_CACHE_HOME')
-	home := os.home_dir()
-	cache := if base.len > 0 { base } else { os.join_path(home, '.cache') }
-	return os.join_path(cache, 'agent-toolkit', 'desktop', 'dock.json')
-}
-
-// persist writes derived dock layout atomically (derived only).
-pub fn (d DockLayout) persist(path string) ! {
-	p := if path.len > 0 { path } else { default_persist_path() }
-	dir := os.dir(p)
-	os.mkdir_all(dir) or { return error('mkdir failed: ${err}') }
+// persist_payload serializes the derived dock layout (derived only).
+// Pure serialization: the Engine owns the persist path and the write;
+// callers that need a path use the Engine dock_persist_path projection.
+pub fn (d DockLayout) persist_payload() string {
 	// Manual JSON to avoid json import variance across V versions
 	mut panels_json := '['
 	for i, panel in d.panels {
@@ -248,10 +239,22 @@ pub fn (d DockLayout) persist(path string) ! {
 		panels_json += '{"id":"${panel.id}","title":"${panel.title}","panel":"${panel.panel}","weight":${panel.weight},"visible":${panel.visible},' + '"closable":${panel.closable}}'
 	}
 	panels_json += ']'
-	payload := '{"revision":${d.revision},"timestamp":${d.timestamp},"panels":${panels_json}}'
-	tmp := '${p}.tmp.${os.getpid()}'
+	return '{"revision":${d.revision},"timestamp":${d.timestamp},"panels":${panels_json}}'
+}
+
+// persist writes a dock payload produced by persist_payload atomically to an
+// explicit path. The path must come from the Engine dock_persist_path
+// projection — the shell never derives persistence paths.
+pub fn (d DockLayout) persist(path string) ! {
+	if path.trim_space() == '' {
+		return error('dock persist path empty: use the Engine dock_persist_path projection')
+	}
+	dir := os.dir(path)
+	os.mkdir_all(dir) or { return error('mkdir failed: ${err}') }
+	payload := d.persist_payload()
+	tmp := '${path}.tmp.${os.getpid()}'
 	os.write_file(tmp, payload) or { return error('write tmp failed: ${err}') }
-	os.mv(tmp, p) or {
+	os.mv(tmp, path) or {
 		os.rm(tmp) or {}
 		return error('rename failed: ${err}')
 	}

--- a/modules/desktop/window.v
+++ b/modules/desktop/window.v
@@ -197,18 +197,49 @@ pub fn (d Desktop) dock_layout() shell.DockLayout {
 	return d.dock
 }
 
-// update_dock persists derived layout (not canonical) and bumps app_state.
+// update_dock persists derived layout (not canonical) via Engine persistence
+// and refreshes the projection. One Engine transaction mirrors revision +
+// payload and writes the derived dock.json file; never blocks boot.
 pub fn (mut d Desktop) update_dock(layout shell.DockLayout) ! {
 	layout.validate()!
 	d.dock = layout
-	// persist derived (best-effort, never blocks boot)
-	d.dock.persist('') or { eprintln('dock persist ignored: ${err}') }
-	// also reflect in Engine state for cross-restart (derived)
-	mut v := d.mutate_via_engine('dock_layout', 'rev:${layout.revision}') or {
-		eprintln('mutate ignored: ${err}')
-		return
+	// persist derived via Engine (best-effort, never blocks boot)
+	d.engine.save_dock_snapshot(layout.persist_payload(), layout.revision) or {
+		eprintln('dock persist ignored: ${err}')
 	}
-	_ = v
+	d.refresh_app_state()
+}
+
+// engine_dock_persist_path exposes the Engine-owned derived dock file path.
+// Views consume this fact; the shell never derives persistence paths.
+pub fn (mut d Desktop) engine_dock_persist_path() string {
+	return d.engine.dock_persist_path()
+}
+
+// engine_save_dock_snapshot persists a serialized dock payload via the Engine.
+pub fn (mut d Desktop) engine_save_dock_snapshot(payload string, revision u64) !u64 {
+	return d.engine.save_dock_snapshot(payload, revision)
+}
+
+// engine_load_dock_snapshot returns the Engine-mirrored dock payload, if any.
+pub fn (mut d Desktop) engine_load_dock_snapshot() ?string {
+	return d.engine.load_dock_snapshot()
+}
+
+// engine_workspace_scaffold returns the Engine-owned scaffold projection for
+// root. Views consume these facts; they never probe the filesystem.
+pub fn (mut d Desktop) engine_workspace_scaffold(root string) desktop_engine.WorkspaceScaffold {
+	return d.engine.workspace_scaffold(root)
+}
+
+// engine_save_ui_state persists shell layout via Engine persistence.
+pub fn (mut d Desktop) engine_save_ui_state(s desktop_engine.UiShellState) !u64 {
+	return d.engine.save_ui_shell_state(s)
+}
+
+// engine_load_ui_state returns the Engine-persisted shell layout.
+pub fn (mut d Desktop) engine_load_ui_state() desktop_engine.UiShellState {
+	return d.engine.load_ui_shell_state()
 }
 
 // theme_snapshot returns current theme.

--- a/modules/desktop_engine/dock_persistence.v
+++ b/modules/desktop_engine/dock_persistence.v
@@ -1,0 +1,89 @@
+module desktop_engine
+
+import os
+
+// Dock persistence — Engine-owned derived persistence for the docking shell.
+//
+// The dock layout is derived state (restorable from defaults), never
+// canonical. The Engine owns the persist path derivation, the atomic file
+// write, and the StateRepository mirror (dock/layout_* keys). The shell keeps
+// only pure serialization (see desktop.shell DockLayout.persist_payload);
+// it never derives paths. Views consume via Desktop proxies, never via
+// direct filesystem access.
+
+// dock_file_name is the derived dock file next to the Engine state file.
+pub const dock_file_name = 'dock.json'
+
+// dock_default_path derives the default dock path from XDG cache
+// (cache/agent-toolkit/desktop/dock.json). Used when the Engine has no
+// explicit persist path.
+pub fn dock_default_path() string {
+	base := os.getenv('XDG_CACHE_HOME')
+	home := os.home_dir()
+	cache := if base.len > 0 { base } else { os.join_path(home, '.cache') }
+	return os.join_path(cache, 'agent-toolkit', 'desktop', dock_file_name)
+}
+
+// dock_path_for derives the dock file for a repository persist path: a
+// sibling of the state file so tests and custom layouts stay isolated.
+// Empty persist_path falls back to the XDG default.
+pub fn dock_path_for(persist_path string) string {
+	if persist_path.trim_space() == '' {
+		return dock_default_path()
+	}
+	return os.join_path(os.dir(persist_path), dock_file_name)
+}
+
+// dock_persist_path returns this Engine's derived dock file path.
+pub fn (mut e Engine) dock_persist_path() string {
+	return dock_path_for(e.repo.persist_path_of())
+}
+
+// save_dock_snapshot persists a serialized dock payload (as produced by the
+// shell serializer): mirrors revision + payload into the StateRepository via
+// a single Transaction (one revision bump, one state_changed event) and
+// writes the derived dock.json file atomically. Strict: file errors return.
+pub fn (mut e Engine) save_dock_snapshot(payload string, revision u64) !u64 {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	if payload.trim_space() == '' {
+		return error('dock payload empty')
+	}
+	mut tx := e.repo.begin('dock')
+	tx.set('dock_layout', 'rev:${revision}')
+	tx.set('dock/layout_revision', revision.str())
+	tx.set('dock/layout_payload', payload)
+	rev := e.put_transaction(mut tx)!
+	path := dock_path_for(e.repo.persist_path_of())
+	os.mkdir_all(os.dir(path)) or { return error('mkdir failed: ${err}') }
+	tmp := '${path}.tmp.${os.getpid()}'
+	os.write_file(tmp, payload) or { return error('write tmp failed: ${err}') }
+	os.mv(tmp, path) or {
+		os.rm(tmp) or {}
+		return error('rename failed: ${err}')
+	}
+	return rev.revision
+}
+
+// load_dock_snapshot returns the mirrored dock payload, if any. Falls back
+// to the derived dock.json file (pre-migration layouts) before giving none.
+pub fn (mut e Engine) load_dock_snapshot() ?string {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	payload := snap.data['dock/layout_payload'] or { '' }
+	if payload != '' {
+		return payload
+	}
+	path := dock_path_for(e.repo.persist_path_of())
+	if os.is_file(path) {
+		if text := os.read_file(path) {
+			if text.trim_space() != '' {
+				return text
+			}
+		}
+	}
+	return none
+}

--- a/modules/desktop_engine/dock_persistence_test.v
+++ b/modules/desktop_engine/dock_persistence_test.v
@@ -1,0 +1,74 @@
+module desktop_engine
+
+import os
+
+fn test_dock_path_derivation_sibling_and_default() {
+	persist := os.join_path('/tmp', 'scratch-${os.getpid()}', 'state.json')
+	assert dock_path_for(persist) == os.join_path('/tmp', 'scratch-${os.getpid()}', dock_file_name)
+	// empty persist path falls back to the XDG-derived default
+	assert dock_path_for('') == dock_default_path()
+	assert dock_default_path().ends_with(os.join_path('agent-toolkit', 'desktop', dock_file_name))
+}
+
+fn test_dock_snapshot_save_load_roundtrip_via_engine() {
+	tmp := os.join_path(os.temp_dir(), 'engine-dock-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	// derived path is a sibling of the state file (isolated, never XDG)
+	assert eng.dock_persist_path() == os.join_path(tmp, dock_file_name)
+	before := eng.api_call_count()
+	payload := '{"revision":7,"timestamp":123,"panels":[{"id":"skills"}]}'
+	rev := eng.save_dock_snapshot(payload, 7) or { panic(err.msg()) }
+	assert rev >= 1
+	assert eng.api_call_count() > before, 'dock save must count as an Engine API call'
+	// repository mirror holds revision + payload (single transaction)
+	snap := eng.snapshot()
+	assert snap.data['dock_layout'] == 'rev:7'
+	assert snap.data['dock/layout_revision'] == '7'
+	assert snap.data['dock/layout_payload'] == payload
+	// derived file holds the exact payload
+	path := eng.dock_persist_path()
+	assert os.is_file(path), 'derived dock.json must exist at ${path}'
+	assert os.read_file(path) or { '' } == payload
+	// load returns the mirrored payload
+	loaded := eng.load_dock_snapshot() or { panic('dock snapshot missing') }
+	assert loaded == payload
+	eng.stop()!
+	// restart: the mirror survives via state.json persistence
+	mut reloaded := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	reloaded.init()!
+	reloaded.start()!
+	defer { reloaded.stop() or {} }
+	again := reloaded.load_dock_snapshot() or { panic('dock snapshot missing after restart') }
+	assert again == payload
+}
+
+fn test_dock_snapshot_rejects_empty_payload() {
+	tmp := os.join_path(os.temp_dir(), 'engine-dock-empty-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	if _ := eng.save_dock_snapshot('', 1) {
+		assert false, 'empty dock payload must be rejected'
+	} else {
+		assert err.msg().contains('empty')
+	}
+	if _ := eng.load_dock_snapshot() {
+		assert false, 'no snapshot persisted yet'
+	} else {
+		assert true
+	}
+}

--- a/modules/desktop_engine/state/state.v
+++ b/modules/desktop_engine/state/state.v
@@ -75,6 +75,15 @@ fn default_persist_path() string {
 	return os.join_path(cache, 'agent-toolkit', 'desktop', 'state.json')
 }
 
+// persist_path_of returns the repository's persistence file path so the
+// Engine can derive sibling derived-state files (dock.json, ui_state.env)
+// next to it instead of discovering XDG paths in views.
+pub fn (mut r StateRepository) persist_path_of() string {
+	r.mu.rlock()
+	defer { r.mu.runlock() }
+	return r.persist_path
+}
+
 // snapshot returns immutable copy of current state (read-locked).
 pub fn (mut r StateRepository) snapshot() State {
 	r.mu.rlock()

--- a/modules/desktop_engine/ui_state_persistence.v
+++ b/modules/desktop_engine/ui_state_persistence.v
@@ -1,0 +1,183 @@
+module desktop_engine
+
+import os
+
+// UI shell persistence — Engine-owned derived persistence for shell layout.
+//
+// The ui_state.env key=value file (term_mode, zoom, lang, insights_tab,
+// swarm_backend, appearance) is derived state, never canonical. The Engine
+// owns the path derivation, the atomic file write, and the StateRepository
+// mirror (ui/* keys) behind one typed struct. Views map their enums to the
+// plain fields and never touch the filesystem.
+
+// ui_state_file_name is the derived shell-layout file next to the state file.
+pub const ui_state_file_name = 'ui_state.env'
+
+// UiShellState is the typed shell-layout projection. lang is the Lang int,
+// appearance the appearance string ('paper' | 'ink' | 'system'); the view
+// owns the enum mapping, the Engine owns clamping + persistence.
+pub struct UiShellState {
+pub mut:
+	term_mode     int
+	zoom          f64
+	lang          int
+	insights_tab  string
+	swarm_backend string
+	appearance    string
+}
+
+// default_ui_shell_state returns the fresh-session shell layout.
+pub fn default_ui_shell_state() UiShellState {
+	return UiShellState{
+		term_mode: 3
+		zoom: 1.0
+		lang: 0
+		insights_tab: 'cost'
+		swarm_backend: 'auto'
+		appearance: 'paper'
+	}
+}
+
+// persisted_terminal_mode clamps a terminal mode for persistence. MAX (2) is
+// session-only: restart it as compact (0) rather than covering the whole
+// application before the user asks again. Out-of-range restarts hidden (3).
+pub fn persisted_terminal_mode(mode int) int {
+	if mode == 2 {
+		return 0
+	}
+	return if mode >= 0 && mode <= 3 { mode } else { 3 }
+}
+
+// encode_ui_state_env serializes shell state to the ui_state.env k=v format.
+pub fn encode_ui_state_env(s UiShellState) string {
+	lines := [
+		'term_mode=${persisted_terminal_mode(s.term_mode)}',
+		'zoom=${s.zoom}',
+		'lang=${s.lang}',
+		'insights_tab=${s.insights_tab}',
+		'swarm_backend=${s.swarm_backend}',
+		'appearance=${s.appearance}',
+	]
+	return lines.join('\n')
+}
+
+// decode_ui_state_env parses the ui_state.env k=v format onto defaults.
+// Unknown keys are ignored; malformed lines are skipped.
+pub fn decode_ui_state_env(text string) UiShellState {
+	mut s := default_ui_shell_state()
+	for line in text.split('\n') {
+		kv := line.split('=')
+		if kv.len != 2 {
+			continue
+		}
+		k, v := kv[0], kv[1]
+		match k {
+			'term_mode' {
+				s.term_mode = persisted_terminal_mode(v.int())
+			}
+			'zoom' {
+				s.zoom = v.f64()
+			}
+			'lang' {
+				s.lang = v.int()
+			}
+			'insights_tab' {
+				s.insights_tab = v
+			}
+			'swarm_backend' {
+				s.swarm_backend = v
+			}
+			'appearance' {
+				s.appearance = v
+			}
+			else {}
+		}
+	}
+	return s
+}
+
+// ui_state_default_path derives the default shell-layout path from XDG cache
+// (cache/agent-toolkit/desktop/ui_state.env). Used when the Engine has no
+// explicit persist path.
+pub fn ui_state_default_path() string {
+	base := os.getenv('XDG_CACHE_HOME')
+	home := os.home_dir()
+	cache := if base.len > 0 { base } else { os.join_path(home, '.cache') }
+	return os.join_path(cache, 'agent-toolkit', 'desktop', ui_state_file_name)
+}
+
+// ui_state_path_for derives the shell-layout file for a repository persist
+// path: a sibling of the state file so tests and custom layouts stay
+// isolated. Empty persist_path falls back to the XDG default.
+pub fn ui_state_path_for(persist_path string) string {
+	if persist_path.trim_space() == '' {
+		return ui_state_default_path()
+	}
+	return os.join_path(os.dir(persist_path), ui_state_file_name)
+}
+
+// ui_state_path returns this Engine's derived shell-layout file path.
+pub fn (mut e Engine) ui_state_path() string {
+	return ui_state_path_for(e.repo.persist_path_of())
+}
+
+// save_ui_shell_state persists shell layout: clamps, mirrors into the
+// StateRepository via a single Transaction (one revision bump), and writes
+// the derived ui_state.env file atomically. Strict: file errors return.
+pub fn (mut e Engine) save_ui_shell_state(s UiShellState) !u64 {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	clamped := UiShellState{
+		term_mode: persisted_terminal_mode(s.term_mode)
+		zoom: s.zoom
+		lang: s.lang
+		insights_tab: s.insights_tab
+		swarm_backend: s.swarm_backend
+		appearance: s.appearance
+	}
+	mut tx := e.repo.begin('ui-state')
+	tx.set('ui/term_mode', clamped.term_mode.str())
+	tx.set('ui/zoom', clamped.zoom.str())
+	tx.set('ui/lang', clamped.lang.str())
+	tx.set('ui/insights_tab', clamped.insights_tab)
+	tx.set('ui/swarm_backend', clamped.swarm_backend)
+	tx.set('ui/appearance', clamped.appearance)
+	rev := e.put_transaction(mut tx)!
+	path := ui_state_path_for(e.repo.persist_path_of())
+	os.mkdir_all(os.dir(path)) or { return error('mkdir failed: ${err}') }
+	tmp := '${path}.tmp.${os.getpid()}'
+	os.write_file(tmp, encode_ui_state_env(clamped)) or { return error('write tmp failed: ${err}') }
+	os.mv(tmp, path) or {
+		os.rm(tmp) or {}
+		return error('rename failed: ${err}')
+	}
+	return rev.revision
+}
+
+// load_ui_shell_state returns the persisted shell layout: repository mirror
+// first, the derived env file (pre-migration layouts) second, defaults when
+// neither exists. Zoom is NOT clamped here — callers clamp for their range.
+pub fn (mut e Engine) load_ui_shell_state() UiShellState {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	snap := e.repo.snapshot()
+	if 'ui/term_mode' in snap.data {
+		return UiShellState{
+			term_mode: persisted_terminal_mode((snap.data['ui/term_mode'] or { '3' }).int())
+			zoom: (snap.data['ui/zoom'] or { '1.0' }).f64()
+			lang: (snap.data['ui/lang'] or { '0' }).int()
+			insights_tab: snap.data['ui/insights_tab'] or { 'cost' }
+			swarm_backend: snap.data['ui/swarm_backend'] or { 'auto' }
+			appearance: snap.data['ui/appearance'] or { 'paper' }
+		}
+	}
+	path := ui_state_path_for(e.repo.persist_path_of())
+	if os.is_file(path) {
+		if text := os.read_file(path) {
+			return decode_ui_state_env(text)
+		}
+	}
+	return default_ui_shell_state()
+}

--- a/modules/desktop_engine/ui_state_persistence_test.v
+++ b/modules/desktop_engine/ui_state_persistence_test.v
@@ -1,0 +1,133 @@
+module desktop_engine
+
+import os
+
+fn test_persisted_terminal_mode_clamps_session_modes() {
+	assert persisted_terminal_mode(0) == 0
+	assert persisted_terminal_mode(1) == 1
+	assert persisted_terminal_mode(2) == 0, 'MAX is session-only, restarts compact'
+	assert persisted_terminal_mode(3) == 3
+	assert persisted_terminal_mode(9) == 3, 'out-of-range restarts hidden'
+	assert persisted_terminal_mode(-1) == 3
+}
+
+fn test_ui_state_env_encode_decode_roundtrip() {
+	s := UiShellState{
+		term_mode: 2
+		zoom: 1.25
+		lang: 1
+		insights_tab: 'waterfall'
+		swarm_backend: 'local'
+		appearance: 'ink'
+	}
+	text := encode_ui_state_env(s)
+	assert text.contains('term_mode=0'), 'MAX encodes as compact: ${text}'
+	assert text.contains('zoom=1.25')
+	assert text.contains('lang=1')
+	assert text.contains('appearance=ink')
+	back := decode_ui_state_env(text)
+	assert back.term_mode == 0
+	assert back.zoom == 1.25
+	assert back.lang == 1
+	assert back.insights_tab == 'waterfall'
+	assert back.swarm_backend == 'local'
+	assert back.appearance == 'ink'
+	// malformed lines are skipped, unknown keys ignored
+	other := decode_ui_state_env('garbage\nterm_mode=1\nbogus=1')
+	assert other.term_mode == 1
+	assert other.appearance == 'paper'
+}
+
+fn test_ui_state_path_derivation_sibling_and_default() {
+	persist := os.join_path('/tmp', 'scratch-${os.getpid()}', 'state.json')
+	assert ui_state_path_for(persist) == os.join_path('/tmp', 'scratch-${os.getpid()}', ui_state_file_name)
+	assert ui_state_path_for('') == ui_state_default_path()
+	assert ui_state_default_path().ends_with(os.join_path('agent-toolkit', 'desktop', ui_state_file_name))
+}
+
+fn test_ui_shell_state_save_load_roundtrip_via_engine() {
+	tmp := os.join_path(os.temp_dir(), 'engine-uistate-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	assert eng.ui_state_path() == os.join_path(tmp, ui_state_file_name)
+	before := eng.api_call_count()
+	rev := eng.save_ui_shell_state(UiShellState{
+		term_mode: 2
+		zoom: 1.25
+		lang: 1
+		insights_tab: 'waterfall'
+		swarm_backend: 'local'
+		appearance: 'ink'
+	}) or { panic(err.msg()) }
+	assert rev >= 1
+	assert eng.api_call_count() > before, 'ui save must count as an Engine API call'
+	// repository mirror holds the clamped layout
+	snap := eng.snapshot()
+	assert snap.data['ui/term_mode'] == '0', 'MAX mirrors as compact'
+	assert snap.data['ui/lang'] == '1'
+	assert snap.data['ui/appearance'] == 'ink'
+	// derived file holds the same k=v layout
+	path := eng.ui_state_path()
+	assert os.is_file(path), 'derived ui_state.env must exist at ${path}'
+	text := os.read_file(path) or { '' }
+	assert text.contains('term_mode=0')
+	assert text.contains('appearance=ink')
+	// load returns the mirrored layout
+	loaded := eng.load_ui_shell_state()
+	assert loaded.term_mode == 0
+	assert loaded.zoom == 1.25
+	assert loaded.lang == 1
+	assert loaded.insights_tab == 'waterfall'
+	assert loaded.appearance == 'ink'
+	eng.stop()!
+	// restart: the mirror survives via state.json persistence
+	mut reloaded := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	reloaded.init()!
+	reloaded.start()!
+	defer { reloaded.stop() or {} }
+	again := reloaded.load_ui_shell_state()
+	assert again.appearance == 'ink'
+	assert again.lang == 1
+}
+
+fn test_ui_shell_state_load_falls_back_to_env_file() {
+	tmp := os.join_path(os.temp_dir(), 'engine-uistate-file-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	// pre-migration layout: env file exists, repository has no ui/* keys
+	os.write_file(os.join_path(tmp, ui_state_file_name), 'term_mode=1\nzoom=1.0\nlang=2\ninsights_tab=cost\nswarm_backend=auto\nappearance=paper') or {
+		panic(err.msg())
+	}
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	loaded := eng.load_ui_shell_state()
+	assert loaded.term_mode == 1
+	assert loaded.lang == 2
+	assert loaded.appearance == 'paper'
+}
+
+fn test_ui_shell_state_load_defaults_when_nothing_persisted() {
+	tmp := os.join_path(os.temp_dir(), 'engine-uistate-fresh-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	loaded := eng.load_ui_shell_state()
+	assert loaded == default_ui_shell_state()
+}

--- a/modules/desktop_engine/workspace_scaffold.v
+++ b/modules/desktop_engine/workspace_scaffold.v
@@ -60,9 +60,13 @@ pub fn probe_workspace_scaffold(root string) WorkspaceScaffold {
 			root: root
 		}
 	}
+	// Canonicalize (macOS /tmp -> /private/tmp, symlinked checkouts, '..'):
+	// the projection root is an identity — revision-keyed view caches must
+	// not double-key the same directory under two spellings.
+	canon := os.real_path(clean)
 	mut entries := []WorkspaceScaffoldEntry{cap: workspace_scaffold_entry_names.len}
 	for name in workspace_scaffold_entry_names {
-		p := os.join_path(clean, name.trim_right('/'))
+		p := os.join_path(canon, name.trim_right('/'))
 		present := if name.ends_with('/') { os.is_dir(p) } else { os.is_file(p) }
 		entries << WorkspaceScaffoldEntry{
 			name: name
@@ -70,7 +74,7 @@ pub fn probe_workspace_scaffold(root string) WorkspaceScaffold {
 		}
 	}
 	return WorkspaceScaffold{
-		root: clean
+		root: canon
 		entries: entries
 	}
 }

--- a/modules/desktop_engine/workspace_scaffold.v
+++ b/modules/desktop_engine/workspace_scaffold.v
@@ -1,0 +1,90 @@
+module desktop_engine
+
+import os
+
+// Workspace scaffold projection — Engine-owned filesystem truth.
+//
+// The scaffold checklist (knowledge/ personas/ packs/ repos/ projects/ +
+// AGENTS.md) mirrors what onboarding_ensure_workspace seeds plus the AGENTS.md
+// contract that marks a workspace initialized. Views consume this projection;
+// they never probe the filesystem themselves.
+
+// workspace_scaffold_entry_names is the canonical scaffold list. A trailing
+// '/' entry must be a directory; a plain entry must be a file.
+pub const workspace_scaffold_entry_names = ['knowledge/', 'personas/', 'packs/', 'repos/', 'projects/',
+	'AGENTS.md']
+
+// WorkspaceScaffoldEntry is one checklist row: name + real directory state.
+pub struct WorkspaceScaffoldEntry {
+pub:
+	name    string
+	present bool
+}
+
+// WorkspaceScaffold is the typed projection for one root: empty entries
+// means unknown (no root), never "all missing".
+pub struct WorkspaceScaffold {
+pub:
+	root     string
+	entries  []WorkspaceScaffoldEntry
+	revision u64
+}
+
+// present_flags returns per-entry presence in canonical order (view compat).
+pub fn (s WorkspaceScaffold) present_flags() []bool {
+	mut out := []bool{cap: s.entries.len}
+	for e in s.entries {
+		out << e.present
+	}
+	return out
+}
+
+// present_count counts entries actually present on disk.
+pub fn (s WorkspaceScaffold) present_count() int {
+	mut n := 0
+	for e in s.entries {
+		if e.present {
+			n++
+		}
+	}
+	return n
+}
+
+// probe_workspace_scaffold checks the REAL directory state of root for each
+// scaffold entry. Empty root or non-directory → empty (unknown, not missing).
+// Pure: no Engine needed, but owned here so the probe lives with the type.
+pub fn probe_workspace_scaffold(root string) WorkspaceScaffold {
+	clean := os.expand_tilde_to_home(root.trim_space())
+	if clean == '' || !os.is_dir(clean) {
+		return WorkspaceScaffold{
+			root: root
+		}
+	}
+	mut entries := []WorkspaceScaffoldEntry{cap: workspace_scaffold_entry_names.len}
+	for name in workspace_scaffold_entry_names {
+		p := os.join_path(clean, name.trim_right('/'))
+		present := if name.ends_with('/') { os.is_dir(p) } else { os.is_file(p) }
+		entries << WorkspaceScaffoldEntry{
+			name: name
+			present: present
+		}
+	}
+	return WorkspaceScaffold{
+		root: clean
+		entries: entries
+	}
+}
+
+// workspace_scaffold returns the typed scaffold projection for root,
+// stamped with the current Engine revision (views memoize on it).
+pub fn (mut e Engine) workspace_scaffold(root string) WorkspaceScaffold {
+	e.mu.lock()
+	e.api_calls++
+	e.mu.unlock()
+	s := probe_workspace_scaffold(root)
+	return WorkspaceScaffold{
+		root: s.root
+		entries: s.entries.clone()
+		revision: e.repo.revision_nr()
+	}
+}

--- a/modules/desktop_engine/workspace_scaffold_test.v
+++ b/modules/desktop_engine/workspace_scaffold_test.v
@@ -1,0 +1,56 @@
+module desktop_engine
+
+import os
+
+fn test_workspace_scaffold_probe_reads_real_directories() {
+	tmp := os.join_path(os.temp_dir(), 'engine-scaffold-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	os.mkdir_all(os.join_path(tmp, 'knowledge')) or { panic(err.msg()) }
+	os.write_file(os.join_path(tmp, 'AGENTS.md'), '# contract\n') or { panic(err.msg()) }
+	// a FILE named packs must not count as the packs/ directory
+	os.write_file(os.join_path(tmp, 'packs'), '') or { panic(err.msg()) }
+	s := probe_workspace_scaffold(tmp)
+	assert s.entries.len == workspace_scaffold_entry_names.len
+	flags := s.present_flags()
+	assert flags.len == workspace_scaffold_entry_names.len
+	assert flags[0], 'knowledge/ exists'
+	assert !flags[1], 'personas/ missing'
+	assert !flags[2], 'packs is a file, not the packs/ directory'
+	assert !flags[3] && !flags[4], 'repos/ and projects/ missing'
+	assert flags[5], 'AGENTS.md exists'
+	assert s.present_count() == 2
+}
+
+fn test_workspace_scaffold_probe_unknown_root_is_empty_not_missing() {
+	assert probe_workspace_scaffold('').entries.len == 0, 'no root → unknown, never "missing"'
+	assert probe_workspace_scaffold('/definitely/not/a/dir/${os.getpid()}').entries.len == 0
+	assert probe_workspace_scaffold('').present_flags().len == 0
+}
+
+fn test_workspace_scaffold_projection_stamps_revision_and_api_call() {
+	tmp := os.join_path(os.temp_dir(), 'engine-scaffold-proj-${os.getpid()}')
+	os.mkdir_all(tmp) or { panic(err.msg()) }
+	defer { os.rmdir_all(tmp) or {} }
+	os.mkdir_all(os.join_path(tmp, 'repos')) or { panic(err.msg()) }
+	mut eng := new_engine(EngineConfig{
+		persist_path: os.join_path(tmp, 'state.json')
+	})
+	eng.init()!
+	eng.start()!
+	defer { eng.stop() or {} }
+	before := eng.api_call_count()
+	s := eng.workspace_scaffold(tmp)
+	assert eng.api_call_count() > before, 'projection must count as an Engine API call'
+	assert s.revision == eng.revision()
+	assert s.entries.len == workspace_scaffold_entry_names.len
+	assert s.root == os.real_path(tmp)
+	mut names := []string{}
+	for e in s.entries {
+		names << e.name
+	}
+	assert names == workspace_scaffold_entry_names
+	flags := s.present_flags()
+	assert !flags[0] && !flags[5], 'knowledge/ and AGENTS.md missing here'
+	assert flags[3], 'repos/ exists'
+}

--- a/modules/desktop_engine/workspace_scaffold_test.v
+++ b/modules/desktop_engine/workspace_scaffold_test.v
@@ -54,3 +54,17 @@ fn test_workspace_scaffold_projection_stamps_revision_and_api_call() {
 	assert !flags[0] && !flags[5], 'knowledge/ and AGENTS.md missing here'
 	assert flags[3], 'repos/ exists'
 }
+
+fn test_workspace_scaffold_probe_canonicalizes_symlinked_root() {
+	base := os.join_path(os.temp_dir(), 'engine-scaffold-link-${os.getpid()}')
+	os.mkdir_all(os.join_path(base, 'real', 'repos')) or { panic(err.msg()) }
+	defer { os.rmdir_all(base) or {} }
+	link := os.join_path(base, 'link')
+	os.symlink(os.join_path(base, 'real'), link) or { panic(err.msg()) }
+	// macOS /tmp -> /private/tmp: probing through a symlink must still
+	// report the canonical root, never the unresolved spelling.
+	s := probe_workspace_scaffold(link)
+	assert s.root == os.real_path(link)
+	assert s.root == os.real_path(os.join_path(base, 'real'))
+	assert s.present_flags()[3], 'repos/ visible through the link'
+}


### PR DESCRIPTION
Architecture cleanup: views consume Engine-owned typed projections instead of discovering domain facts.

- New Engine services + focused tests: workspace_scaffold.v, dock_persistence.v, ui_state_persistence.v (probe real state, unknown-vs-empty invariants, revision/API-call accounting).
- Views route through Engine: workspace_view scaffold checklist, dock persist path/snapshot, ui_state save/load; kanban/check/budget counts stay presentation-only over Engine lists (insights budgets predicate deduped into one helper).
- No behavior change; GUI still gg/sokol-direct, no CLI shell-outs.

Gates (local): focused Engine tests 3/3 PASS; ./make.vsh vet exit 0; ./make.vsh test 12/12 PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Desktop UI preferences, terminal mode, language, appearance, insights tab, and backend selections now persist and restore across sessions.
  - Dock layouts are saved and restored reliably between launches.
  - Workspace views now reflect detected scaffold folders and files more consistently.

- **Bug Fixes**
  - Terminal modes are normalized to supported values when saved or restored.
  - Existing preference files remain supported through fallback loading.

- **Tests**
  - Added coverage for workspace detection, dock persistence, and UI-state round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->