### PR TITLE
docs: reconcile desktop architecture and release-readiness state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Use the narrowest current source of truth instead of old issue prose or historic
 | Desktop journeys / coverage | [`docs/desktop/USER_JOURNEYS.md`](docs/desktop/USER_JOURNEYS.md), [`docs/desktop/WORKFLOW_COVERAGE.md`](docs/desktop/WORKFLOW_COVERAGE.md) |
 | Desktop truth ledger | [`docs/desktop/TRUTH_LEDGER.md`](docs/desktop/TRUTH_LEDGER.md) |
 | Desktop visual acceptance | [`docs/desktop/VISUAL_QA.md`](docs/desktop/VISUAL_QA.md) |
-| Desktop backlog evidence | [`docs/desktop/BACKLOG_AUDIT.md`](docs/desktop/BACKLOG_AUDIT.md) |
+| Desktop backlog evidence (HISTORICAL AUDIT — archived 2026-09-10, do not update) | [`docs/desktop/BACKLOG_AUDIT.md`](docs/desktop/BACKLOG_AUDIT.md) |
 
 Historical ADRs and GitHub issues are evidence, not automatic implementation authority. Reconcile them with current code and governing contracts before acting.
 
@@ -179,7 +179,10 @@ Also read:
 - `USER_JOURNEYS.md` when changing a workflow;
 - `WORKFLOW_COVERAGE.md` when exposing/removing capabilities;
 - `VISUAL_QA.md` for any visual change;
-- `BACKLOG_AUDIT.md` before implementing old Desktop issue text.
+- `BACKLOG_AUDIT.md` is a frozen 2026-09-05 historical snapshot (archived);
+  consult it for provenance only, never as implementation authority — current
+  state lives in the master tracker, `TRUTH_LEDGER.md` and
+  `WORKFLOW_COVERAGE.md`.
 
 ### Desktop invariants
 

--- a/docs/desktop/DESIGN.md
+++ b/docs/desktop/DESIGN.md
@@ -1,6 +1,7 @@
 # Agent Toolkit Desktop Design Contract
 
-**Status:** governing visual and interaction design direction for Agent Toolkit Desktop.
+**Status: CURRENT CONTRACT** — governing visual and interaction design
+direction for Agent Toolkit Desktop. Re-confirmed 2026-09-13 at `ecc4d67c`.
 
 This document defines how Agent Toolkit Desktop should look, feel, and present information. It complements [PRODUCT_VISION.md](PRODUCT_VISION.md), [UX_ARCHITECTURE.md](UX_ARCHITECTURE.md), [USER_JOURNEYS.md](USER_JOURNEYS.md), [WORKFLOW_COVERAGE.md](WORKFLOW_COVERAGE.md), and [VISUAL_QA.md](VISUAL_QA.md). It is not an executable token file and it does not override Engine truth, accessibility, or platform constraints.
 

--- a/docs/desktop/PACKAGING.md
+++ b/docs/desktop/PACKAGING.md
@@ -1,5 +1,8 @@
 # Desktop Packaging
 
+Status: **CURRENT GUIDE** — re-confirmed 2026-09-13 at `ecc4d67c`.
+See [WINDOWS.md](WINDOWS.md) for the honest Windows support status (unproven).
+
 > `VERSION 1.30.0` channel, single-repo-one-binary `V 0.5.2`, `VMODULES=modules`, `gen-embedded`, `distribution/` contracts, `manifest.json`+`SHA256SUMS` per ADR-022, `docs/RELEASING.md` signed-tag gate (maintainer-only, no premature publish).
 
 ## GUI (native desktop) build
@@ -33,7 +36,7 @@ translated strings — it harvests every CJK codepoint from `main.v`.
 
 | Path in archive | Purpose |
 |---|---|
-| `agent-toolkit-desktop` | native binary (fonts/resources embedded; resolves runtime state under XDG cache at first run) |
+| `agent-toolkit-desktop` | native binary (fonts/resources embedded; Engine-owned derived state — `ui_state.env`, `dock.json` — resolves under XDG cache at first run, never in the checkout) |
 | `agent-toolkit-desktop.desktop` | Desktop Entry spec launcher (`StartupWMClass` matches the window title) |
 | `icons/agent-toolkit-desktop-{16,24,32,48,64,128,256,512}.png` + `-scalable.svg` | hicolor icon set — Paper Co. envelope mark (deterministic generator: `packaging/linux/gen-icon.vsh`) |
 | `share/man/man1/agent-toolkit-desktop.1` | man page (synopsis, keymap, env, files) |
