### PR TITLE
fix(packaging): install scalable icon under the Icon basename

### DIFF
--- a/packaging/linux/install-desktop.sh
+++ b/packaging/linux/install-desktop.sh
@@ -107,8 +107,10 @@ add(os.path.join(here, f"{product}.desktop"),
 for size in (16, 24, 32, 48, 64, 128, 256, 512):
     add(os.path.join(here, "icons", f"{product}-{size}.png"),
         os.path.join(xdg_data, "icons", "hicolor", f"{size}x{size}", "apps", f"{product}.png"))
+# Installed name must equal the Icon= basename (hicolor lookup finds
+# scalable/apps/<name>.svg, never <name>-scalable.svg).
 add(os.path.join(here, "icons", f"{product}-scalable.svg"),
-    os.path.join(xdg_data, "icons", "hicolor", "scalable", "apps", f"{product}-scalable.svg"))
+    os.path.join(xdg_data, "icons", "hicolor", "scalable", "apps", f"{product}.svg"))
 add(os.path.join(here, "share", "man", "man1", f"{product}.1"),
     os.path.join(xdg_data, "man", "man1", f"{product}.1"))
 


### PR DESCRIPTION
hicolor lookup for Icon=agent-toolkit-desktop resolves scalable/apps/agent-toolkit-desktop.svg; the installer wrote agent-toolkit-desktop-scalable.svg, which no lookup ever finds.

Sandbox proof (temp HOME/XDG): before — scalable/apps/agent-toolkit-desktop-scalable.svg; after — scalable/apps/agent-toolkit-desktop.svg. Fresh install created=13, idempotent reinstall, uninstall removes 13 owned / preserves pre-existing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux desktop installations so the scalable application icon is saved with the filename expected by the desktop entry, ensuring the icon displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->