@@ -136,9 +139,14 @@ Gatekeeper: `spctl -a -t exec -vv build/AgentToolkit.app` logged (allow ⚠️ f
 
 See also `docs/desktop/WINDOWS.md` cross-ref for Gatekeeper/notarization gaps.
 
-## Windows (7.3) — spike + impl
+## Windows (7.3) — spike decided, impl pending
 
 `distribution/desktop/windows/` + `docs/desktop/WINDOWS.md` spike doc.
+Windows is unproven at HEAD — no `windows-latest` build, window smoke, or
+installer run recorded. The Inno Setup verdict in WINDOWS.md is the
+evaluation gate; the installer implementation and `windows-latest` evidence
+follow the verdict. The Phase-0 feasibility implementation retired in #1206
+does not change this: production is `gg`/`sokol`-direct.
 
 ### Native deps bundling
 
@@ -146,7 +154,7 @@ See also `docs/desktop/WINDOWS.md` cross-ref for Gatekeeper/notarization gaps.
 
 - static link vs DLL side-by-side in `build/windows/`; `make.vsh package-desktop-windows` logs `ldd`/`objdump` + `sha256sum` of bundled DLLs; size impact vs `+4.8M` ELF baseline recorded; fallback to system `DirectWrite`/`GDI` where the `gg`/`sokol` renderer abstracts.
 
-### Installer spike (EVALUATE, not premature pick)
+### Installer spike (decided: Inno Setup — impl pending, not premature pick)
 
 | Criterion | WiX Toolset | Inno Setup | NSIS |
 |---|---|---|---|
@@ -156,7 +164,7 @@ See also `docs/desktop/WINDOWS.md` cross-ref for Gatekeeper/notarization gaps.
 | Per-user vs per-machine | ✅ | ✅ | ✅ |
 | Bundles native DLLs side-by-side | ✅ | ✅ | ✅ |
 | Code sign integration (`signtool`) | ✅ | ✅ | ✅ |
-| `gg`/`sokol` Windows window tested | probe pending (spike 0.3 #1018) | probe pending | probe pending |
+| `gg`/`sokol` Windows window tested | probe pending on `windows-latest` (Phase-0 spike #1018 closed; feasibility implementation retired #1206) | probe pending | probe pending |
 | CI `windows-latest` support | `wix` action | `iscc` | `makensis` |
 
 **Spike verdict: choose Inno Setup** (recommendation — simplicity, Pascal `iss` authoring, `iscc` CI support, bundles DLLs, `signtool` integration). WiX is MSI enterprise alternative, NSIS is lightweight zlib but script ergonomics lower. Verdict justified by probing the `gg`/`sokol` window on Windows, installer UX, CI cost — spike doc is acceptance gate, installer impl follows decision. No renderer code change required.
@@ -171,9 +179,16 @@ Cross-build installer structure on Linux (spike doc + bundle layout) + real `.ex
 
 All packaging respects `V 0.5.2`, single binary, `VMODULES`, `gen-embedded`; aligns `distribution/` contracts, ADR-022 `SHA256SUMS`, `docs/RELEASING.md` publish gated (no premature Homebrew/AUR/NPM/Store publish). No secrets in artifact (`grep` fail), `v vet` green.
 
-## Auto-update (7.4)
+## Auto-update (7.4) — design only, honestly unavailable
 
-`modules/desktop_engine/update_service.v` reuses the existing `release.yml` + `manifest.json` pattern (no second update server). The former `modules/desktop/update/` GUI-side mock feed was removed — update stays honestly unavailable until a real updater exists (see #1063).
+Update stays honestly unavailable until a real feed reader/updater exists:
+no release-feed reader or updater exists, so Update is an
+honestly-unavailable application action in the registry — it cannot execute
+(see #1063 and [WORKFLOW_COVERAGE.md](WORKFLOW_COVERAGE.md)). The design
+below is not implemented. `modules/desktop_engine/update_service.v` would
+reuse the existing `release.yml` + `manifest.json` pattern (no second update
+server). The former `modules/desktop/update/` GUI-side mock feed was
+removed.
 
 - Feed: `https://github.com/ulises-jeremias/agent-toolkit/releases` + `manifest.json` (ADR-022) as signed feed — `net.http` fetches `version`, `assets[] { name, sha256, url, provenance }`, `channel` (`stable` = `VERSION 1.30.0` line).
 - Check: `Engine.check_update(current: VERSION) -> ?UpdateInfo` compares semver, respects `channel: stable|next|pinned:$VERSION`, opt-in `update.auto_check` (default prompt, not silent).

--- a/docs/desktop/PRODUCT_VISION.md
+++ b/docs/desktop/PRODUCT_VISION.md
@@ -1,6 +1,7 @@
 # Agent Toolkit Desktop product vision
 
-Status: governing product direction, adopted 2026-09-05. This document defines the
+Status: **CURRENT CONTRACT** — governing product direction, adopted
+2026-09-05, re-confirmed 2026-09-13 at `ecc4d67c`. This document defines the
 destination, not a claim that current builds meet it. Start with
 [workflow coverage](WORKFLOW_COVERAGE.md) for verified gaps and
 [visual QA](VISUAL_QA.md) for acceptance evidence.

--- a/docs/desktop/TRUTH_LEDGER.md
+++ b/docs/desktop/TRUTH_LEDGER.md
@@ -1,8 +1,9 @@
 # Desktop Engine truth ledger
 
-Status: re-baselined at HEAD `711c9f32`, 2026-09-10 (original engine-truth
-audit baseline 2026-09-06, `origin/main cf4a4eb8`). This ledger classifies
-every Desktop Engine value by authority and records the replacement source for
+Status: **CURRENT CONTRACT** — re-baselined at HEAD `ecc4d67c`, 2026-09-13
+(previous re-baseline `711c9f32`, 2026-09-10; original engine-truth audit
+baseline 2026-09-06, `origin/main cf4a4eb8`). This ledger classifies every
+Desktop Engine value by authority and records the replacement source for
 each contaminated API. It is the contract for the engine-truth audit: **if
 Agent Toolkit cannot prove a fact, it must not manufacture it.** Unknown,
 unavailable, empty and unverified are valid states.
@@ -10,6 +11,37 @@ unavailable, empty and unverified are valid states.
 The slice tags in the inventory below are the historical audit index —
 production code comments and `*_truth_test.v` headers use domain language
 and carry no per-finding slice tags.
+
+## Re-baseline 2026-09-13 (`ecc4d67c`)
+
+Re-evaluated, not just SHA-bumped. Changes since `711c9f32`:
+
+- **Engine-owned persistence (new, #1205).** The Engine now owns three
+  derived-persistence projections, each with typed tests:
+  workspace-scaffold probing (`modules/desktop_engine/workspace_scaffold.v`),
+  dock-layout persistence (`modules/desktop_engine/dock_persistence.v`,
+  derived `dock.json` next to the state file), and shell-layout persistence
+  (`modules/desktop_engine/ui_state_persistence.v`, derived `ui_state.env`
+  for terminal mode, zoom, language, insights tab, swarm backend,
+  appearance). All three are **derived state** under the existing
+  "Desktop derived state" path authority (`EngineConfig.persist_path`,
+  XDG cache) — never canonical, restorable from defaults. Session-only
+  values stay session-only: terminal MAX restarts as compact, never
+  covering the app before the user asks again.
+- **Feasibility spike retired (#1206).** `modules/agent_toolkit_gui/`
+  (Phase-0 feasibility implementation) is removed; the production Desktop
+  is `gg`/`sokol`-direct with zero production imports of it (verified:
+  `grep -rn "import agent_toolkit_gui\|import gui"` over
+  `modules/desktop_engine`, `modules/desktop`, `cmd/agent-toolkit-desktop`
+  returns no production matches). The decision record is retained in
+  [ADR-032](../adrs/ADR-032-desktop-gui-framework.md) (retirement note;
+  gap-matrix appendix preserved as history).
+- **Contamination inventory re-check.** No placeholder digests in
+  production (`sha256:abc`-style values appear only in test comments
+  asserting they are forbidden); regression gates still live in
+  `modules/desktop_engine/*_truth_test.v` (evidence, targets, git,
+  loops/agents, engine, product). Every finding in the inventory below
+  remains resolved.
 
 ## Authority classes
 
@@ -30,7 +62,7 @@ and carry no per-finding slice tags.
 | Runtime artifacts | `Engine.runtime_path` (derived from persist_path) | `os` (mutable scratch) |
 | Active workspace | harness root / `recent_workspace` — never `toolkit_root` | `os` with validated paths |
 
-## Status (final, 2026-09-06)
+## Status (historical audit record, 2026-09-06; re-confirmed 2026-09-13)
 
 The engine-truth audit is complete. Every finding in the inventory below is
 resolved; the regression gates live in `modules/desktop_engine/*_truth_test.v`

--- a/docs/desktop/USER_JOURNEYS.md
+++ b/docs/desktop/USER_JOURNEYS.md
@@ -1,8 +1,10 @@
 # Desktop user journeys
 
-These are acceptance journeys, not current feature claims. Each must cover success,
-empty/loading/error states and safe recovery through the production native UI.
-See [workflow coverage](WORKFLOW_COVERAGE.md) for current evidence.
+Status: **CURRENT GUIDE** — acceptance journeys, re-confirmed 2026-09-13 at
+`ecc4d67c`. These are acceptance journeys, not current feature claims. Each
+must cover success, empty/loading/error states and safe recovery through the
+production native UI. See [workflow coverage](WORKFLOW_COVERAGE.md) for
+current evidence.
 
 | Journey | Required path and outcome |
 |---|---|
@@ -35,9 +37,14 @@ See [workflow coverage](WORKFLOW_COVERAGE.md) for current evidence.
 
 One Engine classifier must distinguish managed Agent Toolkit, existing Agent
 Toolkit, My AI Workspace-style, harness-compatible, arbitrary project and
-invalid/legacy environments. Existing heuristics are inconsistent. The minimum
-managed workspace schema and transactional scaffold remain release-blocking work.
-Do not call an arbitrary cwd a valid workspace because it contains one directory.
+invalid/legacy environments. Existing heuristics are inconsistent. Scaffold
+*observation* is now Engine-owned (`probe_workspace_scaffold` in
+`modules/desktop_engine/workspace_scaffold.v` reports real on-disk presence
+of `knowledge/`, `personas/`, `packs/`, `repos/`, `projects/`, `AGENTS.md`;
+unknown root reads as unknown, never "all missing"); the minimum managed
+workspace schema and transactional scaffold *mutation* remain
+release-blocking work. Do not call an arbitrary cwd a valid workspace
+because it contains one directory.
 
 Executable discovery must not source arbitrary shell startup files. Search bounded
 catalog-supported locations and allow explicit selection of an executable. Explain

--- a/docs/desktop/UX_ARCHITECTURE.md
+++ b/docs/desktop/UX_ARCHITECTURE.md
@@ -1,10 +1,13 @@
 # Desktop UX architecture
 
-Status: intended interaction contract, 2026-09-05. Current implementation is
+Status: **CURRENT CONTRACT** — intended interaction contract, 2026-09-05,
+re-confirmed 2026-09-13 at `ecc4d67c`. Current implementation is
 `cmd/agent-toolkit-desktop/main.v`, using gg/sokol. Historical
-[ADR-032](../adrs/ADR-032-desktop-gui-framework.md) describes a vlang/gui wrapper
-that is not the production renderer. Preserve that history; a superseding ADR is
-required to reconcile the implementation. This document does not approve a rewrite.
+[ADR-032](../adrs/ADR-032-desktop-gui-framework.md) records the vlang/gui
+Phase-0 feasibility decision and the retirement of its implementation
+(`modules/agent_toolkit_gui/` removed 2026-09-13, #1206); production is
+`gg`/`sokol`-direct. Preserve that history. This document does not approve
+a rewrite.
 
 ## Shell and navigation
 
@@ -93,6 +96,13 @@ collapse optional detail. Compact layouts use drawers/tabs, wrapping and scrolli
 they never shrink text to fit or clip primary actions. Validate breakpoints through
 the [resolution matrix](VISUAL_QA.md), including scaled text and long translations.
 
-Persist durable preferences only: appearance, language, density, reduced motion,
-scale, tool paths and setup configuration. Setup & Onboarding can be revisited
+Persist durable preferences only, and persist them through the Engine, never
+from views directly: appearance, language, density, reduced motion, scale,
+tool paths and setup configuration live in the Engine-owned derived
+`ui_state.env` (`modules/desktop_engine/ui_state_persistence.v`); dock
+layout lives in the Engine-owned derived `dock.json`
+(`modules/desktop_engine/dock_persistence.v`). Both are restorable derived
+state under the XDG-cache persist path, mirrored into the StateRepository.
+Session-only view state is never restored: terminal MAX restarts as compact
+(see `persisted_terminal_mode`). Setup & Onboarding can be revisited
 without resetting the environment.

--- a/docs/desktop/VISUAL_QA.md
+++ b/docs/desktop/VISUAL_QA.md
@@ -1,5 +1,7 @@
 # Desktop visual QA
 
+Status: **CURRENT GUIDE** — re-confirmed 2026-09-13 at `ecc4d67c`.
+
 Visual acceptance requires build → run → navigate → capture PNG → open PNG →
 critique → fix → capture and inspect again. Golden comparison detects change, not
 quality. Never call a screenshot reviewed merely because it exists.
@@ -23,13 +25,15 @@ Include modal/text/terminal shortcut precedence, disabled explanations and Escap
 
 ## Build and capture
 
-The current production build reference is HEAD `711c9f32` (2026-09-10).
+The current production build reference is HEAD `ecc4d67c` (2026-09-13;
+previous `711c9f32`, 2026-09-10).
 
-> **Honest note (2026-09-10):** the full 7-viewport/theme/language matrix
+> **Honest note (2026-09-13):** the full 7-viewport/theme/language matrix
 > below remains unmet as a whole — the only fully opened/inspected captures
-> are the 2026-09-05 audit pair plus per-PR screenshots landed since VC0–VC8,
-> which are the de-facto visual evidence. Do not read this section as
-> claiming matrix completion at HEAD.
+> are the 2026-09-05 audit pair plus per-PR screenshots landed since VC0–VC8
+> and the Engine-persistence / spike-retirement refactors (#1205/#1206,
+> no visual change claimed), which are the de-facto visual evidence. Do not
+> read this section as claiming matrix completion at HEAD.
 
 The last fully built + captured baseline was `85853de`; build with:
 

--- a/docs/desktop/WINDOWS.md
+++ b/docs/desktop/WINDOWS.md
@@ -1,5 +1,8 @@
 # Windows — gg/sokol Limitations + Packaging Spike
 
+Status: **CURRENT GUIDE** (platform support honest: Windows is unproven —
+see Status section). Re-confirmed 2026-09-13 at `ecc4d67c`.
+
 > `V 0.5.2`, `VMODULES=modules`, production renderer is `gg`/`sokol`
 > (`import gg` + `gg.new_context`/`run` in `cmd/agent-toolkit-desktop/main.v`;
 > there is no `vlang/gui` dependency in the production path), plane guard: no
@@ -99,9 +102,11 @@ verified by directory listing):
 
 Windows high-DPI + IME gaps link to EPIC 7 §7.2 accessibility (high-DPI token scaling, `reduced-motion`, typography `CJK/emoji/BiDi`). Doc cross-refs `docs/desktop/PACKAGING.md` macOS/Windows packaging and `docs/desktop/WORLD_VIEW.md` workshop metaphor.
 
-## Status (2026-09-10, HEAD `711c9f32`)
+## Status (2026-09-13, HEAD `ecc4d67c`; previous `711c9f32`, 2026-09-10)
 
 Windows is unproven, not claimed: no `windows-latest` build, window smoke,
 or installer run has been recorded. The Inno Setup verdict and the spike
 table above are the evaluation gate; the installer implementation and the
-`windows-latest` evidence follow the verdict. Tracked by #1060.
+`windows-latest` evidence follow the verdict. Tracked by #1060. The
+Phase-0 feasibility implementation retired in #1206 does not change this
+status — the `gg`/`sokol`-direct production path is unchanged.

--- a/docs/desktop/WORKFLOW_COVERAGE.md
+++ b/docs/desktop/WORKFLOW_COVERAGE.md
@@ -1,13 +1,26 @@
 # Desktop workflow coverage
 
-Baseline: `711c9f32a2cfd632f33f3a47b6ad8897caf806b2`, fetched 2026-09-10.
+Status: **CURRENT CONTRACT** — baseline `ecc4d67cb10a4fd37e6d3e365aa33d83da4a006f`, fetched 2026-09-13
+(previous baseline `711c9f32`, 2026-09-10).
 
-> **Re-baseline banner (2026-09-10):** the matrix below is restated as
+> **Re-baseline banner (2026-09-13):** the matrix below is restated as
 > unevidenced-at-HEAD. Per-cell verdicts were carried over unchanged from the
 > 2026-09-05 baseline (`85853de`), which is now historical — per-cell
 > re-verification against the current build is pending and requires running
-> the app; no cell below counts as proven at HEAD. The resolved S4A–S4C
-> ("Dead/split action discovery") note is retained.
+> the app; no cell below counts as proven at HEAD. The resolved shared-action-registry
+> slices 1–3 (historical audit index S4A–S4C, "Dead/split action discovery")
+> note is retained.
+>
+> **Since `711c9f32` (re-evaluated #1205/#1206):** the Engine now owns
+> workspace-scaffold probing, dock-layout persistence (`dock.json`) and
+> shell-layout persistence (`ui_state.env`) as derived state
+> (`modules/desktop_engine/workspace_scaffold.v`,
+> `dock_persistence.v`, `ui_state_persistence.v`, each with typed tests);
+> the Phase-0 feasibility implementation (`modules/agent_toolkit_gui/`) is
+> retired and removed — production is `gg`/`sokol`-direct. No per-cell
+> verdict above is upgraded by this re-baseline; Workspace create/switch and
+> Installed app/launcher rows still require runtime proof against the new
+> persistence behavior.
 
 This ledger is intentionally conservative. A control or method is not proof of a
 working journey. `scripts/gui-coverage.vsh` (`./scripts/gui-coverage.vsh --check`)
@@ -48,7 +61,7 @@ Source paths below refer to the baseline SHA; line numbers will move as fixes la
 | Fabricated running state and telemetry | `cmd/agent-toolkit-desktop/main.v:1754`, `:1859`, `:4463`, `:5155`, `:5311`, `:5359`, `:5420`, `:6970` | Clean setup remains empty; real events and processes produce matching UI |
 | False process success | `modules/desktop_engine/jobs_service.v:263` | Failed spawn reports failure, no running record |
 | Workspace safety and invented state | `onboarding_service.v:138`, `workspace_service.v:160`, `:271`, `:727` | Containment, no-overwrite, partial failure, actual Git and memory state |
-| Dead/split action discovery | Resolved 2026-09-07 (S4A–S4C, #1159 #1160; static `palette_items()` deleted) | Typed registry is the sole palette/search authority; entity identity + availability reasons + typed actions retained (`modules/desktop/palette/registry.v`, `actions.v`); critical-workflow reachability gated by `cmd/agent-toolkit-desktop/registry_reachability_test.v` in Required CI |
+| Dead/split action discovery | Resolved 2026-09-07 (shared-action-registry slices 1–3, historical index S4A–S4C, #1159 #1160; static `palette_items()` deleted) | Typed registry is the sole palette/search authority; entity identity + availability reasons + typed actions retained (`modules/desktop/palette/registry.v`, `actions.v`); critical-workflow reachability gated by `cmd/agent-toolkit-desktop/registry_reachability_test.v` in Required CI |
 | Domain duplication | CLI `dispatch.v` imports core; Desktop install services duplicate logic; `loops_service.v:480` invokes own CLI | Shared typed domain execution with GUI/CLI parity tests |
 | Native capability misreporting | `modules/desktop/backend/backend.v:139`, `:164`, `:193` | Actual clipboard/dialog operation or explicit unsupported result |
 | Terminal exit and identity | `modules/pty/pty.v:197`; `modules/ghostty/ghostty.v:5` | Reaped child/closed fd, no unexpected restart, honest VT compatibility |

--- a/docs/desktop/assets/design/README.md
+++ b/docs/desktop/assets/design/README.md
@@ -1,5 +1,7 @@
 # Desktop design references
 
+Status: **CURRENT GUIDE** — re-confirmed 2026-09-13 at `ecc4d67c`.
+
 These generated images are **directional visual references**, not implementation screenshots and not sources of product/runtime truth.
 
 - [`concept-board.jpg`](concept-board.jpg) — visual-language overview: Paper Co., pixel-art office, Hornero craftsmanship, terminal contrast, palette and component direction.


### PR DESCRIPTION
Docs-only reconciliation against ecc4d67c (post #1204/#1205/#1206).

- TRUTH_LEDGER + WORKFLOW_COVERAGE re-baselined with re-evaluated claims (Engine-owned scaffold/dock/ui-state persistence, spike retirement); per-cell verdicts stay honestly unevidenced-at-HEAD.
- Doc classification: CURRENT CONTRACT vs CURRENT GUIDE vs frozen HISTORICAL AUDIT (BACKLOG_AUDIT, S4_HANDOFF); campaign labels rewritten to domain language in current docs.
- README/PRODUCT_VISION/DESIGN/UX/USER_JOURNEYS/VISUAL_QA/PACKAGING/WINDOWS updated for the new architecture.